### PR TITLE
fix: кнопки связок в форме записи не сабмитят форму (type=button) (#15)

### DIFF
--- a/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
+++ b/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
@@ -109,13 +109,14 @@ function AddEntryBindingPanel({
 
       <div className="flex gap-2">
         <button
+          type="button"
           onClick={handleSave}
           disabled={!sourceId || create.isPending}
           className="px-3 py-1.5 rounded-md text-sm font-medium text-white disabled:opacity-40 bg-brand"
         >
           {create.isPending ? 'Сохранение...' : 'Сохранить привязку'}
         </button>
-        <button onClick={onDone} className="px-3 py-1.5 rounded-md text-sm font-medium text-fg2 bg-muted">
+        <button type="button" onClick={onDone} className="px-3 py-1.5 rounded-md text-sm font-medium text-fg2 bg-muted">
           Отмена
         </button>
       </div>
@@ -160,17 +161,17 @@ function EntryBindingRow({
             {targetFieldKey && ` · таблица: ${targetFieldKey}`}
           </div>
         </div>
-        <button onClick={() => setEditing(e => !e)} className="p-1.5 rounded text-xs text-fg3" title="Редактировать маппинг">
+        <button type="button" onClick={() => setEditing(e => !e)} className="p-1.5 rounded text-xs text-fg3" title="Редактировать маппинг">
           <Pencil size={13} />
         </button>
         {!confirming ? (
-          <button onClick={() => setConfirming(true)} className="p-1.5 rounded text-fg4 hover:text-danger transition-colors" title="Удалить">
+          <button type="button" onClick={() => setConfirming(true)} className="p-1.5 rounded text-fg4 hover:text-danger transition-colors" title="Удалить">
             <Trash2 size={13} />
           </button>
         ) : (
           <div className="flex items-center gap-1.5 text-xs">
-            <button onClick={handleDelete} disabled={del.isPending} className="px-2 py-0.5 rounded text-white text-xs bg-danger">Да</button>
-            <button onClick={() => setConfirming(false)} className="px-2 py-0.5 rounded text-xs bg-muted text-fg2">Нет</button>
+            <button type="button" onClick={handleDelete} disabled={del.isPending} className="px-2 py-0.5 rounded text-white text-xs bg-danger">Да</button>
+            <button type="button" onClick={() => setConfirming(false)} className="px-2 py-0.5 rounded text-xs bg-muted text-fg2">Нет</button>
           </div>
         )}
       </div>
@@ -187,10 +188,10 @@ function EntryBindingRow({
             onChange={(m, t) => { setMappingState(m); setTargetFieldKey(t); }}
           />
           <div className="flex gap-2">
-            <button onClick={handleSave} disabled={update.isPending} className="px-3 py-1.5 rounded-md text-sm font-medium text-white bg-brand">
+            <button type="button" onClick={handleSave} disabled={update.isPending} className="px-3 py-1.5 rounded-md text-sm font-medium text-white bg-brand">
               {update.isPending ? 'Сохранение...' : 'Сохранить'}
             </button>
-            <button onClick={() => setEditing(false)} className="px-3 py-1.5 rounded-md text-sm font-medium text-fg3">
+            <button type="button" onClick={() => setEditing(false)} className="px-3 py-1.5 rounded-md text-sm font-medium text-fg3">
               Отмена
             </button>
           </div>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #15

## Причина (точная)
В диалоге «Редактировать запись» (Общие данные) секция «Наборы данных» рендерится ВНУТРИ `<form onSubmit>` формы записи (`CatalogEntryForm`). Кнопки в `EntryDataSetBindings` (карандаш «редактировать связку», корзина, «Да/Нет», «Сохранить/Отмена» редактора) были **без `type="button"`** → по HTML дефолтят в `type="submit"` → клик **сабмитил форму** (сохранение + закрытие диалога), а inline-редактор маппинга не успевал показаться. Отсюда симптом: «диалог связки не открывается, а диалог записи закрывается».

На вкладке «Данные» документа те же кнопки работают, потому что там они **не внутри формы**.

## Фикс
- `type="button"` проставлен всем 8 кнопкам в `EntryDataSetBindings.tsx`.
- Собственные кнопки `CatalogEntryForm` уже были с `type="button"`; `MappingEditor` кнопок не содержит (на `<select>`), поэтому открытие редактора теперь безопасно.

## Версия
`0.2.3 → 0.2.4` (баг-фикс). **Обновление без ручных действий.**

## Проверки
- Frontend **106** зелёные, tsc чистый.
- Как проверить: Общие данные → открыть запись → секция «Наборы данных» → карандаш у связки → открывается редактор маппинга (диалог записи НЕ закрывается); «Да» в подтверждении удаления удаляет связку без закрытия; «Сохранить/Отмена» в редакторе работают.