### PR TITLE
feat: тэг таблицы ГОСТ → тип, сходимость с материализацией #19 (#29, Фаза 2)

### DIFF
--- a/src/client/src/shared/api/tags.ts
+++ b/src/client/src/shared/api/tags.ts
@@ -17,7 +17,7 @@ export const FUNCTIONAL_TAG = {
   datasetHasTitleBlock: 'dataset.hasTitleBlock',
 } as const;
 
-export type TagScope = 'Field' | 'Type' | 'Dataset';
+export type TagScope = 'Field' | 'Type' | 'Dataset' | 'GostDocument';
 
 export interface TagDefinition {
   code: string;
@@ -42,7 +42,10 @@ export function fieldTags(all: TagDefinition[] | undefined, fieldType: string): 
 }
 
 export function typeTags(all: TagDefinition[] | undefined, kind: string): TagDefinition[] {
-  return (all ?? []).filter(t => t.scope === 'Type' && (t.appliesTo.length === 0 || t.appliesTo.includes(kind)));
+  // Type-тэги + GostDocument-тэги (issue #29): пометив тип тэгом таблицы (Спецификация/Кабельный
+  // журнал), админ объявляет его целевым типом материализации для таких таблиц ГОСТ-документов.
+  return (all ?? []).filter(t => (t.scope === 'Type' || t.scope === 'GostDocument')
+    && (t.appliesTo.length === 0 || t.appliesTo.includes(kind)));
 }
 
 export function datasetTags(all: TagDefinition[] | undefined): TagDefinition[] {

--- a/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
+++ b/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
@@ -3,8 +3,15 @@ using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Application.Schema;
 
-/// <summary>Поле эффективной схемы типа: ключ, тип (string/complex/array/doc-ref/doc-array/…), typeId (для составных/массивов/ссылок).</summary>
-public record SchemaFieldInfo(string Key, string Type, Guid? TypeId);
+/// <summary>Поле эффективной схемы типа: ключ, тип (string/complex/array/doc-ref/doc-array/…), typeId (для составных/массивов/ссылок), заголовок.</summary>
+public record SchemaFieldInfo(string Key, string Type, Guid? TypeId, string? Title = null);
+
+/// <summary>Скалярное ли поле (пригодное для табличного распознавания/материализации из плоских колонок).</summary>
+public static class SchemaFieldKinds
+{
+    private static readonly HashSet<string> NonScalar = ["complex", "array", "doc-ref", "doc-array", "file", "image"];
+    public static bool IsScalar(string type) => !NonScalar.Contains(type);
+}
 
 /// <summary>
 /// Backend-чтение эффективной схемы типа документа (с учётом наследования по ParentId) — аналог
@@ -85,7 +92,8 @@ public static class DocumentTypeSchemaReader
                 var type = f.TryGetProperty("type", out var ty) && ty.ValueKind == JsonValueKind.String ? ty.GetString()! : "string";
                 Guid? typeId = f.TryGetProperty("typeId", out var ti) && ti.ValueKind == JsonValueKind.String
                     && Guid.TryParse(ti.GetString(), out var g) ? g : null;
-                fields.Add(new SchemaFieldInfo(key, type, typeId));
+                var title = f.TryGetProperty("title", out var tl) && tl.ValueKind == JsonValueKind.String ? tl.GetString() : null;
+                fields.Add(new SchemaFieldInfo(key, type, typeId, title));
             }
 
         if (root.TryGetProperty("excludedFields", out var ex) && ex.ValueKind == JsonValueKind.Array)

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
@@ -3,6 +3,7 @@ using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Notifications;
 using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Domain.Notifications;
 using BHS.CRG.Infrastructure.Persistence;
@@ -478,6 +479,14 @@ public class DataSetPdfRecognitionService(
             "Распознавание групп листов PDF завершено", msg, "Распознавание PDF", ct: ct);
     }
 
+    // Тип поля схемы → тип поля распознавания (консервативно: число/дата, остальное — строка).
+    private static string MapRecognitionType(string schemaType) => schemaType switch
+    {
+        "number" => "number",
+        "date" => "date",
+        _ => "string",
+    };
+
     private static string SanitizeFileName(string name)
     {
         var invalid = Path.GetInvalidFileNameChars();
@@ -726,10 +735,34 @@ public class DataSetPdfRecognitionService(
         if (group is null)
             throw new ArgumentException("Документ с указанной страницей не найден в группировке.");
 
+        // Тэг таблицы документа → целевой ТИП, объявивший этот тэг (issue #29, «тип объявляет тэг»):
+        // таблица распознаётся в поля типа и материализуется в него (#19). Fallback — легаси
+        // хардкод-колонки GostTableFields, пока целевой тип не объявлен (переходный период).
         var tag = (group.Tags ?? []).FirstOrDefault(t => GostTableFields.ColumnsForTag(t) is not null);
-        var columns = tag is null ? null : GostTableFields.ColumnsForTag(tag);
-        if (columns is null)
+        if (tag is null)
             throw new ArgumentException("У документа не задан тип таблицы (спецификация/кабельный журнал).");
+
+        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var targetType = allTypes.FirstOrDefault(t => SchemaTags.TypeHasTag(t, allTypes, tag));
+
+        IReadOnlyList<RecognitionField> columns;
+        List<SchemaFieldInfo> typeFields = [];
+        if (targetType is not null)
+        {
+            var typesById = allTypes.ToDictionary(t => t.Id);
+            typeFields = DocumentTypeSchemaReader.EffectiveFields(targetType.Id, typesById)
+                .Where(f => SchemaFieldKinds.IsScalar(f.Type))
+                .ToList();
+            if (typeFields.Count == 0)
+                throw new ArgumentException($"У типа «{targetType.Name}» нет скалярных полей для распознавания таблицы.");
+            columns = typeFields
+                .Select(f => new RecognitionField(f.Key, f.Title ?? f.Key, MapRecognitionType(f.Type)))
+                .ToList();
+        }
+        else
+        {
+            columns = GostTableFields.ColumnsForTag(tag)!;
+        }
 
         await using var stream = await blob.DownloadAsync(documents.File.BlobPath, ct);
         using var ms = new MemoryStream();
@@ -780,6 +813,10 @@ public class DataSetPdfRecognitionService(
             db.DataSetSources.Add(tableSource);
         }
         tableSource.UpdateCache(schemaJson, rows.Count, dataJson);
+        // Сходимость с #19 (issue #29): тэг разрешился в тип → источник-таблица материализуется в него.
+        // Маппинг идентичный (ключ→колонка) — распознавали прямо в ключи полей типа.
+        if (targetType is not null)
+            tableSource.SetMaterialization(targetType.Id, JsonSerializer.Serialize(typeFields.ToDictionary(f => f.Key, f => f.Key)));
         await db.SaveChangesAsync(ct);
         await notifications.PublishAsync(NotificationSeverity.Info, "Таблица распознана",
             $"«{sourceName}» — строк: {rows.Count}. Доступна как отдельный источник (выгрузка XLSX/CSV).", "Распознавание PDF", ct: ct);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #29 (Фаза 2 эпика #27)

Сведение функциональных тэгов таблиц ГОСТ-документов с материализацией (#19). Механизм — **«тип объявляет тэг»** (решение пользователя): админ помечает ТИП документа тэгом таблицы (Спецификация/Кабельный журнал) = «целевой тип для таких таблиц».

## Изменения
- **`RecognizeDocumentTableAsync`**: тэг группы → `DocumentType`, объявивший этот тэг (`SchemaTags.TypeHasTag`). Таблица распознаётся в **скалярные поля типа** (RecognitionField из effective-схемы), а созданный `gost-table`-источник **материализуется в этот тип** (#19, идентичный маппинг ключ→колонка).
- **Fallback** на легаси `GostTableFields`, пока целевой тип не объявлен → обратная совместимость (все 321 тест зелёные на fallback-пути).
- `DocumentTypeSchemaReader`: `+Title` у `SchemaFieldInfo`, `+SchemaFieldKinds.IsScalar`.
- **Frontend**: GOST-doc тэги доступны как тип-тэги (`typeTags` + `TagScope 'GostDocument'`) — админ объявляет целевой тип в редакторе типа.

## Не в этой фазе (follow-up)
- Интеграционный тест нового тэг→тип пути (нужен scripted-recognizer под «Строки»); fallback покрыт.
- Полное удаление `GostTableFields` (Архитектор планировал) — оставлен fallback'ом на переходный период; отдельный cleanup, когда целевые типы объявлены.

## Как включить
Пометить тип документа (напр. составной «Строка спецификации» со скалярными полями) тэгом **«Спецификация / ведомость»** в редакторе типа → таблицы спецификаций будут распознаваться в него и материализоваться.

## Версия
`0.6.0 → 0.7.0` (фича). Схема БД не менялась. Обновление без ручных действий.

Backend **321** тест, `tsc -b` чистый.

Дальше: #30 (Фаза 3) — унификация PDF-источников с #20.