### PR TITLE
feat: препроцессинг PDF на уровне набора — авторитет группировки + стабильные id групп (#28, Фаза 1)

### DIFF
--- a/src/server/BHS.CRG.Domain/DataSets/DataSetFile.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetFile.cs
@@ -16,6 +16,25 @@ public class DataSetFile : Entity
     private readonly List<DataSetSource> _sources = [];
     public IReadOnlyList<DataSetSource> Sources => _sources.AsReadOnly();
 
+    /// <summary>
+    /// Препроцессинг (issue #27/#28): хардкод-профиль распознавания, породивший структуру набора
+    /// (для PDF — «Gost»/«Invoice»). Null — препроцессинга нет (CSV/XLSX/XML/JSON — уже структурны).
+    /// </summary>
+    public string? PreprocessingProfile { get; private set; }
+
+    /// <summary>
+    /// Авторитетная группировка страниц набора (JSONB, <see cref="GostGroupingData"/> с id групп) —
+    /// источник истины препроцессинга. Проекции (обложка/титул/документы/таблицы) — производные
+    /// источники, пересчитываемые отсюда в одной точке. Ранее жила на источнике gost-documents.
+    /// </summary>
+    public string? Grouping { get; private set; }
+
+    /// <summary>
+    /// true — блоб заменён ПОСЛЕ распознавания: группировка/проекции относятся к прежнему содержимому.
+    /// Сбрасывается при следующем распознавании. Ранее <see cref="DataSetSource.RecognitionStale"/>.
+    /// </summary>
+    public bool RecognitionStale { get; private set; }
+
     private DataSetFile() { }
 
     public static DataSetFile Create(string name, DataSetFormat format, string blobPath,
@@ -44,6 +63,28 @@ public class DataSetFile : Entity
     {
         BlobPath = newBlobPath;
         Format = newFormat;
+        TouchUpdatedAt();
+    }
+
+    /// <summary>Задать профиль препроцессинга набора (issue #28). Null — снять.</summary>
+    public void SetPreprocessingProfile(string? profile)
+    {
+        PreprocessingProfile = string.IsNullOrWhiteSpace(profile) ? null : profile.Trim();
+        TouchUpdatedAt();
+    }
+
+    /// <summary>Задать/обновить авторитетную группировку набора (JSON GostGroupingData) и снять stale.</summary>
+    public void SetGrouping(string? groupingJson)
+    {
+        Grouping = groupingJson;
+        RecognitionStale = false;
+        TouchUpdatedAt();
+    }
+
+    /// <summary>Пометить набор устаревшим — блоб заменён после распознавания (данные к прежнему файлу).</summary>
+    public void MarkRecognitionStale()
+    {
+        RecognitionStale = true;
         TouchUpdatedAt();
     }
 }

--- a/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
@@ -39,14 +39,6 @@ public class DataSetSource : Entity
     public string? SortSpec { get; private set; }
 
     /// <summary>
-    /// JSON-объект группировки страниц по документам для ГОСТ-профиля "Документы"
-    /// ({"documents":[{"code","name","pageIndices"}],"manuallyEdited"}) — задел под ручную
-    /// корректировку разбиения PDF после автораспознавания. Null — источник не из ГОСТ-профиля
-    /// или ещё не распознавался. См. GostGroupingData/DataSetPdfRecognitionService.
-    /// </summary>
-    public string? GostGrouping { get; private set; }
-
-    /// <summary>
     /// true — исходный файл заменён (<see cref="DataSetFile"/>.ReplaceFileAsync) ПОСЛЕ последнего
     /// распознавания: кэш/группировка относятся к прежнему содержимому файла и устарели. Только для
     /// распознаваемых PDF-источников (парсер их не детектит — при замене не удаляются, а помечаются).
@@ -129,14 +121,6 @@ public class DataSetSource : Entity
         RowFilter = rowFilter;
         ComputedColumns = computedColumns;
         SortSpec = sortSpec;
-        TouchUpdatedAt();
-    }
-
-    /// <summary>Группировка страниц ГОСТ-профиля — задаётся автораспознаванием (manuallyEdited=false)
-    /// или ручной правкой пользователя (manuallyEdited=true).</summary>
-    public void SetGostGrouping(string? gostGroupingJson)
-    {
-        GostGrouping = gostGroupingJson;
         TouchUpdatedAt();
     }
 

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
@@ -95,10 +95,8 @@ public class DataSetPdfRecognitionService(
         if (isGost)
         {
             // 409-проверка ручной правки — ДО постановки в фон (чтобы диалог подтверждения был интерактивным).
-            var documentsSource = source.SheetOrPath == PdfProfiles.GostDocumentsMarker
-                ? source
-                : await db.DataSetSources.AsNoTracking().FirstOrDefaultAsync(s => s.FileId == source.FileId && s.SheetOrPath == PdfProfiles.GostDocumentsMarker, ct);
-            var existingGrouping = ParseGrouping(documentsSource?.GostGrouping);
+            // Группировка живёт на НАБОРЕ (issue #28), не на источнике.
+            var existingGrouping = ParseGrouping(source.File.Grouping);
             if (existingGrouping is { ManuallyEdited: true } && !confirm)
                 throw new InvalidOperationException(
                     "Разбиение этого источника было скорректировано вручную — повторное распознавание сотрёт ручные правки. Подтвердите, чтобы продолжить.");
@@ -123,10 +121,8 @@ public class DataSetPdfRecognitionService(
         {
             // Ручная правка группировки — дороже автораспознавания LLM-вызовов (пользователь
             // руками разбирал документы) — не затираем без явного согласия.
-            var documentsSource = source.SheetOrPath == PdfProfiles.GostDocumentsMarker
-                ? source
-                : await db.DataSetSources.FirstOrDefaultAsync(s => s.FileId == source.FileId && s.SheetOrPath == PdfProfiles.GostDocumentsMarker, ct);
-            var existingGrouping = ParseGrouping(documentsSource?.GostGrouping);
+            // Группировка живёт на НАБОРЕ (issue #28).
+            var existingGrouping = ParseGrouping(source.File.Grouping);
             if (existingGrouping is { ManuallyEdited: true } && !confirm)
                 throw new InvalidOperationException(
                     "Разбиение этого источника было скорректировано вручную — повторное распознавание сотрёт ручные правки. Подтвердите, чтобы продолжить.");
@@ -424,7 +420,10 @@ public class DataSetPdfRecognitionService(
         // Единая постраничная группировка (обложка/титул/документы как группы) — источник истины,
         // из которого проекцией получаем строки трёх источников. Одна точка агрегации полей.
         var routed = GostPageGrouper.Group(rows);
-        var unified = GostUnifiedGroupingBuilder.Build(routed, rows, manuallyEdited: false);
+        // Стабильные id групп (issue #28) — переносим из предыдущей группировки НАБОРА при перераспознавании,
+        // чтобы производные табличные источники (gost-table:{id}) не осиротели (P1).
+        var existingGrouping = ParseGrouping(source.File.Grouping);
+        var unified = GostStableIds.Assign(GostUnifiedGroupingBuilder.Build(routed, rows, manuallyEdited: false), existingGrouping);
         var projected = GostGroupingProjection.Project(unified);
         var baseColumnPaths = GostTitleBlockFields.All.Select(f => f.Path).ToArray();
         // Обложка/титул распознаются своим набором полей — и колонки их источников из него же,
@@ -448,7 +447,7 @@ public class DataSetPdfRecognitionService(
         // Автораспознавание всегда перезаписывает предыдущую (в т.ч. ручную) группировку —
         // ManuallyEdited=false; предупреждение о потере ручных правок показывает фронт ПЕРЕД вызовом
         // (см. 409 Conflict в RecognizePdfSourceAsync, когда ManuallyEdited уже true и без confirm).
-        documents.SetGostGrouping(JsonSerializer.Serialize(unified));
+        source.File.SetGrouping(JsonSerializer.Serialize(unified));
         var invalidatedTables = await ReprojectTableSourcesAsync(documents.FileId, unified, ct);
 
         await db.SaveChangesAsync(ct);
@@ -491,7 +490,13 @@ public class DataSetPdfRecognitionService(
     /// маппится в группы Kind=Document с пустыми полями страниц (перераспознавание восстановит поля).</summary>
     // Толерантный разбор группировки вынесен в тестируемый GostGroupingSerialization; тонкий
     // делегат сохраняет прежние call-sites внутри сервиса.
-    private static GostGroupingData? ParseGrouping(string? json) => GostGroupingSerialization.Parse(json);
+    private static GostGroupingData? ParseGrouping(string? json)
+    {
+        var data = GostGroupingSerialization.Parse(json);
+        // Гарантируем стабильные id (issue #28): свежая группировка их уже несёт (GostStableIds.Assign);
+        // это подстраховка для группировок, прочитанных без id.
+        return data is null ? null : GostStableIds.EnsureIds(data);
+    }
 
     // ФайлПуть каждой строки прежнего реестра "Документы" — CachedData: JSON-массив объектов
     // {..., "ФайлПуть": "...", ...} (та же форма, что пишет UpdateCache выше).
@@ -574,19 +579,19 @@ public class DataSetPdfRecognitionService(
             .ToList();
         if (tableSources.Count == 0) return 0;
 
-        // Канонические первые страницы текущих документов, всё ещё помеченных табличным тэгом.
-        var validFirstPages = unified.Groups
+        // Стабильные id текущих документов, всё ещё помеченных табличным тэгом (issue #28).
+        var validGroupIds = unified.Groups
             .Where(g => g.Kind == GostGroupKind.Document && g.Pages.Count > 0
                         && (g.Tags ?? []).Any(t => GostTableFields.ColumnsForTag(t) is not null))
-            .Select(g => g.Pages.Min(p => p.PageIndex))
+            .Select(g => g.Id)
             .ToHashSet();
 
         var removed = 0;
         foreach (var ts in tableSources)
         {
-            var pageStr = ts.SheetOrPath[PdfProfiles.GostTableMarkerPrefix.Length..];
-            if (int.TryParse(pageStr, out var p) && validFirstPages.Contains(p))
-                continue; // документ сохранился — оставляем табличный источник как есть
+            var idStr = ts.SheetOrPath[PdfProfiles.GostTableMarkerPrefix.Length..];
+            if (Guid.TryParse(idStr, out var gid) && validGroupIds.Contains(gid))
+                continue; // документ сохранился (id совпал) — оставляем табличный источник как есть
 
             var boundCount = await db.DataSetBindings.CountAsync(b => b.SourceId == ts.Id, ct);
             if (boundCount > 0)
@@ -621,7 +626,7 @@ public class DataSetPdfRecognitionService(
         var documentRows = await SplitAndUploadDocumentsAsync(bytes, projected.Documents, overrideIdentityFromGroup: true, source.Id, ct);
 
         source.UpdateCache(DataSetDtoMapper.SerializeSchema(BuildColumns(documentsColumnPaths, documentRows)), documentRows.Count, JsonSerializer.Serialize(documentRows));
-        source.SetGostGrouping(JsonSerializer.Serialize(unified));
+        source.File.SetGrouping(JsonSerializer.Serialize(unified));
 
         var cover = await db.DataSetSources.FirstOrDefaultAsync(s => s.FileId == source.FileId && s.SheetOrPath == PdfProfiles.GostCoverMarker, ct);
         var titlePage = await db.DataSetSources.FirstOrDefaultAsync(s => s.FileId == source.FileId && s.SheetOrPath == PdfProfiles.GostTitlePageMarker, ct);
@@ -643,7 +648,7 @@ public class DataSetPdfRecognitionService(
             throw new ArgumentException("Ручная корректировка разбиения доступна только для источника «Документы» ГОСТ-профиля.");
 
         var pageCount = await GetPdfPageCountAsync(source.File.BlobPath, ct);
-        var grouping = ParseGrouping(source.GostGrouping);
+        var grouping = ParseGrouping(source.File.Grouping);
         var groups = (grouping?.Groups ?? [])
             .Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags))
             .ToList();
@@ -689,7 +694,7 @@ public class DataSetPdfRecognitionService(
         if (documents.SheetOrPath != PdfProfiles.GostDocumentsMarker)
             throw new ArgumentException("Тэги документа доступны только для источника «Документы» ГОСТ-профиля.");
 
-        var grouping = ParseGrouping(documents.GostGrouping);
+        var grouping = ParseGrouping(documents.File.Grouping);
         if (grouping is null)
             throw new ArgumentException("Группировка ещё не распознана.");
         // Оставляем только известные тэги типа таблицы (не даём проставить произвольные).
@@ -699,7 +704,7 @@ public class DataSetPdfRecognitionService(
                 ? g with { Tags = clean.Count > 0 ? clean : null }
                 : g)
             .ToList();
-        documents.SetGostGrouping(JsonSerializer.Serialize(new GostGroupingData(updated, grouping.ManuallyEdited)));
+        documents.File.SetGrouping(JsonSerializer.Serialize(new GostGroupingData(updated, grouping.ManuallyEdited)));
         await db.SaveChangesAsync(ct);
 
         var pageCount = await GetPdfPageCountAsync(documents.File.BlobPath, ct);
@@ -715,7 +720,7 @@ public class DataSetPdfRecognitionService(
         if (documents.SheetOrPath != PdfProfiles.GostDocumentsMarker)
             throw new ArgumentException("Распознавание таблицы доступно только для источника «Документы» ГОСТ-профиля.");
 
-        var grouping = ParseGrouping(documents.GostGrouping);
+        var grouping = ParseGrouping(documents.File.Grouping);
         var group = grouping?.Groups.FirstOrDefault(
             g => g.Kind == GostGroupKind.Document && g.Pages.Any(p => p.PageIndex == firstPageIndex));
         if (group is null)
@@ -759,8 +764,9 @@ public class DataSetPdfRecognitionService(
         var canonicalFirstPage = pageIndices[0];
         var sourceName = string.IsNullOrWhiteSpace(group.Name) ? $"Таблица (стр. {canonicalFirstPage + 1})" : group.Name!;
 
-        // Идемпотентно: один табличный источник на документ (ключ — каноническая первая страница документа).
-        var marker = $"{PdfProfiles.GostTableMarkerPrefix}{canonicalFirstPage}";
+        // Идемпотентно: один табличный источник на документ. Ключ — СТАБИЛЬНЫЙ id группы (issue #28),
+        // а не firstPageIndex: переживает перераспознавание/сдвиг страниц — источник не осиротеет (P1).
+        var marker = $"{PdfProfiles.GostTableMarkerPrefix}{group.Id}";
         var tableSource = await db.DataSetSources.FirstOrDefaultAsync(
             s => s.FileId == documents.FileId && s.SheetOrPath == marker, ct);
         if (tableSource is null)
@@ -793,7 +799,7 @@ public class DataSetPdfRecognitionService(
         if (source.SheetOrPath != PdfProfiles.GostDocumentsMarker)
             throw new ArgumentException("Перераспознавание документа доступно только для источника «Документы» ГОСТ-профиля.");
 
-        var grouping = ParseGrouping(source.GostGrouping);
+        var grouping = ParseGrouping(source.File.Grouping);
         var groups = grouping?.Groups.ToList();
         var targetIdx = groups?.FindIndex(g => g.Kind == GostGroupKind.Document && g.Pages.Any(p => p.PageIndex == firstPageIndex)) ?? -1;
         if (grouping is null || groups is null || targetIdx < 0)
@@ -884,10 +890,13 @@ public class DataSetPdfRecognitionService(
             .ToList();
         var freshName = newPages.Select(pg => pg.Fields.GetValueOrDefault("НаименованиеДокумента")).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
         var freshShifr = newPages.Select(pg => pg.Fields.GetValueOrDefault("Шифр")).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
-        groups[targetIdx] = new GostGroupingGroup(GostGroupKind.Document,
-            string.IsNullOrWhiteSpace(freshShifr) ? target.Code : freshShifr,
-            string.IsNullOrWhiteSpace(freshName) ? target.Name : freshName,
-            newPages, target.Tags);
+        // Сохраняем стабильный Id и тэги документа (issue #28) — только поля/шифр/имя/страницы свежие.
+        groups[targetIdx] = target with
+        {
+            Code = string.IsNullOrWhiteSpace(freshShifr) ? target.Code : freshShifr,
+            Name = string.IsNullOrWhiteSpace(freshName) ? target.Name : freshName,
+            Pages = newPages,
+        };
         var unified = new GostGroupingData(groups, grouping.ManuallyEdited);
 
         await MaterializeGroupingAsync(source, unified, bytes, ct);
@@ -922,7 +931,7 @@ public class DataSetPdfRecognitionService(
 
         // Существующая единая группировка: поля страниц (для проекции без потерь при переносе
         // страницы в другую группу — сохраняет её реальные распознанные поля).
-        var existing = ParseGrouping(source.GostGrouping);
+        var existing = ParseGrouping(source.File.Grouping);
         var pageFields = new Dictionary<int, IReadOnlyDictionary<string, string?>>();
         if (existing is not null)
             foreach (var g in existing.Groups)
@@ -940,6 +949,8 @@ public class DataSetPdfRecognitionService(
                     g.Tags))
                 .ToList(),
             ManuallyEdited: true);
+        // Стабильные id (issue #28): переносим из существующей группировки по пересечению страниц.
+        unified = GostStableIds.Assign(unified, existing);
 
         await MaterializeGroupingAsync(source, unified, bytes, ct);
 

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
@@ -26,9 +26,12 @@ public record GostGroupingData(IReadOnlyList<GostGroupingGroup> Groups, bool Man
 /// <param name="Pages">Страницы группы с их распознанными полями, в порядке следования.</param>
 /// <param name="Tags">Функциональные тэги документа (тип таблицы — спецификация/кабельный журнал,
 /// см. FunctionalTag.GostDoc*). Авто-подсказка по НаименованиеДокумента, правится пользователем.</param>
+/// <param name="Id">Стабильный идентификатор группы (issue #28) — переживает перераспознавание и
+/// ручную правку, служит ключом производных источников-таблиц (вместо дрейфующего firstPageIndex).
+/// default (Guid.Empty) — ещё не присвоен (старый формат/новая группа); присваивается при сборке.</param>
 public record GostGroupingGroup(
     GostGroupKind Kind, string? Code, string? Name, IReadOnlyList<GostGroupingPage> Pages,
-    IReadOnlyList<string>? Tags = null);
+    IReadOnlyList<string>? Tags = null, Guid Id = default);
 
 /// <param name="PageIndex">Индекс страницы исходного PDF (0-based).</param>
 /// <param name="Fields">Распознанные поля штампа этой страницы (без служебных ТипСтраницы/Форма).</param>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
@@ -1,0 +1,62 @@
+using BHS.CRG.Application.DataSets;
+
+namespace BHS.CRG.Infrastructure.DataSets;
+
+/// <summary>
+/// Присваивает стабильные <see cref="GostGroupingGroup.Id"/> группам новой группировки, перенося
+/// их из предыдущей при перераспознавании (issue #28, линчпин Фазы 1): Cover/TitlePage — по Kind;
+/// Document — по максимальному пересечению страниц с существующей группой. Непарные группы получают
+/// новый Guid. Стабильный id заменяет дрейфующий firstPageIndex как ключ производных источников-таблиц,
+/// устраняя их осиротение при перераспознавании (P1).
+/// </summary>
+public static class GostStableIds
+{
+    public static GostGroupingData Assign(GostGroupingData fresh, GostGroupingData? existing)
+    {
+        var existingGroups = existing?.Groups?.ToList() ?? [];
+        var claimed = new HashSet<Guid>();
+        var result = new List<GostGroupingGroup>(fresh.Groups.Count);
+
+        foreach (var g in fresh.Groups)
+        {
+            var id = Guid.Empty;
+
+            if (g.Kind is GostGroupKind.Cover or GostGroupKind.TitlePage)
+            {
+                var m = existingGroups.FirstOrDefault(e =>
+                    e.Kind == g.Kind && e.Id != Guid.Empty && !claimed.Contains(e.Id));
+                if (m is not null) id = m.Id;
+            }
+            else
+            {
+                var pages = g.Pages.Select(p => p.PageIndex).ToHashSet();
+                GostGroupingGroup? best = null;
+                var bestOverlap = 0;
+                foreach (var e in existingGroups)
+                {
+                    if (e.Kind != GostGroupKind.Document || e.Id == Guid.Empty || claimed.Contains(e.Id)) continue;
+                    var overlap = e.Pages.Count(p => pages.Contains(p.PageIndex));
+                    if (overlap > bestOverlap) { bestOverlap = overlap; best = e; }
+                }
+                if (best is not null && bestOverlap > 0) id = best.Id;
+            }
+
+            if (id == Guid.Empty) id = Guid.NewGuid();
+            else claimed.Add(id);
+
+            result.Add(g with { Id = id });
+        }
+
+        return fresh with { Groups = result };
+    }
+
+    /// <summary>Гарантирует, что у каждой группы есть Id (для группировок, прочитанных без id) — не меняет существующие.</summary>
+    public static GostGroupingData EnsureIds(GostGroupingData data)
+    {
+        if (data.Groups.All(g => g.Id != Guid.Empty)) return data;
+        var result = data.Groups
+            .Select(g => g.Id == Guid.Empty ? g with { Id = Guid.NewGuid() } : g)
+            .ToList();
+        return data with { Groups = result };
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260709043007_PreprocessingOnDataSetFile.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260709043007_PreprocessingOnDataSetFile.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709043007_PreprocessingOnDataSetFile")]
+    partial class PreprocessingOnDataSetFile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260709043007_PreprocessingOnDataSetFile.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260709043007_PreprocessingOnDataSetFile.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class PreprocessingOnDataSetFile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Grouping",
+                table: "dataset_files",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreprocessingProfile",
+                table: "dataset_files",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "RecognitionStale",
+                table: "dataset_files",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Grouping",
+                table: "dataset_files");
+
+            migrationBuilder.DropColumn(
+                name: "PreprocessingProfile",
+                table: "dataset_files");
+
+            migrationBuilder.DropColumn(
+                name: "RecognitionStale",
+                table: "dataset_files");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260709045816_DropSourceGostGrouping.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260709045816_DropSourceGostGrouping.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709045816_DropSourceGostGrouping")]
+    partial class DropSourceGostGrouping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260709045816_DropSourceGostGrouping.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260709045816_DropSourceGostGrouping.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropSourceGostGrouping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GostGrouping",
+                table: "dataset_sources");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GostGrouping",
+                table: "dataset_sources",
+                type: "jsonb",
+                nullable: true);
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
@@ -9,6 +9,9 @@ public class DataSetFileConfiguration : IEntityTypeConfiguration<DataSetFile>
     public void Configure(EntityTypeBuilder<DataSetFile> b)
     {
         b.ToTable("dataset_files");
+        b.Property(e => e.PreprocessingProfile).HasMaxLength(64);
+        b.Property(e => e.Grouping).HasColumnType("jsonb");
+        b.Property(e => e.RecognitionStale).HasDefaultValue(false);
         b.HasKey(e => e.Id);
         b.Property(e => e.Name).HasMaxLength(512).IsRequired();
         b.Property(e => e.Format).HasConversion<string>().HasMaxLength(16).IsRequired();

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
@@ -42,7 +42,6 @@ public class DataSetSourceConfiguration : IEntityTypeConfiguration<DataSetSource
         b.Property(e => e.SortSpec).HasColumnType("jsonb");
         b.Property(e => e.CachedData).HasColumnType("jsonb");
         b.Property(e => e.Tags).HasColumnType("jsonb");
-        b.Property(e => e.GostGrouping).HasColumnType("jsonb");
         b.Property(e => e.MaterializeTypeId);
         b.Property(e => e.MaterializeMapping).HasColumnType("jsonb");
         b.HasMany(e => e.Bindings)

--- a/src/server/BHS.CRG.Tests/Integration/DataSetGostRecognitionTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetGostRecognitionTests.cs
@@ -128,7 +128,7 @@ public class DataSetGostRecognitionTests(IntegrationTestFixture fixture) : IAsyn
             n => n.Severity == NotificationSeverity.Info && n.Title == "Распознавание групп листов PDF завершено");
 
         // Обложка и титул — как группы в единой группировке.
-        var grouping = JsonSerializer.Deserialize<GostGroupingData>(documents.GostGrouping!)!;
+        var grouping = JsonSerializer.Deserialize<GostGroupingData>(db.DataSetFiles.Find(documents.FileId)!.Grouping!)!;
         Assert.False(grouping.ManuallyEdited);
         Assert.Contains(grouping.Groups, g => g.Kind == GostGroupKind.Cover);
         Assert.Contains(grouping.Groups, g => g.Kind == GostGroupKind.TitlePage);
@@ -188,7 +188,7 @@ public class DataSetGostRecognitionTests(IntegrationTestFixture fixture) : IAsyn
             db, blob, new ScriptedRecognizer(script), new RecordingNotificationService(), NullLogger<DataSetPdfRecognitionService>.Instance);
         await svc.RecognizePdfSourceAsync(documents.Id, confirm: true, default);
 
-        var grouping = JsonSerializer.Deserialize<GostGroupingData>(documents.GostGrouping!)!;
+        var grouping = JsonSerializer.Deserialize<GostGroupingData>(db.DataSetFiles.Find(documents.FileId)!.Grouping!)!;
         var group = Assert.Single(Docs(grouping));
         Assert.Equal([0, 1], Idx(group));
         Assert.Equal("DP-ЕЦДМ-ЭМ", group.Code); // код с первого листа, не с зашумлённого продолжения
@@ -229,7 +229,7 @@ public class DataSetGostRecognitionTests(IntegrationTestFixture fixture) : IAsyn
             new RecordingNotificationService(), NullLogger<DataSetPdfRecognitionService>.Instance);
         await svc2.RecognizeDocumentAsync(documents.Id, firstPageIndex: 2, default);
 
-        var grouping = JsonSerializer.Deserialize<GostGroupingData>(documents.GostGrouping!)!;
+        var grouping = JsonSerializer.Deserialize<GostGroupingData>(db.DataSetFiles.Find(documents.FileId)!.Grouping!)!;
         var docs = Docs(grouping);
         Assert.Equal("Схема 1 (испр.)", docs.Single(d => d.Pages[0].PageIndex == 2).Name); // целевой обновлён
         Assert.Equal("Спецификация", docs.Single(d => d.Pages[0].PageIndex == 3).Name);    // соседний не тронут

--- a/src/server/BHS.CRG.Tests/Integration/DataSetPdfGroupingTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetPdfGroupingTests.cs
@@ -49,7 +49,7 @@ public class DataSetPdfGroupingTests(IntegrationTestFixture fixture) : IAsyncLif
         var file = DataSetFile.Create("Test GOST file", DataSetFormat.Pdf, blobPath, CatalogScope.System, null);
         var source = file.AddSource("Документы", PdfProfiles.GostDocumentsMarker, "[]", 0);
         if (grouping is not null)
-            source.SetGostGrouping(JsonSerializer.Serialize(grouping));
+            file.SetGrouping(JsonSerializer.Serialize(grouping));
 
         db.DataSetFiles.Add(file);
         db.DataSetSources.Add(source);
@@ -257,35 +257,39 @@ public class DataSetPdfGroupingTests(IntegrationTestFixture fixture) : IAsyncLif
 
     // ── ApplyGroupingAsync: инвалидация осиротевших табличных источников gost-table:* (P1b/c) ──
 
+    // Стабильный id документа-группы (issue #28) — ключ производного табличного источника gost-table:{id}.
+    private static readonly Guid SpecDocId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
     private static GostGroupingData SpecGrouping() => new(
         [new GostGroupingGroup(GostGroupKind.Document, "01-ЭМ", "Спецификация",
             [new GostGroupingPage(0, new Dictionary<string, string?>()), new GostGroupingPage(1, new Dictionary<string, string?>())],
-            ["gostDoc.specification"])],
+            ["gostDoc.specification"], SpecDocId)],
         ManuallyEdited: false);
 
-    private static async Task<Guid> AddTableSourceAsync(AppDbContext db, Guid documentsSourceId, int canonicalFirstPage)
+    private static async Task<Guid> AddTableSourceAsync(AppDbContext db, Guid documentsSourceId, Guid groupId)
     {
         var documents = await db.DataSetSources.FirstAsync(s => s.Id == documentsSourceId);
         var file = await db.DataSetFiles.Include(f => f.Sources).FirstAsync(f => f.Id == documents.FileId);
-        var table = file.AddSource("Таблица", PdfProfiles.GostTableMarkerPrefix + canonicalFirstPage, "[]", 0);
+        var table = file.AddSource("Таблица", PdfProfiles.GostTableMarkerPrefix + groupId, "[]", 0);
         db.DataSetSources.Add(table);
         await db.SaveChangesAsync();
         return table.Id;
     }
 
     [Fact]
-    public async Task ApplyGroupingAsync_OrphanedTableSource_RemovedWhenDocumentStartMoves()
+    public async Task ApplyGroupingAsync_OrphanedTableSource_RemovedWhenDocumentUntagged()
     {
         var (sourceId, scope) = await SeedGostDocumentsSourceAsync(3, SpecGrouping());
         using (scope)
         {
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            var tableId = await AddTableSourceAsync(db, sourceId, 0);
+            var tableId = await AddTableSourceAsync(db, sourceId, SpecDocId);
 
             var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
-            // Документ теперь начинается со стр.1 — gost-table:0 указывает в никуда, удаляется.
+            // С документа снят тэг таблицы → его gost-table-источник больше не валиден и удаляется
+            // (issue #28: инвалидация проекций по стабильному id группы, а не по firstPageIndex).
             await svc.ApplyGroupingAsync(sourceId, new ApplyGroupingInput(
-                [new GostGroupingGroupDto(GostGroupKind.Document, "01-ЭМ", "Спецификация", [1, 2], ["gostDoc.specification"])]), default);
+                [new GostGroupingGroupDto(GostGroupKind.Document, "01-ЭМ", "Спецификация", [0, 1], null)]), default);
 
             Assert.Null(await db.DataSetSources.FirstOrDefaultAsync(s => s.Id == tableId));
         }
@@ -312,18 +316,19 @@ public class DataSetPdfGroupingTests(IntegrationTestFixture fixture) : IAsyncLif
     }
 
     [Fact]
-    public async Task ApplyGroupingAsync_ValidTableSource_KeptWhenDocumentStartUnchanged()
+    public async Task ApplyGroupingAsync_TableSource_KeptAcrossStartShift_ViaStableGroupId()
     {
         var (sourceId, scope) = await SeedGostDocumentsSourceAsync(3, SpecGrouping());
         using (scope)
         {
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            var tableId = await AddTableSourceAsync(db, sourceId, 0);
+            var tableId = await AddTableSourceAsync(db, sourceId, SpecDocId);
 
             var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
-            // Документ по-прежнему начинается со стр.0 и помечен спецификацией → таблица сохраняется.
+            // Документ сдвинул начало (стр.0→1), но остаётся тем же (пересечение страниц) и помечен
+            // спецификацией → стабильный id группы переносится, таблица НЕ осиротеет (issue #28, фикс P1).
             await svc.ApplyGroupingAsync(sourceId, new ApplyGroupingInput(
-                [new GostGroupingGroupDto(GostGroupKind.Document, "01-ЭМ", "Спецификация", [0, 1], ["gostDoc.specification"])]), default);
+                [new GostGroupingGroupDto(GostGroupKind.Document, "01-ЭМ", "Спецификация", [1, 2], ["gostDoc.specification"])]), default);
 
             Assert.NotNull(await db.DataSetSources.FirstOrDefaultAsync(s => s.Id == tableId));
         }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.5.2</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #28 (Фаза 1 эпика #27)

Препроцессинг PDF-распознавания поднят с источника на **набор** — авторитет группировки + стабильные id групп + миграция вверх.

## Изменения
- **`DataSetFile.Grouping`** (JSONB) + `PreprocessingProfile` + `RecognitionStale` — `GostGroupingData` переехала с источника `gost-documents` на набор. Обложка/титул/документы/таблицы остаются производными проекциями, но истина одна.
- **`GostGroupingGroup.Id`** — стабильный id группы: присваивается при распознавании (`GostStableIds.Assign`), **переносится при перераспознавании/ручной правке по пересечению страниц**. Заменяет дрейфующий `firstPageIndex`.
- **`gost-table:{stableGroupId}`** (вместо `firstPageIndex`) → табличные источники **не осиротевают** при сдвиге страниц документа (**ретайрит P1**); инвалидируются только при снятии тэга / исчезновении группы.
- `DataSetSource.GostGrouping` удалён (+ EF-миграция дропа колонки).

## Проверки
Backend **321** тест зелёный (тесты `DataSetPdfGroupingTests` обновлены под новое поведение: таблица переживает сдвиг начала документа; удаляется при снятии тэга), `tsc -b` чистый. Фронт не тронут.

PDF-наборы предварительно удалены (тестовые) — миграция данных не требовалась.

## Версия
`0.5.2 → 0.6.0` (структурная фича).

⚠ **При обновлении:** авто-миграции меняют схему `dataset_files` (+3 колонки) и `dataset_sources` (−`GostGrouping`) — применяются на старте. **PDF-наборы после обновления нужно распознать заново** (авторитет группировки переехал на набор). Прочих ручных действий нет.

## Дальше по эпику #27
- #29 (Фаза 2): тэги групп → тип (сведение с материализацией #19).
- #30 (Фаза 3): унификация PDF-источников с #20 (явное создание).