### PR TITLE
feat: имя скачиваемого файла = имя документа + суффикс-шаблон (#9)

### DIFF
--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from './client';
 import type { DocumentSet, DocumentInstance, DocumentSearchResult } from './types';
+import { filenameFromContentDisposition } from './attachments';
 
 /** Поиск документов по всем комплектам (имя документа/типа + текст реквизитов). Пустой q → без запроса. */
 export function useSearchDocuments(q: string, constructionId?: string) {
@@ -185,10 +186,12 @@ export async function downloadGeneratedFile(instanceId: string, templateId?: str
   const response = await apiClient.get(path, {
     responseType: 'blob',
   });
+  // Имя формирует бэкенд (имя документа + суффикс-шаблон, спецсимволы → _), достаём из Content-Disposition.
+  const filename = filenameFromContentDisposition(response.headers['content-disposition'], 'document.pdf');
   const url = URL.createObjectURL(response.data as Blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'document.pdf';
+  a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -3,6 +3,7 @@ using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Application.Generation;
 using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Templates;
 using MediatR;
 
 namespace BHS.CRG.Api.Endpoints.Generation;
@@ -46,36 +47,40 @@ public static class GenerationEndpoints
         });
 
         g.MapGet("/download/{instanceId:guid}/{format}", async (
-            Guid instanceId, string format, IMediator m, IBlobStorage blob) =>
+            Guid instanceId, string format, IMediator m, IBlobStorage blob,
+            IRepository<DocumentType> docTypes, IRepository<Template> templates, CancellationToken ct) =>
         {
             if (!string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase))
                 return Results.BadRequest(new { error = $"Неизвестный формат: «{format}». Поддерживается только PDF." });
 
-            var inst = await m.Send(new GetDocumentInstanceQuery(instanceId));
+            var inst = await m.Send(new GetDocumentInstanceQuery(instanceId), ct);
             if (inst is null) return Results.NotFound();
 
             var generatedFile = inst.GeneratedFiles.FirstOrDefault(f => f.Format == OutputFormat.Pdf);
             if (generatedFile is null) return Results.NotFound();
 
-            var stream = await blob.DownloadAsync(generatedFile.BlobPath);
-            return Results.File(stream, "application/pdf", "document.pdf");
+            var name = await BuildDownloadNameAsync(inst, generatedFile.TemplateId, docTypes, templates, ct);
+            var stream = await blob.DownloadAsync(generatedFile.BlobPath, ct);
+            return Results.File(stream, "application/pdf", name);
         });
 
         // Скачивание файла конкретного шаблона (мульти-шаблонная генерация — файлов может быть несколько).
         g.MapGet("/download/{instanceId:guid}/{templateId:guid}/{format}", async (
-            Guid instanceId, Guid templateId, string format, IMediator m, IBlobStorage blob) =>
+            Guid instanceId, Guid templateId, string format, IMediator m, IBlobStorage blob,
+            IRepository<DocumentType> docTypes, IRepository<Template> templates, CancellationToken ct) =>
         {
             if (!string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase))
                 return Results.BadRequest(new { error = $"Неизвестный формат: «{format}». Поддерживается только PDF." });
 
-            var inst = await m.Send(new GetDocumentInstanceQuery(instanceId));
+            var inst = await m.Send(new GetDocumentInstanceQuery(instanceId), ct);
             if (inst is null) return Results.NotFound();
 
             var generatedFile = inst.GeneratedFiles.FirstOrDefault(f => f.Format == OutputFormat.Pdf && f.TemplateId == templateId);
             if (generatedFile is null) return Results.NotFound();
 
-            var stream = await blob.DownloadAsync(generatedFile.BlobPath);
-            return Results.File(stream, "application/pdf", "document.pdf");
+            var name = await BuildDownloadNameAsync(inst, templateId, docTypes, templates, ct);
+            var stream = await blob.DownloadAsync(generatedFile.BlobPath, ct);
+            return Results.File(stream, "application/pdf", name);
         });
 
         // Отладочный пакет: template.typ + data.json + typeblocks.typ + userlib.typ —
@@ -171,6 +176,25 @@ public static class GenerationEndpoints
             var data = await plugin.FetchAsync(req.EntityType, req.ExternalId);
             return Results.Ok(data);
         });
+    }
+
+    // Имя скачиваемого файла: «Имя документа - Имя шаблона.pdf» (спецсимволы → '_'). Имя документа —
+    // из instance.Name, иначе имя типа; суффикс-шаблон — если файл сгенерирован конкретным шаблоном.
+    static async Task<string> BuildDownloadNameAsync(DocumentInstance inst, Guid? templateId,
+        IRepository<DocumentType> docTypes, IRepository<Template> templates, CancellationToken ct)
+    {
+        var docName = inst.Name;
+        if (string.IsNullOrWhiteSpace(docName))
+            docName = (await docTypes.GetByIdAsync(inst.DocumentTypeId, ct))?.Name ?? "Документ";
+
+        var name = FileNames.Sanitize(docName, "документ");
+        if (templateId is { } tid)
+        {
+            var tpl = await templates.GetByIdAsync(tid, ct);
+            if (tpl is not null && !string.IsNullOrWhiteSpace(tpl.Name))
+                name += " - " + FileNames.Sanitize(tpl.Name, "шаблон");
+        }
+        return name + ".pdf";
     }
 
     static object ToDto(ResolutionDiagnostic d) => new

--- a/src/server/BHS.CRG.Application/Common/FileNames.cs
+++ b/src/server/BHS.CRG.Application/Common/FileNames.cs
@@ -1,0 +1,13 @@
+namespace BHS.CRG.Application.Common;
+
+public static class FileNames
+{
+    /// <summary>Имя файла без запрещённых символов (недопустимые → '_'). Пусто/только мусор → fallback.</summary>
+    public static string Sanitize(string? name, string fallback = "файл")
+    {
+        if (string.IsNullOrWhiteSpace(name)) return fallback;
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitized = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
+        return string.IsNullOrWhiteSpace(sanitized) ? fallback : sanitized;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Domain.DataSets;
 
@@ -13,12 +14,7 @@ namespace BHS.CRG.Infrastructure.DataSets;
 public static class DataSetDtoMapper
 {
     /// <summary>Имя файла без запрещённых символов (для скачиваемых выгрузок/разрезанных PDF).</summary>
-    public static string SanitizeFileName(string name)
-    {
-        var invalid = Path.GetInvalidFileNameChars();
-        var sanitized = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
-        return string.IsNullOrWhiteSpace(sanitized) ? "данные" : sanitized;
-    }
+    public static string SanitizeFileName(string name) => FileNames.Sanitize(name, "данные");
 
     public static DataSetFormat? DetectFormat(string fileName) =>
         Path.GetExtension(fileName).ToLowerInvariant() switch

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #9

(Пересоздан после мёрджа #10 — прежний PR #11 закрылся при удалении базовой ветки стека. Диф — только #9.)

Сгенерированный PDF скачивался как `document.pdf`. Теперь имя формируется бэкендом в `Content-Disposition`: «Имя документа - Имя шаблона.pdf», спецсимволы → `_`.
- Имя документа = `instance.Name`, иначе имя типа. Суффикс = имя шаблона (`generatedFile.TemplateId`).
- Санитайзер вынесен в общий `Application/Common/FileNames.Sanitize`; `DataSetDtoMapper.SanitizeFileName` делегирует.
- Фронт `downloadGeneratedFile` берёт имя из `Content-Disposition` (RFC5987 — кириллица корректна).

Версия `0.2.1 → 0.2.2`. Обновление без ручных действий. Протестировано пользователем.