### PR TITLE
fix: вычисляемые колонки видны в маппинге материализации/полей документа (#49)

### DIFF
--- a/src/client/src/features/document-sets/editor/ApplyTemplateDialog.tsx
+++ b/src/client/src/features/document-sets/editor/ApplyTemplateDialog.tsx
@@ -16,9 +16,14 @@ function ColumnMatchPreview({
   template: DataSetBindingTemplate;
   source: DataSetSource;
 }) {
+  // Вычисляемые колонки (Transformation) не персистятся в cachedSchema — без их алиасов шаблон,
+  // ссылающийся на такую колонку, ложно считался бы «не совпадающим» (issue #49).
   const availableColumns = useMemo<Set<string>>(
-    () => new Set(parseSourceColumnNames(source.cachedSchema)),
-    [source.cachedSchema],
+    () => {
+      const computedAliases = (source.computedColumns ?? []).map(c => c.alias).filter(Boolean);
+      return new Set([...parseSourceColumnNames(source.cachedSchema), ...computedAliases]);
+    },
+    [source.cachedSchema, source.computedColumns],
   );
 
   const entries = Object.entries(template.columnMappings).filter(([, col]) => col);

--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -45,7 +45,12 @@ export function MappingEditor({
   /** Скрыть селектор «Режим использования» (для материализации на источнике — режима нет). */
   hideModeSelector?: boolean;
 }) {
-  const columnNames = useMemo(() => parseSourceColumnNames(source.cachedSchema), [source.cachedSchema]);
+  // Вычисляемые колонки (Transformation) не персистятся в cachedSchema — доступны для маппинга только
+  // если их алиасы явно домешать (issue #49; тот же паттерн, что в SourcesExpander.tsx).
+  const columnNames = useMemo(() => {
+    const computedAliases = (source.computedColumns ?? []).map(c => c.alias).filter(Boolean);
+    return [...new Set([...parseSourceColumnNames(source.cachedSchema), ...computedAliases])];
+  }, [source.cachedSchema, source.computedColumns]);
 
   // Поля, доступные для маппинга: для скалярного режима — поля документа,
   // для табличного — поля типа элемента (составной тип для `array`;

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.14.0</Version>
+    <Version>0.14.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #49.

## Причина
Вычисляемые колонки (Transformation) не персистятся в `cachedSchema`. `MappingEditor` (материализация + маппинг полей документа) и `ColumnMatchPreview` (превью применения шаблона) брали список колонок только из `cachedSchema`, игнорируя `source.computedColumns` — вычисляемая колонка (напр. «НомерСхемы») не появлялась ни в одном маппинге и ложно считалась «не совпадающей» при просмотре шаблона.

## Фикс
Домешиваем алиасы `computedColumns` к списку колонок — тем же паттерном, что уже был в `SourcesExpander.tsx`.

## Проверка
tsc чист · frontend 106. Только фронт, бэкенд не менялся. Версия 0.14.0 → 0.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)