### PR TITLE
feat: усилить визуальную иерархию панели «Каталог общих данных» (#8)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -59,9 +59,9 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
       const isDocKind = documentTypes.some(dt => dt.id === entry.compositeTypeId);
       return (
         <div key={entry.id}
-          className={`flex items-center gap-3 pl-6 pr-3 py-2 group hover:bg-muted transition-colors ${idx > 0 ? 'border-t border-stroke' : ''}`}>
+          className={`flex items-center gap-3 pl-3 pr-3 py-2 group hover:bg-muted transition-colors ${idx > 0 ? 'border-t border-stroke' : ''}`}>
           {isDocKind && <FileText size={12} className="text-warning shrink-0" />}
-          <span className="flex-1 text-sm font-medium text-fg1 truncate">{entry.displayName}</span>
+          <span className="flex-1 text-sm text-fg1 truncate">{entry.displayName}</span>
           {isDocKind && <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>}
           <button onClick={() => setEditEntry(entry)}
             className="p-1 text-stroke-strong hover:text-fg2 opacity-0 group-hover:opacity-100 transition-all">
@@ -76,6 +76,30 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
         </div>
       );
     });
+  }
+
+  // Группа типа: uppercase-микрозаголовок на заливке bg-base (сильный «заголовочный» сигнал),
+  // записи — плоские, на bg-surface, с левым рейлом-коннектором. Три канала различия уровней
+  // (типографика + заливка + рейл) — issue #8, слабая визуальная иерархия.
+  function renderGroup(key: string, label: string, items: CommonDataEntry[], muted = false) {
+    const isOpen = expandedTypes.has(key);
+    return (
+      <div key={key} className="border border-stroke rounded-lg overflow-hidden bg-surface">
+        <button onClick={() => toggleType(key)} aria-expanded={isOpen}
+          className="w-full flex items-center gap-2 px-3 py-1.5 bg-base hover:bg-muted transition-colors text-left">
+          {isOpen
+            ? <ChevronUp size={12} className="text-fg4 shrink-0" />
+            : <ChevronDown size={12} className="text-fg4 shrink-0" />}
+          <span className={`flex-1 text-xs font-semibold uppercase tracking-wide ${muted ? 'text-fg4' : 'text-fg2'}`}>{label}</span>
+          <span className="text-xs text-fg4">{items.length}</span>
+        </button>
+        {isOpen && (
+          <div className="bg-surface">
+            <div className="ml-3 border-l border-stroke">{renderEntries(items)}</div>
+          </div>
+        )}
+      </div>
+    );
   }
 
   return (
@@ -102,38 +126,8 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
             <p className="text-sm text-fg4 text-center py-2">Записей нет</p>
           ) : (
             <div className="space-y-1">
-              {grouped.map(({ ct, items }) => {
-                const isOpen = expandedTypes.has(ct.id);
-                return (
-                  <div key={ct.id} className="border border-stroke rounded-lg overflow-hidden bg-surface">
-                    <button onClick={() => toggleType(ct.id)}
-                      className="w-full flex items-center gap-2 px-3 py-2 hover:bg-base transition-colors text-left">
-                      {isOpen
-                        ? <ChevronUp size={12} className="text-fg4 shrink-0" />
-                        : <ChevronDown size={12} className="text-fg4 shrink-0" />}
-                      <span className="flex-1 text-sm font-medium text-fg2">{ct.name}</span>
-                      <span className="text-xs text-fg4">{items.length}</span>
-                    </button>
-                    {isOpen && <div className="border-t border-stroke">{renderEntries(items)}</div>}
-                  </div>
-                );
-              })}
-              {noType.length > 0 && (() => {
-                const isOpen = expandedTypes.has('__no_type__');
-                return (
-                  <div className="border border-stroke rounded-lg overflow-hidden bg-surface">
-                    <button onClick={() => toggleType('__no_type__')}
-                      className="w-full flex items-center gap-2 px-3 py-2 hover:bg-base transition-colors text-left">
-                      {isOpen
-                        ? <ChevronUp size={12} className="text-fg4 shrink-0" />
-                        : <ChevronDown size={12} className="text-fg4 shrink-0" />}
-                      <span className="flex-1 text-sm font-medium text-fg3 italic">Без типа</span>
-                      <span className="text-xs text-fg4">{noType.length}</span>
-                    </button>
-                    {isOpen && <div className="border-t border-stroke">{renderEntries(noType)}</div>}
-                  </div>
-                );
-              })()}
+              {grouped.map(({ ct, items }) => renderGroup(ct.id, ct.name, items))}
+              {noType.length > 0 && renderGroup('__no_type__', 'Без типа', noType, true)}
             </div>
           )}
           <button onClick={() => setAddOpen(true)}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #8

Уровни в раскрытой панели «Каталог общих данных» (панель → группа-тип → запись) сливались: у заголовков групп и строк-записей был один фон `bg-surface`, один `text-sm font-medium`, схожий паддинг — различие только в отступе. Схема согласована с Дизайнером и подтверждена пользователем (охват: только каталог).

## Что сделано (три канала различия уровней)
- **Заголовок группы**: `text-xs font-semibold uppercase tracking-wide` на заливке-полосе `bg-base` — сильный «заголовочный» сигнал (переиспользует паттерн секций полей из того же файла).
- **Записи**: плоские (снят `font-medium`), на `bg-surface`, с **левым рейлом-коннектором** (`ml-3 border-l`), отступ `pl-6 → pl-3`.
- `aria-expanded` на заголовках групп. Плотность сохранена (uppercase-кегль меньше, паддинг полосы `py-1.5`).
- Инлайн-дубли двух блоков групп сведены в общий `renderGroup`.

## Версия
`0.2.0 → 0.2.1` (визуальная полировка). Если считаешь «изменением фичи» — переименую в MINOR. **Обновление без ручных действий.**

## Проверки
- Frontend **106** зелёные, tsc чистый (изменение чисто фронтовое).
- Как проверить: Стройки → стройка → раскрыть «Каталог общих данных» → группы-типы теперь uppercase-заголовки на заливке, записи под ними — плоские с левым рейлом; уровни явно различимы.

## Не в этом PR
Единый grouped-list язык для RefPicker (#5) и «Наборов данных» — по решению пользователя отдельно (RefPicker уже с scope-бейдж-заголовками).