### PR TITLE
fix(requisites): обязательное поле со скалярной привязкой к набору данных больше не блокирует сохранение

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -49,11 +49,24 @@ function SourceBoundDocField() {
   );
 }
 
-function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef }: {
+/// Компактный индикатор для скалярного поля, заполняемого привязкой (issue #55): иконка в строке
+/// лейбла (тот же слот, что занимает тип-хинт) вместо полноразмерной плашки — иначе при «один
+/// биндинг → много полей» форма превращается в стену одинаковых боксов.
+function SourceBoundBadge({ onGoToDataTab }: { onGoToDataTab: () => void }) {
+  return (
+    <button type="button" onClick={onGoToDataTab}
+      title="Заполняется из привязанного источника данных — открыть вкладку «Данные»"
+      className="ml-1 inline-flex align-middle text-brand hover:text-brand-hover">
+      <Database size={11} />
+    </button>
+  );
+}
+
+function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef, onGoToDataTab }: {
   instance: DocumentInstance; setId: string; schemaFields: SchemaField[];
   allDocTypes: DocumentType[]; docType: DocumentType | undefined;
   otherInstances: DocumentInstance[]; onClose: () => void;
-  onDirty: (dirty: boolean) => void; saveRef: SaveRef;
+  onDirty: (dirty: boolean) => void; saveRef: SaveRef; onGoToDataTab: () => void;
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const [values, setValues] = useState<Record<string, unknown>>(() => ({ ...instance.requisites }));
@@ -63,13 +76,24 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const mutation = useUpdateRequisites();
 
-  // Поля-ссылки на документы, заполняемые табличной связкой источника (issue #17):
-  // источник перезаписывает поле при генерации, поэтому ручной ввод для них отключаем.
+  // Поля, заполняемые привязкой к набору данных при генерации — источник перезаписывает их,
+  // поэтому ручной ввод отключаем и не требуем от формы реквизитов (issue #55):
+  // табличные (targetFieldKey, issue #17) + скалярные (ключи мэппинга, issue #55). Для скалярной
+  // привязки эффективный маппинг — собственный (binding.mapping), а если он пуст — с материализации
+  // источника (binding.source.materializeMapping, issue #19), см. DataSetMappingValue.EffectiveMappingJson.
   const { data: dsBindings = [] } = useListDataSetBindings({ instanceId: instance.id });
-  const sourceBoundFields = useMemo(
-    () => new Set(dsBindings.filter(b => b.targetFieldKey).map(b => b.targetFieldKey!)),
-    [dsBindings],
-  );
+  const sourceBoundFields = useMemo(() => {
+    const s = new Set<string>();
+    for (const b of dsBindings) {
+      if (b.targetFieldKey) { s.add(b.targetFieldKey); continue; }
+      const effectiveMapping = Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {});
+      for (const key of Object.keys(effectiveMapping)) s.add(key);
+    }
+    return s;
+  }, [dsBindings]);
+  // Обязательное поле, покрытое активной привязкой, не блокирует сохранение реквизитов —
+  // значение подставится при генерации (DataSetResolver.InjectAsync), форма его не хранит.
+  const isFieldMissing = (f: SchemaField, val: unknown) => isMissing(f, val) && !sourceBoundFields.has(f.key);
 
   function getPrimitiveDef(field: SchemaField): PrimitiveTypeDef | undefined {
     if (field.type !== 'primitive') return undefined;
@@ -100,7 +124,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   // Сохраняет реквизиты. Возвращает true при успехе. НЕ закрывает редактор.
   async function handleSaveCore(): Promise<boolean> {
     setError('');
-    const missingRequired = schemaFields.filter(f => isMissing(f, values[f.key]));
+    const missingRequired = schemaFields.filter(f => isFieldMissing(f, values[f.key]));
     if (missingRequired.length > 0) {
       setShowValidation(true);
       setError(`Заполните обязательные поля: ${missingRequired.map(f => f.title).join(', ')}`);
@@ -147,7 +171,8 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
         {fields.map(field => {
           const raw = values[field.key];
-          const missing = showValidation && isMissing(field, raw);
+          const missing = showValidation && isFieldMissing(field, raw);
+          const bound = sourceBoundFields.has(field.key);
           const primitiveDef = getPrimitiveDef(field);
           const constraintError = constraintErrors[field.key];
           const hasError = missing || !!constraintError;
@@ -161,6 +186,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
                     {!field.required && <span className="ml-1 text-[10px] text-fg4 font-normal">опц.</span>}
+                    {bound && <SourceBoundBadge onGoToDataTab={onGoToDataTab} />}
                   </label>
                 )}
                 {field.type === 'complex' ? (
@@ -202,7 +228,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                 ) : (
                   <PrimitiveInput field={field} value={raw}
                     onChange={v => setValue(field.key, v, primitiveDef)}
-                    invalid={hasError} primitiveTypeDef={primitiveDef} />
+                    invalid={hasError} primitiveTypeDef={primitiveDef} readOnly={bound} />
                 )}
                 {missing && <p className="text-xs text-danger mt-1">Обязательное поле</p>}
                 {!missing && constraintError && <p className="text-xs text-danger mt-1">{constraintError}</p>}
@@ -219,10 +245,11 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                 {primitiveDef && (
                   <span className="ml-1 text-[10px] text-fg4 font-normal">· {primitiveDef.name}</span>
                 )}
+                {bound && <SourceBoundBadge onGoToDataTab={onGoToDataTab} />}
               </label>
               <PrimitiveInput field={field} value={raw}
                 onChange={v => setValue(field.key, v, primitiveDef)}
-                invalid={hasError} primitiveTypeDef={primitiveDef} />
+                invalid={hasError} primitiveTypeDef={primitiveDef} readOnly={bound} />
               {missing && <p className="text-[11px] text-danger mt-0.5">Обязательное поле</p>}
               {!missing && constraintError && <p className="text-[11px] text-danger mt-0.5">{constraintError}</p>}
             </div>
@@ -241,7 +268,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
           return <div key={section.key}>{renderFields(section.fields)}</div>;
         }
         const isExpanded = expandedGroups.has(section.key);
-        const hasMissing = showValidation && section.fields.some(f => isMissing(f, values[f.key]));
+        const hasMissing = showValidation && section.fields.some(f => isFieldMissing(f, values[f.key]));
         return (
           <div key={section.key} className="border border-stroke rounded-lg overflow-hidden">
             <button type="button"
@@ -651,7 +678,8 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
       {tab === 'requisites' && (
         <RequisitesTab instance={instance} setId={setId} schemaFields={schemaFields}
           allDocTypes={allDocTypes} docType={docType} otherInstances={otherInstances}
-          onClose={onClose} onDirty={setDirty} saveRef={saveRef} />
+          onClose={onClose} onDirty={setDirty} saveRef={saveRef}
+          onGoToDataTab={() => requestTab('datasets')} />
       )}
       {tab === 'datasets' && (
         <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">

--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -40,18 +40,18 @@ export function validateConstraint(value: unknown, def: PrimitiveTypeDef): strin
   return null;
 }
 
-export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeDef }: {
+export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeDef, readOnly }: {
   field: SchemaField; value: unknown; onChange: (val: unknown) => void; invalid: boolean;
-  primitiveTypeDef?: PrimitiveTypeDef;
+  primitiveTypeDef?: PrimitiveTypeDef; readOnly?: boolean;
 }) {
   const strVal = value == null ? '' : String(value);
-  const cls = fieldInputClass(invalid);
+  const cls = fieldInputClass(invalid, readOnly);
   if (field.type === 'text')
-    return <textarea value={strVal} onChange={e => onChange(e.target.value)} rows={3} className={cls + ' resize-y'} />;
+    return <textarea value={strVal} onChange={e => onChange(e.target.value)} rows={3} readOnly={readOnly} className={cls + ' resize-y'} />;
   if (field.type === 'boolean')
     return (
       <label className="flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" checked={!!value} onChange={e => onChange(e.target.checked)} className="w-4 h-4 rounded border-stroke-strong text-brand" />
+        <input type="checkbox" checked={!!value} onChange={e => onChange(e.target.checked)} disabled={readOnly} className="w-4 h-4 rounded border-stroke-strong text-brand" />
         <span className="text-sm text-fg2">{field.title}</span>
       </label>
     );
@@ -60,7 +60,7 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
     if (opts.length === 0)
       return <p className="text-xs text-fg4 italic py-1">Нет вариантов — добавьте их в схеме типа документа</p>;
     return (
-      <select value={strVal} onChange={e => onChange(e.target.value)} className={cls}>
+      <select value={strVal} onChange={e => onChange(e.target.value)} disabled={readOnly} className={cls}>
         <option value="">— выберите —</option>
         {opts.map(opt => <option key={opt} value={opt}>{opt}</option>)}
       </select>
@@ -69,7 +69,7 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
   if (field.type === 'primitive' && primitiveTypeDef) {
     const bt = primitiveTypeDef.baseType;
     if (bt === 'date') {
-      return <DateInput value={strVal} onChange={v => onChange(v)} className={cls} />;
+      return <DateInput value={strVal} onChange={v => onChange(v)} className={cls} disabled={readOnly} />;
     }
     const step = bt === 'number' && primitiveTypeDef.constraints.integer ? 1 : undefined;
     return (
@@ -78,6 +78,7 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
         step={step}
         placeholder={primitiveTypeDef.description}
         value={strVal}
+        readOnly={readOnly}
         onChange={e => {
           const v = e.target.value;
           onChange(bt === 'number' ? (v === '' ? '' : Number(v)) : v);
@@ -87,12 +88,13 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
     );
   }
   if (field.type === 'date') {
-    return <DateInput value={strVal} onChange={v => onChange(v)} className={cls} />;
+    return <DateInput value={strVal} onChange={v => onChange(v)} className={cls} disabled={readOnly} />;
   }
   return (
     <input
       type={field.type === 'number' ? 'number' : 'text'}
       value={strVal}
+      readOnly={readOnly}
       onChange={e => {
         const v = e.target.value;
         onChange(field.type === 'number' ? (v === '' ? '' : Number(v)) : v);

--- a/src/client/src/features/document-sets/fields/constants.ts
+++ b/src/client/src/features/document-sets/fields/constants.ts
@@ -17,7 +17,10 @@ export const SCOPE_COLORS: Record<CatalogScope, string> = {
   System: 'bg-muted text-fg2',
 };
 
-export function fieldInputClass(invalid = false) {
+export function fieldInputClass(invalid = false, readOnly = false) {
+  if (readOnly) {
+    return 'w-full border rounded-md px-3 py-2 text-sm text-fg3 bg-muted border-stroke cursor-not-allowed';
+  }
   return `w-full border rounded-md px-3 py-2 text-sm text-fg1 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface ${
     invalid ? 'border-danger focus-visible:ring-danger' : 'border-stroke-strong'
   }`;

--- a/src/client/src/shared/ui/DateInput.tsx
+++ b/src/client/src/shared/ui/DateInput.tsx
@@ -7,9 +7,10 @@ interface DateInputProps {
   onChange: (iso: string) => void;
   /** Applied to the outer container div (border, bg, padding, focus-within:ring, width) */
   className?: string;
+  disabled?: boolean;
 }
 
-export function DateInput({ value, onChange, className = '' }: DateInputProps) {
+export function DateInput({ value, onChange, className = '', disabled = false }: DateInputProps) {
   const [d, setD] = useState('');
   const [m, setM] = useState('');
   const [y, setY] = useState('');
@@ -110,7 +111,8 @@ export function DateInput({ value, onChange, className = '' }: DateInputProps) {
 
   const seg = [
     'border-0 outline-none bg-transparent text-center min-w-0 p-0',
-    'focus:bg-brand-subtle rounded-sm tabular-nums',
+    disabled ? 'cursor-not-allowed' : 'focus:bg-brand-subtle',
+    'rounded-sm tabular-nums',
   ].join(' ');
 
   return (
@@ -120,6 +122,7 @@ export function DateInput({ value, onChange, className = '' }: DateInputProps) {
         placeholder="ДД" maxLength={2}
         style={{ width: '2.2ch' }}
         value={d}
+        disabled={disabled}
         onChange={e => handleD(e.target.value)}
         onKeyDown={onDayKey}
         onFocus={onFocus}
@@ -132,6 +135,7 @@ export function DateInput({ value, onChange, className = '' }: DateInputProps) {
         placeholder="ММ" maxLength={2}
         style={{ width: '2.2ch' }}
         value={m}
+        disabled={disabled}
         onChange={e => handleM(e.target.value)}
         onKeyDown={onMonKey}
         onFocus={onFocus}
@@ -144,6 +148,7 @@ export function DateInput({ value, onChange, className = '' }: DateInputProps) {
         placeholder="ГГГГ" maxLength={4}
         style={{ width: '4ch' }}
         value={y}
+        disabled={disabled}
         onChange={e => handleY(e.target.value)}
         onKeyDown={onYrKey}
         onFocus={onFocus}

--- a/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
+++ b/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
@@ -21,7 +21,7 @@ public record BindingFileDto(Guid Id, string Name, string Format, string Scope, 
 
 public record BindingSourceDto(
     Guid Id, string Name, string SheetOrPath, string CachedSchema, int CachedRowCount, BindingFileDto? File,
-    Guid? MaterializeTypeId = null);
+    Guid? MaterializeTypeId = null, Dictionary<string, string>? MaterializeMapping = null);
 
 /// <summary>Привязка — только Mapping. Filter/Transformation/Sort живут на DataSetSource.
 /// Владелец — ровно одно из InstanceId/CommonDataEntryId задано.</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -84,7 +84,8 @@ public static class DataSetDtoMapper
             b.Source.File is null ? null : new BindingFileDto(
                 b.Source.File.Id, b.Source.File.Name, b.Source.File.Format.ToString(),
                 b.Source.File.Scope.ToString(), b.Source.File.ScopeId),
-            b.Source.MaterializeTypeId));
+            b.Source.MaterializeTypeId,
+            b.Source.MaterializeMapping is null ? null : JsonSerializer.Deserialize<Dictionary<string, string>>(b.Source.MaterializeMapping)));
 
     public static DataSetBindingTemplateDto MapTemplate(DataSetBindingTemplate t) => new(
         t.Id, t.DocumentTypeId, t.Name, t.TargetFieldKey,

--- a/src/server/BHS.CRG.Tests/Integration/DataSetServiceTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetServiceTests.cs
@@ -211,4 +211,31 @@ public class DataSetServiceTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Assert.Single(list);
         Assert.Equal(src.Id, list[0].SourceId);
     }
+
+    [Fact]
+    public async Task Binding_MaterializedSource_ExposesMaterializeMappingOnSource()
+    {
+        // issue #55: клиент вычисляет "эффективный маппинг" скалярной привязки (какие поля
+        // реквизитов она реально покрывает) без похода на сервер — для этого DataSetBindingDto.Source
+        // должен нести MaterializeMapping (не только MaterializeTypeId), см. DataSetDtoMapper.MapBinding.
+        var typeId = await CreateDocumentTypeAsync();
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var (_, src) = await UploadCsvWithSourceAsync(scope);
+        await svc.SetMaterializationAsync(src.Id, typeId, new() { ["Поле"] = "A" }, default);
+
+        var entry = await scope.ServiceProvider.GetRequiredService<MediatR.IMediator>().Send(
+            new CreateCommonDataEntryCommand("Запись", typeId, JsonDocument.Parse("{}"),
+                BHS.CRG.Domain.Catalog.CatalogScope.System, null));
+        // Своя привязка без явного маппинга — эффективный маппинг берётся с материализации источника.
+        await svc.CreateBindingAsync(new CreateBindingInput(null, entry.Id, src.Id, null, null), default);
+
+        var list = await svc.ListBindingsAsync(null, entry.Id, default);
+        var binding = Assert.Single(list);
+        Assert.Empty(binding.Mapping);
+        Assert.NotNull(binding.Source);
+        Assert.Equal(typeId, binding.Source!.MaterializeTypeId);
+        Assert.NotNull(binding.Source.MaterializeMapping);
+        Assert.Equal("A", binding.Source.MaterializeMapping!["Поле"]);
+    }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.15.0</Version>
+    <Version>0.15.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Проблема

У документа есть обязательное поле реквизитов. Пользователь заполняет его через привязку к
набору данных (скалярный `DataSetBinding`, без `targetFieldKey`) вместо ручного ввода. Форма
реквизитов ничего не знала о таких привязках — `isMissing`/валидация смотрели только на локальное
значение формы, поле навсегда оставалось "не заполнено" и блокировало сохранение реквизитов, хотя
при генерации PDF значение реально подставляется (`DataSetResolver.InjectAsync`).

Существующий прецедент (`sourceBoundFields`, issue #17) уже отключал ручной ввод для табличных
привязок (`targetFieldKey` задан), но не покрывал скалярный случай.

## Консультация

Взял в работу по итогам консультации с Архитектором и Дизайнером (agentId в памяти проекта) —
обсуждали в т.ч. целесообразность переноса самого назначения привязки на поля реквизитов. Оба
согласились, что это избыточно для масштаба бага и плохо ложится на пакетную модель данных
(один биндинг = источник + маппинг сразу на много полей). Решение: узкий фикс валидации +
компактный индикатор с переходом на вкладку "Данные", без изменения модели создания привязок.

## Изменения

- **Backend**: `BindingSourceDto` теперь несёт `MaterializeMapping` (не только `MaterializeTypeId`) —
  нужно клиенту, чтобы резолвить эффективный маппинг скалярной привязки, когда её собственный
  `Mapping` пуст и используется материализация источника (issue #19).
- **Frontend**: `sourceBoundFields` в `RequisitesTab` расширен — покрывает и скалярные привязки
  (ключи `mapping`, либо `source.materializeMapping` как fallback). Такое поле:
  - не учитывается как "не заполнено" при валидации сохранения реквизитов;
  - рендерится read-only (тот же инпут, та же геометрия — не отдельная плашка);
  - получает иконку-индикатор в строке лейбла (переиспользует слот тип-хинта) со ссылкой на
    переход на вкладку "Данные".
- `PrimitiveInput`/`DateInput`/`fieldInputClass` — добавлена поддержка `readOnly`/`disabled`.

## Test plan

- [x] `dotnet test` — 329/329 (добавлен `Binding_MaterializedSource_ExposesMaterializeMappingOnSource`)
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 106/106
- [x] API поднимается и мигрирует без ошибок
- [ ] Живая проверка на реальном документе с обязательным полем + скалярной привязкой

🤖 Generated with [Claude Code](https://claude.com/claude-code)