### PR TITLE
fix: не открывать/скачивать файл во время генерации + graceful preview (#13)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -355,6 +355,9 @@ function GenerationTab({ instance, setId }: { instance: DocumentInstance; setId:
   }
 
   const pdfFiles = instance.generatedFiles.filter(f => f.format === 'Pdf');
+  // Идёт генерация (файлы перезаписываются) — блокируем открытие/скачивание, чтобы не попасть на
+  // заменяемую/устаревшую версию (ссылка на «старый» файл → пустая страница до обновления).
+  const busy = mutation.isPending || instance.status === 'Generating';
 
   return (
     <div className="space-y-5">
@@ -454,12 +457,14 @@ function GenerationTab({ instance, setId }: { instance: DocumentInstance; setId:
               return (
                 <div key={f.id} className="flex items-center gap-2">
                   <span className="text-xs text-fg2 flex-1 min-w-0 truncate" title={tpl?.name}>{tpl ? tpl.name : 'PDF'}</span>
-                  <button onClick={() => previewGeneratedFile(instance.id, f.templateId)}
-                    className="flex items-center gap-1 px-2.5 py-1.5 text-xs border border-stroke rounded-md hover:bg-base">
+                  {/* Во время генерации файл перезаписывается — блокируем открытие/скачивание, чтобы
+                      не открыть неактуальную/заменяемую версию (ссылка ведёт на старое состояние). */}
+                  <button onClick={() => previewGeneratedFile(instance.id, f.templateId)} disabled={busy}
+                    className="flex items-center gap-1 px-2.5 py-1.5 text-xs border border-stroke rounded-md hover:bg-base disabled:opacity-40 disabled:pointer-events-none">
                     <Eye size={13} className="text-brand" /> Открыть
                   </button>
-                  <button onClick={() => downloadGeneratedFile(instance.id, f.templateId)}
-                    className="flex items-center gap-1 px-2.5 py-1.5 text-xs border border-stroke rounded-md hover:bg-base">
+                  <button onClick={() => downloadGeneratedFile(instance.id, f.templateId)} disabled={busy}
+                    className="flex items-center gap-1 px-2.5 py-1.5 text-xs border border-stroke rounded-md hover:bg-base disabled:opacity-40 disabled:pointer-events-none">
                     <Download size={13} className="text-brand" /> Скачать
                   </button>
                 </div>

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -226,6 +226,8 @@ export async function previewGeneratedFile(instanceId: string, templateId?: stri
   // then navigate it to the blob URL once the download completes.
   const newWindow = window.open('', '_blank');
   if (!newWindow) return;
+  // Плейсхолдер, пока грузится (и чтобы при ошибке не осталась «пустая страница»).
+  try { newWindow.document.write('<p style="font:14px sans-serif;color:#555;padding:16px">Загрузка PDF…</p>'); } catch { /* cross-origin — не критично */ }
 
   try {
     const path = templateId ? `/generate/download/${instanceId}/${templateId}/pdf` : `/generate/download/${instanceId}/pdf`;
@@ -236,6 +238,10 @@ export async function previewGeneratedFile(instanceId: string, templateId?: stri
     newWindow.location.href = url;
     // intentionally not revoking — browser needs the URL while the tab is open
   } catch {
-    newWindow.close();
+    // Не оставляем пустую вкладку — показываем понятное сообщение.
+    try {
+      newWindow.document.body.innerHTML =
+        '<p style="font:14px sans-serif;color:#b00;padding:16px">Не удалось открыть файл. Обновите страницу документа и попробуйте снова.</p>';
+    } catch { newWindow.close(); }
   }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #13

## Диагностика
Воспроизвёл через Playwright + прямые запросы:
- **Бэкенд исправен**: сразу после генерации оба download-роута (`/pdf` и `/{templateId}/pdf`) → **200** PDF, имя файла корректно.
- **Штатный поток работает**: Draft → генерация → дождаться кнопки → «Открыть» → download 200, PDF открывается.
- **Сбой** — гонка тайминга: клик «Открыть»/«Скачать» приходится на момент, когда файл перезаписывается генерацией (ссылка ведёт на «старое»/заменяемое состояние) → пустая страница; переоткрытие диалога помогало, т.к. состояние успевало устаканиться.

## Фикс
- **Блокировка кнопок «Открыть»/«Скачать» во время генерации** (`busy = mutation.isPending || status==='Generating'`) — нельзя кликнуть по заменяемой версии.
- **`previewGeneratedFile`**: плейсхолдер «Загрузка PDF…» и при сбое — понятное сообщение во вкладке вместо **пустой страницы** (симптом уходит даже при временно неактуальной ссылке).

## Версия
`0.2.2 → 0.2.3` (баг-фикс). **Обновление без ручных действий.**

## Проверки
- Frontend **106** зелёные, tsc чистый (изменение фронтовое).
- Как проверить: сгенерировать документ → сразу нажать «Открыть»/«Скачать» → должно открыть/скачать актуальный PDF; во время самой генерации кнопки заблокированы; если что-то пойдёт не так — во вкладке будет сообщение, а не пустая страница.
- Если у тебя всё ещё воспроизводится «пустая страница» — открой консоль браузера на вкладке-попапе/основной: теперь будет видно сообщение об ошибке; скинь его, докопаю точную гонку.