### PR TITLE
feat: переименование источников данных, в т.ч. PDF-проекций (#43)

### DIFF
--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -2,14 +2,14 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ChevronDown, ChevronRight, Plus, Pencil, Trash2, Copy, Eye, Filter, FunctionSquare, ArrowUpDown, Loader2,
-  BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes, LayoutGrid,
+  BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes, LayoutGrid, Type,
 } from 'lucide-react';
 import { parseSourceColumnNames, countFilterConditions } from '@/shared/api/datasetHelpers';
 import { useSourceRecognizing } from '@/shared/api/jobs';
 import {
   useDeleteDataSetSource, useDuplicateDataSetSource, useSetDataSetSourceProcessing, useListProcessingTemplates,
   usePreviewDataSetSource, useCreateProcessingTemplate, useApplyProcessingTemplate, useRecognizePdfSource, useRecognizeFile,
-  isManualGroupingConflict, exportDataSetSource, useSourceCandidates, useCreateDataSetSource,
+  isManualGroupingConflict, exportDataSetSource, useSourceCandidates, useCreateDataSetSource, useRenameSource,
 } from '@/shared/api/datasets';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { Modal } from '@/shared/ui/Modal';
@@ -91,12 +91,15 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
   const [materializing, setMaterializing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [renaming, setRenaming] = useState(false);
+  const [renameVal, setRenameVal] = useState('');
 
   const setProcessing = useSetDataSetSourceProcessing();
   const createTemplate = useCreateProcessingTemplate();
   const applyTemplateMutation = useApplyProcessingTemplate();
   const deleteMutation = useDeleteDataSetSource();
   const duplicateMutation = useDuplicateDataSetSource();
+  const renameMutation = useRenameSource();
 
   const filterCount = countFilterConditions(src.rowFilter);
   const transformCount = src.computedColumns?.length ?? 0;
@@ -145,6 +148,7 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
       { key: 'export-xls', label: 'XLS', onSelect: () => void exportDataSetSource(src.id, 'xls') },
       { key: 'export-csv', label: 'CSV', onSelect: () => void exportDataSetSource(src.id, 'csv') },
     ] },
+    { key: 'rename', label: 'Переименовать…', icon: <Type size={13} />, onSelect: () => { setRenameVal(src.name); setRenaming(true); } },
     { key: 'duplicate', label: 'Создать копию', icon: <Copy size={13} />, onSelect: () => duplicateMutation.mutate({ id: src.id }), disabled: duplicateMutation.isPending },
     { key: 'materialize', label: src.materializeTypeId ? 'Материализация (настроена)' : 'Материализация…', icon: <Boxes size={13} />, onSelect: () => setMaterializing(true) },
     ...(canManageExtraction && !isPdf ? [{ key: 'edit', label: 'Редактировать', icon: <Pencil size={13} />, onSelect: () => onEdit(src) }] : []),
@@ -206,6 +210,28 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
       )}
       {previewing && <SourcePreviewDialog source={src} onClose={() => setPreviewing(false)} />}
       {materializing && <MaterializationDialog source={src} onClose={() => setMaterializing(false)} />}
+
+      {renaming && (
+        <Modal open onOpenChange={o => { if (!o) setRenaming(false); }} title="Переименовать источник"
+          footer={
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={() => setRenaming(false)}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">Отмена</button>
+              <button type="button" disabled={!renameVal.trim() || renameMutation.isPending}
+                onClick={() => renameMutation.mutateAsync({ id: src.id, name: renameVal.trim() }).then(() => setRenaming(false))}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+                {renameMutation.isPending ? 'Сохранение…' : 'Сохранить'}
+              </button>
+            </div>
+          }>
+          <div className="min-w-[380px]">
+            <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
+            <input value={renameVal} onChange={e => setRenameVal(e.target.value)} autoFocus
+              onKeyDown={e => { if (e.key === 'Enter' && renameVal.trim()) renameMutation.mutateAsync({ id: src.id, name: renameVal.trim() }).then(() => setRenaming(false)); }}
+              className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm" />
+          </div>
+        </Modal>
+      )}
 
       <ConfirmDialog
         open={confirmDelete}

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -101,6 +101,16 @@ export function useUpdateDataSetSource() {
   });
 }
 
+/** Лёгкое переименование источника (issue #43) — только имя, для любого источника (в т.ч. PDF-проекций). */
+export function useRenameSource() {
+  const qc = useQueryClient();
+  return useMutation<DataSetSource, Error, { id: string; name: string }>({
+    mutationFn: ({ id, name }) =>
+      apiClient.put(`/datasets/sources/${id}/name`, { name }).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['datasets', 'files'] }),
+  });
+}
+
 /** Настроить/снять материализацию источника в тип (issue #19). typeId=null снимает. */
 export function useSetMaterialization() {
   const qc = useQueryClient();

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -140,6 +140,19 @@ public static class DataSetEndpoints
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
+        // Лёгкое переименование источника (issue #43) — только имя, без extraction/кэша; для любого
+        // источника, включая PDF-проекции (у них полный PUT /sources/{id} неприменим).
+        g.MapPut("/sources/{sourceId:guid}/name", async (
+            Guid sourceId, RenameSourceRequest req, IDataSetService svc, CancellationToken ct) =>
+        {
+            try
+            {
+                var result = await svc.RenameSourceAsync(sourceId, req.Name, ct);
+                return result is null ? Results.NotFound() : Results.Ok(result);
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
         g.MapDelete("/sources/{sourceId:guid}", async (Guid sourceId, IDataSetService svc, CancellationToken ct) =>
         {
             try { return await svc.DeleteSourceAsync(sourceId, ct) ? Results.NoContent() : Results.NotFound(); }
@@ -360,6 +373,7 @@ public static class DataSetEndpoints
     private record AutoMapRequest(AutoMapFieldDto[] Fields);
     private record AutoMapFieldDto(string Key, string Title);
     private record SourceRequest(string Name, string SheetOrPath, ColumnExprDto[]? ColumnExpressions);
+    private record RenameSourceRequest(string Name);
     private record MaterializationRequest(Guid? TypeId, Dictionary<string, string>? Mapping);
     private record ProcessingRequest(object? RowFilter, object? ComputedColumns, object? SortSpec);
     private record ProcessingTemplateRequest(

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -32,6 +32,9 @@ public interface IDataSetService
     /// <summary>Предпросмотр материализации источника (строки → объекты формы типа).</summary>
     Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, CancellationToken ct);
     Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct);
+    /// <summary>Лёгкое переименование источника (issue #43) — только имя, без extraction/кэша; для любого
+    /// источника, включая PDF-проекции.</summary>
+    Task<DataSetSourceDto?> RenameSourceAsync(Guid sourceId, string name, CancellationToken ct);
     Task<bool> DeleteSourceAsync(Guid sourceId, CancellationToken ct);
 
     /// <summary>Копия источника (тот же locator/колонки/Filter/Transformation/Sort) на том же файле — доступно для любого формата.</summary>

--- a/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
@@ -106,6 +106,14 @@ public class DataSetSource : Entity
         TouchUpdatedAt();
     }
 
+    /// <summary>Лёгкое переименование источника (issue #43) — только имя, не трогает локатор/колонки/кэш.
+    /// Применимо к любому источнику, включая PDF-проекции (у них UpdateDefinition недоступен).</summary>
+    public void Rename(string name)
+    {
+        Name = name.Trim();
+        TouchUpdatedAt();
+    }
+
     /// <summary>Ручное редактирование источника пользователем (имя, локатор, колонки).</summary>
     public void UpdateDefinition(string name, string sheetOrPath, string? columnExpressions)
     {

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -51,6 +51,8 @@ public class DataSetService(
         sources.MaterializePreviewAsync(sourceId, maxRows, ct);
     public Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct) =>
         sources.UpdateSourceAsync(sourceId, input, ct);
+    public Task<DataSetSourceDto?> RenameSourceAsync(Guid sourceId, string name, CancellationToken ct) =>
+        sources.RenameSourceAsync(sourceId, name, ct);
     public Task<bool> DeleteSourceAsync(Guid sourceId, CancellationToken ct) =>
         sources.DeleteSourceAsync(sourceId, ct);
     public Task<DataSetSourceDto?> DuplicateSourceAsync(Guid sourceId, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -292,6 +292,18 @@ public class DataSetSourceService(
         return DataSetDtoMapper.MapSource(source);
     }
 
+    // Лёгкое переименование (issue #43) — только имя, без парсинга/кэша; применимо к любому источнику
+    // (включая PDF-проекции, для которых полное UpdateSource недоступно).
+    public async Task<DataSetSourceDto?> RenameSourceAsync(Guid sourceId, string name, CancellationToken ct)
+    {
+        var source = await db.DataSetSources.FirstOrDefaultAsync(s => s.Id == sourceId, ct);
+        if (source == null) return null;
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Укажите название.");
+        source.Rename(name);
+        await db.SaveChangesAsync(ct);
+        return DataSetDtoMapper.MapSource(source);
+    }
+
     public async Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct)
     {
         var source = await db.DataSetSources.Include(s => s.File).FirstOrDefaultAsync(s => s.Id == sourceId, ct);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #43.

Лёгкое переименование любого источника (только имя, без extraction/кэша):
- Domain: `DataSetSource.Rename`.
- API: `RenameSourceAsync` + `PUT /datasets/sources/{id}/name`.
- Фронт: `useRenameSource` + пункт «Переименовать...» в kebab-меню строки источника + диалог.

Применимо к PDF-проекциям (Обложка/Титул/Документы/Таблица), для которых полный UpdateSource недоступен.
Версия 0.11.0 -> 0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)