### PR TITLE
fix: быстрые кандидаты создания источника для всех форматов, не только PDF (#34)

### DIFF
--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -261,10 +261,12 @@ export function SourcesExpander({
   // прочие форматы — полное создание/редактирование/переименование/удаление.
   const canManageExtraction = true;
   const sources = file.sources;
-  // PDF (issue #30): логические таблицы распознанного набора (Обложка/Титул), которых ещё нет
-  // как источников — создаются явно в один клик. «Документы» авто-создаётся при выборе профиля.
-  const { data: pdfCandidates = [] } = useSourceCandidates(open && isPdf ? file.id : undefined);
+  // Кандидаты на источник (issue #30/#34): для всех форматов — логические таблицы/листы набора,
+  // которых ещё нет как источников, создаются в один клик. PDF — Обложка/Титул из распознанной
+  // группировки; XLSX — листы; CSV — «весь файл»; JSON — верхнеуровневые массивы.
+  const { data: candidates = [] } = useSourceCandidates(open ? file.id : undefined);
   const createSource = useCreateDataSetSource();
+  const availableCandidates = candidates.filter(c => !sources.some(s => s.sheetOrPath === c.sheetOrPath));
 
   if (sources.length === 0 && !canManageExtraction)
     return <span className="text-xs text-fg4">Нет источников</span>;
@@ -291,10 +293,10 @@ export function SourcesExpander({
             <SourceRow key={src.id} src={src} isPdf={isPdf} canManageExtraction={canManageExtraction}
               templates={templates} maxColumns={maxColumns} onEdit={setEditing} />
           ))}
-          {isPdf && pdfCandidates.length > 0 && (
+          {availableCandidates.length > 0 && (
             <div className="border-t border-stroke pt-2 mt-1 space-y-1">
-              <p className="text-[11px] text-fg4">Доступно из распознанного набора:</p>
-              {pdfCandidates.map(c => (
+              <p className="text-[11px] text-fg4">{isPdf ? 'Доступно из распознанного набора:' : 'Доступно из набора:'}</p>
+              {availableCandidates.map(c => (
                 <div key={c.sheetOrPath} className="flex items-center gap-2 text-xs">
                   <span className="text-fg2">{c.name} <span className="text-fg4">· {c.rowCount} строк</span></span>
                   <button type="button" disabled={createSource.isPending}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #34

## Причина
Ярлык «Создать» из кандидата (один клик) в `SourcesExpander` был загейчен на `isPdf` (добавлен в Фазе 3, #30), хотя `source-candidates` отдаёт кандидатов для всех форматов (XLSX — листы, CSV — «весь файл», JSON — массивы) ещё с #20. Поэтому у Excel быстрого ярлыка не было — только диалог «Добавить источник».

## Фикс
- Снят гейт `isPdf` — секция кандидатов быстрого создания показывается для любого формата.
- Кандидаты **фильтруются по уже созданным источникам** (по `sheetOrPath`) — не предлагаем дубли для листов XLSX, у которых источник уже есть.
- Подпись формат-нейтральная.

## Версия
`0.8.0 → 0.8.1` (баг-фикс, фронт). Без миграций и ручных действий. tsc чистый, frontend 106.