### PR TITLE
fix: раздел в breadcrumbs кликабелен — переход прямо к разделу (#25)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -126,7 +126,7 @@ function SetDetail() {
         {sectionName && (
           <>
             <ChevronRight size={14} />
-            <span className="text-fg4">{sectionName}</span>
+            <Link to={`/document-sets/${constructionId}?section=${set.sectionId}`} className="hover:text-fg2 transition-colors">{sectionName}</Link>
           </>
         )}
         <ChevronRight size={14} />
@@ -364,7 +364,7 @@ function SectionCard({ section, construction, expanded, onToggle, allDocTypes }:
   }
 
   return (
-    <div className="border border-stroke rounded-xl overflow-hidden">
+    <div id={`section-${section.id}`} className="border border-stroke rounded-xl overflow-hidden scroll-mt-4">
       <div className="flex items-center bg-surface px-4 py-3 gap-2">
         <button onClick={onToggle} className="flex-1 flex items-center gap-3 text-left">
           {expanded ? <ChevronUp size={16} className="text-fg4 shrink-0" /> : <ChevronDown size={16} className="text-fg4 shrink-0" />}
@@ -510,11 +510,22 @@ function ConstructionDetail() {
   const { constructionId } = useParams<{ constructionId: string }>();
   const { data: construction, isLoading } = useGetConstruction(constructionId!);
   const { data: docTypes = [] } = useListDocumentTypes();
-  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
+  const [searchParams] = useSearchParams();
+  const focusSectionId = searchParams.get('section');
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(
+    () => focusSectionId ? new Set([focusSectionId]) : new Set());
   const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [newSectionName, setNewSectionName] = useState('');
   const [sectionError, setSectionError] = useState('');
   const createSection = useCreateSection();
+
+  // Переход из хлебных крошек по ?section= — раскрыть этот раздел и подскроллить к нему.
+  useEffect(() => {
+    if (!focusSectionId || !construction) return;
+    setExpandedSections(prev => new Set([...prev, focusSectionId]));
+    const el = document.getElementById(`section-${focusSectionId}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [focusSectionId, construction]);
 
   function toggleSection(id: string) {
     setExpandedSections(prev => {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #25

## Причина
В хлебных крошках комплекта (**Стройки → Стройка → Раздел → Комплект**) сегмент «Раздел» рендерился как `<span>`, а не ссылка — перейти к разделу было нельзя. Отдельного маршрута для раздела нет: страница стройки показывает разделы раскрывающимися карточками.

## Фикс
- Раздел в breadcrumb → `Link` на `/document-sets/{constructionId}?section={sectionId}`.
- `ConstructionDetail` читает `?section=` → авто-раскрывает раздел и скроллит к нему (`scrollIntoView`); карточке — `id="section-{id}"` + `scroll-mt-4`.

Без нового роутинга — переход на страницу стройки с фокусом на нужном разделе.

## Версия
`0.5.1 → 0.5.2` (баг-фикс, фронт). Без миграций и ручных действий. tsc чистый, frontend 106.