### PR TITLE
fix(documents): удаление типа документа проверяет использование

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -6,6 +6,7 @@ import {
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { apiError } from '@/shared/utils/apiError';
 import {
   useListDocumentTypes,
   useCreateDocumentType,
@@ -724,7 +725,9 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
         description={<p>Это повлияет на все документы и шаблоны, использующие этот тип. Действие необратимо.</p>}
         confirmLabel={`Удалить тип «${docType.name}»`}
         requireCheckbox="Понимаю, что это необратимо"
-        onConfirm={() => deleteMutation.mutate(docType.id)}
+        onConfirm={() => deleteMutation.mutate(docType.id, {
+          onError: err => alert(apiError(err, 'Не удалось удалить тип.')),
+        })}
       />
     </div>
   );

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -43,7 +43,7 @@ public static class DocumentTypeEndpoints
         admin.MapPut("/{id:guid}", async (Guid id, UpdateTypeRequest req, IMediator m) =>
         {
             try { return Results.Ok(await m.Send(new UpdateDocumentTypeCommand(id, req.Name, req.Code, req.ParentId))); }
-            catch (InvalidOperationException ex) { return Results.Conflict(ex.Message); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
         admin.MapPut("/{id:guid}/schema", async (Guid id, UpdateSchemaRequest req, IMediator m)
@@ -59,7 +59,7 @@ public static class DocumentTypeEndpoints
         admin.MapDelete("/{id:guid}", async (Guid id, IMediator m) =>
         {
             try { await m.Send(new DeleteDocumentTypeCommand(id)); return Results.NoContent(); }
-            catch (InvalidOperationException ex) { return Results.Conflict(ex.Message); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
     }
 

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -37,6 +37,9 @@ public interface IDataSetService
     Task<DataSetSourceDto?> RenameSourceAsync(Guid sourceId, string name, CancellationToken ct);
     Task<bool> DeleteSourceAsync(Guid sourceId, CancellationToken ct);
 
+    /// <summary>Есть ли источник, материализуемый в documentTypeId (issue #57 — проверка перед удалением типа документа).</summary>
+    Task<bool> AnySourceMaterializedAsTypeAsync(Guid documentTypeId, CancellationToken ct);
+
     /// <summary>Копия источника (тот же locator/колонки/Filter/Transformation/Sort) на том же файле — доступно для любого формата.</summary>
     Task<DataSetSourceDto?> DuplicateSourceAsync(Guid sourceId, CancellationToken ct);
 

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -1,12 +1,20 @@
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Templates;
 using MediatR;
 
 namespace BHS.CRG.Application.Documents;
 
-public class DocumentTypeHandlers(IRepository<DocumentType> repo) :
+public class DocumentTypeHandlers(
+    IRepository<DocumentType> repo,
+    IRepository<DocumentInstance> instanceRepo,
+    IRepository<Template> templateRepo,
+    IRepository<QualityDocument> qualityDocRepo,
+    IRepository<CommonDataEntry> commonDataEntryRepo,
+    IDataSetService dataSetService) :
     IRequestHandler<CreateDocumentTypeCommand, DocumentType>,
     IRequestHandler<UpdateDocumentTypeCommand, DocumentType>,
     IRequestHandler<UpdateDocumentTypeSchemaCommand, DocumentType>,
@@ -104,12 +112,47 @@ public class DocumentTypeHandlers(IRepository<DocumentType> repo) :
         return dt;
     }
 
+    // issue #57: удаление типа не проверяло использование — документы/шаблоны/записи каталога,
+    // созданные на его основе, оставались с "висячей" ссылкой (ни FK в БД, ни прикладной проверки не
+    // было ни для одной из этих точек). Ниже — прикладная проверка (по образцу уже существовавшей
+    // ParentId-проверки и DataSetSourceService.DeleteSourceAsync), а не настоящий FK в БД: единственный
+    // реальный FK в модели — self-reference ParentId (дерево внутри одной таблицы), все остальные
+    // межагрегатные ссылки в проекте уже сознательно "мягкие" (CommonDataEntry.CompositeTypeId,
+    // DataSetSource.MaterializeTypeId и т.д.) — вводить здесь исключение было бы немотивированным
+    // расхождением с конвенцией, а не усилением защиты.
     public async Task Handle(DeleteDocumentTypeCommand cmd, CancellationToken ct)
     {
         var dt = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
         var all = await repo.GetAllAsync(ct);
         if (all.Any(x => x.ParentId == cmd.Id))
             throw new InvalidOperationException("Нельзя удалить тип, от которого наследуются другие типы.");
+
+        if ((await instanceRepo.FindAsync(i => i.DocumentTypeId == cmd.Id, ct)).Count > 0)
+            throw new InvalidOperationException("Нельзя удалить тип — по нему уже созданы документы.");
+
+        if ((await templateRepo.FindAsync(t => t.DocumentTypeId == cmd.Id, ct)).Count > 0)
+            throw new InvalidOperationException("Нельзя удалить тип — для него есть шаблоны.");
+
+        if ((await qualityDocRepo.FindAsync(q => q.DocumentTypeId == cmd.Id, ct)).Count > 0)
+            throw new InvalidOperationException("Нельзя удалить тип — есть документы качества этого типа.");
+
+        if ((await commonDataEntryRepo.FindAsync(e => e.CompositeTypeId == cmd.Id, ct)).Count > 0)
+            throw new InvalidOperationException("Нельзя удалить тип — есть записи каталога этого типа.");
+
+        if ((await dataSetService.ListTemplatesAsync(cmd.Id, ct)).Count > 0)
+            throw new InvalidOperationException("Нельзя удалить тип — для него есть шаблоны привязки наборов данных.");
+
+        if (await dataSetService.AnySourceMaterializedAsTypeAsync(cmd.Id, ct))
+            throw new InvalidOperationException("Нельзя удалить тип — на него материализован источник набора данных.");
+
+        // Тип может использоваться как составной подтип внутри схемы ДРУГОГО типа (complex/array/
+        // doc-ref/doc-array поле с typeId == cmd.Id) — сам себя (собственную схему) не проверяем,
+        // иначе self-referential составной тип (напр. дерево) стал бы неудаляемым навсегда.
+        var usedInSchemas = all.Where(t => t.Id != cmd.Id && DocumentTypeSchemaReader.ReferencesType(t.Schema, cmd.Id)).ToList();
+        if (usedInSchemas.Count > 0)
+            throw new InvalidOperationException(
+                $"Нельзя удалить тип — используется как составной подтип в схеме: {string.Join(", ", usedInSchemas.Select(t => t.Name))}.");
+
         repo.Remove(dt);
         await repo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
+++ b/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
@@ -67,6 +67,18 @@ public static class DocumentTypeSchemaReader
     public static SchemaFieldInfo? Field(Guid typeId, string key, IReadOnlyDictionary<Guid, DocumentType> byId)
         => EffectiveFields(typeId, byId).FirstOrDefault(f => f.Key == key);
 
+    /// <summary>
+    /// Ссылается ли схема (СОБСТВЕННЫЕ поля типа — без резолва наследования) на составной/ссылочный
+    /// тип documentTypeId через complex/array/doc-ref/doc-array поле (issue #57, п.7 — проверка перед
+    /// удалением типа документа). Наследование резолвить не нужно: ссылка typeId хранится там, где
+    /// поле было изначально объявлено, а не синтезируется заново для каждого потомка.
+    /// </summary>
+    public static bool ReferencesType(JsonDocument schema, Guid documentTypeId)
+    {
+        var (fields, _, _) = ParseSchema(schema);
+        return fields.Any(f => f.TypeId == documentTypeId && (IsSingleComposite(f.Type) || IsMultiValued(f.Type)));
+    }
+
     /// <summary>true, если childId == ancestorId либо childId — потомок ancestorId по ParentId.</summary>
     public static bool IsSameOrDescendant(Guid childId, Guid ancestorId, IReadOnlyDictionary<Guid, DocumentType> byId)
     {

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -55,6 +55,8 @@ public class DataSetService(
         sources.RenameSourceAsync(sourceId, name, ct);
     public Task<bool> DeleteSourceAsync(Guid sourceId, CancellationToken ct) =>
         sources.DeleteSourceAsync(sourceId, ct);
+    public Task<bool> AnySourceMaterializedAsTypeAsync(Guid documentTypeId, CancellationToken ct) =>
+        sources.AnySourceMaterializedAsTypeAsync(documentTypeId, ct);
     public Task<DataSetSourceDto?> DuplicateSourceAsync(Guid sourceId, CancellationToken ct) =>
         sources.DuplicateSourceAsync(sourceId, ct);
     public Task<IReadOnlyList<string>> ListZipXmlEntriesAsync(Guid fileId, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -383,6 +383,9 @@ public class DataSetSourceService(
         return true;
     }
 
+    public Task<bool> AnySourceMaterializedAsTypeAsync(Guid documentTypeId, CancellationToken ct) =>
+        db.DataSetSources.AnyAsync(s => s.MaterializeTypeId == documentTypeId, ct);
+
     // Человекочитаемое описание, где именно используется источник (для сообщения об ошибке
     // удаления) — по DocumentInstance (документ + комплект) и по CommonDataEntry (запись каталога).
     private async Task<List<string>> DescribeBindingUsagesAsync(List<DataSetBinding> bindings, CancellationToken ct)

--- a/src/server/BHS.CRG.Tests/Integration/DocumentTypeHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentTypeHandlerTests.cs
@@ -1,5 +1,9 @@
 using System.Text.Json;
+using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Application.Templates;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,8 +18,19 @@ public class DocumentTypeHandlerTests(IntegrationTestFixture fixture) : IAsyncLi
 
     private IMediator Mediator(IServiceScope scope) =>
         scope.ServiceProvider.GetRequiredService<IMediator>();
+    private IDataSetService DataSets(IServiceScope scope) =>
+        scope.ServiceProvider.GetRequiredService<IDataSetService>();
 
     private static JsonDocument EmptySchema() => JsonDocument.Parse(@"{""fields"":[]}");
+
+    private async Task<Guid> CreateSetAsync(IServiceScope scope)
+    {
+        var m = Mediator(scope);
+        var c = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "Раздел"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, "Комплект"));
+        return set.Id;
+    }
 
     // ── Create ────────────────────────────────────────────────────────────────
 
@@ -144,5 +159,145 @@ public class DocumentTypeHandlerTests(IntegrationTestFixture fixture) : IAsyncLi
         using var scope2 = fixture.Services.CreateScope();
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             Mediator(scope2).Send(new DeleteDocumentTypeCommand(parent.Id)));
+    }
+
+    // issue #57: удаление типа не проверяло использование — ниже тесты на каждую из добавленных проверок.
+
+    [Fact]
+    public async Task Delete_Unused_Succeeds()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Неиспользуемый", "UNUSED1", DocumentTypeKind.Document, null, EmptySchema()));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id));
+
+        using var scope3 = fixture.Services.CreateScope();
+        Assert.Null(await Mediator(scope3).Send(new GetDocumentTypeQuery(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_WithDocumentInstance_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Тип с документом", "DI1", DocumentTypeKind.Document, null, EmptySchema()));
+        var setId = await CreateSetAsync(scope);
+        await Mediator(scope).Send(new AddDocumentToSetCommand(setId, dt.Id));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_WithTemplate_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Тип с шаблоном", "TPL1", DocumentTypeKind.Document, null, EmptySchema()));
+        await Mediator(scope).Send(new CreateTemplateCommand(dt.Id, "Шаблон", "= Заголовок"));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_WithQualityDocument_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Тип документа качества", "QD1", DocumentTypeKind.Document, null, EmptySchema()));
+        await Mediator(scope).Send(new CreateQualityDocumentCommand(
+            dt.Id, "Сертификат", EmptySchema(), CatalogScope.System, null, QualityDocSource.Manual, null, null, null));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_WithCommonDataEntry_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Составной тип", "CDE1", DocumentTypeKind.Composite, null, EmptySchema()));
+        await Mediator(scope).Send(new CreateCommonDataEntryCommand(
+            "Запись", dt.Id, JsonDocument.Parse("{}"), CatalogScope.System, null));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_WithBindingTemplate_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Тип с шаблоном привязки", "BT1", DocumentTypeKind.Document, null, EmptySchema()));
+        await DataSets(scope).CreateTemplateAsync(dt.Id, new CreateTemplateInput("Маппинг", null, null), default);
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_WithMaterializedSource_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = DataSets(scope);
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Тип материализации", "MAT1", DocumentTypeKind.Composite, null, EmptySchema()));
+
+        var csv = System.Text.Encoding.UTF8.GetBytes("A,B\n1,2\n");
+        var file = await svc.UploadFileAsync(new UploadFileInput(csv, "t.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Данные", candidate.SheetOrPath, null), default);
+        await svc.SetMaterializationAsync(source.Id, dt.Id, new(), default);
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(dt.Id)));
+    }
+
+    [Fact]
+    public async Task Delete_ReferencedAsComplexFieldInOtherTypeSchema_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var composite = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Организация", "ORG1", DocumentTypeKind.Composite, null, EmptySchema()));
+        var userSchema = JsonDocument.Parse(
+            $$"""{"fields":[{"key":"org","type":"complex","typeId":"{{composite.Id}}"}]}""");
+        await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Договор", "CTR1", DocumentTypeKind.Document, null, userSchema));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteDocumentTypeCommand(composite.Id)));
+        Assert.Contains("Договор", ex.Message);
+    }
+
+    [Fact]
+    public async Task Delete_SelfReferentialSchema_DoesNotBlockOwnDeletion()
+    {
+        // Составной тип, чья СОБСТВЕННАЯ схема ссылается сам на себя (напр. дерево) — самоссылка не
+        // должна учитываться при проверке "кто использует этот тип", иначе тип станет неудаляемым навсегда.
+        using var scope = fixture.Services.CreateScope();
+        var created = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Узел дерева", "TREE1", DocumentTypeKind.Composite, null, EmptySchema()));
+        var selfRefSchema = JsonDocument.Parse(
+            $$"""{"fields":[{"key":"children","type":"array","typeId":"{{created.Id}}"}]}""");
+        using var scope2 = fixture.Services.CreateScope();
+        await Mediator(scope2).Send(new UpdateDocumentTypeSchemaCommand(created.Id, selfRefSchema));
+
+        using var scope3 = fixture.Services.CreateScope();
+        await Mediator(scope3).Send(new DeleteDocumentTypeCommand(created.Id));
+
+        using var scope4 = fixture.Services.CreateScope();
+        Assert.Null(await Mediator(scope4).Send(new GetDocumentTypeQuery(created.Id)));
     }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.15.1</Version>
+    <Version>0.15.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Проблема

Удаление типа документа (`DELETE /api/document-types/{id}`) проверяло только наследование
(`ParentId`). Документы, шаблоны и другие сущности, созданные на основе типа, оставались с
"висячей" ссылкой на несуществующий тип — доступ к их данным (схема, реквизиты, генерация)
ломался, хотя JSON-данные физически оставались в БД.

## Консультация

Взял в работу по итогам консультации с Архитектором (agentId в памяти проекта). Полная
инвентаризация точек использования и решение по scope — см. issue #57 и комментарий там же.

## Изменения

Прикладная проверка перед удалением (НЕ FK в БД — единственный реальный FK в модели,
self-reference `ParentId`, не годится образцом для межагрегатных ссылок, которые везде в
проекте сознательно "мягкие"; `DocumentTypeHandlers.Handle(DeleteDocumentTypeCommand)`):

1. `DocumentInstance.DocumentTypeId` — есть документы этого типа
2. `Template.DocumentTypeId` — есть шаблоны
3. `QualityDocument.DocumentTypeId` — есть документы качества
4. `CommonDataEntry.CompositeTypeId` — есть записи каталога
5. `DataSetBindingTemplate.DocumentTypeId` (через `IDataSetService.ListTemplatesAsync`) — есть шаблоны привязки
6. `DataSetSource.MaterializeTypeId` (новый метод `IDataSetService.AnySourceMaterializedAsTypeAsync`) — есть материализованный источник
7. `DocumentType.Schema` других типов — тип используется как составной подтип (`complex`/`array`/`doc-ref`/`doc-array` поле с `typeId`), новый метод `DocumentTypeSchemaReader.ReferencesType`. Собственная схема удаляемого типа не проверяется — иначе self-referential составной тип (дерево) стал бы неудаляемым.

**Осознанно не реализовано** (см. комментарий в issue): ссылки `@@ref:{"typeId":"..."}` внутри
`DataSetBinding.Mapping`/`DataSetSource.MaterializeMapping` — резолвер уже деградирует мягко
для dangling-ссылок (лог + `ResolutionDiagnostic`), отдельная статическая проверка не оправдана.

## Test plan

- [x] `dotnet test` — 338/338 (9 новых тестов: по одному на каждую точку 1-7 + happy-path + self-reference edge case)
- [x] `dotnet build` — чисто

🤖 Generated with [Claude Code](https://claude.com/claude-code)