### PR TITLE
feat: препроцессинг PDF на уровне НАБОРА — редактор разбиения/тэги/таблицы без источника (#40)

### DIFF
--- a/src/client/src/features/datasets/PdfGroupingEditor.tsx
+++ b/src/client/src/features/datasets/PdfGroupingEditor.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { ArrowLeft, ChevronDown, Loader2, Pencil, Trash2, AlertTriangle, Save, ZoomIn } from 'lucide-react';
-import { useFilePages, useApplyGrouping, loadPageThumbnailUrl, loadPageImageUrl } from '@/shared/api/datasets';
+import { ArrowLeft, ChevronDown, Loader2, Pencil, Trash2, AlertTriangle, Save, ZoomIn, Table2, RefreshCw } from 'lucide-react';
+import {
+  useFilePages, useApplyGrouping, useRecognizeDocumentTable, useRecognizeDocument,
+  loadPageThumbnailUrl, loadPageImageUrl,
+} from '@/shared/api/datasets';
 import type { GostGroupingGroup, GostGroupKind } from '@/shared/api/types';
 import { Modal } from '@/shared/ui/Modal';
 
 const DEFAULT_CODE = '(без шифра)';
+/** Тэги типа таблицы документа (спецификация / кабельный журнал) — распознаются и выгружаются. */
+const TABLE_TAGS: { code: string; label: string }[] = [
+  { code: 'gostDoc.specification', label: 'Спецификация / ведомость' },
+  { code: 'gostDoc.cableJournal', label: 'Кабельный журнал' },
+];
 const KIND_LABEL: Record<Exclude<GostGroupKind, 'Document'>, string> = {
   Cover: 'Обложка',
   TitlePage: 'Титульный лист',
@@ -200,20 +208,27 @@ function SelectionActionBar({
 // ─── Группа (документ / обложка / титульный лист) ────────────────────────────────────────────────
 
 function GroupSection({
-  fileId, group, otherGroups, selected, suspiciousOnly,
-  onToggle, onRename, onMoveSelected, onSplitSelected, onDisband, onView,
+  fileId, group, otherGroups, selected, suspiciousOnly, dirty,
+  onToggle, onRename, onMoveSelected, onSplitSelected, onDisband, onView, onSetTag,
+  onRecognizeTable, onRecognizeDoc, tableBusyPage, docBusyPage,
 }: {
   fileId: string;
   group: EditableGroup;
   otherGroups: EditableGroup[];
   selected: Set<number>;
   suspiciousOnly: boolean;
+  dirty: boolean;
   onToggle: (pageIndex: number, e: React.MouseEvent) => void;
   onRename: (groupId: string, code: string, name: string | null) => void;
   onMoveSelected: (targetGroupId: string | 'new') => void;
   onSplitSelected: () => void;
   onDisband: (groupId: string) => void;
   onView: (pageIndex: number) => void;
+  onSetTag: (groupId: string, tag: string) => void;
+  onRecognizeTable: (firstPageIndex: number) => void;
+  onRecognizeDoc: (firstPageIndex: number) => void;
+  tableBusyPage: number | null;
+  docBusyPage: number | null;
 }) {
   const [editing, setEditing] = useState(false);
   const [codeVal, setCodeVal] = useState(group.code);
@@ -221,6 +236,8 @@ function GroupSection({
   const isSpecial = group.kind !== 'Document';
   const suspicious = isSuspicious(group);
   const hasSelectionHere = group.pageIndices.some(p => selected.has(p));
+  const firstPage = group.pageIndices[0];
+  const currentTag = group.tags.find(t => TABLE_TAGS.some(x => x.code === t)) ?? '';
 
   // В режиме «только подозрительные» скрываем обложку/титул и полностью корректные документы.
   if (suspiciousOnly && (isSpecial || !suspicious)) return null;
@@ -267,6 +284,34 @@ function GroupSection({
         )}
       </div>
 
+      {/* Тэг типа таблицы + распознавание таблицы/документа — препроцессинг на уровне набора (issue #40).
+          Таблица/перераспознавание работают по СОХРАНЁННОЙ группировке (первая страница), поэтому при
+          несохранённых правках заблокированы с подсказкой. */}
+      {!isSpecial && firstPage !== undefined && (
+        <div className="flex items-center gap-2 mb-2 flex-wrap">
+          <select value={currentTag} onChange={e => onSetTag(group.id, e.target.value)}
+            title="Тип таблицы документа — распознаётся и выгружается (XLSX/CSV)"
+            className="text-[11px] border border-stroke rounded px-1 py-0.5 bg-surface text-fg3 max-w-[170px] disabled:opacity-50">
+            <option value="">— тип таблицы</option>
+            {TABLE_TAGS.map(t => <option key={t.code} value={t.code}>{t.label}</option>)}
+          </select>
+          {currentTag && (
+            <button onClick={() => onRecognizeTable(firstPage)} disabled={dirty || tableBusyPage === firstPage}
+              title={dirty ? 'Сначала сохраните разбиение' : 'Распознать таблицу этого документа как отдельный источник данных'}
+              className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-base disabled:opacity-50">
+              {tableBusyPage === firstPage ? <Loader2 size={12} className="animate-spin" /> : <Table2 size={12} />}
+              Таблица
+            </button>
+          )}
+          <button onClick={() => onRecognizeDoc(firstPage)} disabled={dirty || docBusyPage === firstPage}
+            title={dirty ? 'Сначала сохраните разбиение' : 'Перераспознать только этот документ (не весь набор)'}
+            className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-base disabled:opacity-50">
+            {docBusyPage === firstPage ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+            Перераспознать
+          </button>
+        </div>
+      )}
+
       {group.pageIndices.length === 0 ? (
         <p className="text-xs text-fg4 italic">Нет страниц — перенесите сюда выделенные из других групп.</p>
       ) : (
@@ -298,6 +343,8 @@ export function PdfGroupingEditor() {
   const navigate = useNavigate();
   const { data, isLoading, error } = useFilePages(fileId ?? null);
   const applyMutation = useApplyGrouping(fileId!);
+  const recognizeTable = useRecognizeDocumentTable(fileId!);
+  const recognizeDoc = useRecognizeDocument(fileId!);
 
   const [groups, setGroups] = useState<EditableGroup[] | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -378,6 +425,11 @@ export function PdfGroupingEditor() {
     mutateGroups(prev => prev.map(g => g.id === groupId ? { ...g, code, name } : g));
   }
 
+  // Тип таблицы документа — локальная правка, сохраняется вместе с разбиением («Сохранить»).
+  function handleSetTag(groupId: string, tag: string) {
+    mutateGroups(prev => prev.map(g => g.id === groupId ? { ...g, tags: tag ? [tag] : [] } : g));
+  }
+
   async function handleSave() {
     if (!groups) return;
     const payload: GostGroupingGroup[] = groups
@@ -442,9 +494,14 @@ export function PdfGroupingEditor() {
         {groups.map(g => (
           <GroupSection
             key={g.id} fileId={fileId} group={g} otherGroups={groups.filter(o => o.id !== g.id)}
-            selected={selected} suspiciousOnly={suspiciousOnly}
+            selected={selected} suspiciousOnly={suspiciousOnly} dirty={dirty}
             onToggle={toggle} onRename={handleRename} onMoveSelected={handleMoveSelected}
             onSplitSelected={handleSplitSelected} onDisband={handleDisband} onView={setViewerPage}
+            onSetTag={handleSetTag}
+            onRecognizeTable={p => recognizeTable.mutate(p)}
+            onRecognizeDoc={p => recognizeDoc.mutate(p)}
+            tableBusyPage={recognizeTable.isPending ? (recognizeTable.variables ?? null) : null}
+            docBusyPage={recognizeDoc.isPending ? (recognizeDoc.variables ?? null) : null}
           />
         ))}
 

--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -40,6 +40,10 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
 }) {
   const tabular = isTabularFormat(format);
   const isZip = format === 'Zip';
+  const isPdf = format === 'Pdf';
+  // PDF-источник — проекция из СЫРЬЯ распознанного набора (issue #40): выбор кандидата
+  // (Обложка/Титул/Документы), как выбор листа в Excel. Никаких XPath/колонок.
+  const usesCandidates = tabular || isPdf;
   const needsSheet = format === 'Xls' || format === 'Xlsx';
   const pathFormat: PathFormat = format === 'Json' ? 'Json' : 'Xml';
   const PathBuilder = pathFormat === 'Json' ? JsonPathBuilder : XPathBuilder;
@@ -57,17 +61,18 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
 
   const { data: zipEntries = [] } = useListZipXmlEntries(isZip ? fileId : undefined);
   // Кандидаты (листы/«весь файл») — подсказки для табличных форматов в режиме создания.
-  const { data: candidates = [] } = useSourceCandidates(tabular ? fileId : undefined);
+  const { data: candidates = [] } = useSourceCandidates(usesCandidates ? fileId : undefined);
   const create = useCreateDataSetSource();
   const update = useUpdateDataSetSource();
   const isPending = create.isPending || update.isPending;
 
-  // Новый табличный источник: как только приедут кандидаты — подставить первый лист/«весь файл» и имя.
+  // Новый источник из кандидата (лист/«весь файл»/PDF-проекция): как только приедут кандидаты —
+  // подставить первый и его имя.
   useEffect(() => {
-    if (initial || !tabular || candidates.length === 0) return;
+    if (initial || !usesCandidates || candidates.length === 0) return;
     setSheetOrPath(prev => prev || candidates[0].sheetOrPath);
     setName(prev => prev || candidates[0].name);
-  }, [initial, tabular, candidates]);
+  }, [initial, usesCandidates, candidates]);
 
   // Текущее значение может отсутствовать в списке (архив обновился) — не терять его молча.
   const entryOptions = entryPath && !zipEntries.includes(entryPath) ? [entryPath, ...zipEntries] : zipEntries;
@@ -98,7 +103,11 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
     let finalSheetOrPath: string;
     let finalColumns: ColumnExprDef[] | null;
 
-    if (tabular) {
+    if (isPdf) {
+      if (!sheetOrPath.trim()) { setError('Выберите данные набора для источника'); return; }
+      finalSheetOrPath = sheetOrPath.trim(); // маркер кандидата (gost-cover/gost-titlepage/gost-documents)
+      finalColumns = null;                    // проекция из группировки, колонки готовы
+    } else if (tabular) {
       if (needsSheet && !sheetOrPath.trim()) { setError('Выберите лист'); return; }
       // CSV — весь файл: extraction тривиальна, sheetOrPath из кандидата (обычно "default").
       finalSheetOrPath = sheetOrPath.trim() || candidates[0]?.sheetOrPath || 'default';
@@ -150,7 +159,24 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
             className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm" />
         </div>
 
-        {tabular ? (
+        {isPdf ? (
+          <div>
+            <label className="block text-sm font-medium text-fg1 mb-1">Данные набора</label>
+            <select value={sheetOrPath} onChange={e => { setSheetOrPath(e.target.value); const c = candidates.find(x => x.sheetOrPath === e.target.value); if (c) setName(prev => prev || c.name); }}
+              className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm">
+              <option value="">— выберите —</option>
+              {candidates.map(c => (
+                <option key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</option>
+              ))}
+            </select>
+            {candidates.length === 0 && (
+              <p className="text-xs text-fg4 mt-1">Набор ещё не распознан — сначала запустите «Распознать».</p>
+            )}
+            {selectedCandidate && selectedCandidate.columns.length > 0 && (
+              <p className="text-xs text-fg4 mt-1">Колонки: {selectedCandidate.columns.join(', ')}</p>
+            )}
+          </div>
+        ) : tabular ? (
           needsSheet ? (
             <div>
               <label className="block text-sm font-medium text-fg1 mb-1">Лист</label>

--- a/src/client/src/features/datasets/SourcePreviewDialog.tsx
+++ b/src/client/src/features/datasets/SourcePreviewDialog.tsx
@@ -1,35 +1,20 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Loader2, FileText, ExternalLink, LayoutGrid, Table2, RefreshCw } from 'lucide-react';
+import { Loader2, FileText, ExternalLink } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import {
-  usePreviewDataSetSource, useFilePages, useSetDocumentTags, useRecognizeDocumentTable, useRecognizeDocument,
-} from '@/shared/api/datasets';
+import { usePreviewDataSetSource } from '@/shared/api/datasets';
 import { openAttachmentInNewTab, formatBytes } from '@/shared/api/attachments';
 import type { DataSetPreview, DataSetSource } from '@/shared/api/types';
 
 const MAX_ROWS = 200;
 
-/** Тэги типа таблицы документа (спецификация / кабельный журнал) — распознаются и выгружаются. */
-const TABLE_TAGS: { code: string; label: string }[] = [
-  { code: 'gostDoc.specification', label: 'Спецификация / ведомость' },
-  { code: 'gostDoc.cableJournal', label: 'Кабельный журнал' },
-];
-
 /**
- * Специализированный просмотр для источника «Документы» (PDF, sheetOrPath === 'gost-documents'):
- * вместо сырых строковых колонок — карточки по документу с именем, числом листов, размером
- * и кнопкой открытия физически разделённого под-PDF (ФайлПуть — путь в MinIO). ФайлПуть может
- * быть пустым, если разбиение конкретного документа не удалось (backend логирует предупреждение
- * и оставляет колонку пустой) — это ожидаемо, кнопка в этом случае просто неактивна.
+ * Просмотр источника «Документы» (PDF, sheetOrPath === 'gost-documents'): карточки по документу с
+ * именем, числом листов, размером и кнопкой открытия физически разделённого под-PDF (ФайлПуть — путь
+ * в MinIO). ФайлПуть может быть пустым, если разбиение конкретного документа не удалось — кнопка тогда
+ * неактивна. Действия препроцессинга (разбиение, тэги, распознавание таблиц/документов) — на уровне
+ * НАБОРА в редакторе разбиения (кнопка «Разбиение» у набора, issue #40), не здесь.
  */
-function GostDocumentsPreview({ fileId, sourceName, data }: { fileId: string; sourceName: string; data: DataSetPreview }) {
-  const navigate = useNavigate();
-  const { data: grouping } = useFilePages(fileId);
-  const setTags = useSetDocumentTags(fileId);
-  const recognizeTable = useRecognizeDocumentTable(fileId);
-  const recognizeDoc = useRecognizeDocument(fileId);
-  const docGroups = (grouping?.groups ?? []).filter(g => g.kind === 'Document');
+function GostDocumentsPreview({ data }: { data: DataSetPreview }) {
   const nameIdx = data.columns.indexOf('НаименованиеДокумента');
   const pagesIdx = data.columns.indexOf('КоличествоЛистов');
   const sizeIdx = data.columns.indexOf('РазмерБайт');
@@ -44,34 +29,12 @@ function GostDocumentsPreview({ fileId, sourceName, data }: { fileId: string; so
 
   return (
     <div className="space-y-1.5">
-      <div className="flex justify-end mb-1">
-        <button
-          onClick={() => navigate(`/datasets/files/${fileId}/grouping`, { state: { sourceName } })}
-          className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-base transition-colors"
-          title="Перенести страницы между документами, разделить/объединить группы вручную">
-          <LayoutGrid size={12} /> Редактировать разбиение
-        </button>
-      </div>
-      {recognizeTable.isError && (
-        <p className="text-xs text-danger px-1">
-          {(recognizeTable.error as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Не удалось распознать таблицу'}
-        </p>
-      )}
-      {recognizeTable.isSuccess && (
-        <p className="text-xs text-fg3 px-1">
-          Распознавание таблицы запущено — прогресс в индикаторе задач вверху; результат появится в источниках файла (выгрузка XLSX/CSV) и в уведомлениях.
-        </p>
-      )}
       {data.rows.map((row, i) => {
         const name = nameIdx >= 0 ? row[nameIdx] : null;
         const pages = pagesIdx >= 0 ? row[pagesIdx] : null;
         const sizeRaw = sizeIdx >= 0 ? row[sizeIdx] : null;
         const path = pathIdx >= 0 ? row[pathIdx] : null;
         const size = sizeRaw != null && sizeRaw !== '' && !Number.isNaN(Number(sizeRaw)) ? formatBytes(Number(sizeRaw)) : null;
-        const group = docGroups[i];
-        const firstPage = group?.pageIndices[0];
-        const currentTag = group?.tags?.find(t => TABLE_TAGS.some(x => x.code === t)) ?? '';
-        const recognizing = recognizeTable.isPending && recognizeTable.variables === firstPage;
         return (
           <div key={i} className="flex items-center gap-3 rounded-md px-3 py-2 bg-muted">
             <FileText size={14} className="text-fg4 shrink-0" />
@@ -83,37 +46,6 @@ function GostDocumentsPreview({ fileId, sourceName, data }: { fileId: string; so
                 {pages ? `${pages} л.` : '—'}{size ? ` · ${size}` : ''}
               </div>
             </div>
-            {group && firstPage !== undefined && (
-              <select value={currentTag} disabled={setTags.isPending}
-                onChange={e => setTags.mutate({ firstPageIndex: firstPage, tags: e.target.value ? [e.target.value] : [] })}
-                title="Тип таблицы документа — распознаётся и выгружается (XLSX/CSV)"
-                className="text-[11px] border border-stroke rounded px-1 py-0.5 bg-surface text-fg3 max-w-[150px] shrink-0 disabled:opacity-50">
-                <option value="">— тип таблицы</option>
-                {TABLE_TAGS.map(t => <option key={t.code} value={t.code}>{t.label}</option>)}
-              </select>
-            )}
-            {currentTag && firstPage !== undefined && (
-              <button
-                onClick={() => recognizeTable.mutate(firstPage)}
-                disabled={recognizing}
-                title="Распознать таблицу этого документа как отдельный источник данных"
-                className="flex items-center gap-1 shrink-0 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-surface disabled:opacity-50">
-                {recognizing ? <Loader2 size={12} className="animate-spin" /> : <Table2 size={12} />}
-                Таблица
-              </button>
-            )}
-            {group && firstPage !== undefined && (
-              <button
-                onClick={() => recognizeDoc.mutate(firstPage)}
-                disabled={recognizeDoc.isPending && recognizeDoc.variables === firstPage}
-                title="Перераспознать только этот документ (не весь набор)"
-                className="flex items-center gap-1 shrink-0 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-surface disabled:opacity-50">
-                {recognizeDoc.isPending && recognizeDoc.variables === firstPage
-                  ? <Loader2 size={12} className="animate-spin" />
-                  : <RefreshCw size={12} />}
-                Перераспознать
-              </button>
-            )}
             <button
               onClick={() => path && handleOpen(i, path)}
               disabled={!path || opening === i}
@@ -161,7 +93,7 @@ export function SourcePreviewDialog({ source, onClose }: { source: DataSetSource
       ) : !data || data.columns.length === 0 ? (
         <p className="text-sm text-fg4 py-4 text-center">Нет данных — либо строки не найдены, либо все отфильтрованы.</p>
       ) : isGostDocuments ? (
-        <GostDocumentsPreview fileId={source.fileId} sourceName={source.name} data={data} />
+        <GostDocumentsPreview data={data} />
       ) : (
         <div className="overflow-x-auto rounded-lg border border-stroke">
           <table className="text-xs w-full">

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -254,6 +254,7 @@ export function SourcesExpander({
   const recognizeFile = useRecognizeFile();
   const recognizeSource = useRecognizePdfSource();
   const [recognizeConflict, setRecognizeConflict] = useState(false);
+  const [profileDialog, setProfileDialog] = useState(false); // диалог выбора профиля PDF (только для «Распознать»)
   const navigate = useNavigate();
   const profile = file.preprocessingProfile;
   // ГОСТ-набор: профиль gost ИЛИ есть проекции/таблицы из его группировки (legacy-наборы без профиля).
@@ -274,7 +275,7 @@ export function SourcesExpander({
     } else if (profile === 'invoice' && invoiceHeader) {
       recognizeSource.mutate({ id: invoiceHeader.id, confirm });
     } else {
-      setEditing('new'); setOpen(true); // профиль не выбран → диалог профиля (ставит профиль + распознаёт)
+      setProfileDialog(true); // профиль не выбран → диалог выбора профиля (ставит профиль + распознаёт)
     }
   }
 
@@ -336,18 +337,17 @@ export function SourcesExpander({
         </div>
       )}
 
+      {/* «Добавить источник» — обычный диалог создания источника для ВСЕХ форматов, включая PDF
+          (выбор кандидата-проекции, как лист Excel). Диалог выбора профиля — только у «Распознать». */}
       {editing && (
-        isPdf ? (
-          <PdfSourceDialog fileId={file.id} onClose={() => setEditing(null)} />
-        ) : (
-          <SourceEditorDialog
-            fileId={file.id}
-            format={file.format}
-            initial={editing === 'new' ? undefined : editing}
-            onClose={() => setEditing(null)}
-          />
-        )
+        <SourceEditorDialog
+          fileId={file.id}
+          format={file.format}
+          initial={editing === 'new' ? undefined : editing}
+          onClose={() => setEditing(null)}
+        />
       )}
+      {profileDialog && <PdfSourceDialog fileId={file.id} onClose={() => setProfileDialog(false)} />}
 
       <ConfirmDialog
         open={recognizeConflict}

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   ChevronDown, ChevronRight, Plus, Pencil, Trash2, Copy, Eye, Filter, FunctionSquare, ArrowUpDown, Loader2,
-  BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes,
+  BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes, LayoutGrid,
 } from 'lucide-react';
 import { parseSourceColumnNames, countFilterConditions } from '@/shared/api/datasetHelpers';
 import { useSourceRecognizing } from '@/shared/api/jobs';
@@ -253,7 +254,12 @@ export function SourcesExpander({
   const recognizeFile = useRecognizeFile();
   const recognizeSource = useRecognizePdfSource();
   const [recognizeConflict, setRecognizeConflict] = useState(false);
+  const navigate = useNavigate();
   const profile = file.preprocessingProfile;
+  // ГОСТ-набор: профиль gost ИЛИ есть проекции/таблицы из его группировки (legacy-наборы без профиля).
+  const isGostDataset = profile === 'gost-titleblock'
+    || sources.some(s => s.sheetOrPath === 'gost-documents' || s.sheetOrPath === 'gost-cover'
+      || s.sheetOrPath === 'gost-titlepage' || s.sheetOrPath.startsWith('gost-table:'));
   const invoiceHeader = sources.find(s => s.sheetOrPath === 'invoice-header');
   const gostRecognizing = useSourceRecognizing(file.id);
   const invoiceRecognizing = useSourceRecognizing(invoiceHeader?.id ?? '');
@@ -289,6 +295,14 @@ export function SourcesExpander({
           <button onClick={() => handleRecognizeDataset()} disabled={recognizeBusy || recognizing}
             className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover disabled:opacity-50">
             <ScanText size={11} /> {recognizing ? 'Распознаётся…' : profile ? 'Распознать заново' : 'Распознать'}
+          </button>
+        )}
+        {/* Редактор разбиения — на уровне НАБОРА (issue #40): доступен без создания источника «Документы». */}
+        {isPdf && isGostDataset && (
+          <button onClick={() => navigate(`/datasets/files/${file.id}/grouping`, { state: { sourceName: file.name } })}
+            className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover"
+            title="Перенести страницы между документами, задать тип таблицы, распознать таблицу — на уровне набора">
+            <LayoutGrid size={11} /> Разбиение
           </button>
         )}
         {canManageExtraction && (

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #40. Follow-up к #38.

## Проблема
После #38 бэкенд препроцессинга набор-centric, но вход в UI (редактор разбиения, тэги, таблицы, перераспознавание) оставался внутри превью источника «Документы» — приходилось сперва создавать источник.

## Решение
- **Кнопка «Разбиение»** у ГОСТ-набора (рядом с «Распознать») → редактор `/datasets/files/{fileId}/grouping`. Доступна без создания источника.
- **Тэги/таблица/перераспознавание — в редакторе разбиения**: в заголовке каждой группы-документа выбор типа таблицы (спецификация/кабельный журнал), «Распознать таблицу», «Перераспознать документ». Тэг — локальная правка (сохраняется с разбиением); таблица/перераспознавание — по сохранённой группировке (заблокированы при несохранённых правках с подсказкой).
- **Превью источника «Документы»** очищено от действий препроцессинга — чистый просмотр (карточки + открытие под-PDF).

## Вне рамок
Отдельный кандидат «Таблица» в списке источников набора.

## Проверка
tsc чист · frontend 106 · только фронт (бэкенд уже fileId из #38). Версия 0.9.0 → 0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)