### PR TITLE
feat: явное создание источников для всех форматов + управление CSV/XLS/XLSX (#20)

### DIFF
--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -1,17 +1,22 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { useCreateDataSetSource, useUpdateDataSetSource, useListZipXmlEntries } from '@/shared/api/datasets';
+import { useCreateDataSetSource, useUpdateDataSetSource, useListZipXmlEntries, useSourceCandidates } from '@/shared/api/datasets';
 import { XPathBuilder } from './xpath/XPathBuilder';
 import { JsonPathBuilder } from './jsonpath/JsonPathBuilder';
-import type { ColumnExprDef, DataSetSource } from '@/shared/api/types';
+import type { ColumnExprDef, DataSetSource, DataSetFormat } from '@/shared/api/types';
 
-type SourceFormat = 'Xml' | 'Json';
+type PathFormat = 'Xml' | 'Json';
 
-const DEFAULT_ROW_SELECTOR: Record<SourceFormat, string> = { Xml: '/Root/Item', Json: '$.items[*]' };
+const DEFAULT_ROW_SELECTOR: Record<PathFormat, string> = { Xml: '/Root/Item', Json: '$.items[*]' };
+
+/** Табличные форматы: extraction = лист (XLSX/XLS) или весь файл (CSV); колонки — автоматически. */
+function isTabularFormat(f: DataSetFormat): boolean {
+  return f === 'Csv' || f === 'Xls' || f === 'Xlsx';
+}
 
 /** Для ZIP-архивов sheetOrPath хранится как "путь/в/архиве.xml::/Row/Selector" (см. ZipDataSetParser). */
-function splitZipPath(sheetOrPath: string | undefined, isZip: boolean, format: SourceFormat): { entryPath: string; rowSelector: string } {
+function splitZipPath(sheetOrPath: string | undefined, isZip: boolean, format: PathFormat): { entryPath: string; rowSelector: string } {
   if (!isZip) return { entryPath: '', rowSelector: sheetOrPath ?? DEFAULT_ROW_SELECTOR[format] };
   if (!sheetOrPath) return { entryPath: '', rowSelector: DEFAULT_ROW_SELECTOR[format] };
   const idx = sheetOrPath.indexOf('::');
@@ -21,23 +26,29 @@ function splitZipPath(sheetOrPath: string | undefined, isZip: boolean, format: S
 }
 
 /**
- * Ручное создание/редактирование источника XML- или JSON-файла (в т.ч. XML внутри ZIP/GSFX):
- * имя + (для ZIP — выбор файла в архиве) + row-selector (XPath/JSONPath-builder) + список колонок
- * (каждая — относительный путь). Скаляр — частный случай: row-selector с условиями/фильтром
- * сужен до одного узла, одна колонка (или несколько — тоже ок).
+ * Явное создание/редактирование источника на основе сырого набора (issue #20). Форма формат-зависимая:
+ * - CSV — только имя (весь файл, extraction тривиальна);
+ * - XLS/XLSX — имя + выбор листа (подсказки листов из детекта, `sheetOrPath` = имя листа);
+ * - XML/JSON/ZIP — row-selector (XPath/JSONPath-builder) + список колонок (каждая — относительный путь).
+ * Колонки для табличных форматов определяются автоматически по заголовку.
  */
-export function SourceEditorDialog({ fileId, isZip = false, format = 'Xml', initial, onClose }: {
+export function SourceEditorDialog({ fileId, format, initial, onClose }: {
   fileId: string;
-  isZip?: boolean;
-  format?: SourceFormat;
+  format: DataSetFormat;
   initial?: DataSetSource;
   onClose: () => void;
 }) {
-  const PathBuilder = format === 'Json' ? JsonPathBuilder : XPathBuilder;
-  const initialSplit = splitZipPath(initial?.sheetOrPath, isZip, format);
+  const tabular = isTabularFormat(format);
+  const isZip = format === 'Zip';
+  const needsSheet = format === 'Xls' || format === 'Xlsx';
+  const pathFormat: PathFormat = format === 'Json' ? 'Json' : 'Xml';
+  const PathBuilder = pathFormat === 'Json' ? JsonPathBuilder : XPathBuilder;
+
+  const initialSplit = splitZipPath(initial?.sheetOrPath, isZip, pathFormat);
   const [name, setName] = useState(initial?.name ?? '');
   const [entryPath, setEntryPath] = useState(initialSplit.entryPath);
-  const [sheetOrPath, setSheetOrPath] = useState(initialSplit.rowSelector);
+  // В табличном режиме sheetOrPath — имя листа (XLSX) / «весь файл» (CSV); в path-режиме — row-selector.
+  const [sheetOrPath, setSheetOrPath] = useState(tabular ? (initial?.sheetOrPath ?? '') : initialSplit.rowSelector);
   const [columns, setColumns] = useState<ColumnExprDef[]>(() => {
     try { return initial?.columnExpressions ? JSON.parse(initial.columnExpressions) : []; }
     catch { return []; }
@@ -45,12 +56,22 @@ export function SourceEditorDialog({ fileId, isZip = false, format = 'Xml', init
   const [error, setError] = useState('');
 
   const { data: zipEntries = [] } = useListZipXmlEntries(isZip ? fileId : undefined);
+  // Кандидаты (листы/«весь файл») — подсказки для табличных форматов в режиме создания.
+  const { data: candidates = [] } = useSourceCandidates(tabular ? fileId : undefined);
   const create = useCreateDataSetSource();
   const update = useUpdateDataSetSource();
   const isPending = create.isPending || update.isPending;
 
+  // Новый табличный источник: как только приедут кандидаты — подставить первый лист/«весь файл» и имя.
+  useEffect(() => {
+    if (initial || !tabular || candidates.length === 0) return;
+    setSheetOrPath(prev => prev || candidates[0].sheetOrPath);
+    setName(prev => prev || candidates[0].name);
+  }, [initial, tabular, candidates]);
+
   // Текущее значение может отсутствовать в списке (архив обновился) — не терять его молча.
   const entryOptions = entryPath && !zipEntries.includes(entryPath) ? [entryPath, ...zipEntries] : zipEntries;
+  const selectedCandidate = candidates.find(c => c.sheetOrPath === sheetOrPath);
 
   // Полный row-selector с учётом ZIP-адресации — для предпросмотра (null = ещё не готов, напр.
   // архив без выбранного файла). Колонки предпросматриваются относительно него же.
@@ -73,22 +94,28 @@ export function SourceEditorDialog({ fileId, isZip = false, format = 'Xml', init
   async function handleSave() {
     setError('');
     if (!name.trim()) { setError('Укажите название'); return; }
-    if (isZip && !entryPath.trim()) { setError('Выберите файл внутри архива'); return; }
-    if (!sheetOrPath.trim()) { setError('Укажите row-selector (путь к строкам)'); return; }
-    const cleanColumns = columns.filter(c => c.name.trim() && c.expr.trim());
-    const finalSheetOrPath = isZip ? `${entryPath.trim()}::${sheetOrPath.trim()}` : sheetOrPath.trim();
+
+    let finalSheetOrPath: string;
+    let finalColumns: ColumnExprDef[] | null;
+
+    if (tabular) {
+      if (needsSheet && !sheetOrPath.trim()) { setError('Выберите лист'); return; }
+      // CSV — весь файл: extraction тривиальна, sheetOrPath из кандидата (обычно "default").
+      finalSheetOrPath = sheetOrPath.trim() || candidates[0]?.sheetOrPath || 'default';
+      finalColumns = null; // колонки определяются автоматически по заголовку
+    } else {
+      if (isZip && !entryPath.trim()) { setError('Выберите файл внутри архива'); return; }
+      if (!sheetOrPath.trim()) { setError('Укажите row-selector (путь к строкам)'); return; }
+      finalSheetOrPath = isZip ? `${entryPath.trim()}::${sheetOrPath.trim()}` : sheetOrPath.trim();
+      const clean = columns.filter(c => c.name.trim() && c.expr.trim());
+      finalColumns = clean.length ? clean : null;
+    }
 
     try {
       if (initial) {
-        await update.mutateAsync({
-          id: initial.id, name: name.trim(), sheetOrPath: finalSheetOrPath,
-          columnExpressions: cleanColumns.length ? cleanColumns : null,
-        });
+        await update.mutateAsync({ id: initial.id, name: name.trim(), sheetOrPath: finalSheetOrPath, columnExpressions: finalColumns });
       } else {
-        await create.mutateAsync({
-          fileId, name: name.trim(), sheetOrPath: finalSheetOrPath,
-          columnExpressions: cleanColumns.length ? cleanColumns : null,
-        });
+        await create.mutateAsync({ fileId, name: name.trim(), sheetOrPath: finalSheetOrPath, columnExpressions: finalColumns });
       }
       onClose();
     } catch (e: unknown) {
@@ -97,9 +124,12 @@ export function SourceEditorDialog({ fileId, isZip = false, format = 'Xml', init
     }
   }
 
+  const dialogTitle = initial
+    ? 'Редактировать источник'
+    : `Новый источник (${isZip ? 'XML в архиве' : format})`;
+
   return (
-    <Modal open onOpenChange={open => { if (!open) onClose(); }}
-      title={initial ? 'Редактировать источник' : `Новый источник (${isZip ? 'XML в архиве' : format})`} wide
+    <Modal open onOpenChange={open => { if (!open) onClose(); }} title={dialogTitle} wide
       footer={
         <div className="flex justify-end gap-2">
           <button type="button" onClick={onClose}
@@ -116,66 +146,94 @@ export function SourceEditorDialog({ fileId, isZip = false, format = 'Xml', init
         <div>
           <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
           <input value={name} onChange={e => setName(e.target.value)}
-            placeholder="Позиции спецификации"
+            placeholder={tabular ? 'Позиции спецификации' : 'Позиции спецификации'}
             className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm" />
         </div>
 
-        {isZip && (
-          <div>
-            <label className="block text-sm font-medium text-fg1 mb-1">Файл в архиве</label>
-            <select value={entryPath} onChange={e => setEntryPath(e.target.value)}
-              className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm font-mono">
-              <option value="">— выберите XML-файл в архиве —</option>
-              {entryOptions.map(p => <option key={p} value={p}>{p}</option>)}
-            </select>
-            {entryOptions.length === 0 && (
-              <p className="text-xs text-fg4 mt-1">В архиве не найдено XML-файлов.</p>
+        {tabular ? (
+          needsSheet ? (
+            <div>
+              <label className="block text-sm font-medium text-fg1 mb-1">Лист</label>
+              <select value={sheetOrPath} onChange={e => setSheetOrPath(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm">
+                <option value="">— выберите лист —</option>
+                {candidates.map(c => (
+                  <option key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</option>
+                ))}
+              </select>
+              {candidates.length === 0 && (
+                <p className="text-xs text-fg4 mt-1">Листы не обнаружены.</p>
+              )}
+              {selectedCandidate && selectedCandidate.columns.length > 0 && (
+                <p className="text-xs text-fg4 mt-1">Колонки: {selectedCandidate.columns.join(', ')}</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs text-fg4">
+              Весь файл — колонки определяются автоматически по заголовку
+              {candidates[0]?.columns.length ? `: ${candidates[0].columns.join(', ')}` : ''}.
+            </p>
+          )
+        ) : (
+          <>
+            {isZip && (
+              <div>
+                <label className="block text-sm font-medium text-fg1 mb-1">Файл в архиве</label>
+                <select value={entryPath} onChange={e => setEntryPath(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm font-mono">
+                  <option value="">— выберите XML-файл в архиве —</option>
+                  {entryOptions.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+                {entryOptions.length === 0 && (
+                  <p className="text-xs text-fg4 mt-1">В архиве не найдено XML-файлов.</p>
+                )}
+              </div>
             )}
-          </div>
-        )}
 
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">
-            Row-selector — путь к строкам (одна строка = один узел; условия сужают до конкретных)
-          </label>
-          <PathBuilder value={sheetOrPath} onChange={setSheetOrPath} placeholder={DEFAULT_ROW_SELECTOR[format]}
-            preview={v => { const rs = composeRowSelector(v); return rs ? { fileId, rowSelector: rs } : null; }} />
-        </div>
+            <div>
+              <label className="block text-sm font-medium text-fg1 mb-1">
+                Row-selector — путь к строкам (одна строка = один узел; условия сужают до конкретных)
+              </label>
+              <PathBuilder value={sheetOrPath} onChange={setSheetOrPath} placeholder={DEFAULT_ROW_SELECTOR[pathFormat]}
+                preview={v => { const rs = composeRowSelector(v); return rs ? { fileId, rowSelector: rs } : null; }} />
+            </div>
 
-        <div className="border-t border-stroke pt-3">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm font-medium text-fg1">
-              Колонки <span className="text-xs font-normal text-fg4">— относительно узла строки</span>
-            </p>
-            <button type="button" onClick={addColumn}
-              className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover">
-              <Plus size={13} /> Колонка
-            </button>
-          </div>
-          {columns.length === 0 && (
-            <p className="text-xs text-fg4 py-1">
-              Колонок нет — будут определены автоматически по дочерним элементам/атрибутам строки.
-            </p>
-          )}
-          <div className="space-y-2">
-            {columns.map((col, i) => (
-              <div key={i} className="flex items-start gap-2">
-                <input value={col.name} onChange={e => updateColumn(i, { name: e.target.value })}
-                  placeholder="Название колонки"
-                  className="w-40 shrink-0 px-2 py-1.5 rounded-md border border-stroke-strong bg-surface text-sm" />
-                <div className="flex-1 min-w-0">
-                  <PathBuilder value={col.expr} onChange={expr => updateColumn(i, { expr })}
-                    placeholder={format === 'Json' ? 'id или name или info.code' : '@id или Name или Info/Code'}
-                    preview={v => { const rs = composeRowSelector(sheetOrPath); return rs && v.trim() ? { fileId, rowSelector: rs, expr: v } : null; }} />
-                </div>
-                <button type="button" onClick={() => removeColumn(i)}
-                  className="p-1.5 text-fg4 hover:text-danger shrink-0">
-                  <Trash2 size={14} />
+            <div className="border-t border-stroke pt-3">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-sm font-medium text-fg1">
+                  Колонки <span className="text-xs font-normal text-fg4">— относительно узла строки</span>
+                </p>
+                <button type="button" onClick={addColumn}
+                  className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover">
+                  <Plus size={13} /> Колонка
                 </button>
               </div>
-            ))}
-          </div>
-        </div>
+              {columns.length === 0 && (
+                <p className="text-xs text-fg4 py-1">
+                  Колонок нет — будут определены автоматически по дочерним элементам/атрибутам строки.
+                </p>
+              )}
+              <div className="space-y-2">
+                {columns.map((col, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <input value={col.name} onChange={e => updateColumn(i, { name: e.target.value })}
+                      placeholder="Название колонки"
+                      className="w-40 shrink-0 px-2 py-1.5 rounded-md border border-stroke-strong bg-surface text-sm" />
+                    <div className="flex-1 min-w-0">
+                      <PathBuilder value={col.expr} onChange={expr => updateColumn(i, { expr })}
+                        placeholder={pathFormat === 'Json' ? 'id или name или info.code' : '@id или Name или Info/Code'}
+                        preview={v => { const rs = composeRowSelector(sheetOrPath); return rs && v.trim() ? { fileId, rowSelector: rs, expr: v } : null; }} />
+                    </div>
+                    <button type="button" onClick={() => removeColumn(i)}
+                      className="p-1.5 text-fg4 hover:text-danger shrink-0">
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
 
         {error && <p className="text-sm text-danger">{error}</p>}
       </div>

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -246,7 +246,10 @@ export function SourcesExpander({
   const [editing, setEditing] = useState<DataSetSource | 'new' | null>(null);
   const { data: templates = [] } = useListProcessingTemplates();
   const isPdf = file.format === 'Pdf';
-  const canManageExtraction = file.format === 'Xml' || file.format === 'Zip' || file.format === 'Json' || isPdf;
+  // Управление источниками (создать/удалить) — для всех форматов (issue #20). PDF создаёт источники
+  // через распознавание (PdfSourceDialog) и не редактируется вручную (см. гейт `!isPdf` у «Редактировать»);
+  // прочие форматы — полное создание/редактирование/переименование/удаление.
+  const canManageExtraction = true;
   const sources = file.sources;
 
   if (sources.length === 0 && !canManageExtraction)
@@ -283,8 +286,7 @@ export function SourcesExpander({
         ) : (
           <SourceEditorDialog
             fileId={file.id}
-            isZip={file.format === 'Zip'}
-            format={file.format === 'Json' ? 'Json' : 'Xml'}
+            format={file.format}
             initial={editing === 'new' ? undefined : editing}
             onClose={() => setEditing(null)}
           />

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -110,6 +110,23 @@ export function useListZipXmlEntries(fileId: string | undefined) {
   });
 }
 
+/** Кандидат на источник в сыром файле (лист XLSX, top-level массив JSON, «весь файл» CSV) — подсказка. */
+export interface SourceCandidate {
+  name: string;
+  sheetOrPath: string;
+  columns: string[];
+  rowCount: number;
+}
+
+/** Детект кандидатов на источник (без персиста) — подсказки в один клик в диалоге создания. */
+export function useSourceCandidates(fileId: string | undefined) {
+  return useQuery<SourceCandidate[]>({
+    queryKey: ['datasets', 'source-candidates', fileId],
+    queryFn: () => apiClient.get(`/datasets/files/${fileId}/source-candidates`).then(r => r.data),
+    enabled: !!fileId,
+  });
+}
+
 export interface ExpressionPreviewSpec {
   fileId: string;
   /** Полный row-selector (с учётом "entry::" для ZIP) — контекст, либо сам предпросматриваемый путь. */

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -66,6 +66,20 @@ public static class DataSetEndpoints
         g.MapGet("/files/{fileId:guid}/sources", async (Guid fileId, IDataSetService svc, CancellationToken ct) =>
             Results.Ok(await svc.ListSourcesAsync(fileId, ct)));
 
+        // Кандидаты на источник в сыром файле (листы/массивы/«весь файл») — без персиста, для
+        // подсказок в диалоге создания источника. Пусто для XML (строится вручную builder'ом).
+        g.MapGet("/files/{fileId:guid}/source-candidates", async (Guid fileId, IDataSetService svc, CancellationToken ct) =>
+        {
+            var candidates = await svc.DetectSourceCandidatesAsync(fileId, ct);
+            return Results.Ok(candidates.Select(c => new
+            {
+                name = c.Name,
+                sheetOrPath = c.SheetOrPath,
+                columns = c.Columns.Select(col => col.Name).ToList(),
+                rowCount = c.RowCount,
+            }));
+        });
+
         g.MapGet("/sources/{sourceId:guid}/preview", async (
             Guid sourceId, int maxRows, IDataSetService svc, CancellationToken ct) =>
         {

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -18,6 +18,8 @@ public interface IDataSetService
 
     // ── Sources ─────────────────────────────────────────────────────────────────
     Task<IReadOnlyList<DataSetSourceDto>> ListSourcesAsync(Guid fileId, CancellationToken ct);
+    /// <summary>Детект кандидатов на источник в сыром файле (без персиста) — подсказки для диалога создания.</summary>
+    Task<IReadOnlyList<DataSetSourceInfo>> DetectSourceCandidatesAsync(Guid fileId, CancellationToken ct);
     Task<SourcePreviewDto?> PreviewSourceAsync(Guid sourceId, int maxRows, CancellationToken ct);
     /// <summary>Выгрузка ВСЕХ строк источника (после обработки) в CSV/XLS/XLSX. format: "csv"/"xls"/"xlsx" (по умолчанию xlsx).</summary>
     Task<SourceExportDto?> ExportSourceAsync(Guid sourceId, string? format, CancellationToken ct);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetFileService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetFileService.cs
@@ -66,12 +66,10 @@ public class DataSetFileService(
         await using var uploadStream = new MemoryStream(input.Bytes);
         var blobPath = await blob.UploadAsync(input.FileName, uploadStream, input.ContentType ?? "application/octet-stream", ct);
 
-        var parser = parserFactory.GetParser(format);
-        var sourceInfos = await parser.DetectSourcesAsync(input.Bytes, ct);
-
+        // Набор = только сырьё; источники создаются пользователем ЯВНО (см. issue #20 и философию
+        // наборов данных). При загрузке источники НЕ авто-создаются — диалог создания источника
+        // предлагает детект как подсказки (GET /files/{id}/source-candidates).
         var dataSetFile = DataSetFile.Create(name, format, blobPath, scope, scopeId);
-        foreach (var info in sourceInfos)
-            dataSetFile.AddSource(info.Name, info.SheetOrPath, DataSetDtoMapper.SerializeSchema(info.Columns), info.RowCount);
 
         db.DataSetFiles.Add(dataSetFile);
         await db.SaveChangesAsync(ct);
@@ -93,44 +91,34 @@ public class DataSetFileService(
         var newBlobPath = await blob.UploadAsync(input.FileName, uploadStream, input.ContentType ?? "application/octet-stream", ct);
 
         var parser = parserFactory.GetParser(format);
-        var sourceInfos = await parser.DetectSourcesAsync(input.Bytes, ct);
 
-        // Match existing sources by sheetOrPath (then name) to preserve bindings.
-        var updatedSourceIds = new HashSet<Guid>();
-        foreach (var info in sourceInfos)
+        // Источники управляются пользователем ЯВНО (issue #20): при замене файла НЕ авто-создаём и
+        // НЕ авто-удаляем источники — только пере-разбираем СУЩЕСТВУЮЩИЕ против нового блоба.
+        var staleSources = 0;
+        foreach (var src in file.Sources.ToList())
         {
-            var existing = file.Sources.FirstOrDefault(s => s.SheetOrPath == info.SheetOrPath)
-                ?? file.Sources.FirstOrDefault(s => s.Name == info.Name);
-            if (existing != null)
-            {
-                existing.UpdateCache(DataSetDtoMapper.SerializeSchema(info.Columns), info.RowCount);
-                updatedSourceIds.Add(existing.Id);
-            }
-            else
-            {
-                var added = file.AddSource(info.Name, info.SheetOrPath, DataSetDtoMapper.SerializeSchema(info.Columns), info.RowCount);
-                // file уже отслеживается — см. пояснение в DataSetSourceService.CreateSourceAsync (иначе Modified вместо Added).
-                db.DataSetSources.Add(added);
-                updatedSourceIds.Add(added.Id);
-            }
-        }
-
-        // Drop sources no longer present in the file, unless they still have bindings.
-        // Распознаваемые PDF-источники (gost-*/invoice-*/gost-table:*) парсер НЕ детектит — их нельзя
-        // трактовать как «исчезнувшие из файла»: данные приходят из распознавания, не из структуры.
-        // Их сохраняем и помечаем устаревшими (файл заменён после распознавания) — vision-перераспознавание
-        // запускается только явным действием пользователя, не автоматически при замене файла.
-        var staleRecognitionSources = 0;
-        foreach (var src in file.Sources.Where(s => !updatedSourceIds.Contains(s.Id)).ToList())
-        {
+            // Распознанные PDF-источники (gost-*/invoice-*/gost-table:*) не переразбираем структурно —
+            // данные приходят из vision-распознавания, не из структуры файла. Помечаем устаревшими;
+            // пере-распознавание — только явным действием пользователя.
             if (PdfProfiles.IsRecognitionMarker(src.SheetOrPath))
             {
                 src.MarkRecognitionStale();
-                staleRecognitionSources++;
+                staleSources++;
                 continue;
             }
-            var hasBindings = await db.DataSetBindings.AnyAsync(b => b.SourceId == src.Id, ct);
-            if (!hasBindings) db.DataSetSources.Remove(src);
+            try
+            {
+                var parsed = await parser.ParseAsync(input.Bytes, src.SheetOrPath, src.ColumnExpressions, ct);
+                src.UpdateCache(DataSetDtoMapper.SerializeSchema(parsed.Columns), parsed.Rows.Count);
+            }
+            catch (Exception ex)
+            {
+                // Источник не разбирается против нового файла (лист/путь исчез или сменился формат) —
+                // помечаем устаревшим, но НЕ удаляем (источник создан пользователем явно).
+                logger.LogWarning(ex, "Источник {SourceId} не разобран при замене файла {FileId}", src.Id, id);
+                src.MarkRecognitionStale();
+                staleSources++;
+            }
         }
 
         file.UpdateBlobPath(newBlobPath, format);
@@ -138,11 +126,11 @@ public class DataSetFileService(
 
         await db.SaveChangesAsync(ct);
 
-        if (staleRecognitionSources > 0)
+        if (staleSources > 0)
             await notifications.PublishAsync(NotificationSeverity.Warning,
-                "Файл набора обновлён — нужно перераспознать",
-                $"Файл «{file.Name}» заменён. Распознанные PDF-источники ({staleRecognitionSources}) помечены устаревшими: " +
-                "данные относятся к прежнему файлу. Перераспознайте их вручную (кнопка «Распознать»).",
+                "Файл набора обновлён — проверьте источники",
+                $"Файл «{file.Name}» заменён. Источников, требующих внимания: {staleSources} " +
+                "(PDF-распознавание — перераспознайте вручную; прочие — проверьте определение источника, если данные не совпали).",
                 "Наборы данных", ct: ct);
 
         return DataSetDtoMapper.MapFile(file);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -35,6 +35,8 @@ public class DataSetService(
     // ── Sources ───────────────────────────────────────────────────────────────
     public Task<IReadOnlyList<DataSetSourceDto>> ListSourcesAsync(Guid fileId, CancellationToken ct) =>
         sources.ListSourcesAsync(fileId, ct);
+    public Task<IReadOnlyList<DataSetSourceInfo>> DetectSourceCandidatesAsync(Guid fileId, CancellationToken ct) =>
+        sources.DetectSourceCandidatesAsync(fileId, ct);
     public Task<SourcePreviewDto?> PreviewSourceAsync(Guid sourceId, int maxRows, CancellationToken ct) =>
         sources.PreviewSourceAsync(sourceId, maxRows, ct);
     public Task<SourceExportDto?> ExportSourceAsync(Guid sourceId, string? format, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -29,6 +29,24 @@ public class DataSetSourceService(
         return sources.Select(DataSetDtoMapper.MapSource).ToList();
     }
 
+    /// <summary>
+    /// Детект «кандидатов» на источник в сыром файле (листы XLSX, top-level массивы JSON, «весь файл»
+    /// для CSV) — БЕЗ персиста. Используется диалогом создания источника как подсказки в один клик.
+    /// Для XML парсер кандидатов не даёт (пусто) — источник строится вручную через XPath-builder.
+    /// </summary>
+    public async Task<IReadOnlyList<DataSetSourceInfo>> DetectSourceCandidatesAsync(Guid fileId, CancellationToken ct)
+    {
+        var file = await db.DataSetFiles.AsNoTracking().FirstOrDefaultAsync(f => f.Id == fileId, ct)
+            ?? throw new KeyNotFoundException($"DataSetFile {fileId} not found");
+
+        await using var stream = await blob.DownloadAsync(file.BlobPath, ct);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, ct);
+
+        var parser = parserFactory.GetParser(file.Format);
+        return await parser.DetectSourcesAsync(ms.ToArray(), ct);
+    }
+
     public async Task<SourcePreviewDto?> PreviewSourceAsync(Guid sourceId, int maxRows, CancellationToken ct)
     {
         var source = await db.DataSetSources.Include(s => s.File).AsNoTracking()

--- a/src/server/BHS.CRG.Tests/Integration/DataSetServiceTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetServiceTests.cs
@@ -124,18 +124,36 @@ public class DataSetServiceTests(IntegrationTestFixture fixture) : IAsyncLifetim
         await Svc(scope).UploadFileAsync(
             new UploadFileInput(CsvBytes, "test.csv", "text/csv", "Тест", "System", null), default);
 
+    // Источники создаются ЯВНО (issue #20): загрузить CSV + создать источник «весь файл» из кандидата.
+    private async Task<(DataSetFileDto File, DataSetSourceDto Source)> UploadCsvWithSourceAsync(IServiceScope scope)
+    {
+        var file = await UploadCsvAsync(scope);
+        var candidate = (await Svc(scope).DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await Svc(scope).CreateSourceAsync(
+            file.Id, new CreateSourceInput("Данные", candidate.SheetOrPath, null), default);
+        return (file, source);
+    }
+
     [Fact]
-    public async Task UploadCsv_DetectsSourceWithColumns()
+    public async Task UploadCsv_NoAutoSources_CandidatesDetectColumns()
     {
         using var scope = fixture.Services.CreateScope();
         var file = await UploadCsvAsync(scope);
 
-        Assert.Single(file.Sources);
-        var sources = await Svc(scope).ListSourcesAsync(file.Id, default);
-        Assert.Single(sources);
-        // Колонки — в кэше схемы (JSON [{name,sampleValues}]); имена A/B встречаются как значения "name".
-        Assert.Contains("\"A\"", sources[0].CachedSchema);
-        Assert.Contains("\"B\"", sources[0].CachedSchema);
+        // Набор = сырьё: источники НЕ авто-создаются при загрузке (issue #20).
+        Assert.Empty(file.Sources);
+
+        // Детект-кандидаты предлагают «весь файл» с колонками A/B — подсказка для явного создания.
+        var candidates = await Svc(scope).DetectSourceCandidatesAsync(file.Id, default);
+        Assert.Single(candidates);
+        Assert.Contains(candidates[0].Columns, c => c.Name == "A");
+        Assert.Contains(candidates[0].Columns, c => c.Name == "B");
+
+        // Явное создание источника из кандидата кэширует те же колонки.
+        var source = await Svc(scope).CreateSourceAsync(
+            file.Id, new CreateSourceInput("Данные", candidates[0].SheetOrPath, null), default);
+        Assert.Contains("\"A\"", source.CachedSchema);
+        Assert.Contains("\"B\"", source.CachedSchema);
     }
 
     [Fact]
@@ -143,8 +161,8 @@ public class DataSetServiceTests(IntegrationTestFixture fixture) : IAsyncLifetim
     {
         // Прямая проверка хрупкого EF add-tracking (копия — новый дочерний источник на отслеживаемом файле).
         using var scope = fixture.Services.CreateScope();
-        var file = await UploadCsvAsync(scope);
-        var srcId = file.Sources[0].Id;
+        var (file, src) = await UploadCsvWithSourceAsync(scope);
+        var srcId = src.Id;
 
         var copy = await Svc(scope).DuplicateSourceAsync(srcId, default);
         Assert.NotNull(copy);
@@ -162,8 +180,8 @@ public class DataSetServiceTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Guid srcId;
         using (var scope = fixture.Services.CreateScope())
         {
-            var file = await UploadCsvAsync(scope);
-            srcId = file.Sources[0].Id;
+            var (_, src) = await UploadCsvWithSourceAsync(scope);
+            srcId = src.Id;
             var entry = await scope.ServiceProvider.GetRequiredService<MediatR.IMediator>().Send(
                 new CreateCommonDataEntryCommand("Запись", typeId, JsonDocument.Parse("{}"),
                     BHS.CRG.Domain.Catalog.CatalogScope.System, null));
@@ -180,17 +198,17 @@ public class DataSetServiceTests(IntegrationTestFixture fixture) : IAsyncLifetim
     {
         var typeId = await CreateDocumentTypeAsync();
         using var scope = fixture.Services.CreateScope();
-        var file = await UploadCsvAsync(scope);
+        var (_, src) = await UploadCsvWithSourceAsync(scope);
         var entry = await scope.ServiceProvider.GetRequiredService<MediatR.IMediator>().Send(
             new CreateCommonDataEntryCommand("Запись", typeId, JsonDocument.Parse("{}"),
                 BHS.CRG.Domain.Catalog.CatalogScope.System, null));
 
         var created = await Svc(scope).CreateBindingAsync(
-            new CreateBindingInput(null, entry.Id, file.Sources[0].Id, null, new() { ["Поле"] = "A" }), default);
+            new CreateBindingInput(null, entry.Id, src.Id, null, new() { ["Поле"] = "A" }), default);
         Assert.NotNull(created);
 
         var list = await Svc(scope).ListBindingsAsync(null, entry.Id, default);
         Assert.Single(list);
-        Assert.Equal(file.Sources[0].Id, list[0].SourceId);
+        Assert.Equal(src.Id, list[0].SourceId);
     }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.2.4</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #20

Реализует уточнённую философию наборов данных (см. #19): **набор = чистое сырьё**, **источники создаются на его базе явной операцией** и несут весь пайплайн.

## Изменения

**Загрузка = только набор.** `UploadFileAsync` больше не авто-создаёт источники (раньше CSV → «default», XLS → по листу, JSON → массивы).

**Детект как подсказки.** Новый `GET /api/datasets/files/{id}/source-candidates` — `DetectSourcesAsync` без персиста: XLSX → листы, JSON → верхнеуровневые массивы, CSV → «весь файл». Диалог создания предлагает их в один клик.

**Полное управление источником для всех форматов** (кроме PDF, где extraction = распознавание): создать / редактировать / **переименовать** / удалить. Снят гейт `canManageExtraction`, отсекавший CSV/XLS/XLSX.
→ **чинит баг:** у XLSX «Создать копию» делала «X (копия)» без возможности переименовать.

**`SourceEditorDialog` формат-зависимый:**
- CSV — только имя (весь файл, колонки авто);
- XLS/XLSX — имя + выбор листа (`sheetOrPath` = лист, колонки авто);
- XML/JSON/ZIP — XPath/JSONPath-builder + колонки (как было).

**`ReplaceFileAsync`** — при замене файла переразбирает СУЩЕСТВУЮЩИЕ источники против нового блоба (обновляет кэш; помечает устаревшими при сбое разбора), без авто-добавления/удаления. Побочно устраняет прежнее «замена файла удаляла несвязанный XML-источник».

## Версия
`0.2.4 → 0.3.0` (фича). Схема БД не менялась, миграции нет.

⚠ **При обновлении:** ранее загруженные наборы уже имеют авто-созданные источники — они **продолжают работать**; новое поведение касается только НОВЫХ загрузок. Ручных действий не требуется.

## Проверки
- Backend **321** тест зелёный; frontend **106** + `tsc -b` чистый.
- Живой прогон через API: upload CSV → **0 источников**; candidates → колонки; create → 200 (2 строки); rename → 200; delete source/file → 204.

## Как проверить в UI
Наборы данных → загрузить CSV/XLSX → у набора «Добавить источник»: для XLSX выбрать лист, для CSV задать имя → источник создан; «Создать копию» → у копии доступно «Редактировать» (переименование).
