### PR TITLE
feat: таблица по тэгу группы — сырьё/кандидат, без авто-создания источника (#42)

### DIFF
--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -88,9 +88,10 @@ public interface IDataSetService
     Task<GostGroupingDto?> ApplyGroupingAsync(Guid fileId, ApplyGroupingInput input, CancellationToken ct);
     /// <summary>Лёгкая установка тэгов документа (тип таблицы) без пересборки разбиения.</summary>
     Task<GostGroupingDto?> SetDocumentTagsAsync(Guid fileId, int firstPageIndex, IReadOnlyList<string> tags, CancellationToken ct);
-    /// <summary>Распознать таблицу помеченного документа ГОСТ-профиля (спецификация/кабельный журнал)
-    /// и создать/обновить отдельный табличный источник. firstPageIndex — любая страница документа.</summary>
-    Task<DataSetSourceDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct);
+    /// <summary>Распознать таблицу помеченного документа ГОСТ-профиля (спецификация/кабельный журнал):
+    /// пишет строки как СЫРЬЁ на группу (Grouping) — доступна как кандидат «Таблица …», источник создаёт
+    /// пользователь (issue #42). Источника НЕ создаёт. firstPageIndex — любая страница документа.</summary>
+    Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct);
 
     /// <summary>Пути XML-записей внутри ZIP-файла — для выбора при ручном создании источника.</summary>
     Task<IReadOnlyList<string>> ListZipXmlEntriesAsync(Guid fileId, CancellationToken ct);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
@@ -434,7 +434,9 @@ public class DataSetPdfRecognitionService(
         // проекции) не осиротели.
         var routed = GostPageGrouper.Group(rows);
         var existingGrouping = ParseGrouping(file.Grouping);
-        var unified = GostStableIds.Assign(GostUnifiedGroupingBuilder.Build(routed, rows, manuallyEdited: false), existingGrouping);
+        // carryUserData: полное ре-распознавание переносит тэги/табличное сырьё с прежних групп по
+        // стабильному id (свежие группы приходят без тэгов — иначе пользовательская разметка потерялась бы).
+        var unified = GostStableIds.Assign(GostUnifiedGroupingBuilder.Build(routed, rows, manuallyEdited: false), existingGrouping, carryUserData: true);
 
         // Материализация СЫРЬЯ на наборе: режем под-PDF в группы (BlobPath в Grouping), пишем Grouping,
         // переспроецируем существующие источники-проекции, чистим осиротевшие блобы. Источников НЕ создаём.
@@ -598,18 +600,28 @@ public class DataSetPdfRecognitionService(
         if (tableSources.Count == 0) return 0;
 
         // Стабильные id текущих документов, всё ещё помеченных табличным тэгом (issue #28).
-        var validGroupIds = unified.Groups
+        var validGroups = unified.Groups
             .Where(g => g.Kind == GostGroupKind.Document && g.Pages.Count > 0
                         && (g.Tags ?? []).Any(t => GostTableFields.ColumnsForTag(t) is not null))
-            .Select(g => g.Id)
-            .ToHashSet();
+            .ToDictionary(g => g.Id);
 
         var removed = 0;
         foreach (var ts in tableSources)
         {
             var idStr = ts.SheetOrPath[PdfProfiles.GostTableMarkerPrefix.Length..];
-            if (Guid.TryParse(idStr, out var gid) && validGroupIds.Contains(gid))
-                continue; // документ сохранился (id совпал) — оставляем табличный источник как есть
+            if (Guid.TryParse(idStr, out var gid) && validGroups.TryGetValue(gid, out var g))
+            {
+                // Документ сохранился (id совпал) — РЕ-ПРОЕЦИРУЕМ источник из нового табличного сырья группы
+                // (issue #42). TableData перенесено GostStableIds.Assign; при смене состава страниц оно
+                // помечено stale — пробрасываем на источник (пользователь перераспознает таблицу).
+                if (!string.IsNullOrEmpty(g.TableData))
+                {
+                    var rowCount = JsonSerializer.Deserialize<List<Dictionary<string, string?>>>(g.TableData)?.Count ?? 0;
+                    ts.UpdateCache(g.TableColumns ?? "[]", rowCount, g.TableData);
+                    if (g.TableStale) ts.MarkRecognitionStale();
+                }
+                continue;
+            }
 
             var boundCount = await db.DataSetBindings.CountAsync(b => b.SourceId == ts.Id, ct);
             if (boundCount > 0)
@@ -699,7 +711,7 @@ public class DataSetPdfRecognitionService(
             grouping.ManuallyEdited, pageCount);
     }
 
-    public async Task<DataSetSourceDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct)
+    public async Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct)
     {
         var file = await db.DataSetFiles.Include(f => f.Sources).FirstOrDefaultAsync(f => f.Id == fileId, ct);
         if (file == null) return null;
@@ -741,15 +753,25 @@ public class DataSetPdfRecognitionService(
             columns = GostTableFields.ColumnsForTag(tag)!;
         }
 
-        await using var stream = await blob.DownloadAsync(file.BlobPath, ct);
-        using var ms = new MemoryStream();
-        await stream.CopyToAsync(ms, ct);
-        var bytes = ms.ToArray();
-
-        var pageIndices = group.Pages.Select(p => p.PageIndex).OrderBy(i => i).ToList();
+        // Под-PDF документа для vision: переиспользуем уже вырезанный при распознавании блок (group.BlobPath,
+        // issue #38) — не режем заново. Fallback — вырезать из полного PDF (старые наборы без BlobPath).
         byte[] subPdf;
-        try { subPdf = PdfPageSplitter.ExtractPages(bytes, pageIndices); }
-        catch (Exception ex) { throw new ArgumentException($"Не удалось выделить страницы документа: {ex.Message}"); }
+        if (!string.IsNullOrEmpty(group.BlobPath))
+        {
+            await using var s = await blob.DownloadAsync(group.BlobPath, ct);
+            using var m = new MemoryStream();
+            await s.CopyToAsync(m, ct);
+            subPdf = m.ToArray();
+        }
+        else
+        {
+            await using var s = await blob.DownloadAsync(file.BlobPath, ct);
+            using var m = new MemoryStream();
+            await s.CopyToAsync(m, ct);
+            var pageIndices = group.Pages.Select(p => p.PageIndex).OrderBy(i => i).ToList();
+            try { subPdf = PdfPageSplitter.ExtractPages(m.ToArray(), pageIndices); }
+            catch (Exception ex) { throw new ArgumentException($"Не удалось выделить страницы документа: {ex.Message}"); }
+        }
 
         RecognitionResult result;
         try
@@ -768,34 +790,31 @@ public class DataSetPdfRecognitionService(
             .ToArray();
         var schemaJson = DataSetDtoMapper.SerializeSchema(schema);
         var dataJson = JsonSerializer.Serialize(rows);
-        // Ключ и имя — по КАНОНИЧЕСКОЙ первой странице документа (минимум страниц группы), а не по
-        // входному firstPageIndex: иначе два вызова с разными страницами одного документа создали бы
-        // два источника-дубля. firstPageIndex — лишь «указатель на документ», не идентичность таблицы.
-        var canonicalFirstPage = pageIndices[0];
-        var sourceName = string.IsNullOrWhiteSpace(group.Name) ? $"Таблица (стр. {canonicalFirstPage + 1})" : group.Name!;
+        var tableName = string.IsNullOrWhiteSpace(group.Name) ? "Таблица" : $"Таблица — {group.Name}";
 
-        // Идемпотентно: один табличный источник на документ. Ключ — СТАБИЛЬНЫЙ id группы (issue #28),
-        // а не firstPageIndex: переживает перераспознавание/сдвиг страниц — источник не осиротеет (P1).
-        var marker = $"{PdfProfiles.GostTableMarkerPrefix}{group.Id}";
-        var tableSource = file.Sources.FirstOrDefault(s => s.SheetOrPath == marker);
-        if (tableSource is null)
+        // issue #42: распознанная таблица — СЫРЬЁ набора, живёт на группе (в Grouping), а НЕ авто-источник.
+        // Кандидат «Таблица …» проецирует её в источник по запросу пользователя (CreatePdfProjectionSource).
+        var updated = grouping with
         {
-            tableSource = file.AddSource(sourceName, marker, schemaJson, rows.Count);
-            // Тип таблицы (спецификация/кабельный журнал) НЕ дублируем в DataSetSource.Tags: тэг живёт
-            // на группе-документе (GostGrouping, scope GostDocument), а тип источника уже неявно задан
-            // фиксированными колонками GostTableFields. Ранее сюда клался документный тэг в поле под
-            // Dataset-scope тэги источника — семантическое смешение, ничего его не читало (P7).
-            db.DataSetSources.Add(tableSource);
-        }
-        tableSource.UpdateCache(schemaJson, rows.Count, dataJson);
-        // Сходимость с #19 (issue #29): тэг разрешился в тип → источник-таблица материализуется в него.
-        // Маппинг идентичный (ключ→колонка) — распознавали прямо в ключи полей типа.
-        if (targetType is not null)
-            tableSource.SetMaterialization(targetType.Id, JsonSerializer.Serialize(typeFields.ToDictionary(f => f.Key, f => f.Key)));
+            Groups = grouping.Groups
+                .Select(gg => gg.Id == group.Id
+                    ? gg with { TableData = dataJson, TableColumns = schemaJson, TableStale = false }
+                    : gg)
+                .ToList(),
+        };
+        file.SetGrouping(JsonSerializer.Serialize(updated));
+        // Если пользователь УЖЕ создал источник-проекцию этой таблицы — обновляем его кэш (ре-распознавание).
+        file.Sources.FirstOrDefault(s => s.SheetOrPath == $"{PdfProfiles.GostTableMarkerPrefix}{group.Id}")
+            ?.UpdateCache(schemaJson, rows.Count, dataJson);
         await db.SaveChangesAsync(ct);
+
         await notifications.PublishAsync(NotificationSeverity.Info, "Таблица распознана",
-            $"«{sourceName}» — строк: {rows.Count}. Доступна как отдельный источник (выгрузка XLSX/CSV).", "Распознавание PDF", ct: ct);
-        return DataSetDtoMapper.MapSource(tableSource);
+            $"«{tableName}» — строк: {rows.Count}. Доступна как кандидат — создайте из него источник в наборе.", "Распознавание PDF", ct: ct);
+
+        var pageCount = await GetPdfPageCountAsync(file.BlobPath, ct);
+        return new GostGroupingDto(
+            updated.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
+            updated.ManuallyEdited, pageCount);
     }
 
     /// <summary>Точечное перераспознавание ОДНОГО документа (P6): заново распознаёт только страницы его

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -83,7 +83,7 @@ public class DataSetService(
         pdfRecognition.ApplyGroupingAsync(fileId, input, ct);
     public Task<GostGroupingDto?> SetDocumentTagsAsync(Guid fileId, int firstPageIndex, IReadOnlyList<string> tags, CancellationToken ct) =>
         pdfRecognition.SetDocumentTagsAsync(fileId, firstPageIndex, tags, ct);
-    public Task<DataSetSourceDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct) =>
+    public Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct) =>
         pdfRecognition.RecognizeDocumentTableAsync(fileId, firstPageIndex, ct);
 
     // ── Processing templates ────────────────────────────────────────────────────

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -2,8 +2,10 @@ using System.IO.Compression;
 using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Infrastructure.Persistence;
+using BHS.CRG.Infrastructure.Recognition;
 using Microsoft.EntityFrameworkCore;
 
 namespace BHS.CRG.Infrastructure.DataSets;
@@ -70,6 +72,19 @@ public class DataSetSourceService(
             candidates.Add(new DataSetSourceInfo("Обложка", PdfProfiles.GostCoverMarker, ColumnsFromRows(projected.Cover), projected.Cover.Count));
         if (projected.TitlePage.Count > 0 && !existing.Contains(PdfProfiles.GostTitlePageMarker))
             candidates.Add(new DataSetSourceInfo("Титульный лист", PdfProfiles.GostTitlePageMarker, ColumnsFromRows(projected.TitlePage), projected.TitlePage.Count));
+
+        // Таблицы (issue #42): группа-документ с табличным тэгом и распознанным СЫРЬЁМ таблицы (TableData)
+        // → кандидат «Таблица …». Источник-проекцию создаёт пользователь (ключ gost-table:{стабильный id}).
+        foreach (var g in grouping.Groups)
+        {
+            if (g.Kind != GostGroupKind.Document || g.Id == Guid.Empty) continue;
+            var hasTableTag = (g.Tags ?? []).Any(t => GostTableFields.ColumnsForTag(t) is not null);
+            if (!hasTableTag || string.IsNullOrEmpty(g.TableData)) continue;
+            var marker = $"{PdfProfiles.GostTableMarkerPrefix}{g.Id}";
+            if (existing.Contains(marker)) continue;
+            var name = string.IsNullOrWhiteSpace(g.Name) ? "Таблица" : $"Таблица — {g.Name}";
+            candidates.Add(new DataSetSourceInfo(name, marker, ColumnsFromSchemaJson(g.TableColumns), RowCountOf(g.TableData)));
+        }
         return candidates;
     }
 
@@ -78,6 +93,18 @@ public class DataSetSourceService(
         var names = rows.SelectMany(r => r.Keys).Distinct().ToList();
         return names.Select(n => new DataSetColumnInfo(n,
             rows.Take(3).Select(r => r.GetValueOrDefault(n) ?? "").ToArray())).ToList();
+    }
+
+    private static IReadOnlyList<DataSetColumnInfo> ColumnsFromSchemaJson(string? schemaJson)
+    {
+        var cols = JsonSerializer.Deserialize<CachedColumnInfo[]>(schemaJson ?? "[]", CachedSchemaJson) ?? [];
+        return cols.Select(c => new DataSetColumnInfo(c.Name, c.SampleValues)).ToList();
+    }
+
+    private static int RowCountOf(string? dataJson)
+    {
+        try { return JsonSerializer.Deserialize<List<Dictionary<string, string?>>>(dataJson ?? "[]")?.Count ?? 0; }
+        catch { return 0; }
     }
 
     public async Task<SourcePreviewDto?> PreviewSourceAsync(Guid sourceId, int maxRows, CancellationToken ct)
@@ -207,24 +234,59 @@ public class DataSetSourceService(
         return DataSetDtoMapper.MapSource(source);
     }
 
-    // Источник-проекция PDF (issue #30): Обложка/Титул проецируются из группировки набора и кэшируются
-    // в CachedData (LoadRowsAsync читает PDF-строки из кэша). «Документы» и gost-table создаются
-    // распознаванием/тэгом, здесь не обрабатываются.
+    // Источник-проекция PDF (issue #30/#38/#42): обложка/титул/документы/таблица проецируются из СЫРЬЯ
+    // набора (группировка) и кэшируются в CachedData (LoadRowsAsync читает из кэша).
     private async Task<DataSetSourceDto> CreatePdfProjectionSourceAsync(
         Domain.DataSets.DataSetFile file, string name, string marker, CancellationToken ct)
     {
         var grouping = GostGroupingSerialization.Parse(file.Grouping)
             ?? throw new ArgumentException("Набор ещё не распознан — сначала запустите распознавание.");
+
+        // Таблица (issue #42): проекция распознанного СЫРЬЯ таблицы группы (TableData) + материализация
+        // в целевой тип по табличному тэгу. Ключ — стабильный id группы (gost-table:{id}).
+        if (marker.StartsWith(PdfProfiles.GostTableMarkerPrefix, StringComparison.Ordinal))
+            return await CreateTableProjectionSourceAsync(file, name, marker, grouping, ct);
+
         var projected = GostGroupingProjection.Project(grouping);
         // Проекция-источник из СЫРЬЯ набора (issue #38): обложка/титул/документы проецируются из
         // группировки. «Документы» несут ФайлПуть/РазмерБайт (под-PDF вырезаны при распознавании).
         var rows = marker == PdfProfiles.GostCoverMarker ? projected.Cover
             : marker == PdfProfiles.GostTitlePageMarker ? projected.TitlePage
             : marker == PdfProfiles.GostDocumentsMarker ? projected.Documents.Select(d => d.Fields).ToList()
-            : throw new ArgumentException("Для PDF источник создаётся из кандидата обложки/титула/документов.");
+            : throw new ArgumentException("Для PDF источник создаётся из кандидата обложки/титула/документов/таблицы.");
 
         var columns = ColumnsFromRows(rows);
         var source = file.AddSource(name, marker, DataSetDtoMapper.SerializeSchema(columns), rows.Count, null, JsonSerializer.Serialize(rows));
+        db.DataSetSources.Add(source);
+        await db.SaveChangesAsync(ct);
+        return DataSetDtoMapper.MapSource(source);
+    }
+
+    private async Task<DataSetSourceDto> CreateTableProjectionSourceAsync(
+        Domain.DataSets.DataSetFile file, string name, string marker, GostGroupingData grouping, CancellationToken ct)
+    {
+        var idStr = marker[PdfProfiles.GostTableMarkerPrefix.Length..];
+        if (!Guid.TryParse(idStr, out var gid))
+            throw new ArgumentException("Некорректный маркер таблицы.");
+        var group = grouping.Groups.FirstOrDefault(g => g.Id == gid && g.Kind == GostGroupKind.Document)
+            ?? throw new ArgumentException("Документ таблицы не найден в группировке.");
+        if (string.IsNullOrEmpty(group.TableData))
+            throw new ArgumentException("Таблица ещё не распознана — распознайте её в редакторе разбиения.");
+
+        var source = file.AddSource(name, marker, group.TableColumns ?? "[]", RowCountOf(group.TableData), null, group.TableData);
+        // Материализация в целевой тип по табличному тэгу (issue #29/#19): строки распознаны прямо в ключи
+        // полей типа, поэтому маппинг тождественный (колонка→одноимённое поле).
+        var tag = (group.Tags ?? []).FirstOrDefault(t => GostTableFields.ColumnsForTag(t) is not null);
+        if (tag is not null)
+        {
+            var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+            var targetType = allTypes.FirstOrDefault(t => SchemaTags.TypeHasTag(t, allTypes, tag));
+            if (targetType is not null)
+            {
+                var cols = JsonSerializer.Deserialize<CachedColumnInfo[]>(group.TableColumns ?? "[]", CachedSchemaJson) ?? [];
+                source.SetMaterialization(targetType.Id, JsonSerializer.Serialize(cols.ToDictionary(c => c.Name, c => c.Name)));
+            }
+        }
         db.DataSetSources.Add(source);
         await db.SaveChangesAsync(ct);
         return DataSetDtoMapper.MapSource(source);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
@@ -34,10 +34,17 @@ public record GostGroupingData(IReadOnlyList<GostGroupingGroup> Groups, bool Man
 /// источник-проекция «Документы» несли ФайлПуть без предварительного анкер-источника. Null — обложка/
 /// титул или сбой разрезания.</param>
 /// <param name="BlobSize">Размер вырезанного под-PDF в байтах (колонка РазмерБайт). Null — блоба нет.</param>
+/// <param name="TableData">Распознанные строки таблицы документа (JSON-массив) — СЫРЬЁ (issue #42):
+/// формируется при распознавании таблицы помеченной тэгом группы, живёт ЗДЕСЬ (на наборе), кандидат
+/// «Таблица …» проецирует его в источник по запросу пользователя. Null — таблица не распознана.</param>
+/// <param name="TableColumns">Схема строк таблицы (JSON [{name,sampleValues}]) — для кандидата/проекции.</param>
+/// <param name="TableStale">true — состав страниц группы изменился после распознавания таблицы: строки
+/// относятся к прежним границам, нужно перераспознать. Тэги переносятся всегда, TableData — с этим флагом.</param>
 public record GostGroupingGroup(
     GostGroupKind Kind, string? Code, string? Name, IReadOnlyList<GostGroupingPage> Pages,
     IReadOnlyList<string>? Tags = null, Guid Id = default,
-    string? BlobPath = null, long? BlobSize = null);
+    string? BlobPath = null, long? BlobSize = null,
+    string? TableData = null, string? TableColumns = null, bool TableStale = false);
 
 /// <param name="PageIndex">Индекс страницы исходного PDF (0-based).</param>
 /// <param name="Fields">Распознанные поля штампа этой страницы (без служебных ТипСтраницы/Форма).</param>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
@@ -11,7 +11,11 @@ namespace BHS.CRG.Infrastructure.DataSets;
 /// </summary>
 public static class GostStableIds
 {
-    public static GostGroupingData Assign(GostGroupingData fresh, GostGroupingData? existing)
+    /// <param name="carryUserData">true — переносить пользовательскую разметку (тэги + табличное сырьё)
+    /// с прежних групп по стабильному id: нужно при полном РЕ-РАСПОЗНАВАНИИ (свежие группы приходят без
+    /// тэгов, иначе они бы потерялись). false (ручная правка ApplyGrouping) — тэги во fresh авторитетны
+    /// (в т.ч. снятие тэга), переносим только Id.</param>
+    public static GostGroupingData Assign(GostGroupingData fresh, GostGroupingData? existing, bool carryUserData = false)
     {
         var existingGroups = existing?.Groups?.ToList() ?? [];
         var claimed = new HashSet<Guid>();
@@ -20,12 +24,13 @@ public static class GostStableIds
         foreach (var g in fresh.Groups)
         {
             var id = Guid.Empty;
+            GostGroupingGroup? matched = null;
 
             if (g.Kind is GostGroupKind.Cover or GostGroupKind.TitlePage)
             {
                 var m = existingGroups.FirstOrDefault(e =>
                     e.Kind == g.Kind && e.Id != Guid.Empty && !claimed.Contains(e.Id));
-                if (m is not null) id = m.Id;
+                if (m is not null) { id = m.Id; matched = m; }
             }
             else
             {
@@ -38,13 +43,30 @@ public static class GostStableIds
                     var overlap = e.Pages.Count(p => pages.Contains(p.PageIndex));
                     if (overlap > bestOverlap) { bestOverlap = overlap; best = e; }
                 }
-                if (best is not null && bestOverlap > 0) id = best.Id;
+                if (best is not null && bestOverlap > 0) { id = best.Id; matched = best; }
             }
 
             if (id == Guid.Empty) id = Guid.NewGuid();
             else claimed.Add(id);
 
-            result.Add(g with { Id = id });
+            // Перенос пользовательской разметки/сырья по стабильному id (issue #42) — только при полном
+            // ре-распознавании (carryUserData): тэги переносим (ручной выбор типа таблицы не теряется),
+            // табличное сырьё (TableData/Columns) тоже, но если состав страниц изменился — помечаем stale.
+            // Порог доминирования: сырьё переносим только при существенном пересечении (иначе чужая группа
+            // унаследовала бы таблицу). При ручной правке (carryUserData=false) тэги во fresh авторитетны.
+            var carried = g with { Id = id };
+            if (matched is not null && carryUserData)
+            {
+                var freshPages = g.Pages.Select(p => p.PageIndex).ToHashSet();
+                var existPages = matched.Pages.Select(p => p.PageIndex).ToHashSet();
+                var samePages = freshPages.SetEquals(existPages);
+                var overlap = freshPages.Count(existPages.Contains);
+                var dominant = overlap * 2 >= Math.Max(freshPages.Count, existPages.Count); // ≥половины большей группы
+                carried = carried with { Tags = matched.Tags ?? g.Tags };
+                if (dominant && !string.IsNullOrEmpty(matched.TableData))
+                    carried = carried with { TableData = matched.TableData, TableColumns = matched.TableColumns, TableStale = matched.TableStale || !samePages };
+            }
+            result.Add(carried);
         }
 
         return fresh with { Groups = result };

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #42. Follow-up к #38/#40.

## Модель
Таблица, распознанная по функциональному тэгу группы (спецификация/кабельный журнал), теперь формирует **СЫРЬЁ набора** (кандидат «Таблица …»), а не авто-создаёт источник. Источник-проекцию создаёт пользователь — как Обложка/Титул/Документы.

## Изменения
- `GostGroupingGroup` += `TableData`/`TableColumns`/`TableStale` — сырьё таблицы на группе (в `Grouping`).
- `RecognizeDocumentTableAsync`: vision (переиспользует `group.BlobPath`) → пишет сырьё в группу, источник НЕ создаёт; обновляет уже созданный источник-проекцию, если есть. Возврат → `GostGroupingDto?`.
- `PdfCandidatesAsync`: кандидат «Таблица — {имя}» для групп с табличным тэгом и распознанным `TableData`.
- `CreatePdfProjectionSourceAsync`: ветка `gost-table:{id}` → проекция + материализация в целевой тип по тэгу.
- `GostStableIds.Assign(carryUserData)`: полное ре-распознавание переносит тэги + табличное сырьё по стабильному id (argmax/one-to-one/порог доминирования; смена состава страниц → `TableStale`). **Заодно чинит потерю пользовательских тэгов при ре-распознавании альбома.** Ручная правка — тэги во fresh авторитетны.
- `ReprojectTableSourcesAsync`: выжившие table-источники ре-проецируются из нового `TableData`.

## Уточнения Архитектора (учтены)
Сырьё на группе (инлайн ок для старта; blob — позже при пухлых альбомах) · идентичность argmax+one-to-one+порог+stale · переиспользование `group.BlobPath` · материализация при create-source.

## Проверка
Backend **321** · frontend **106** · tsc чист. Миграций нет (`Grouping` — jsonb). Версия 0.10.0 → 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)