### PR TITLE
fix: блокировать «Распознать», пока идёт распознавание источника (#3)

### DIFF
--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -4,6 +4,7 @@ import {
   BookmarkPlus, ScanText, FileDown, Download, AlertTriangle,
 } from 'lucide-react';
 import { parseSourceColumnNames, countFilterConditions } from '@/shared/api/datasetHelpers';
+import { useSourceRecognizing } from '@/shared/api/jobs';
 import {
   useDeleteDataSetSource, useDuplicateDataSetSource, useSetDataSetSourceProcessing, useListProcessingTemplates,
   usePreviewDataSetSource, useCreateProcessingTemplate, useApplyProcessingTemplate, useRecognizePdfSource,
@@ -95,6 +96,9 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
   const deleteMutation = useDeleteDataSetSource();
   const duplicateMutation = useDuplicateDataSetSource();
   const recognizeMutation = useRecognizePdfSource();
+  // Идёт ли уже распознавание по этому источнику (фоновая задача) — чтобы не запускать дубль:
+  // recognizeMutation.isPending живёт только до 202-ответа, поэтому этого мало.
+  const recognizing = useSourceRecognizing(src.id);
 
   const filterCount = countFilterConditions(src.rowFilter);
   const transformCount = src.computedColumns?.length ?? 0;
@@ -150,7 +154,7 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
       { key: 'export-csv', label: 'CSV', onSelect: () => void exportDataSetSource(src.id, 'csv') },
     ] },
     { key: 'duplicate', label: 'Создать копию', icon: <Copy size={13} />, onSelect: () => duplicateMutation.mutate({ id: src.id }), disabled: duplicateMutation.isPending },
-    ...(isPdf && !passiveLabel ? [{ key: 'recognize', label: 'Распознать', icon: <ScanText size={13} />, onSelect: handleRecognize, disabled: recognizeMutation.isPending }] : []),
+    ...(isPdf && !passiveLabel ? [{ key: 'recognize', label: recognizing ? 'Распознаётся…' : 'Распознать', icon: <ScanText size={13} />, onSelect: handleRecognize, disabled: recognizeMutation.isPending || recognizing }] : []),
     ...(canManageExtraction && !isPdf ? [{ key: 'edit', label: 'Редактировать', icon: <Pencil size={13} />, onSelect: () => onEdit(src) }] : []),
     ...(canManageExtraction ? [{ key: 'delete', label: 'Удалить источник', icon: <Trash2 size={13} />, danger: true, onSelect: () => { setDeleteError(null); setConfirmDelete(true); } }] : []),
   ];

--- a/src/client/src/shared/api/jobs.ts
+++ b/src/client/src/shared/api/jobs.ts
@@ -6,12 +6,17 @@ import { apiClient } from './client';
 export interface ActiveJob {
   id: string;
   kind: string;
+  /** Цель задачи — для распознавания это id источника (sourceId). */
+  targetId: string;
   status: 'Queued' | 'Running';
   title: string;
   progress: string | null;
   createdAt: string;
   startedAt: string | null;
 }
+
+/** Виды задач распознавания PDF-источника (для блокировки повторного запуска по этому источнику). */
+const RECOGNITION_KINDS = ['RecognizeGostSet', 'RecognizeDocument', 'RecognizeTable'];
 
 /**
  * Активные фоновые задачи пользователя (источник данных индикатора). Поллит `/jobs/active`: часто, пока
@@ -44,6 +49,20 @@ export function useActiveJobs(): ActiveJob[] {
   }, [jobs, qc]);
 
   return jobs ?? [];
+}
+
+/**
+ * Идёт ли по данному источнику активная задача распознавания — для блокировки повторного запуска
+ * (кнопка «Распознать»). Читает тот же кэш `['jobs','active']`, что и индикатор (общий поллинг), без
+ * side-эффектов инвалидции (они живут в единственном useActiveJobs в AppShell).
+ */
+export function useSourceRecognizing(sourceId: string): boolean {
+  const { data } = useQuery<ActiveJob[]>({
+    queryKey: ['jobs', 'active'],
+    queryFn: () => apiClient.get('/jobs/active').then(r => r.data as ActiveJob[]),
+    refetchInterval: q => ((q.state.data?.length ?? 0) > 0 ? 2000 : 10000),
+  });
+  return (data ?? []).some(j => j.targetId === sourceId && RECOGNITION_KINDS.includes(j.kind));
 }
 
 /** Отмена задачи из очереди (только Queued — 409 для выполняемых). После — обновляем список активных. */

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -154,6 +154,9 @@ public static class DataSetEndpoints
         {
             try
             {
+                // Защита от повторного запуска, пока по этому источнику уже идёт распознавание.
+                if (await jobs.HasActiveForTargetAsync(UserId(user), sourceId, ct))
+                    return Results.Conflict(new { error = "По этому источнику уже идёт распознавание." });
                 // Пред-валидация синхронно (формат, 409 ручной правки). GOST-набор (минуты) → фоновая
                 // задача, 202+jobId сразу (реквест не держится). Счёт/legacy (секунды) → синхронно.
                 var plan = await svc.PlanRecognitionAsync(sourceId, confirm ?? false, ct);
@@ -223,6 +226,8 @@ public static class DataSetEndpoints
         g.MapPost("/sources/{sourceId:guid}/recognize-table", async (
             Guid sourceId, RecognizeTableRequest req, IJobService jobs, ClaimsPrincipal user, CancellationToken ct) =>
         {
+            if (await jobs.HasActiveForTargetAsync(UserId(user), sourceId, ct))
+                return Results.Conflict(new { error = "По этому источнику уже идёт распознавание." });
             var payload = JsonSerializer.Serialize(new { firstPageIndex = req.FirstPageIndex });
             var jobId = await jobs.EnqueueAsync(JobKind.RecognizeTable, UserId(user), sourceId, "Распознавание таблицы", payload, ct);
             return Results.Accepted($"/api/jobs/active", new { jobId });
@@ -232,6 +237,8 @@ public static class DataSetEndpoints
         g.MapPost("/sources/{sourceId:guid}/recognize-document", async (
             Guid sourceId, RecognizeTableRequest req, IJobService jobs, ClaimsPrincipal user, CancellationToken ct) =>
         {
+            if (await jobs.HasActiveForTargetAsync(UserId(user), sourceId, ct))
+                return Results.Conflict(new { error = "По этому источнику уже идёт распознавание." });
             var payload = JsonSerializer.Serialize(new { firstPageIndex = req.FirstPageIndex });
             var jobId = await jobs.EnqueueAsync(JobKind.RecognizeDocument, UserId(user), sourceId, "Перераспознавание документа", payload, ct);
             return Results.Accepted($"/api/jobs/active", new { jobId });

--- a/src/server/BHS.CRG.Application/Jobs/IJobService.cs
+++ b/src/server/BHS.CRG.Application/Jobs/IJobService.cs
@@ -6,6 +6,7 @@ namespace BHS.CRG.Application.Jobs;
 public record JobDto(
     Guid Id,
     string Kind,
+    Guid TargetId,
     string Status,
     string Title,
     string? Progress,
@@ -23,6 +24,9 @@ public interface IJobService
 
     /// <summary>Активные (Queued/Running) задачи пользователя — источник данных индикатора.</summary>
     Task<IReadOnlyList<JobDto>> GetActiveForUserAsync(Guid userId, CancellationToken ct);
+
+    /// <summary>Есть ли у пользователя активная (Queued/Running) задача по данной цели — защита от дубля.</summary>
+    Task<bool> HasActiveForTargetAsync(Guid userId, Guid targetId, CancellationToken ct);
 
     /// <summary>Отменить свою задачу — ТОЛЬКО пока она в очереди (Queued). true — отменена; false —
     /// нельзя (уже выполняется/завершена/не найдена/чужая). Выполняемые добегают до конца.</summary>

--- a/src/server/BHS.CRG.Infrastructure/Jobs/JobService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Jobs/JobService.cs
@@ -27,8 +27,12 @@ public class JobService(AppDbContext db, JobQueue queue) : IJobService
             .OrderBy(j => j.CreatedAt)
             .ToListAsync(ct);
         return jobs.Select(j => new JobDto(
-            j.Id, j.Kind.ToString(), j.Status.ToString(), j.Title, j.Progress, j.CreatedAt, j.StartedAt)).ToList();
+            j.Id, j.Kind.ToString(), j.TargetId, j.Status.ToString(), j.Title, j.Progress, j.CreatedAt, j.StartedAt)).ToList();
     }
+
+    public Task<bool> HasActiveForTargetAsync(Guid userId, Guid targetId, CancellationToken ct)
+        => db.Jobs.AsNoTracking().AnyAsync(j => j.UserId == userId && j.TargetId == targetId
+            && (j.Status == JobStatus.Queued || j.Status == JobStatus.Running), ct);
 
     public async Task<bool> CancelAsync(Guid jobId, Guid userId, CancellationToken ct)
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #3

## Проблема
Кнопка «Распознать» в PDF-источниках снова становилась активной сразу после ответа сервера (202), хотя фоновая задача распознавания ещё выполнялась → можно было запустить дубль. Причина: `disabled` был привязан только к `recognizeMutation.isPending`, который живёт лишь на время HTTP-запроса.

## Что сделано
**Frontend**
- `ActiveJob` получил `targetId`.
- Новый хук `useSourceRecognizing(sourceId)` — читает общий кэш `['jobs','active']` (тот же поллинг, что у индикатора, без side-эффектов) и возвращает `true`, если по источнику идёт задача распознавания (`RecognizeGostSet/Document/Table`).
- Кнопка «Распознать»: `disabled` при активной задаче + подпись «Распознаётся…».

**Backend (defense-in-depth)**
- `JobDto.TargetId`; `IJobService.HasActiveForTargetAsync`.
- Три recognize-эндпоинта (`/recognize`, `/recognize-table`, `/recognize-document`) отдают **409**, если по источнику уже есть активная задача — защита от дубля из гонок/других вкладок.

## Версия
`0.1.0 → 0.1.1` (баг-фикс). **Обновление без ручных действий** (миграций/конфига нет).

## Проверки
- Backend **321** + frontend **106** зелёные, tsc чистый.
- Как проверить: открыть PDF-источник → «Распознать» → пока идёт задача (виден прогресс в индикаторе), пункт меню должен быть заблокирован и подписан «Распознаётся…»; по завершении — снова активен.