### PR TITLE
feat: ленивое извлечение «ТекстЛиста» документа — субстрат для regex-извлечения доп-полей (#51)

### DIFF
--- a/src/client/src/features/datasets/PdfGroupingEditor.tsx
+++ b/src/client/src/features/datasets/PdfGroupingEditor.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { ArrowLeft, ChevronDown, Loader2, Pencil, Trash2, AlertTriangle, Save, ZoomIn, Table2, RefreshCw } from 'lucide-react';
+import { ArrowLeft, ChevronDown, Loader2, Pencil, Trash2, AlertTriangle, Save, ZoomIn, Table2, RefreshCw, FileText } from 'lucide-react';
 import {
-  useFilePages, useApplyGrouping, useRecognizeDocumentTable, useRecognizeDocument,
+  useFilePages, useApplyGrouping, useRecognizeDocumentTable, useRecognizeDocument, useRecognizeDocumentText,
   loadPageThumbnailUrl, loadPageImageUrl,
 } from '@/shared/api/datasets';
 import type { GostGroupingGroup, GostGroupKind } from '@/shared/api/types';
@@ -210,7 +210,7 @@ function SelectionActionBar({
 function GroupSection({
   fileId, group, otherGroups, selected, suspiciousOnly, dirty,
   onToggle, onRename, onMoveSelected, onSplitSelected, onDisband, onView, onSetTag,
-  onRecognizeTable, onRecognizeDoc, tableBusyPage, docBusyPage,
+  onRecognizeTable, onRecognizeDoc, onRecognizeText, tableBusyPage, docBusyPage, textBusyPage,
 }: {
   fileId: string;
   group: EditableGroup;
@@ -227,8 +227,10 @@ function GroupSection({
   onSetTag: (groupId: string, tag: string) => void;
   onRecognizeTable: (firstPageIndex: number) => void;
   onRecognizeDoc: (firstPageIndex: number) => void;
+  onRecognizeText: (firstPageIndex: number) => void;
   tableBusyPage: number | null;
   docBusyPage: number | null;
+  textBusyPage: number | null;
 }) {
   const [editing, setEditing] = useState(false);
   const [codeVal, setCodeVal] = useState(group.code);
@@ -303,6 +305,12 @@ function GroupSection({
               Таблица
             </button>
           )}
+          <button onClick={() => onRecognizeText(firstPage)} disabled={dirty || textBusyPage === firstPage}
+            title={dirty ? 'Сначала сохраните разбиение' : 'Извлечь весь текст документа (для регулярных выражений в вычисляемых колонках)'}
+            className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-base disabled:opacity-50">
+            {textBusyPage === firstPage ? <Loader2 size={12} className="animate-spin" /> : <FileText size={12} />}
+            Текст
+          </button>
           <button onClick={() => onRecognizeDoc(firstPage)} disabled={dirty || docBusyPage === firstPage}
             title={dirty ? 'Сначала сохраните разбиение' : 'Перераспознать только этот документ (не весь набор)'}
             className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-base disabled:opacity-50">
@@ -345,6 +353,7 @@ export function PdfGroupingEditor() {
   const applyMutation = useApplyGrouping(fileId!);
   const recognizeTable = useRecognizeDocumentTable(fileId!);
   const recognizeDoc = useRecognizeDocument(fileId!);
+  const recognizeText = useRecognizeDocumentText(fileId!);
 
   const [groups, setGroups] = useState<EditableGroup[] | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -500,8 +509,10 @@ export function PdfGroupingEditor() {
             onSetTag={handleSetTag}
             onRecognizeTable={p => recognizeTable.mutate(p)}
             onRecognizeDoc={p => recognizeDoc.mutate(p)}
+            onRecognizeText={p => recognizeText.mutate(p)}
             tableBusyPage={recognizeTable.isPending ? (recognizeTable.variables ?? null) : null}
             docBusyPage={recognizeDoc.isPending ? (recognizeDoc.variables ?? null) : null}
+            textBusyPage={recognizeText.isPending ? (recognizeText.variables ?? null) : null}
           />
         ))}
 

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -312,6 +312,16 @@ export function useRecognizeDocumentTable(fileId: string) {
   });
 }
 
+/** Извлечь ВЕСЬ текст документа (issue #51) — лениво, по запросу; колонка «ТекстЛиста» в реестре «Документы». */
+export function useRecognizeDocumentText(fileId: string) {
+  const qc = useQueryClient();
+  return useMutation<{ jobId?: string }, unknown, number>({
+    mutationFn: (firstPageIndex) =>
+      apiClient.post(`/datasets/files/${fileId}/recognize-text`, { firstPageIndex }).then(r => r.data),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['jobs', 'active'] }); },
+  });
+}
+
 // ── Обработка источника (Filter/Transformation/Sort) — лёгкая правка, файл не трогает ─────
 
 export function useSetDataSetSourceProcessing() {

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -306,6 +306,17 @@ public static class DataSetEndpoints
             return Results.Accepted($"/api/jobs/active", new { jobId });
         });
 
+        // Извлечь ВЕСЬ текст документа (issue #51) — лениво, по запросу. Vision-вызов → фоновая задача.
+        g.MapPost("/files/{fileId:guid}/recognize-text", async (
+            Guid fileId, RecognizeTableRequest req, IJobService jobs, ClaimsPrincipal user, CancellationToken ct) =>
+        {
+            if (await jobs.HasActiveForTargetAsync(UserId(user), fileId, ct))
+                return Results.Conflict(new { error = "По этому набору уже идёт распознавание." });
+            var payload = JsonSerializer.Serialize(new { firstPageIndex = req.FirstPageIndex });
+            var jobId = await jobs.EnqueueAsync(JobKind.RecognizeDocumentText, UserId(user), fileId, "Извлечение текста документа", payload, ct);
+            return Results.Accepted($"/api/jobs/active", new { jobId });
+        });
+
         // Точечное перераспознавание ОДНОГО документа набора (не всего альбома, P6) → фоновая задача.
         g.MapPost("/files/{fileId:guid}/recognize-document", async (
             Guid fileId, RecognizeTableRequest req, IJobService jobs, ClaimsPrincipal user, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -95,6 +95,10 @@ public interface IDataSetService
     /// пишет строки как СЫРЬЁ на группу (Grouping) — доступна как кандидат «Таблица …», источник создаёт
     /// пользователь (issue #42). Источника НЕ создаёт. firstPageIndex — любая страница документа.</summary>
     Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct);
+    /// <summary>Извлечь ВЕСЬ текст документа (issue #51), лениво по запросу пользователя — колонка
+    /// «ТекстЛиста» в реестре «Документы», субстрат для вычисляемых колонок (regex-извлечение доп-полей).
+    /// Без гейта по тэгу/типу (в отличие от таблиц). firstPageIndex — любая страница документа.</summary>
+    Task<GostGroupingDto?> RecognizeDocumentTextAsync(Guid fileId, int firstPageIndex, CancellationToken ct);
 
     /// <summary>Пути XML-записей внутри ZIP-файла — для выбора при ручном создании источника.</summary>
     Task<IReadOnlyList<string>> ListZipXmlEntriesAsync(Guid fileId, CancellationToken ct);

--- a/src/server/BHS.CRG.Domain/Jobs/Job.cs
+++ b/src/server/BHS.CRG.Domain/Jobs/Job.cs
@@ -13,6 +13,8 @@ public enum JobKind
     AssembleDocumentSet = 3,
     /// <summary>Отправка собранного комплекта подписчикам по email (вложение/ссылка).</summary>
     SendEmail = 4,
+    /// <summary>Извлечение всего текста документа (issue #51) — лениво, по запросу пользователя.</summary>
+    RecognizeDocumentText = 5,
 }
 
 /// <summary>Статус фоновой задачи. Активные (для индикатора) — Queued/Running.</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
@@ -526,8 +526,10 @@ public class DataSetPdfRecognitionService(
     private async Task RefreshProjectionSourcesAsync(Guid fileId, ProjectedRows projected, CancellationToken ct)
     {
         var coverColumnPaths = GostCoverTitleFields.All.Select(f => f.Path).ToArray();
+        // ТекстЛиста (issue #51) — извлекается лениво, колонка в схеме всегда, значение пустое, пока
+        // пользователь не запросил извлечение для конкретного документа.
         var documentsColumnPaths = GostTitleBlockFields.All.Select(f => f.Path)
-            .Concat(["КоличествоЛистов", "ФайлПуть", "РазмерБайт"]).ToArray();
+            .Concat(["КоличествоЛистов", "ФайлПуть", "РазмерБайт", "ТекстЛиста"]).ToArray();
 
         static DataSetColumnInfo[] Cols(IReadOnlyList<string> paths, IReadOnlyList<IReadOnlyDictionary<string, string?>> data) =>
             paths.Select(p => new DataSetColumnInfo(p, data.Take(3).Select(r => r.TryGetValue(p, out var v) ? v ?? "" : "").ToArray())).ToArray();
@@ -838,6 +840,84 @@ public class DataSetPdfRecognitionService(
         return new GostGroupingDto(
             updated.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
             updated.ManuallyEdited, pageCount);
+    }
+
+    /// <summary>
+    /// Извлекает ВЕСЬ текст документа (issue #51) — ЛЕНИВО, по запросу пользователя (не при авто-
+    /// распознавании альбома — иначе риск truncation-отравления ответа модели на каждом листе и
+    /// раздувания Grouping без пользы, если текст нужен не для всех документов). Один vision-вызов по
+    /// под-PDF документа (не по страницам — весь документ) → результат ОДНА строка (reading-order,
+    /// join пробелом) → пишется как СЫРЬЁ на группу (SheetText), доступна как колонка «ТекстЛиста» в
+    /// реестре «Документы» — субстрат для вычисляемых колонок (regex-извлечение доп-полей).
+    /// Доступно для ЛЮБОГО документа — без гейта по тэгу/типу (в отличие от таблиц: тексту не нужно
+    /// заранее знать «форму», это просто текст). firstPageIndex — любая страница документа.
+    /// </summary>
+    public async Task<GostGroupingDto?> RecognizeDocumentTextAsync(Guid fileId, int firstPageIndex, CancellationToken ct)
+    {
+        var file = await db.DataSetFiles.Include(f => f.Sources).FirstOrDefaultAsync(f => f.Id == fileId, ct);
+        if (file == null) return null;
+        if (file.Format != DataSetFormat.Pdf)
+            throw new ArgumentException("Извлечение текста доступно только для PDF-набора.");
+
+        var grouping = ParseGrouping(file.Grouping);
+        var group = grouping?.Groups.FirstOrDefault(
+            g => g.Kind == GostGroupKind.Document && g.Pages.Any(p => p.PageIndex == firstPageIndex));
+        if (group is null)
+            throw new ArgumentException("Документ с указанной страницей не найден в группировке.");
+
+        // Под-PDF документа для vision: переиспользуем уже вырезанный при распознавании блок (group.BlobPath,
+        // issue #38) — не режем заново. Fallback — вырезать из полного PDF (старые наборы без BlobPath).
+        byte[] subPdf;
+        if (!string.IsNullOrEmpty(group.BlobPath))
+        {
+            await using var s = await blob.DownloadAsync(group.BlobPath, ct);
+            using var m = new MemoryStream();
+            await s.CopyToAsync(m, ct);
+            subPdf = m.ToArray();
+        }
+        else
+        {
+            await using var s = await blob.DownloadAsync(file.BlobPath, ct);
+            using var m = new MemoryStream();
+            await s.CopyToAsync(m, ct);
+            var pageIndices = group.Pages.Select(p => p.PageIndex).OrderBy(i => i).ToList();
+            try { subPdf = PdfPageSplitter.ExtractPages(m.ToArray(), pageIndices); }
+            catch (Exception ex) { throw new ArgumentException($"Не удалось выделить страницы документа: {ex.Message}"); }
+        }
+
+        RecognitionResult result;
+        try
+        {
+            result = await recognizer.RecognizeAsync(subPdf, "application/pdf",
+                [DocumentTextFields.Field], RecognitionShared.BuildFullTextPrompt, ct: ct);
+        }
+        catch (Exception ex) when (ex is RecognitionUnavailableException or RecognitionLimitException)
+        {
+            throw new ArgumentException($"Распознавание недоступно: {ex.Message}");
+        }
+
+        var text = result.Values.GetValueOrDefault(DocumentTextFields.Path) ?? "";
+        var docName = string.IsNullOrWhiteSpace(group.Name) ? "документ" : group.Name;
+
+        var updatedText = grouping! with
+        {
+            Groups = grouping.Groups
+                .Select(gg => gg.Id == group.Id ? gg with { SheetText = text, SheetTextStale = false } : gg)
+                .ToList(),
+        };
+        file.SetGrouping(JsonSerializer.Serialize(updatedText));
+        // Реестр «Документы» уже мог существовать (пользователь создал источник из кандидата) — обновляем
+        // его кэш новой проекцией, тем же паттерном, что RefreshProjectionSourcesAsync у авто-распознавания.
+        await RefreshProjectionSourcesAsync(file.Id, GostGroupingProjection.Project(updatedText), ct);
+        await db.SaveChangesAsync(ct);
+
+        await notifications.PublishAsync(NotificationSeverity.Info, "Текст документа извлечён",
+            $"«{docName}» — {text.Length} символов. Доступен в колонке «ТекстЛиста» источника «Документы».", "Распознавание PDF", ct: ct);
+
+        var pageCountText = await GetPdfPageCountAsync(file.BlobPath, ct);
+        return new GostGroupingDto(
+            updatedText.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
+            updatedText.ManuallyEdited, pageCountText);
     }
 
     /// <summary>Точечное перераспознавание ОДНОГО документа (P6): заново распознаёт только страницы его

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -87,6 +87,8 @@ public class DataSetService(
         pdfRecognition.SetDocumentTagsAsync(fileId, firstPageIndex, tags, ct);
     public Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct) =>
         pdfRecognition.RecognizeDocumentTableAsync(fileId, firstPageIndex, ct);
+    public Task<GostGroupingDto?> RecognizeDocumentTextAsync(Guid fileId, int firstPageIndex, CancellationToken ct) =>
+        pdfRecognition.RecognizeDocumentTextAsync(fileId, firstPageIndex, ct);
 
     // ── Processing templates ────────────────────────────────────────────────────
     public Task<IReadOnlyList<DataSetProcessingTemplateDto>> ListProcessingTemplatesAsync(CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
@@ -40,11 +40,20 @@ public record GostGroupingData(IReadOnlyList<GostGroupingGroup> Groups, bool Man
 /// <param name="TableColumns">Схема строк таблицы (JSON [{name,sampleValues}]) — для кандидата/проекции.</param>
 /// <param name="TableStale">true — состав страниц группы изменился после распознавания таблицы: строки
 /// относятся к прежним границам, нужно перераспознать. Тэги переносятся всегда, TableData — с этим флагом.</param>
+/// <param name="SheetText">Весь текст документа (issue #51) — все страницы группы, reading-order
+/// (сверху-вниз, слева-направо), одна строка (join пробелом). СЫРЬЁ: извлекается ЛЕНИВО по запросу
+/// пользователя (не при авто-распознавании альбома — иначе риск truncation-отравления ответа модели
+/// и раздувания Grouping без пользы, если текст нужен не для всех документов). Доступен как колонка
+/// «ТекстЛиста» в реестре «Документы» — субстрат для вычисляемых колонок (напр. regex-извлечение
+/// доп-полей). Null — не извлечён.</param>
+/// <param name="SheetTextStale">true — состав страниц группы изменился после извлечения текста (аналог
+/// TableStale) — текст относится к прежним границам, нужно извлечь заново.</param>
 public record GostGroupingGroup(
     GostGroupKind Kind, string? Code, string? Name, IReadOnlyList<GostGroupingPage> Pages,
     IReadOnlyList<string>? Tags = null, Guid Id = default,
     string? BlobPath = null, long? BlobSize = null,
-    string? TableData = null, string? TableColumns = null, bool TableStale = false);
+    string? TableData = null, string? TableColumns = null, bool TableStale = false,
+    string? SheetText = null, bool SheetTextStale = false);
 
 /// <param name="PageIndex">Индекс страницы исходного PDF (0-based).</param>
 /// <param name="Fields">Распознанные поля штампа этой страницы (без служебных ТипСтраницы/Форма).</param>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingProjection.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingProjection.cs
@@ -54,6 +54,10 @@ public static class GostGroupingProjection
                         fields["ФайлПуть"] = group.BlobPath;
                         fields["РазмерБайт"] = group.BlobSize?.ToString() ?? "";
                     }
+                    // Весь текст документа (issue #51) — из ЛЕНИВОГО извлечения (RecognizeDocumentTextAsync),
+                    // не при авто-распознавании альбома. Null, пока пользователь не запросил извлечение.
+                    if (!string.IsNullOrEmpty(group.SheetText))
+                        fields["ТекстЛиста"] = group.SheetText;
                     documents.Add(new ProjectedDocument(
                         group.Id, group.Code ?? "", group.Name, group.Pages.Select(p => p.PageIndex).ToList(), fields));
                     break;

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
@@ -65,6 +65,9 @@ public static class GostStableIds
                 carried = carried with { Tags = matched.Tags ?? g.Tags };
                 if (dominant && !string.IsNullOrEmpty(matched.TableData))
                     carried = carried with { TableData = matched.TableData, TableColumns = matched.TableColumns, TableStale = matched.TableStale || !samePages };
+                // Извлечённый текст документа (issue #51) — тот же перенос, что TableData.
+                if (dominant && !string.IsNullOrEmpty(matched.SheetText))
+                    carried = carried with { SheetText = matched.SheetText, SheetTextStale = matched.SheetTextStale || !samePages };
             }
             result.Add(carried);
         }

--- a/src/server/BHS.CRG.Infrastructure/Jobs/JobBackgroundService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Jobs/JobBackgroundService.cs
@@ -81,6 +81,11 @@ public class JobBackgroundService(
                         .RecognizeDocumentTableAsync(targetId, ParseFirstPageIndex(payload), ct);
                     break;
 
+                case JobKind.RecognizeDocumentText:
+                    await scope.ServiceProvider.GetRequiredService<DataSetPdfRecognitionService>()
+                        .RecognizeDocumentTextAsync(targetId, ParseFirstPageIndex(payload), ct);
+                    break;
+
                 case JobKind.AssembleDocumentSet:
                     await scope.ServiceProvider.GetRequiredService<DocumentSetAssemblyService>()
                         .AssembleAsync(targetId, ParseInstanceIds(payload), userId, ct, (c, t) => report("документов", c, t));

--- a/src/server/BHS.CRG.Infrastructure/Recognition/DocumentTextFields.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/DocumentTextFields.cs
@@ -1,0 +1,18 @@
+using BHS.CRG.Application.QualityDocs;
+
+namespace BHS.CRG.Infrastructure.Recognition;
+
+/// <summary>
+/// Поле для ленивого извлечения всего текста документа (issue #51) — по образцу InvoiceFields/
+/// GostTableFields, но проще: один скалярный вызов вместо реестра колонок. Субстрат для
+/// вычисляемых колонок (напр. regex-извлечение доп-полей: ТекстЛиста.match(/паттерн/)).
+/// </summary>
+public static class DocumentTextFields
+{
+    /// <summary>Ключ поля в проекции «Документы» и в ответе распознавателя.</summary>
+    public const string Path = "ТекстЛиста";
+
+    public static readonly RecognitionField Field = new(Path,
+        "Весь текст документа одной строкой: все страницы по порядку, на каждой странице — сверху вниз, " +
+        "слева направо; фрагменты объединены ОДНИМ пробелом, без переносов строк", "string");
+}

--- a/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionShared.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionShared.cs
@@ -119,6 +119,22 @@ public static class RecognitionShared
         return sb.ToString();
     }
 
+    /// <summary>Промпт для ленивого извлечения ВСЕГО текста документа (issue #51) — субстрат для
+    /// пользовательских вычисляемых колонок (regex и т.п.), не структурированные поля.</summary>
+    public static string BuildFullTextPrompt(IReadOnlyList<RecognitionField> fields)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Ты извлекаешь ВЕСЬ текст документа (скан-копия, одна или несколько страниц) для");
+        sb.AppendLine("последующего текстового поиска. Включай весь читаемый текст: штампы, таблицы, подписи,");
+        sb.AppendLine("примечания — ничего не пропускай и не суммаризируй.");
+        AppendCommonInstructions(sb, fields);
+        sb.AppendLine();
+        sb.Append("Поле ").Append(DocumentTextFields.Path)
+          .AppendLine(" — верни ОДНОЙ строкой: страницы по порядку следования, на каждой странице —");
+        sb.AppendLine("сверху вниз, слева направо; фрагменты раздели ОДНИМ пробелом. Без переносов строк и markdown.");
+        return sb.ToString();
+    }
+
     private static void AppendCommonInstructions(StringBuilder sb, IReadOnlyList<RecognitionField> fields)
     {
         sb.AppendLine("Извлеки значения СТРОГО для перечисленных полей. Ответ — один JSON-объект {\"путь\": \"значение\"} без markdown и пояснений.");

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.14.1</Version>
+    <Version>0.15.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #51.

## Формулировка (после дизайн-прохода с Архитектором)
Пользователь: для определённых документов нужно извлекать доп-информацию с листа по своему шаблону (regex). Гранулярность — одно значение на документ.

## Решение — БЕЗ новой подсистемы
Композиция уже существующего:
`ТекстЛиста (субстрат, лениво) → вычисляемая колонка с regex (Jint) → маппинг (#49) → материализация (#19)`

## Дизайн-корректировки Архитектора
- **Ленивое, opt-in per-документ** извлечение (кнопка «Текст» в редакторе разбиения) — НЕ универсальный пасс-1 на каждый лист (риск truncation-отравления ответа модели + раздувание `Grouping` без пользы).
- **Гранулярность — на документ**, не на лист (подтверждено пользователем).
- Без гейта по тэгу/типу (в отличие от таблиц — тексту не нужно заранее знать «форму»).

## Реализация
- `GostGroupingGroup` += `SheetText`/`SheetTextStale` — сырьё на группе, перенос по стабильному id при ре-распознавании (тот же паттерн, что `TableData` из #42).
- `RecognizeDocumentTextAsync(fileId, firstPageIndex)` — переиспользует уже вырезанный под-PDF документа, пишет сырьё, ре-проецирует источник «Документы».
- `JobKind.RecognizeDocumentText` + `POST /files/{fileId}/recognize-text` (фоновая задача).
- Кнопка «Текст» в редакторе разбиения рядом с «Таблица»/«Перераспознать».

## Проверка
Backend **321** · frontend **106** · tsc чист. Миграций нет (`Grouping` — jsonb). Версия 0.14.1 → 0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)