### PR TITLE
feat: наполнение полей doc-array из источника данных (табличная связка) (#17)

### DIFF
--- a/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
+++ b/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
@@ -39,7 +39,7 @@ function AddEntryBindingPanel({
   const create = useCreateDataSetBinding();
 
   const selectedSource = allSources.find(s => s.id === sourceId);
-  const arrayFields = schemaFields.filter(f => f.type === 'array');
+  const tabularFields = schemaFields.filter(f => f.type === 'array' || f.type === 'doc-array');
   const scalarFields = schemaFields.filter(f => isScalarField(f) && f.type !== 'file');
 
   async function handleSourceChange(id: string) {
@@ -97,7 +97,7 @@ function AddEntryBindingPanel({
         <MappingEditor
           source={selectedSource}
           schemaFields={schemaFields}
-          arrayFields={arrayFields}
+          tabularFields={tabularFields}
           allDocTypes={allDocTypes}
           mapping={mapping}
           targetFieldKey={targetFieldKey}
@@ -139,7 +139,7 @@ function EntryBindingRow({
 
   const source = binding.source;
   const file = source?.file;
-  const arrayFields = schemaFields.filter(f => f.type === 'array');
+  const tabularFields = schemaFields.filter(f => f.type === 'array' || f.type === 'doc-array');
   const mappedCount = Object.keys(mapping).filter(k => mapping[k]).length;
 
   async function handleSave() {
@@ -181,7 +181,7 @@ function EntryBindingRow({
           <MappingEditor
             source={source}
             schemaFields={schemaFields}
-            arrayFields={arrayFields}
+            tabularFields={tabularFields}
             allDocTypes={allDocTypes}
             mapping={mapping}
             targetFieldKey={targetFieldKey}

--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -14,7 +14,7 @@ import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
 export function MappingEditor({
   source,
   schemaFields,
-  arrayFields,
+  tabularFields,
   allDocTypes,
   mapping,
   targetFieldKey,
@@ -22,7 +22,7 @@ export function MappingEditor({
 }: {
   source: DataSetSource;
   schemaFields: SchemaField[];
-  arrayFields: SchemaField[];
+  tabularFields: SchemaField[];
   allDocTypes: DocumentType[];
   mapping: Record<string, string>;
   targetFieldKey: string | null;
@@ -31,15 +31,17 @@ export function MappingEditor({
   const columnNames = useMemo(() => parseSourceColumnNames(source.cachedSchema), [source.cachedSchema]);
 
   // Поля, доступные для маппинга: для скалярного режима — поля документа,
-  // для табличного — поля составного типа элемента массива.
+  // для табличного — поля типа элемента (составной тип для `array`;
+  // тип-документ, на который ссылается `doc-array`, — строки источника
+  // разворачиваются в объекты его формы, см. DataSetResolver).
   const effectiveFields = useMemo(() => {
     if (targetFieldKey === null) return schemaFields;
-    const arrayField = arrayFields.find(f => f.key === targetFieldKey);
-    if (!arrayField?.typeId) return [];
-    const compositeType = allDocTypes.find(dt => dt.id === arrayField.typeId);
-    if (!compositeType) return [];
-    return resolveEffectiveFields(compositeType, allDocTypes);
-  }, [targetFieldKey, arrayFields, allDocTypes, schemaFields]);
+    const tabularField = tabularFields.find(f => f.key === targetFieldKey);
+    if (!tabularField?.typeId) return [];
+    const elementType = allDocTypes.find(dt => dt.id === tabularField.typeId);
+    if (!elementType) return [];
+    return resolveEffectiveFields(elementType, allDocTypes);
+  }, [targetFieldKey, tabularFields, allDocTypes, schemaFields]);
 
   const scalarMappable = effectiveFields.filter(f => isScalarField(f) && f.type !== 'file');
   // Составные поля заполняются ссылкой на запись каталога (по значению колонки).
@@ -88,8 +90,10 @@ export function MappingEditor({
           className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1"
         >
           <option value="">Скалярный — первая строка заполняет отдельные поля</option>
-          {arrayFields.map(f => (
-            <option key={f.key} value={f.key}>Табличный → {f.title} ({f.key})</option>
+          {tabularFields.map(f => (
+            <option key={f.key} value={f.key}>
+              Табличный → {f.title} ({f.key}){f.type === 'doc-array' ? ' — документы' : ''}
+            </option>
           ))}
         </select>
       </div>
@@ -97,7 +101,7 @@ export function MappingEditor({
       <div>
         <label className="block text-xs font-medium mb-1 text-fg3">
           Маппинг колонок файла → поля
-          {targetFieldKey && <span className="ml-1 font-normal text-fg4">(поля «{arrayFields.find(f => f.key === targetFieldKey)?.title ?? targetFieldKey}»)</span>}
+          {targetFieldKey && <span className="ml-1 font-normal text-fg4">(поля «{tabularFields.find(f => f.key === targetFieldKey)?.title ?? targetFieldKey}»)</span>}
         </label>
         <div className="space-y-1.5">
           {scalarMappable.map(f => (
@@ -211,7 +215,9 @@ function AddBindingPanel({
   const create = useCreateDataSetBinding();
 
   const selectedSource = allSources.find(s => s.id === sourceId);
-  const arrayFields = schemaFields.filter(f => f.type === 'array');
+  // Цели табличного режима: inline-массив (`array`) и список ссылок на документы
+  // (`doc-array`) — строки источника разворачиваются в объекты формы элемента-типа.
+  const tabularFields = schemaFields.filter(f => f.type === 'array' || f.type === 'doc-array');
   const scalarFields = schemaFields.filter(f => isScalarField(f) && f.type !== 'file');
 
   async function handleSourceChange(id: string) {
@@ -273,7 +279,7 @@ function AddBindingPanel({
         <MappingEditor
           source={selectedSource}
           schemaFields={schemaFields}
-          arrayFields={arrayFields}
+          tabularFields={tabularFields}
           allDocTypes={allDocTypes}
           mapping={mapping}
           targetFieldKey={targetFieldKey}
@@ -324,7 +330,9 @@ function BindingRow({
 
   const source = binding.source;
   const file = source?.file;
-  const arrayFields = schemaFields.filter(f => f.type === 'array');
+  // Цели табличного режима: inline-массив (`array`) и список ссылок на документы
+  // (`doc-array`) — строки источника разворачиваются в объекты формы элемента-типа.
+  const tabularFields = schemaFields.filter(f => f.type === 'array' || f.type === 'doc-array');
   const scalarFields = schemaFields.filter(f => isScalarField(f) && f.type !== 'file');
 
   async function handleAutoRemap() {
@@ -396,7 +404,7 @@ function BindingRow({
           <MappingEditor
             source={source}
             schemaFields={schemaFields}
-            arrayFields={arrayFields}
+            tabularFields={tabularFields}
             allDocTypes={allDocTypes}
             mapping={mapping}
             targetFieldKey={targetFieldKey}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
-import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail } from 'lucide-react';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
 import { EmailSendDialog } from '../EmailSendDialog';
@@ -22,6 +22,7 @@ import {
   DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup,
 } from '../fields';
 import { DataSetsTab } from './DataSetsTab';
+import { useListDataSetBindings } from '@/shared/api/datasets';
 import { QualityLinksTab } from './QualityLinksTab';
 import { DocumentTemplateParams } from './DocumentTemplateParams';
 import { Modal } from '@/shared/ui/Modal';
@@ -32,6 +33,20 @@ type SaveRef = { current: (() => Promise<boolean>) | null };
 function parseIdArray(json: string | null): string[] {
   if (!json) return [];
   try { const a = JSON.parse(json); return Array.isArray(a) ? a as string[] : []; } catch { return []; }
+}
+
+/// Плашка для doc-ref/doc-array поля, которое заполняется привязанным источником данных:
+/// ручные ссылки скрываем, т.к. при генерации источник перезаписывает поле целиком
+/// (см. issue #17 — «источник ИЛИ ссылки», взаимоисключающе).
+function SourceBoundDocField() {
+  return (
+    <div className="flex items-center gap-2 border border-brand/40 rounded-lg px-3 py-2 bg-brand/5">
+      <Database size={14} className="text-brand shrink-0" />
+      <span className="text-xs text-fg3">
+        Заполняется из привязанного источника данных — правьте связку на вкладке «Данные».
+      </span>
+    </div>
+  );
 }
 
 function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef }: {
@@ -47,6 +62,14 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   const [showValidation, setShowValidation] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const mutation = useUpdateRequisites();
+
+  // Поля-ссылки на документы, заполняемые табличной связкой источника (issue #17):
+  // источник перезаписывает поле при генерации, поэтому ручной ввод для них отключаем.
+  const { data: dsBindings = [] } = useListDataSetBindings({ instanceId: instance.id });
+  const sourceBoundFields = useMemo(
+    () => new Set(dsBindings.filter(b => b.targetFieldKey).map(b => b.targetFieldKey!)),
+    [dsBindings],
+  );
 
   function getPrimitiveDef(field: SchemaField): PrimitiveTypeDef | undefined {
     if (field.type !== 'primitive') return undefined;
@@ -157,11 +180,15 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                     onChange={v => setValue(field.key, v)} showValidation={showValidation}
                     setId={setId} otherInstances={otherInstances} docRefMode="instance" />
                 ) : field.type === 'doc-ref' ? (
-                  <DocRefField field={field} allDocTypes={allDocTypes} value={raw}
-                    onChange={v => setValue(field.key, v)} otherInstances={otherInstances} setId={setId} />
+                  sourceBoundFields.has(field.key) ? <SourceBoundDocField /> : (
+                    <DocRefField field={field} allDocTypes={allDocTypes} value={raw}
+                      onChange={v => setValue(field.key, v)} otherInstances={otherInstances} setId={setId} />
+                  )
                 ) : field.type === 'doc-array' ? (
-                  <DocArrayField field={field} allDocTypes={allDocTypes} value={raw}
-                    onChange={v => setValue(field.key, v)} otherInstances={otherInstances} setId={setId} />
+                  sourceBoundFields.has(field.key) ? <SourceBoundDocField /> : (
+                    <DocArrayField field={field} allDocTypes={allDocTypes} value={raw}
+                      onChange={v => setValue(field.key, v)} otherInstances={otherInstances} setId={setId} />
+                  )
                 ) : field.type === 'image' ? (
                   <ImageField value={raw} onChange={v => setValue(field.key, v)} />
                 ) : field.type === 'file' ? (

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.2.4</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #17

Реализован **вариант D** (резолвер-centric), согласованный с Архитектором: `DataSetBinding` остаётся consumer-side, поля-ссылки `doc-array` наполняются из источника табличной связкой, без материализации теневых сущностей.

## Почему без изменений бэкенда
Резолв определяется **формой хранимого значения**, а не типом поля схемы. `EntityResolver` уже разворачивает `{$ref:instance}` в плоские поля экземпляра → строка-из-источника и прямая ссылка после резолва **неразличимы**. Табличная ветка `DataSetResolver`/preview пишет массив объектов независимо от типа поля, а порядок пайплайна (`EntityResolver` → `DataSetResolver` перезаписывает поле → 2-й проход разрешает `$ref` из `@@ref`) даёт правило «источник побеждает ручные ссылки».

## Изменения (frontend)
- **MappingEditor** (`DataSetsTab.tsx`): цель табличного режима теперь `array` **+ `doc-array`** (`tabularFields`); поля маппинга — из `resolveEffectiveFields` ссылаемого типа-документа. `@@ref`/`@@file` внутри уже поддержаны.
- **Связки записей каталога** (`EntryDataSetBindings.tsx`) — то же.
- **Реквизиты** (`editor/index.tsx`): `doc-ref`/`doc-array` с активной связкой источника → read-only плашка «заполняется из источника» (взаимоисключающе: источник ИЛИ ручные ссылки).

## Живая проверка
Табличная связка «Схемы» (`doc-array`) → источник «Исполнительные схемы для АОС ЭОМ-1 — Документы» → `GET /datasets/bindings/preview` вернул **15 объектов**, каждый с корректным file-вложением (`{$type:'file', blobPath, fileName, mimeType, size}` — имя без GUID-префикса, реальный размер) и колонками `Шифр`/`Листов`/`Наименование`. Тестовая связка удалена после проверки.

## Отложено (follow-up)
`doc-ref` (скаляр → один объект) — требует осведомлённости о **кардинальности** поля в трёх местах (resolve/preview/merge), backend-парсинга схемы сейчас нет, конкретного кейса нет. Отдельная задача при появлении потребности.

## Как пользоваться
У **ссылаемого типа** (напр. «Исполнительная схема») должны быть заведены поля для маппинга — сейчас тип без полей, поэтому предварительно добавьте `Наименование`/`Шифр`/`Листов`/`Файл`(file) и т.п. Это устраняет и озвученную проблему дублирующих типов: схема остаётся **одним** типом-документом (не заводим её второй раз как составной тип ради inline-`array`).

## Версия
`0.2.4 → 0.3.0` (фича). Схема БД не менялась, миграции нет. **Обновление без ручных действий.**

## Проверки
Frontend **106** зелёные, `tsc -b` чистый.
