### PR TITLE
fix: превью привязки учитывает материализацию источника — «Документы качества» снова находят материалы (#23)

### DIFF
--- a/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
+++ b/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
@@ -157,7 +157,9 @@ function EntryBindingRow({
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium truncate text-fg1">{source?.name ?? '—'}</div>
           <div className="text-xs text-fg4 mt-0.5">
-            {file?.name} · {mappedCount} пол{mappedCount === 1 ? 'е' : 'я'} привязано
+            {file?.name} · {source?.materializeTypeId
+              ? `материализация → ${allDocTypes.find(t => t.id === source.materializeTypeId)?.name ?? 'тип'}`
+              : `${mappedCount} пол${mappedCount === 1 ? 'е' : 'я'} привязано`}
             {targetFieldKey && ` · таблица: ${targetFieldKey}`}
           </div>
         </div>

--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -420,7 +420,9 @@ function BindingRow({
           </div>
           <div className="flex items-center gap-2 mt-0.5 flex-wrap">
             <span className="text-xs text-fg4">
-              {file?.name} · {mappedCount} пол{mappedCount === 1 ? 'е' : 'я'} привязано
+              {file?.name} · {source?.materializeTypeId
+                ? `материализация → ${allDocTypes.find(t => t.id === source.materializeTypeId)?.name ?? 'тип'}`
+                : `${mappedCount} пол${mappedCount === 1 ? 'е' : 'я'} привязано`}
               {targetFieldKey && ` · таблица: ${targetFieldKey}`}
             </span>
           </div>

--- a/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
+++ b/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
@@ -19,7 +19,8 @@ public record DataSetFileDto(
 public record BindingFileDto(Guid Id, string Name, string Format, string Scope, Guid? ScopeId);
 
 public record BindingSourceDto(
-    Guid Id, string Name, string SheetOrPath, string CachedSchema, int CachedRowCount, BindingFileDto? File);
+    Guid Id, string Name, string SheetOrPath, string CachedSchema, int CachedRowCount, BindingFileDto? File,
+    Guid? MaterializeTypeId = null);
 
 /// <summary>Привязка — только Mapping. Filter/Transformation/Sort живут на DataSetSource.
 /// Владелец — ровно одно из InstanceId/CommonDataEntryId задано.</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -85,7 +85,12 @@ public class DataSetBindingService(
             {
                 var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, binding.Source, ct);
 
-                var mapping = JsonSerializer.Deserialize<Dictionary<string, string>>(binding.Mapping) ?? [];
+                // Материализованный источник (issue #19/#23): привязка без своего маппинга берёт маппинг
+                // с источника — как и резолвер генерации. Иначе превью пустое и материалы/сертификаты не
+                // извлекаются на вкладке «Документы качества».
+                var mappingJson = DataSetMappingValue.EffectiveMappingJson(
+                    binding.Mapping, binding.Source.MaterializeTypeId, binding.Source.MaterializeMapping);
+                var mapping = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson) ?? [];
 
                 if (binding.TargetFieldKey is null)
                 {

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -83,7 +83,8 @@ public static class DataSetDtoMapper
             b.Source.Id, b.Source.Name, b.Source.SheetOrPath, b.Source.CachedSchema, b.Source.CachedRowCount,
             b.Source.File is null ? null : new BindingFileDto(
                 b.Source.File.Id, b.Source.File.Name, b.Source.File.Format.ToString(),
-                b.Source.File.Scope.ToString(), b.Source.File.ScopeId)));
+                b.Source.File.Scope.ToString(), b.Source.File.ScopeId),
+            b.Source.MaterializeTypeId));
 
     public static DataSetBindingTemplateDto MapTemplate(DataSetBindingTemplate t) => new(
         t.Id, t.DocumentTypeId, t.Name, t.TargetFieldKey,

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingValue.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingValue.cs
@@ -110,4 +110,23 @@ public static class DataSetMappingValue
             ["size"] = size,
         };
     }
+
+    // ── Материализация: эффективный маппинг привязки (issue #19/#23) ──────────────
+
+    /// <summary>Маппинг «пустой» (значит, берём материализацию источника): null/пустой объект/все значения пусты.</summary>
+    public static bool IsEmptyMapping(string? mappingJson)
+    {
+        if (string.IsNullOrWhiteSpace(mappingJson)) return true;
+        var m = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson);
+        return m is null || m.Count == 0 || m.Values.All(string.IsNullOrEmpty);
+    }
+
+    /// <summary>
+    /// Эффективный маппинг привязки: если у привязки нет своего маппинга, а источник материализован —
+    /// берём маппинг с источника (тип↔тип). Единый источник истины для резолвера (генерация) и превью.
+    /// </summary>
+    public static string EffectiveMappingJson(string bindingMapping, Guid? sourceMaterializeTypeId, string? sourceMaterializeMapping)
+        => sourceMaterializeTypeId is not null && IsEmptyMapping(bindingMapping)
+            ? (sourceMaterializeMapping ?? "{}")
+            : bindingMapping;
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -51,8 +51,8 @@ public class DataSetResolver(
                 // Материализация на источнике (issue #19): если источник настроен на материализацию, а
                 // привязка не несёт собственного маппинга — маппинг берётся с источника (тип↔тип), а
                 // привязка играет роль типизированного указателя. Иначе — легаси-маппинг привязки.
-                var useMaterialization = binding.Source.MaterializeTypeId is not null && IsEmptyMapping(binding.Mapping);
-                var mappingJson = useMaterialization ? (binding.Source.MaterializeMapping ?? "{}") : binding.Mapping;
+                var mappingJson = DataSetMappingValue.EffectiveMappingJson(
+                    binding.Mapping, binding.Source.MaterializeTypeId, binding.Source.MaterializeMapping);
                 var mapping = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson) ?? [];
 
                 if (binding.TargetFieldKey is null)
@@ -192,15 +192,6 @@ public class DataSetResolver(
                 return entry.Id;
         }
         return null;
-    }
-
-    // Маппинг привязки считается «пустым» (значит, берём материализацию источника), если он null,
-    // пустой объект или все значения пусты.
-    private static bool IsEmptyMapping(string? mappingJson)
-    {
-        if (string.IsNullOrWhiteSpace(mappingJson)) return true;
-        var m = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson);
-        return m is null || m.Count == 0 || m.Values.All(string.IsNullOrEmpty);
     }
 
     // Нормализация для сопоставления: регистр, окружающие пробелы и завершающие

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #23

## Причина
Регрессия из #19: материализация-осведомлённым был сделан только резолвер генерации, а **превью привязки** (`DataSetBindingService.PreviewBindingsAsync`) использовало только `binding.Mapping`. Для типизированного указателя (материализованный источник + пустой маппинг привязки) превью выходило пустым → вкладка «Документы качества» не извлекала материалы (0 материалов, «Обновить» не помогал); строка на вкладке «Данные» врала «0 поля привязано».

## Фикс
- Общий хелпер `DataSetMappingValue.EffectiveMappingJson` / `IsEmptyMapping` — единый источник истины «эффективного маппинга привязки» для резолвера и превью (дедупликация логики #19).
- `PreviewBindingsAsync` берёт маппинг с источника, если у привязки нет своего (как резолвер генерации).
- `BindingSourceDto` + `materializeTypeId`; строка привязки на вкладке «Данные» показывает «материализация → Тип» вместо «0 поля привязано».

## Живая проверка
`GET /datasets/bindings/preview` для «Реестра материалов» → **151 строка** (`mode=tabular, target=Материалы`) с полями `Артикул`/`Наименование`/`Группа`/`Количество`. Вкладка «Документы качества» снова извлекает материалы и подсказывает сертификаты.

## Версия
`0.5.0 → 0.5.1` (баг-фикс). Схема БД не менялась, миграции нет. Обновление без ручных действий.

Backend **321** тест, frontend **106**, `tsc -b` чистый.