### PR TITLE
feat(schema): переиспользуемый тип перечисления EnumType

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -3,20 +3,22 @@ import { Plus, Pencil, Trash2, Search, Link2, Unlink, ChevronDown, ChevronUp } f
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
 import { useListCommonData, useCreateCommonDataEntry, useUpdateCommonDataEntry, useDeleteCommonDataEntry } from '@/shared/api/commonData';
-import type { CommonDataEntry, DocumentType } from '@/shared/api/types';
+import type { CommonDataEntry, DocumentType, EnumTypeDef } from '@/shared/api/types';
 import { resolveEffectiveFields, groupEffectiveFields, parseSchemaFields, getDefaultValues, type SchemaField } from '@/shared/api/schema';
 import { PrimitiveInput, FileField, ImageField, SystemArrayFieldEditor, SystemComplexField, DocRefCatalogField, BaseEntryPickerModal } from './systemFields';
 
 // ─── Entry form (add / edit) ──────────────────────────────────────────────────
 
 function EntryForm({
-  entry, compositeTypes, documentTypes, allDocTypes, onClose,
+  entry, compositeTypes, documentTypes, allDocTypes, enumTypes, onClose,
 }: {
   entry: CommonDataEntry | null;
   compositeTypes: DocumentType[];
   documentTypes: DocumentType[];
   allDocTypes: DocumentType[];
+  enumTypes: EnumTypeDef[];
   onClose: () => void;
 }) {
   const [displayName, setDisplayName] = useState(entry?.displayName ?? '');
@@ -94,10 +96,10 @@ function EntryForm({
                   {field.title}{field.required && <span className="ml-0.5 text-danger">*</span>}
                 </label>
                 {field.type === 'array' ? (
-                  <SystemArrayFieldEditor field={field} allDocTypes={allDocTypes}
+                  <SystemArrayFieldEditor field={field} allDocTypes={allDocTypes} enumTypes={enumTypes}
                     value={values[field.key]} onChange={v => setValue(field.key, v)} />
                 ) : (
-                  <SystemComplexField field={field} allDocTypes={allDocTypes}
+                  <SystemComplexField field={field} allDocTypes={allDocTypes} enumTypes={enumTypes}
                     value={values[field.key]} onChange={v => setValue(field.key, v)} />
                 )}
               </div>
@@ -121,7 +123,9 @@ function EntryForm({
                 ) : field.type === 'file' ? (
                   <FileField value={values[field.key]} onChange={v => setValue(field.key, v)} />
                 ) : (
-                  <PrimitiveInput field={field} value={values[field.key]} onChange={v => setValue(field.key, v)} />
+                  <PrimitiveInput field={field} value={values[field.key]}
+                    enumTypeDef={field.type === 'enum' ? enumTypes.find(et => et.id === field.typeId) : undefined}
+                    onChange={v => setValue(field.key, v)} />
                 )}
               </>
             )}
@@ -261,6 +265,7 @@ export function SystemCommonDataPage() {
   }
 
   const { data: allDocTypes = [] } = useListDocumentTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const { data: entries = [], isLoading } = useListCommonData({ scope: 'System' });
   const deleteMutation = useDeleteCommonDataEntry();
 
@@ -414,12 +419,12 @@ export function SystemCommonDataPage() {
 
       <Modal open={addOpen} onOpenChange={setAddOpen} title="Новая запись" wide flushBody>
         {addOpen && (
-          <EntryForm entry={null} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} onClose={() => setAddOpen(false)} />
+          <EntryForm entry={null} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} enumTypes={enumTypes} onClose={() => setAddOpen(false)} />
         )}
       </Modal>
       <Modal open={!!editEntry} onOpenChange={o => { if (!o) setEditEntry(null); }} title="Редактировать запись" wide flushBody>
         {editEntry && (
-          <EntryForm entry={editEntry} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} onClose={() => setEditEntry(null)} />
+          <EntryForm entry={editEntry} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} enumTypes={enumTypes} onClose={() => setEditEntry(null)} />
         )}
       </Modal>
       <ConfirmDialog

--- a/src/client/src/features/common-data/systemFields.tsx
+++ b/src/client/src/features/common-data/systemFields.tsx
@@ -7,13 +7,13 @@ import {
 } from '@/shared/api/attachments';
 import { Modal } from '@/shared/ui/Modal';
 import { useListCommonData } from '@/shared/api/commonData';
-import type { CommonDataEntry, DocumentType, FieldRef } from '@/shared/api/types';
+import type { CommonDataEntry, DocumentType, FieldRef, EnumTypeDef } from '@/shared/api/types';
 import { isFieldRef } from '@/shared/api/types';
 import { resolveEffectiveFields, getDefaultValues, isSubtypeOf, type SchemaField } from '@/shared/api/schema';
 // ─── Primitive field input ─────────────────────────────────────────────────────
 
-export function PrimitiveInput({ field, value, onChange }: {
-  field: SchemaField; value: unknown; onChange: (v: unknown) => void;
+export function PrimitiveInput({ field, value, onChange, enumTypeDef }: {
+  field: SchemaField; value: unknown; onChange: (v: unknown) => void; enumTypeDef?: EnumTypeDef;
 }) {
   const cls = 'w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface text-fg1';
   const strVal = value == null ? '' : String(value);
@@ -27,6 +27,14 @@ export function PrimitiveInput({ field, value, onChange }: {
       </label>
     );
   if (field.type === 'enum') {
+    if (enumTypeDef) {
+      return (
+        <select value={strVal} onChange={e => onChange(e.target.value)} className={cls}>
+          <option value="">— выберите —</option>
+          {enumTypeDef.values.map(v => <option key={v.code} value={v.code}>{v.label}</option>)}
+        </select>
+      );
+    }
     const opts = (field.options ?? []).filter(o => o !== '');
     if (opts.length === 0)
       return <p className="text-xs text-fg4 italic py-1">Нет вариантов — добавьте их в схеме типа документа</p>;
@@ -307,8 +315,8 @@ function SystemRefPickerModal({ open, onOpenChange, compositeType, allDocTypes, 
 
 // ─── Array (repeating rows) field editor ─────────────────────────────────────
 
-export function SystemArrayFieldEditor({ field, allDocTypes, value, onChange }: {
-  field: SchemaField; allDocTypes: DocumentType[];
+export function SystemArrayFieldEditor({ field, allDocTypes, enumTypes, value, onChange }: {
+  field: SchemaField; allDocTypes: DocumentType[]; enumTypes: EnumTypeDef[];
   value: unknown; onChange: (v: unknown[]) => void;
 }) {
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
@@ -385,13 +393,14 @@ export function SystemArrayFieldEditor({ field, allDocTypes, value, onChange }: 
                           </label>
                         )}
                         {sf.type === 'complex' ? (
-                          <SystemComplexField field={sf} allDocTypes={allDocTypes}
+                          <SystemComplexField field={sf} allDocTypes={allDocTypes} enumTypes={enumTypes}
                             value={row[sf.key]} onChange={v => updateRow(i, { ...row, [sf.key]: v })} />
                         ) : sf.type === 'doc-ref' ? (
                           <DocRefCatalogField field={sf} allDocTypes={allDocTypes}
                             value={row[sf.key]} onChange={v => updateRow(i, { ...row, [sf.key]: v ?? undefined })} />
                         ) : (
                           <PrimitiveInput field={sf} value={row[sf.key]}
+                            enumTypeDef={sf.type === 'enum' ? enumTypes.find(et => et.id === sf.typeId) : undefined}
                             onChange={v => updateRow(i, { ...row, [sf.key]: v })} />
                         )}
                       </div>
@@ -409,8 +418,8 @@ export function SystemArrayFieldEditor({ field, allDocTypes, value, onChange }: 
 
 // ─── Complex field for system catalog entries ──────────────────────────────────
 
-export function SystemComplexField({ field, allDocTypes, value, onChange }: {
-  field: SchemaField; allDocTypes: DocumentType[];
+export function SystemComplexField({ field, allDocTypes, enumTypes, value, onChange }: {
+  field: SchemaField; allDocTypes: DocumentType[]; enumTypes: EnumTypeDef[];
   value: unknown; onChange: (v: Record<string, unknown> | FieldRef) => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -457,13 +466,15 @@ export function SystemComplexField({ field, allDocTypes, value, onChange }: {
                 </label>
               )}
               {sf.type === 'complex' ? (
-                <SystemComplexField field={sf} allDocTypes={allDocTypes}
+                <SystemComplexField field={sf} allDocTypes={allDocTypes} enumTypes={enumTypes}
                   value={subValues[sf.key]} onChange={v => onChange({ ...subValues, [sf.key]: v })} />
               ) : sf.type === 'doc-ref' ? (
                 <DocRefCatalogField field={sf} allDocTypes={allDocTypes}
                   value={subValues[sf.key]} onChange={v => onChange({ ...subValues, [sf.key]: v ?? undefined })} />
               ) : (
-                <PrimitiveInput field={sf} value={subValues[sf.key]} onChange={v => onChange({ ...subValues, [sf.key]: v })} />
+                <PrimitiveInput field={sf} value={subValues[sf.key]}
+                  enumTypeDef={sf.type === 'enum' ? enumTypes.find(et => et.id === sf.typeId) : undefined}
+                  onChange={v => onChange({ ...subValues, [sf.key]: v })} />
               )}
             </div>
           ))}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
 import { EmailSendDialog } from '../EmailSendDialog';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
 import {
   useUpdateRequisites, useGenerateDocument,
   useSetDocumentTemplates, useRenameDocumentInstance,
@@ -12,7 +13,7 @@ import {
 } from '@/shared/api/documentSets';
 import { useListTemplates } from '@/shared/api/templates';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
-import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef } from '@/shared/api/types';
+import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import {
   groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, type SchemaField,
 } from '@/shared/api/schema';
@@ -69,6 +70,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   onDirty: (dirty: boolean) => void; saveRef: SaveRef; onGoToDataTab: () => void;
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const [values, setValues] = useState<Record<string, unknown>>(() => ({ ...instance.requisites }));
   const [constraintErrors, setConstraintErrors] = useState<Record<string, string>>({});
   const [error, setError] = useState('');
@@ -94,6 +96,11 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   // Обязательное поле, покрытое активной привязкой, не блокирует сохранение реквизитов —
   // значение подставится при генерации (DataSetResolver.InjectAsync), форма его не хранит.
   const isFieldMissing = (f: SchemaField, val: unknown) => isMissing(f, val) && !sourceBoundFields.has(f.key);
+
+  function getEnumDef(field: SchemaField): EnumTypeDef | undefined {
+    if (field.type !== 'enum' || !field.typeId) return undefined;
+    return enumTypes.find(et => et.id === field.typeId);
+  }
 
   function getPrimitiveDef(field: SchemaField): PrimitiveTypeDef | undefined {
     if (field.type !== 'primitive') return undefined;
@@ -228,7 +235,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                 ) : (
                   <PrimitiveInput field={field} value={raw}
                     onChange={v => setValue(field.key, v, primitiveDef)}
-                    invalid={hasError} primitiveTypeDef={primitiveDef} readOnly={bound} />
+                    invalid={hasError} primitiveTypeDef={primitiveDef} enumTypeDef={getEnumDef(field)} readOnly={bound} />
                 )}
                 {missing && <p className="text-xs text-danger mt-1">Обязательное поле</p>}
                 {!missing && constraintError && <p className="text-xs text-danger mt-1">{constraintError}</p>}
@@ -249,7 +256,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
               </label>
               <PrimitiveInput field={field} value={raw}
                 onChange={v => setValue(field.key, v, primitiveDef)}
-                invalid={hasError} primitiveTypeDef={primitiveDef} readOnly={bound} />
+                invalid={hasError} primitiveTypeDef={primitiveDef} enumTypeDef={getEnumDef(field)} readOnly={bound} />
               {missing && <p className="text-[11px] text-danger mt-0.5">Обязательное поле</p>}
               {!missing && constraintError && <p className="text-[11px] text-danger mt-0.5">{constraintError}</p>}
             </div>

--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -1,7 +1,7 @@
 import { isoToRu, ruToISO } from '@/shared/utils/date';
 import { DateInput } from '@/shared/ui/DateInput';
 import type { SchemaField } from '@/shared/api/schema';
-import type { PrimitiveTypeDef, FieldConstraints } from '@/shared/api/types';
+import type { PrimitiveTypeDef, FieldConstraints, EnumTypeDef } from '@/shared/api/types';
 import { isFieldRef } from '@/shared/api/types';
 import { fieldInputClass } from './constants';
 
@@ -40,9 +40,9 @@ export function validateConstraint(value: unknown, def: PrimitiveTypeDef): strin
   return null;
 }
 
-export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeDef, readOnly }: {
+export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeDef, enumTypeDef, readOnly }: {
   field: SchemaField; value: unknown; onChange: (val: unknown) => void; invalid: boolean;
-  primitiveTypeDef?: PrimitiveTypeDef; readOnly?: boolean;
+  primitiveTypeDef?: PrimitiveTypeDef; enumTypeDef?: EnumTypeDef; readOnly?: boolean;
 }) {
   const strVal = value == null ? '' : String(value);
   const cls = fieldInputClass(invalid, readOnly);
@@ -56,6 +56,14 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
       </label>
     );
   if (field.type === 'enum') {
+    if (enumTypeDef) {
+      return (
+        <select value={strVal} onChange={e => onChange(e.target.value)} disabled={readOnly} className={cls}>
+          <option value="">— выберите —</option>
+          {enumTypeDef.values.map(v => <option key={v.code} value={v.code}>{v.label}</option>)}
+        </select>
+      );
+    }
     const opts = (field.options ?? []).filter(o => o !== '');
     if (opts.length === 0)
       return <p className="text-xs text-fg4 italic py-1">Нет вариантов — добавьте их в схеме типа документа</p>;

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -19,7 +19,7 @@ import {
 import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
-import type { DocumentType, DocumentTypeKind } from '@/shared/api/types';
+import type { DocumentType, DocumentTypeKind, EnumTypeDef } from '@/shared/api/types';
 import {
   parseSchemaFields,
   resolveEffectiveFields,
@@ -35,13 +35,14 @@ import { GroupEditor } from './GroupEditor';
 import { JsonPreview, FieldBuilder, DefaultValueCell } from './FieldBuilder';
 
 function InheritedFieldsPanel({
-  parentEffectiveFields, excludedFields, fieldOverrides, compositeTypes,
+  parentEffectiveFields, excludedFields, fieldOverrides, compositeTypes, enumTypes,
   onExclude, onInclude, onOverrideRequired, onOverrideDefaultValue, onResetOverride,
 }: {
   parentEffectiveFields: SchemaField[];
   excludedFields: string[];
   fieldOverrides: Record<string, { required?: boolean; defaultValue?: unknown }>;
   compositeTypes: DocumentType[];
+  enumTypes: EnumTypeDef[];
   onExclude: (key: string) => void;
   onInclude: (key: string) => void;
   onOverrideRequired: (key: string, required: boolean) => void;
@@ -115,7 +116,7 @@ function InheritedFieldsPanel({
               </div>
             ) : <span />}
             {!isExcluded
-              ? <DefaultValueCell field={field} override={override} onOverrideDefaultValue={onOverrideDefaultValue} />
+              ? <DefaultValueCell field={field} override={override} enumTypes={enumTypes} onOverrideDefaultValue={onOverrideDefaultValue} />
               : <span />
             }
             {isExcluded ? (
@@ -486,6 +487,7 @@ function SchemaEditor({ docType, allDocTypes }: {
             excludedFields={excludedFields}
             fieldOverrides={fieldOverrides}
             compositeTypes={compositeTypes}
+            enumTypes={enumTypes}
             onExclude={handleExclude}
             onInclude={handleInclude}
             onOverrideRequired={handleOverrideRequired}

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/shared/api/documentTypes';
 import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
 import type { DocumentType, DocumentTypeKind } from '@/shared/api/types';
 import {
   parseSchemaFields,
@@ -237,6 +238,7 @@ function CreateForm({
   allDocTypes: DocumentType[];
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const [name, setName] = useState('');
   const [code, setCode] = useState('');
   const [parentId, setParentId] = useState('');
@@ -361,7 +363,7 @@ function CreateForm({
         </div>
         {showJson
           ? <JsonPreview fields={fields} groups={[]} excludedFields={[]} fieldOverrides={{}} />
-          : <FieldBuilder fields={fields} onChange={setFields} disabledKeys={inheritedKeys} compositeTypes={compositeTypes} primitiveTypes={primitiveTypes} allDocTypes={allDocTypes} />}
+          : <FieldBuilder fields={fields} onChange={setFields} disabledKeys={inheritedKeys} compositeTypes={compositeTypes} primitiveTypes={primitiveTypes} enumTypes={enumTypes} allDocTypes={allDocTypes} />}
       </div>
 
       {error && <p className="text-sm text-danger">{error}</p>}
@@ -387,6 +389,7 @@ function SchemaEditor({ docType, allDocTypes }: {
   allDocTypes: DocumentType[];
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const schemaDef = docType.schema as unknown as SchemaDefinition;
   const [fields, setFields] = useState<SchemaField[]>(() => parseSchemaFields(docType.schema));
   const [groups, setGroups] = useState<FieldGroup[]>(() => schemaDef.groups ?? []);
@@ -511,7 +514,7 @@ function SchemaEditor({ docType, allDocTypes }: {
         {showJson
           ? <JsonPreview fields={fields} groups={groups} excludedFields={excludedFields} fieldOverrides={fieldOverrides} />
           : <FieldBuilder fields={fields} onChange={f => { setFields(f); setSaved(false); }}
-              disabledKeys={inheritedKeys} compositeTypes={compositeTypes} primitiveTypes={primitiveTypes} allDocTypes={allDocTypes} />}
+              disabledKeys={inheritedKeys} compositeTypes={compositeTypes} primitiveTypes={primitiveTypes} enumTypes={enumTypes} allDocTypes={allDocTypes} />}
       </div>
 
       {!showJson && effectiveFields.length > 0 && (

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/shared/api/enumTypes';
 import type { EnumOptionDef, EnumTypeDef } from '@/shared/api/types';
 import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
+import { toCamelKey } from './schemaConstants';
 
 // ─── Values editor (список код|имя) ────────────────────────────────────────────
 
@@ -70,12 +71,19 @@ function EnumForm({ initial, onSaved, onCancel }: {
   const create = useCreateEnumType();
   const update = useUpdateEnumType(initial?.id ?? '');
 
+  // См. DocumentTypesPage.handleNameChange/FieldBuilder.updateTitle — тот же принцип: код
+  // перегенерируется из названия, пока совпадает с авто-значением (или пуст); ручная правка
+  // кода отключает автогенерацию. Код не ограничен латиницей — тот же toCamelKey уже даёт
+  // кириллические PascalCase-коды для DocumentType/ключей полей, никакого спец. формата не нужно.
+  function handleNameChange(v: string) {
+    const isCodeAuto = !code.trim() || code === toCamelKey(name);
+    setName(v);
+    if (isCodeAuto) setCode(toCamelKey(v));
+  }
+
   async function handleSave() {
     if (!name.trim()) { setError('Укажите название'); return; }
     if (!code.trim()) { setError('Укажите код'); return; }
-    if (!/^[a-zA-Z][a-zA-Z0-9_]*$/.test(code.trim())) {
-      setError('Код: только латинские буквы, цифры и _'); return;
-    }
     const cleaned = values.map(v => ({ code: v.code.trim(), label: v.label.trim() })).filter(v => v.code && v.label);
     if (cleaned.length === 0) { setError('Добавьте хотя бы один вариант'); return; }
     const codes = new Set<string>();
@@ -106,7 +114,7 @@ function EnumForm({ initial, onSaved, onCancel }: {
             className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
             placeholder="Статус документа"
             value={name}
-            onChange={e => setName(e.target.value)}
+            onChange={e => handleNameChange(e.target.value)}
           />
         </div>
         <div>

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -1,0 +1,291 @@
+import { useState } from 'react';
+import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
+import { Modal } from '@/shared/ui/Modal';
+import {
+  useListEnumTypes,
+  useCreateEnumType,
+  useUpdateEnumType,
+  useDeleteEnumType,
+  useSetEnumTypeGroup,
+  buildEnumTypeDto,
+} from '@/shared/api/enumTypes';
+import type { EnumOptionDef, EnumTypeDef } from '@/shared/api/types';
+import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
+
+// ─── Values editor (список код|имя) ────────────────────────────────────────────
+
+function ValuesEditor({ values, onChange }: { values: EnumOptionDef[]; onChange: (v: EnumOptionDef[]) => void }) {
+  function update(i: number, patch: Partial<EnumOptionDef>) {
+    onChange(values.map((v, vi) => vi === i ? { ...v, ...patch } : v));
+  }
+  function remove(i: number) {
+    onChange(values.filter((_, vi) => vi !== i));
+  }
+  return (
+    <div className="space-y-1.5">
+      <div className="grid grid-cols-[1fr_1fr_auto] gap-1.5 text-xs text-fg4 px-0.5">
+        <span>Код</span>
+        <span>Отображаемое имя</span>
+        <span />
+      </div>
+      {values.map((v, i) => (
+        <div key={i} className="grid grid-cols-[1fr_1fr_auto] gap-1.5 items-center">
+          <input
+            value={v.code}
+            onChange={e => update(i, { code: e.target.value })}
+            placeholder="APPROVED"
+            className="border border-stroke-strong rounded px-2 py-1 text-xs font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-brand bg-surface"
+          />
+          <input
+            value={v.label}
+            onChange={e => update(i, { label: e.target.value })}
+            placeholder="Согласован"
+            className="border border-stroke-strong rounded px-2 py-1 text-xs focus:outline-none focus-visible:ring-1 focus-visible:ring-brand bg-surface"
+          />
+          <button type="button" onClick={() => remove(i)} className="p-0.5 text-fg4 hover:text-danger">
+            <Trash2 size={12} />
+          </button>
+        </div>
+      ))}
+      <button type="button"
+        onClick={() => onChange([...values, { code: '', label: '' }])}
+        className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover">
+        <Plus size={11} /> Добавить вариант
+      </button>
+    </div>
+  );
+}
+
+// ─── Enum form (инлайн для редактирования строки, в модалке для создания) ─────
+
+function EnumForm({ initial, onSaved, onCancel }: {
+  initial?: EnumTypeDef; onSaved: () => void; onCancel: () => void;
+}) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [code, setCode] = useState(initial?.code ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [values, setValues] = useState<EnumOptionDef[]>(initial?.values ?? []);
+  const [error, setError] = useState('');
+
+  const create = useCreateEnumType();
+  const update = useUpdateEnumType(initial?.id ?? '');
+
+  async function handleSave() {
+    if (!name.trim()) { setError('Укажите название'); return; }
+    if (!code.trim()) { setError('Укажите код'); return; }
+    if (!/^[a-zA-Z][a-zA-Z0-9_]*$/.test(code.trim())) {
+      setError('Код: только латинские буквы, цифры и _'); return;
+    }
+    const cleaned = values.map(v => ({ code: v.code.trim(), label: v.label.trim() })).filter(v => v.code && v.label);
+    if (cleaned.length === 0) { setError('Добавьте хотя бы один вариант'); return; }
+    const codes = new Set<string>();
+    for (const v of cleaned) {
+      if (codes.has(v.code)) { setError(`Код «${v.code}» повторяется`); return; }
+      codes.add(v.code);
+    }
+    setError('');
+    const dto = buildEnumTypeDto(name.trim(), code.trim(), description.trim() || undefined, cleaned);
+    try {
+      if (initial) await update.mutateAsync(dto);
+      else await create.mutateAsync(dto);
+      onSaved();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Ошибка сохранения');
+    }
+  }
+
+  const isPending = create.isPending || update.isPending;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
+            placeholder="Статус документа"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-fg1 mb-1">Код</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm font-mono"
+            placeholder="status"
+            value={code}
+            onChange={e => setCode(e.target.value)}
+            disabled={!!initial}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-fg1 mb-1">Описание</label>
+        <input
+          type="text"
+          className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
+          placeholder="Необязательное описание типа"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+      </div>
+
+      <div className="border-t border-stroke pt-3">
+        <p className="text-sm font-medium text-fg1 mb-3">Варианты</p>
+        <ValuesEditor values={values} onChange={setValues} />
+      </div>
+
+      {error && <p className="text-sm text-danger">{error}</p>}
+
+      <div className="flex justify-end gap-2 border-t border-stroke pt-3">
+        <button type="button" onClick={onCancel}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">
+          Отмена
+        </button>
+        <button type="button" onClick={handleSave} disabled={isPending}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+          {isPending ? 'Сохранение…' : 'Сохранить'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+function EnumTypeRow({ type, allGroups, expanded, onToggle }: {
+  type: EnumTypeDef; allGroups: string[]; expanded: boolean; onToggle: () => void;
+}) {
+  const deleteMutation = useDeleteEnumType();
+  const groupMutation = useSetEnumTypeGroup();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    setDeleteError('');
+    setConfirmDelete(true);
+  }
+
+  return (
+    <div className={`overflow-hidden group ${expanded ? 'bg-base' : ''}`}>
+      <div className="flex items-center hover:bg-base transition-colors">
+        <button onClick={onToggle}
+          className="flex-1 min-w-0 flex items-center gap-2 px-4 py-2.5 text-left">
+          {expanded
+            ? <ChevronUp size={15} className="text-fg4 shrink-0" />
+            : <ChevronDown size={15} className="text-fg4 shrink-0" />}
+          <span className="text-sm font-medium text-fg1 shrink-0">{type.name}</span>
+          <span className="text-xs text-fg4 font-mono shrink-0">{type.code}</span>
+          <span className="flex-1" />
+          <span className="text-xs text-fg4 shrink-0 truncate max-w-[280px]">
+            {type.values.length === 0
+              ? <span className="italic">нет вариантов</span>
+              : type.values.map(v => v.label).join(', ')}
+          </span>
+        </button>
+        <span className="pr-1" onClick={e => e.stopPropagation()}>
+          <GroupPicker groups={allGroups} value={type.group}
+            onChange={group => groupMutation.mutate({ id: type.id, group })} />
+        </span>
+        <button onClick={handleDelete} disabled={deleteMutation.isPending}
+          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30"
+          title="Удалить">
+          <Trash2 size={14} />
+        </button>
+      </div>
+      {expanded && (
+        <div className="px-4 pb-5 pt-3 border-t border-stroke bg-base">
+          <EnumForm initial={type} onSaved={onToggle} onCancel={onToggle} />
+        </div>
+      )}
+      {confirmDelete && (
+        <Modal open onOpenChange={o => { if (!o) setConfirmDelete(false); }} title="Удалить тип перечисления"
+          footer={
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted"
+              >
+                Отмена
+              </button>
+              <button
+                type="button"
+                disabled={deleteMutation.isPending}
+                onClick={() => deleteMutation.mutateAsync(type.id)
+                  .then(() => setConfirmDelete(false))
+                  .catch((e: unknown) => {
+                    const err = e as { response?: { data?: { error?: string } }; message?: string };
+                    setDeleteError(err?.response?.data?.error || err?.message || 'Не удалось удалить тип.');
+                  })}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-danger text-white hover:bg-danger disabled:opacity-50"
+              >
+                Удалить
+              </button>
+            </div>
+          }>
+          <div className="space-y-4 min-w-[360px]">
+            <p className="text-sm text-fg2">
+              Тип <span className="font-semibold text-fg1">«{type.name}»</span> будет удалён.
+              Поля документов, использующие этот тип, перестанут резолвить варианты.
+            </p>
+            {deleteError && <p className="text-sm text-danger">{deleteError}</p>}
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+// ─── Section ──────────────────────────────────────────────────────────────────
+
+export function EnumTypesSection() {
+  const { data: types = [], isLoading } = useListEnumTypes();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const sorted = [...types].sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+  const allGroups = [...new Set(sorted.map(t => t.group).filter((g): g is string => !!g))]
+    .sort((a, b) => a.localeCompare(b, 'ru'));
+
+  function toggleExpanded(id: string) {
+    setExpandedId(prev => prev === id ? null : id);
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-xs text-fg3">
+          Переиспользуемые списки вариантов (код + отображаемое имя) для полей типа «Перечисление»
+        </p>
+        <button onClick={() => setCreateOpen(true)}
+          className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
+          <Plus size={16} /> Добавить тип
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="text-center text-fg4 text-sm py-10">Загрузка...</div>
+      ) : types.length === 0 ? (
+        <div className="text-center text-fg4 text-sm py-10">
+          Типов перечисления ещё нет. Создайте тип, например «Статус документа».
+        </div>
+      ) : (
+        <TypeGroupAccordion items={sorted} getGroup={t => t.group} renderItem={t => (
+          <EnumTypeRow key={t.id} type={t} allGroups={allGroups}
+            expanded={expandedId === t.id} onToggle={() => toggleExpanded(t.id)} />
+        )} />
+      )}
+
+      <Modal open={createOpen} onOpenChange={setCreateOpen} title="Новый тип перечисления">
+        {createOpen && (
+          <EnumForm onSaved={() => setCreateOpen(false)} onCancel={() => setCreateOpen(false)} />
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -1,7 +1,7 @@
 import { useId } from 'react';
 import { Plus, Trash2, ArrowUp, ArrowDown, Cpu } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
-import type { DocumentType, PrimitiveTypeDef } from '@/shared/api/types';
+import type { DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import type { SchemaField, FieldGroup } from '@/shared/api/schema';
 import { PRIMITIVE_TYPES, toCamelKey } from './schemaConstants';
 import { useTagRegistry, fieldTags } from '@/shared/api/tags';
@@ -42,10 +42,11 @@ interface FieldBuilderProps {
   disabledKeys?: Set<string>;
   compositeTypes: DocumentType[];
   primitiveTypes: PrimitiveTypeDef[];
+  enumTypes: EnumTypeDef[];
   allDocTypes: DocumentType[];
 }
 
-export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, primitiveTypes, allDocTypes }: FieldBuilderProps) {
+export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, primitiveTypes, enumTypes, allDocTypes }: FieldBuilderProps) {
   const uid = useId();
   const { data: tagRegistry } = useTagRegistry();
 
@@ -68,6 +69,10 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
     }
     return fieldTags(tagRegistry, f.type);
   };
+  // Легаси enum-поле (issue #59): options заданы инлайн, typeId не выбран — создано до появления
+  // реестра EnumType. Продолжает редактироваться старым инлайн-списком, без принудительного переноса.
+  const isLegacyEnum = (f: SchemaField) => f.type === 'enum' && !f.typeId && (f.options?.length ?? 0) > 0;
+  const enumTypeDefFor = (f: SchemaField) => f.type === 'enum' ? enumTypes.find(et => et.id === f.typeId) : undefined;
   const setImageOpt = (i: number, patch: Partial<NonNullable<SchemaField['image']>>) => {
     const merged = { ...(fields[i].image ?? {}), ...patch };
     const cleaned = Object.fromEntries(Object.entries(merged).filter(([, v]) => v !== undefined && v !== ''));
@@ -137,8 +142,10 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
                   const t = e.target.value as SchemaField['type'];
                   update(i, {
                     type: t,
-                    typeId: (t === 'complex' || t === 'primitive' || t === 'array' || t === 'doc-ref' || t === 'doc-array') ? '' : undefined,
-                    options: t === 'enum' ? (field.options ?? []) : undefined,
+                    typeId: (t === 'complex' || t === 'primitive' || t === 'array' || t === 'doc-ref' || t === 'doc-array' || t === 'enum') ? '' : undefined,
+                    // Легаси options НЕ предзаполняем для нового enum-поля (issue #59) — новые
+                    // поля идут через typeId; сохраняем, только если уже были (переключение туда-обратно).
+                    options: t === 'enum' ? field.options : undefined,
                     defaultValue: undefined,
                   });
                 }}
@@ -227,6 +234,24 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
                 </select>
               </div>
             )}
+            {/* Enum type selector (issue #59) — только для НЕ-легаси enum-полей: у легаси (options
+                инлайн, typeId не выбран) остаётся старый инлайн-редактор ниже. */}
+            {field.type === 'enum' && !isLegacyEnum(field) && (
+              <div className="ml-[calc(33%+0.5rem)] mr-[calc(5rem)]">
+                <select
+                  value={field.typeId ?? ''}
+                  onChange={e => update(i, { typeId: e.target.value })}
+                  className={`w-full border rounded-md px-2 py-1.5 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface ${
+                    !field.typeId ? 'border-yellow-400 text-fg4' : 'border-stroke-strong'
+                  }`}
+                >
+                  <option value="">Выберите тип перечисления...</option>
+                  {enumTypes.map(et => (
+                    <option key={et.id} value={et.id}>{et.name} ({et.code})</option>
+                  ))}
+                </select>
+              </div>
+            )}
             {/* Default value editor */}
             {field.type !== 'complex' && field.type !== 'array' && field.type !== 'primitive'
               && field.type !== 'doc-ref' && field.type !== 'doc-array' && (
@@ -249,9 +274,11 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
                     className="flex-1 border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand"
                   >
                     <option value="">— не задано —</option>
-                    {(field.options ?? []).filter(o => o).map(opt => (
-                      <option key={opt} value={opt}>{opt}</option>
-                    ))}
+                    {enumTypeDefFor(field)
+                      ? enumTypeDefFor(field)!.values.map(v => <option key={v.code} value={v.code}>{v.label}</option>)
+                      : (field.options ?? []).filter(o => o).map(opt => (
+                          <option key={opt} value={opt}>{opt}</option>
+                        ))}
                   </select>
                 ) : field.type === 'date' ? (
                   <DateInput
@@ -276,8 +303,8 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
                 )}
               </div>
             )}
-            {/* Enum options editor */}
-            {field.type === 'enum' && (
+            {/* Enum options editor — только легаси (options инлайн, без typeId, issue #59) */}
+            {isLegacyEnum(field) && (
               <div className="ml-[calc(33%+0.5rem)] mr-[calc(5rem)] space-y-1.5">
                 {(field.options ?? []).map((opt, oi) => (
                   <div key={oi} className="flex items-center gap-1.5">
@@ -420,6 +447,9 @@ export function DefaultValueCell({ field, override, onOverrideDefaultValue }: {
     );
   }
   if (field.type === 'enum') {
+    // typeId-резолв (issue #59) сюда не проброшен (как и primitiveTypeDef для type="primitive"
+    // выше по isPrimitive) — для таких полей переопределение default value здесь недоступно.
+    if (field.typeId) return <span className="text-xs text-stroke-strong">—</span>;
     const opts = (field.options ?? []).filter(o => o);
     return (
       <select value={hasDv ? String(cur) : ''} onChange={e => {

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -421,9 +421,10 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
 
 // ─── Default value cell (module-level to avoid remount on each render) ────────
 
-export function DefaultValueCell({ field, override, onOverrideDefaultValue }: {
+export function DefaultValueCell({ field, override, enumTypes, onOverrideDefaultValue }: {
   field: SchemaField;
   override?: { required?: boolean; defaultValue?: unknown };
+  enumTypes: EnumTypeDef[];
   onOverrideDefaultValue: (key: string, value: unknown) => void;
 }) {
   const isPrimitive = field.type !== 'complex' && field.type !== 'array' && field.type !== 'primitive';
@@ -447,16 +448,16 @@ export function DefaultValueCell({ field, override, onOverrideDefaultValue }: {
     );
   }
   if (field.type === 'enum') {
-    // typeId-резолв (issue #59) сюда не проброшен (как и primitiveTypeDef для type="primitive"
-    // выше по isPrimitive) — для таких полей переопределение default value здесь недоступно.
-    if (field.typeId) return <span className="text-xs text-stroke-strong">—</span>;
-    const opts = (field.options ?? []).filter(o => o);
+    const enumTypeDef = field.typeId ? enumTypes.find(et => et.id === field.typeId) : undefined;
+    if (field.typeId && !enumTypeDef) return <span className="text-xs text-stroke-strong">—</span>;
     return (
       <select value={hasDv ? String(cur) : ''} onChange={e => {
         onOverrideDefaultValue(field.key, e.target.value || undefined);
       }} className={inputCls}>
         <option value="">{parentDv !== undefined ? String(parentDv) : 'не задано'}</option>
-        {opts.map(o => <option key={o} value={o}>{o}</option>)}
+        {enumTypeDef
+          ? enumTypeDef.values.map(v => <option key={v.code} value={v.code}>{v.label}</option>)
+          : (field.options ?? []).filter(o => o).map(o => <option key={o} value={o}>{o}</option>)}
       </select>
     );
   }

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -13,6 +13,7 @@ import {
 import type { FieldConstraints, PrimitiveTypeDef } from '@/shared/api/types';
 import { useTagRegistry, fieldTags } from '@/shared/api/tags';
 import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
+import { EnumTypesSection } from './EnumTypesSection';
 
 // ─── Base type options ────────────────────────────────────────────────────────
 
@@ -402,9 +403,9 @@ function FieldTypeRow({ type, allGroups, expanded, onToggle }: {
   );
 }
 
-// ─── Main page ────────────────────────────────────────────────────────────────
+// ─── Primitive section (существующее содержимое страницы, без изменений) ──────
 
-export function PrimitiveTypesPage() {
+function PrimitiveTypesSection() {
   const { data: types = [], isLoading } = useListPrimitiveTypes();
   const [createOpen, setCreateOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -418,14 +419,11 @@ export function PrimitiveTypesPage() {
   }
 
   return (
-    <div className="px-6 py-4">
+    <div>
       <div className="flex items-center justify-between mb-4">
-        <div>
-          <h1 className="text-xl font-semibold text-fg1">Типы полей</h1>
-          <p className="text-xs text-fg3 mt-0.5">
-            Пользовательские типы реквизитов на основе строки, числа или даты с ограничениями
-          </p>
-        </div>
+        <p className="text-xs text-fg3">
+          Пользовательские типы реквизитов на основе строки, числа или даты с ограничениями
+        </p>
         <button onClick={() => setCreateOpen(true)}
           className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
           <Plus size={16} /> Добавить тип
@@ -450,6 +448,42 @@ export function PrimitiveTypesPage() {
           <TypeForm onSaved={() => setCreateOpen(false)} onCancel={() => setCreateOpen(false)} />
         )}
       </Modal>
+    </div>
+  );
+}
+
+// ─── Main page — вкладки «Примитивные»/«Перечисления» (issue #59) ──────────────
+
+type FieldTypesMode = 'primitive' | 'enum';
+
+export function PrimitiveTypesPage() {
+  const [mode, setMode] = useState<FieldTypesMode>('primitive');
+
+  return (
+    <div className="px-6 py-4">
+      <div className="flex items-center justify-between mb-1">
+        <h1 className="text-xl font-semibold text-fg1">Типы полей</h1>
+      </div>
+      <div className="flex items-center gap-1 bg-muted rounded-lg p-0.5 mb-4 w-fit">
+        <button
+          onClick={() => setMode('primitive')}
+          className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
+            mode === 'primitive' ? 'bg-surface text-fg1 font-medium shadow-sm' : 'text-fg3 hover:text-fg2'
+          }`}
+        >
+          Примитивные
+        </button>
+        <button
+          onClick={() => setMode('enum')}
+          className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
+            mode === 'enum' ? 'bg-surface text-fg1 font-medium shadow-sm' : 'text-fg3 hover:text-fg2'
+          }`}
+        >
+          Перечисления
+        </button>
+      </div>
+
+      {mode === 'primitive' ? <PrimitiveTypesSection /> : <EnumTypesSection />}
     </div>
   );
 }

--- a/src/client/src/shared/api/enumTypes.ts
+++ b/src/client/src/shared/api/enumTypes.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from './client';
+import type { EnumOptionDef, EnumTypeDef } from './types';
+
+const QK = 'enumTypes';
+
+export function useListEnumTypes() {
+  return useQuery<EnumTypeDef[]>({
+    queryKey: [QK],
+    queryFn: () => apiClient.get('/enum-types').then(r => r.data),
+  });
+}
+
+interface SaveEnumTypeDto {
+  name: string;
+  code: string;
+  description?: string;
+  values: string;
+}
+
+function toDto(
+  name: string,
+  code: string,
+  description: string | undefined,
+  values: EnumOptionDef[],
+): SaveEnumTypeDto {
+  return { name, code, description: description || undefined, values: JSON.stringify(values) };
+}
+
+export function useCreateEnumType() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: SaveEnumTypeDto) =>
+      apiClient.post<EnumTypeDef>('/enum-types', dto).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [QK] }),
+  });
+}
+
+export function useUpdateEnumType(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: SaveEnumTypeDto) =>
+      apiClient.put<EnumTypeDef>(`/enum-types/${id}`, dto).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [QK] }),
+  });
+}
+
+export function useSetEnumTypeGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, group }: { id: string; group: string | null }) =>
+      apiClient.put<EnumTypeDef>(`/enum-types/${id}/group`, { group }).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [QK] }),
+  });
+}
+
+export function useDeleteEnumType() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiClient.delete(`/enum-types/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [QK] }),
+  });
+}
+
+export { toDto as buildEnumTypeDto };

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -198,6 +198,25 @@ export interface PrimitiveTypeDef {
   updatedAt: string;
 }
 
+// ─── Enum Types (issue #59) ────────────────────────────────────────────────────
+
+/** Один вариант перечисления: код (хранится в реквизитах) + отображаемое имя. */
+export interface EnumOptionDef {
+  code: string;
+  label: string;
+}
+
+export interface EnumTypeDef {
+  id: string;
+  name: string;
+  code: string;
+  description?: string;
+  values: EnumOptionDef[];
+  group: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ─── Backup / Restore ─────────────────────────────────────────────────────────
 
 export interface BackupManifest {

--- a/src/server/BHS.CRG.Api/Endpoints/Catalog/EnumTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Catalog/EnumTypeEndpoints.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using BHS.CRG.Application.Catalog;
+using MediatR;
+
+namespace BHS.CRG.Api.Endpoints.Catalog;
+
+public static class EnumTypeEndpoints
+{
+    public static void MapEnumTypeEndpoints(this IEndpointRouteBuilder app)
+    {
+        var g = app.MapGroup("/api/enum-types").RequireAuthorization();
+        var admin = app.MapGroup("/api/enum-types").RequireAuthorization("Admin");
+
+        g.MapGet("/", async (IMediator m) =>
+            Results.Ok(await m.Send(new ListEnumTypesQuery())));
+
+        admin.MapPost("/", async (EnumTypeRequest req, IMediator m) =>
+            Results.Ok(await m.Send(new CreateEnumTypeCommand(
+                req.Name, req.Code, req.Description, JsonDocument.Parse(req.Values)))));
+
+        admin.MapPut("/{id:guid}", async (Guid id, EnumTypeRequest req, IMediator m) =>
+            Results.Ok(await m.Send(new UpdateEnumTypeCommand(
+                id, req.Name, req.Code, req.Description, JsonDocument.Parse(req.Values)))));
+
+        admin.MapPut("/{id:guid}/group", async (Guid id, SetGroupRequest req, IMediator m)
+            => Results.Ok(await m.Send(new SetEnumTypeGroupCommand(id, req.Group))));
+
+        admin.MapDelete("/{id:guid}", async (Guid id, IMediator m) =>
+        {
+            try { await m.Send(new DeleteEnumTypeCommand(id)); return Results.NoContent(); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+    }
+
+    record EnumTypeRequest(string Name, string Code, string? Description, string Values);
+    record SetGroupRequest(string? Group);
+}

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -114,6 +114,7 @@ builder.Services.AddMediatR(cfg =>
 // ── Repositories ──────────────────────────────────────────────────────────────
 builder.Services.AddScoped<IRepository<CatalogEntity>, Repository<CatalogEntity>>();
 builder.Services.AddScoped<IRepository<PrimitiveType>, Repository<PrimitiveType>>();
+builder.Services.AddScoped<IRepository<EnumType>, Repository<EnumType>>();
 builder.Services.AddScoped<IRepository<DocumentType>, Repository<DocumentType>>();
 builder.Services.AddScoped<IRepository<Construction>, ConstructionRepository>();
 builder.Services.AddScoped<IRepository<Section>, Repository<Section>>();
@@ -274,6 +275,7 @@ app.MapUserEndpoints();
 app.MapBackupEndpoints();
 app.MapCatalogEndpoints();
 app.MapPrimitiveTypeEndpoints();
+app.MapEnumTypeEndpoints();
 app.MapDocumentTypeEndpoints();
 app.MapCommonDataEndpoints();
 app.MapTemplateEndpoints();

--- a/src/server/BHS.CRG.Application/Catalog/Commands.cs
+++ b/src/server/BHS.CRG.Application/Catalog/Commands.cs
@@ -34,3 +34,18 @@ public record UpdatePrimitiveTypeCommand(
 
 public record DeletePrimitiveTypeCommand(Guid Id) : IRequest;
 public record SetPrimitiveTypeGroupCommand(Guid Id, string? Group) : IRequest<PrimitiveType>;
+
+// ── EnumType (issue #59) ────────────────────────────────────────────────────────
+
+public record ListEnumTypesQuery : IRequest<IReadOnlyList<EnumType>>;
+
+public record CreateEnumTypeCommand(
+    string Name, string Code, string? Description, JsonDocument Values
+) : IRequest<EnumType>;
+
+public record UpdateEnumTypeCommand(
+    Guid Id, string Name, string Code, string? Description, JsonDocument Values
+) : IRequest<EnumType>;
+
+public record DeleteEnumTypeCommand(Guid Id) : IRequest;
+public record SetEnumTypeGroupCommand(Guid Id, string? Group) : IRequest<EnumType>;

--- a/src/server/BHS.CRG.Application/Catalog/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Catalog/Handlers.cs
@@ -1,5 +1,7 @@
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
 using MediatR;
 
 namespace BHS.CRG.Application.Catalog;
@@ -104,6 +106,72 @@ public class PrimitiveTypeHandlers(IRepository<PrimitiveType> repo) :
         var pt = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"PrimitiveType {cmd.Id} not found");
         repo.Remove(pt);
+        await repo.SaveChangesAsync(ct);
+    }
+}
+
+public class EnumTypeHandlers(IRepository<EnumType> repo, IRepository<DocumentType> docTypeRepo) :
+    IRequestHandler<ListEnumTypesQuery, IReadOnlyList<EnumType>>,
+    IRequestHandler<CreateEnumTypeCommand, EnumType>,
+    IRequestHandler<UpdateEnumTypeCommand, EnumType>,
+    IRequestHandler<SetEnumTypeGroupCommand, EnumType>,
+    IRequestHandler<DeleteEnumTypeCommand>
+{
+    public Task<IReadOnlyList<EnumType>> Handle(ListEnumTypesQuery _, CancellationToken ct)
+        => repo.GetAllAsync(ct);
+
+    public async Task<EnumType> Handle(CreateEnumTypeCommand cmd, CancellationToken ct)
+    {
+        await EnsureCodeUniqueAsync(cmd.Code, excludeId: null, ct);
+        var et = EnumType.Create(cmd.Name, cmd.Code.Trim(), cmd.Description, cmd.Values);
+        await repo.AddAsync(et, ct);
+        await repo.SaveChangesAsync(ct);
+        return et;
+    }
+
+    public async Task<EnumType> Handle(UpdateEnumTypeCommand cmd, CancellationToken ct)
+    {
+        var et = await repo.GetByIdAsync(cmd.Id, ct)
+            ?? throw new KeyNotFoundException($"EnumType {cmd.Id} not found");
+        await EnsureCodeUniqueAsync(cmd.Code, excludeId: cmd.Id, ct);
+        et.Update(cmd.Name, cmd.Code.Trim(), cmd.Description, cmd.Values);
+        repo.Update(et);
+        await repo.SaveChangesAsync(ct);
+        return et;
+    }
+
+    // Код типа перечисления должен быть уникален (без учёта регистра и краёв).
+    private async Task EnsureCodeUniqueAsync(string code, Guid? excludeId, CancellationToken ct)
+    {
+        var nCode = code.Trim().ToLowerInvariant();
+        var all = await repo.GetAllAsync(ct);
+        if (all.Any(t => (!excludeId.HasValue || t.Id != excludeId.Value) && t.Code.Trim().ToLowerInvariant() == nCode))
+            throw new ArgumentException($"Тип перечисления с кодом «{code.Trim()}» уже существует.");
+    }
+
+    public async Task<EnumType> Handle(SetEnumTypeGroupCommand cmd, CancellationToken ct)
+    {
+        var et = await repo.GetByIdAsync(cmd.Id, ct)
+            ?? throw new KeyNotFoundException($"EnumType {cmd.Id} not found");
+        et.SetGroup(cmd.Group);
+        repo.Update(et);
+        await repo.SaveChangesAsync(ct);
+        return et;
+    }
+
+    // issue #59 (по прецеденту issue #57 — та же класса бага у DocumentType): удаление типа
+    // перечисления, используемого в схеме какого-либо типа документа, оставляло бы enum-поле с
+    // висячим typeId — резолв вариантов молча пропадал бы. Проверяем перед удалением.
+    public async Task Handle(DeleteEnumTypeCommand cmd, CancellationToken ct)
+    {
+        var et = await repo.GetByIdAsync(cmd.Id, ct)
+            ?? throw new KeyNotFoundException($"EnumType {cmd.Id} not found");
+        var allDocTypes = await docTypeRepo.GetAllAsync(ct);
+        var usedIn = allDocTypes.Where(t => DocumentTypeSchemaReader.ReferencesEnumType(t.Schema, cmd.Id)).ToList();
+        if (usedIn.Count > 0)
+            throw new InvalidOperationException(
+                $"Нельзя удалить тип перечисления — используется в схеме: {string.Join(", ", usedIn.Select(t => t.Name))}.");
+        repo.Remove(et);
         await repo.SaveChangesAsync(ct);
     }
 }

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -70,6 +70,8 @@ public class GenerateDocumentHandler(
             // Значения по умолчанию из схемы типа (issue #53) — для полей, оставшихся без значения
             // после реквизитов инстанса и биндингов (самый низкий приоритет).
             await entityResolver.ApplyDefaultsAsync(context, instance, ct);
+            // Enum-поля: код → отображаемое имя (issue #59) — иначе в PDF попадёт сырой код.
+            await entityResolver.ResolveEnumLabelsAsync(context, instance, ct);
             // Подмешиваем документы качества по идентичности материала (артикул/наименование).
             await qualityLinkResolver.InjectAsync(context, instance, ct);
             // Наборы данных могли добавить ссылки на каталог ($ref) в составные поля —

--- a/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
+++ b/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
@@ -58,6 +58,7 @@ public class GetGenerationDebugBundleHandler(
         var context = await entityResolver.ResolveAsync(instance, ct);
         await dataSetResolver.InjectAsync(context, instance, null, ct);
         await entityResolver.ApplyDefaultsAsync(context, instance, ct);
+        await entityResolver.ResolveEnumLabelsAsync(context, instance, ct);
         await qualityLinkResolver.InjectAsync(context, instance, ct);
         // Тот же второй проход, что и при генерации — разрешаем $ref, добавленные наборами данных.
         await entityResolver.ResolveContextRefsAsync(context, instance.DocumentSetId, ct);

--- a/src/server/BHS.CRG.Application/Generation/IEntityResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/IEntityResolver.cs
@@ -27,4 +27,12 @@ public interface IEntityResolver
     /// составные/табличные (complex/array/doc-ref/doc-array/file/image) не трогает.
     /// </summary>
     Task ApplyDefaultsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default);
+
+    /// <summary>
+    /// Резолвит enum-поля реквизитов из кода (хранится в контексте) в отображаемое имя EnumType
+    /// (issue #59) — иначе в PDF попадёт сырой код вместо человекочитаемого текста. Вызывать ПОСЛЕ
+    /// ApplyDefaultsAsync (иначе default-значение enum-поля не получит резолва). Толерантно: код без
+    /// совпадения в реестре остаётся как есть. Только верхнеуровневые скалярные поля.
+    /// </summary>
+    Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
@@ -26,6 +26,7 @@ public class ValidateInstanceResolutionHandler(
         var context = await entityResolver.ResolveAsync(instance, ct);
         await dataSetResolver.InjectAsync(context, instance, diagnostics, ct);
         await entityResolver.ApplyDefaultsAsync(context, instance, ct);
+        await entityResolver.ResolveEnumLabelsAsync(context, instance, ct);
         await entityResolver.ResolveContextRefsAsync(context, instance.DocumentSetId, ct);
         ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
         return diagnostics;

--- a/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
+++ b/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
@@ -1,14 +1,22 @@
 using System.Text.Json;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Application.Schema;
+
+/// <summary>Один вариант перечисления: код (хранится в реквизитах) + отображаемое имя.</summary>
+public record EnumOptionInfo(string Code, string Label);
 
 /// <summary>Поле эффективной схемы типа: ключ, тип (string/complex/array/doc-ref/doc-array/…), typeId (для составных/массивов/ссылок), заголовок.</summary>
 /// <param name="DefaultValue">Значение по умолчанию (issue #53) — из собственного объявления поля, либо
 /// переопределено производным типом через fieldOverrides (для унаследованных полей). Null — не задано.
 /// Применяется резолвером генерации, только если поле НЕ определено ни в реквизитах инстанса, ни через
 /// привязку набора данных (см. EntityResolver.ApplyDefaultsAsync).</param>
-public record SchemaFieldInfo(string Key, string Type, Guid? TypeId, string? Title = null, JsonElement? DefaultValue = null);
+/// <param name="Options">Варианты для type="enum" (issue #59) — из собственного инлайн `options`
+/// (легаси: код==имя) либо резолвлены из EnumType по `typeId`. Null — не enum-поле, либо enumTypesById
+/// не передан вызывающим кодом.</param>
+public record SchemaFieldInfo(string Key, string Type, Guid? TypeId, string? Title = null,
+    JsonElement? DefaultValue = null, IReadOnlyList<EnumOptionInfo>? Options = null);
 
 /// <summary>Скалярное ли поле (пригодное для табличного распознавания/материализации из плоских колонок).</summary>
 public static class SchemaFieldKinds
@@ -28,7 +36,8 @@ public static class DocumentTypeSchemaReader
     /// Эффективные поля типа: base → derived; excludedFields исключают унаследованные;
     /// одноимённые поля наследника перекрывают унаследованные (порядок: сначала базовые).
     /// </summary>
-    public static IReadOnlyList<SchemaFieldInfo> EffectiveFields(Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    public static IReadOnlyList<SchemaFieldInfo> EffectiveFields(Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, EnumType>? enumTypesById = null)
     {
         var chain = new List<DocumentType>();
         var cur = byId.GetValueOrDefault(typeId);
@@ -44,7 +53,7 @@ public static class DocumentTypeSchemaReader
         var order = new List<string>();
         foreach (var t in chain)
         {
-            var (fields, excluded, overrides) = ParseSchema(t.Schema);
+            var (fields, excluded, overrides) = ParseSchema(t.Schema, enumTypesById);
             foreach (var ex in excluded)
                 if (acc.Remove(ex)) order.Remove(ex);
 
@@ -64,8 +73,9 @@ public static class DocumentTypeSchemaReader
         return order.Select(k => acc[k]).ToList();
     }
 
-    public static SchemaFieldInfo? Field(Guid typeId, string key, IReadOnlyDictionary<Guid, DocumentType> byId)
-        => EffectiveFields(typeId, byId).FirstOrDefault(f => f.Key == key);
+    public static SchemaFieldInfo? Field(Guid typeId, string key, IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, EnumType>? enumTypesById = null)
+        => EffectiveFields(typeId, byId, enumTypesById).FirstOrDefault(f => f.Key == key);
 
     /// <summary>
     /// Ссылается ли схема (СОБСТВЕННЫЕ поля типа — без резолва наследования) на составной/ссылочный
@@ -75,8 +85,16 @@ public static class DocumentTypeSchemaReader
     /// </summary>
     public static bool ReferencesType(JsonDocument schema, Guid documentTypeId)
     {
-        var (fields, _, _) = ParseSchema(schema);
+        var (fields, _, _) = ParseSchema(schema, null);
         return fields.Any(f => f.TypeId == documentTypeId && (IsSingleComposite(f.Type) || IsMultiValued(f.Type)));
+    }
+
+    /// <summary>Ссылается ли схема (СОБСТВЕННЫЕ поля типа) на тип перечисления enumTypeId через
+    /// поле type="enum" + typeId (issue #59, проверка перед удалением EnumType).</summary>
+    public static bool ReferencesEnumType(JsonDocument schema, Guid enumTypeId)
+    {
+        var (fields, _, _) = ParseSchema(schema, null);
+        return fields.Any(f => f.Type == "enum" && f.TypeId == enumTypeId);
     }
 
     /// <summary>true, если childId == ancestorId либо childId — потомок ancestorId по ParentId.</summary>
@@ -100,7 +118,8 @@ public static class DocumentTypeSchemaReader
     /// <summary>Поле-одиночная составная сущность/ссылка: complex / doc-ref.</summary>
     public static bool IsSingleComposite(string fieldType) => fieldType is "complex" or "doc-ref";
 
-    private static (List<SchemaFieldInfo> Fields, List<string> Excluded, Dictionary<string, JsonElement> Overrides) ParseSchema(JsonDocument schema)
+    private static (List<SchemaFieldInfo> Fields, List<string> Excluded, Dictionary<string, JsonElement> Overrides) ParseSchema(
+        JsonDocument schema, IReadOnlyDictionary<Guid, EnumType>? enumTypesById)
     {
         var fields = new List<SchemaFieldInfo>();
         var excluded = new List<string>();
@@ -122,7 +141,11 @@ public static class DocumentTypeSchemaReader
                 // ЭТОГО JsonDocument (schema — параметр метода, может быть освобождён вызывающим).
                 JsonElement? defaultValue = f.TryGetProperty("defaultValue", out var dv) && dv.ValueKind != JsonValueKind.Undefined
                     ? dv.Clone() : null;
-                fields.Add(new SchemaFieldInfo(key, type, typeId, title, defaultValue));
+                // Enum-варианты (issue #59): легаси инлайн `options` (код==имя, старое поведение
+                // 1:1) — если пусто, резолвим typeId через EnumType (толерантное сосуществование
+                // обоих представлений, без принудительной миграции).
+                IReadOnlyList<EnumOptionInfo>? options = type == "enum" ? ParseEnumOptions(f, typeId, enumTypesById) : null;
+                fields.Add(new SchemaFieldInfo(key, type, typeId, title, defaultValue, options));
             }
 
         if (root.TryGetProperty("excludedFields", out var ex) && ex.ValueKind == JsonValueKind.Array)
@@ -139,5 +162,39 @@ public static class DocumentTypeSchemaReader
                     overrides[prop.Name] = odv.Clone();
 
         return (fields, excluded, overrides);
+    }
+
+    // Легаси инлайн options (issue #59): каждая строка — и код, и отображаемое имя (как ведёт себя
+    // сегодняшнее поведение enum-поля 1:1). Если options пуст/отсутствует — резолв через typeId.
+    private static IReadOnlyList<EnumOptionInfo>? ParseEnumOptions(
+        JsonElement field, Guid? typeId, IReadOnlyDictionary<Guid, EnumType>? enumTypesById)
+    {
+        if (field.TryGetProperty("options", out var opts) && opts.ValueKind == JsonValueKind.Array)
+        {
+            var list = opts.EnumerateArray()
+                .Where(o => o.ValueKind == JsonValueKind.String)
+                .Select(o => o.GetString()!)
+                .Select(s => new EnumOptionInfo(s, s))
+                .ToList();
+            if (list.Count > 0) return list;
+        }
+        if (typeId is { } tid && enumTypesById is not null && enumTypesById.TryGetValue(tid, out var enumType))
+            return ParseEnumValues(enumType.Values);
+        return null;
+    }
+
+    private static List<EnumOptionInfo> ParseEnumValues(JsonDocument values)
+    {
+        var list = new List<EnumOptionInfo>();
+        if (values.RootElement.ValueKind != JsonValueKind.Array) return list;
+        foreach (var v in values.RootElement.EnumerateArray())
+        {
+            if (v.ValueKind != JsonValueKind.Object) continue;
+            var code = v.TryGetProperty("code", out var c) && c.ValueKind == JsonValueKind.String ? c.GetString() : null;
+            var label = v.TryGetProperty("label", out var l) && l.ValueKind == JsonValueKind.String ? l.GetString() : null;
+            if (code is null || label is null) continue;
+            list.Add(new EnumOptionInfo(code, label));
+        }
+        return list;
     }
 }

--- a/src/server/BHS.CRG.Domain/Catalog/EnumType.cs
+++ b/src/server/BHS.CRG.Domain/Catalog/EnumType.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using BHS.CRG.Domain.Common;
+
+namespace BHS.CRG.Domain.Catalog;
+
+/// <summary>
+/// Переиспользуемый список вариантов для полей типа "enum" (issue #59) — используется в схемах
+/// DocumentType через type="enum" + typeId (вместо инлайн options: string[] в самом поле).
+/// Значения — пары код+имя: код хранится в реквизитах, имя резолвится при отображении/генерации,
+/// чтобы переименование варианта в реестре не портило уже сохранённые документы.
+/// </summary>
+public class EnumType : Entity
+{
+    public string Name { get; private set; } = default!;
+
+    /// <summary>Уникальный код: status, unit, …</summary>
+    public string Code { get; private set; } = default!;
+
+    public string? Description { get; private set; }
+
+    /// <summary>JSON-массив [{code, label}] — варианты перечисления.</summary>
+    public JsonDocument Values { get; private set; } = default!;
+
+    /// <summary>Произвольная группа для отображения на странице типов (null — без группы).</summary>
+    public string? Group { get; private set; }
+
+    private EnumType() { }
+
+    public static EnumType Create(string name, string code, string? description, JsonDocument values)
+        => new() { Name = name, Code = code, Description = description, Values = values };
+
+    public void Update(string name, string code, string? description, JsonDocument values)
+    {
+        Name = name; Code = code; Description = description; Values = values;
+        TouchUpdatedAt();
+    }
+
+    public void SetGroup(string? group) { Group = string.IsNullOrWhiteSpace(group) ? null : group.Trim(); TouchUpdatedAt(); }
+
+    public static EnumType Restore(
+        Guid id, string name, string code, string? description, JsonDocument values,
+        DateTimeOffset createdAt, DateTimeOffset updatedAt, string? group = null)
+        => new()
+        {
+            Id = id, Name = name, Code = code, Description = description, Values = values,
+            CreatedAt = createdAt, UpdatedAt = updatedAt, Group = group,
+        };
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -47,6 +47,36 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     }
 
     /// <summary>
+    /// Резолвит enum-поля реквизитов из кода в отображаемое имя перед генерацией (issue #59): в
+    /// реквизитах хранится стабильный код EnumType.Values, но в PDF должен попасть человекочитаемый
+    /// текст. Scope сознательно ограничен верхнеуровневыми скалярными полями — то же ограничение,
+    /// что уже есть у ApplyDefaultsAsync (не резолвит внутрь строк array/complex полей). Толерантно:
+    /// код без совпадения в Options остаётся как есть (та же философия, что и везде в резолвере).
+    /// </summary>
+    public async Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default)
+    {
+        var allDocTypes = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
+        var enumTypesById = await db.EnumTypes.AsNoTracking().ToDictionaryAsync(e => e.Id, ct);
+        var fields = DocumentTypeSchemaReader.EffectiveFields(instance.DocumentTypeId, allDocTypes, enumTypesById);
+        foreach (var f in fields)
+        {
+            if (f.Type != "enum" || f.Options is null || f.Options.Count == 0) continue;
+            if (!ctx.Data.TryGetValue(f.Key, out var raw)) continue;
+            // ctx.Data хранит JsonElement (реквизиты из FromJson) — но допускаем и обычную строку
+            // (напр. если значение положено напрямую, не через JSON-парсинг).
+            var code = raw switch
+            {
+                JsonElement el when el.ValueKind == JsonValueKind.String => el.GetString(),
+                string s => s,
+                _ => null,
+            };
+            if (code is null) continue;
+            var match = f.Options.FirstOrDefault(o => o.Code == code);
+            if (match is not null) ctx.Set(f.Key, match.Label);
+        }
+    }
+
+    /// <summary>
     /// Единая точка разбора $ref: обходит произвольное JSON-дерево (объекты/массивы на любой
     /// глубине — раньше это были три разошедшиеся копии). <paramref name="depth"/> — общий предел
     /// глубины графа; <paramref name="allowInstanceRefs"/> — разрешено ли на этом шаге разворачивать

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260711064030_AddEnumTypes.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260711064030_AddEnumTypes.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711064030_AddEnumTypes")]
+    partial class AddEnumTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260711064030_AddEnumTypes.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260711064030_AddEnumTypes.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEnumTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "enum_types",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Code = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Description = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Values = table.Column<JsonDocument>(type: "jsonb", nullable: false),
+                    Group = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_enum_types", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_enum_types_Code",
+                table: "enum_types",
+                column: "Code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "enum_types");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
@@ -19,6 +19,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options)
     public DbSet<CatalogEntity> CatalogEntities => Set<CatalogEntity>();
     public DbSet<CommonDataEntry> CommonDataEntries => Set<CommonDataEntry>();
     public DbSet<PrimitiveType> PrimitiveTypes => Set<PrimitiveType>();
+    public DbSet<EnumType> EnumTypes => Set<EnumType>();
     public DbSet<DocumentType> DocumentTypes => Set<DocumentType>();
     public DbSet<Template> Templates => Set<Template>();
     public DbSet<Construction> Constructions => Set<Construction>();

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/EnumTypeConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/EnumTypeConfiguration.cs
@@ -1,0 +1,20 @@
+using BHS.CRG.Domain.Catalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BHS.CRG.Infrastructure.Persistence.Configurations;
+
+public class EnumTypeConfiguration : IEntityTypeConfiguration<EnumType>
+{
+    public void Configure(EntityTypeBuilder<EnumType> b)
+    {
+        b.ToTable("enum_types");
+        b.HasKey(e => e.Id);
+        b.Property(e => e.Name).HasMaxLength(256).IsRequired();
+        b.Property(e => e.Code).HasMaxLength(64).IsRequired();
+        b.HasIndex(e => e.Code).IsUnique();
+        b.Property(e => e.Description).HasMaxLength(512);
+        b.Property(e => e.Values).HasColumnType("jsonb").IsRequired();
+        b.Property(e => e.Group).HasMaxLength(256);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverEnumLabelsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverEnumLabelsTests.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using BHS.CRG.Application.Catalog;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// ResolveEnumLabelsAsync (issue #59): код enum-поля в реквизитах резолвится в отображаемое имя
+/// EnumType перед генерацией — иначе в PDF попадёт сырой код вместо человекочитаемого текста.
+/// </summary>
+[Collection("Integration")]
+public class EntityResolverEnumLabelsTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+
+    private async Task<Guid> SetupSetAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var c = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "Раздел"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, "Комплект"));
+        return set.Id;
+    }
+
+    private async Task<Guid> DocAsync(Guid setId, Guid typeId, string requisites)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var inst = await M(scope).Send(new AddDocumentToSetCommand(setId, typeId));
+        await M(scope).Send(new UpdateRequisitesCommand(inst.Id, J(requisites)));
+        return inst.Id;
+    }
+
+    private async Task ResolveEnumLabelsAsync(GenerationContext ctx, Guid instanceId)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
+        var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
+        await resolver.ResolveEnumLabelsAsync(ctx, inst!, default);
+    }
+
+    [Fact]
+    public async Task EnumFieldWithMatchingCode_ResolvesToLabel()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var enumType = await M(scope).Send(new CreateEnumTypeCommand(
+            "Статус", "STATUS_A", null, J("[{'code':'APPROVED','label':'Согласован'}]")));
+        var typeId = await M(scope).Send(new CreateDocumentTypeCommand("DOC_A", "DOC_A", DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Статус','type':'enum','typeId':'{enumType.Id}'}}]}}")));
+        var setId = await SetupSetAsync();
+        var docId = await DocAsync(setId, typeId.Id, "{'Статус':'APPROVED'}");
+
+        var ctx = new GenerationContext();
+        ctx.Set("Статус", "APPROVED");
+        await ResolveEnumLabelsAsync(ctx, docId);
+
+        Assert.Equal("Согласован", ctx.Data["Статус"]);
+    }
+
+    [Fact]
+    public async Task EnumFieldWithNonMatchingCode_LeftAsIs()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var enumType = await M(scope).Send(new CreateEnumTypeCommand(
+            "Статус", "STATUS_B", null, J("[{'code':'APPROVED','label':'Согласован'}]")));
+        var typeId = await M(scope).Send(new CreateDocumentTypeCommand("DOC_B", "DOC_B", DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Статус','type':'enum','typeId':'{enumType.Id}'}}]}}")));
+        var setId = await SetupSetAsync();
+        var docId = await DocAsync(setId, typeId.Id, "{'Статус':'UNKNOWN_CODE'}");
+
+        var ctx = new GenerationContext();
+        ctx.Set("Статус", "UNKNOWN_CODE");
+        await ResolveEnumLabelsAsync(ctx, docId);
+
+        // Толерантность: код без совпадения в реестре остаётся как есть, а не пропадает/падает.
+        Assert.Equal("UNKNOWN_CODE", ctx.Data["Статус"]);
+    }
+
+    [Fact]
+    public async Task NonEnumField_NotTouched()
+    {
+        var typeId = await M(fixture.Services.CreateScope()).Send(new CreateDocumentTypeCommand("DOC_C", "DOC_C",
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Имя','type':'string'}]}")));
+        var setId = await SetupSetAsync();
+        var docId = await DocAsync(setId, typeId.Id, "{'Имя':'Тест'}");
+
+        var ctx = new GenerationContext();
+        ctx.Set("Имя", "Тест");
+        await ResolveEnumLabelsAsync(ctx, docId);
+
+        Assert.Equal("Тест", ctx.Data["Имя"]);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/EnumTypeHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EnumTypeHandlerTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using BHS.CRG.Application.Catalog;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// CRUD для EnumType (issue #59) — по образцу DocumentTypeHandlerTests (issue #57): проверка
+/// использования перед удалением (тип перечисления, используемый в схеме, удалить нельзя).
+/// </summary>
+[Collection("Integration")]
+public class EnumTypeHandlerTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private IMediator Mediator(IServiceScope scope) =>
+        scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    private static JsonDocument Values(string json) => JsonDocument.Parse(json);
+
+    [Fact]
+    public async Task Create_PersistsEnumType()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var created = await Mediator(scope).Send(new CreateEnumTypeCommand(
+            "Статус", "STATUS1", null, Values("""[{"code":"DRAFT","label":"Черновик"}]""")));
+
+        Assert.NotEqual(Guid.Empty, created.Id);
+        Assert.Equal("Статус", created.Name);
+        Assert.Equal("STATUS1", created.Code);
+    }
+
+    [Fact]
+    public async Task Create_ThrowsOnDuplicateCode()
+    {
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new CreateEnumTypeCommand("Статус", "DUPE1", null, Values("[]")));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            Mediator(scope2).Send(new CreateEnumTypeCommand("Другой статус", "dupe1", null, Values("[]"))));
+    }
+
+    [Fact]
+    public async Task Update_ChangesValues()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var created = await Mediator(scope).Send(new CreateEnumTypeCommand(
+            "Статус", "UPD1", null, Values("""[{"code":"DRAFT","label":"Черновик"}]""")));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var updated = await Mediator(scope2).Send(new UpdateEnumTypeCommand(
+            created.Id, "Статус", "UPD1", "описание",
+            Values("""[{"code":"DRAFT","label":"Черновик"},{"code":"APPROVED","label":"Согласован"}]""")));
+
+        using var doc = updated.Values;
+        Assert.Equal(2, doc.RootElement.GetArrayLength());
+        Assert.Equal("описание", updated.Description);
+    }
+
+    [Fact]
+    public async Task SetGroup_UpdatesGroup()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var created = await Mediator(scope).Send(new CreateEnumTypeCommand("Статус", "GRP1", null, Values("[]")));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var updated = await Mediator(scope2).Send(new SetEnumTypeGroupCommand(created.Id, "Общие"));
+
+        Assert.Equal("Общие", updated.Group);
+    }
+
+    [Fact]
+    public async Task Delete_Unused_Succeeds()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var created = await Mediator(scope).Send(new CreateEnumTypeCommand("Статус", "DEL1", null, Values("[]")));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Mediator(scope2).Send(new DeleteEnumTypeCommand(created.Id));
+
+        using var scope3 = fixture.Services.CreateScope();
+        var all = await Mediator(scope3).Send(new ListEnumTypesQuery());
+        Assert.DoesNotContain(all, e => e.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task Delete_ReferencedInDocumentTypeSchema_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var enumType = await Mediator(scope).Send(new CreateEnumTypeCommand(
+            "Статус", "DEL2", null, Values("""[{"code":"DRAFT","label":"Черновик"}]""")));
+
+        var schema = JsonDocument.Parse(
+            $$"""{"fields":[{"key":"status","type":"enum","typeId":"{{enumType.Id}}"}]}""");
+        await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Акт", "ACT1", DocumentTypeKind.Document, null, schema));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeleteEnumTypeCommand(enumType.Id)));
+        Assert.Contains("Акт", ex.Message);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
+++ b/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
@@ -55,6 +55,7 @@ public class IntegrationTestFixture : WebApplicationFactory<Program>
                 catalog_entities,
                 common_data_entries,
                 primitive_types,
+                enum_types,
                 dataset_bindings,
                 dataset_binding_templates,
                 dataset_processing_templates,

--- a/src/server/BHS.CRG.Tests/Schema/DocumentTypeSchemaReaderTests.cs
+++ b/src/server/BHS.CRG.Tests/Schema/DocumentTypeSchemaReaderTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.Schema;
+
+/// <summary>
+/// Резолв enum-вариантов (issue #59): легаси инлайн options (код==имя) и typeId → EnumType.Values —
+/// оба представления толерантно сосуществуют, downstream получает одинаковую форму Options.
+/// </summary>
+public class DocumentTypeSchemaReaderTests
+{
+    private static DocumentType Type(string schemaJson) =>
+        DocumentType.Create("T", "C", DocumentTypeKind.Document, null, JsonDocument.Parse(schemaJson));
+
+    private static EnumType Enum(string valuesJson) =>
+        EnumType.Create("Статус", "STATUS", null, JsonDocument.Parse(valuesJson));
+
+    [Fact]
+    public void EffectiveFields_LegacyInlineOptions_ResolvesCodeEqualsLabel()
+    {
+        var dt = Type("""{"fields":[{"key":"status","type":"enum","options":["Черновик","Согласован"]}]}""");
+        var fields = DocumentTypeSchemaReader.EffectiveFields(dt.Id, new Dictionary<Guid, DocumentType> { [dt.Id] = dt });
+
+        var field = Assert.Single(fields);
+        Assert.NotNull(field.Options);
+        Assert.Equal(2, field.Options!.Count);
+        Assert.Equal(new EnumOptionInfo("Черновик", "Черновик"), field.Options[0]);
+        Assert.Equal(new EnumOptionInfo("Согласован", "Согласован"), field.Options[1]);
+    }
+
+    [Fact]
+    public void EffectiveFields_TypeIdWithEnumTypesById_ResolvesCodeLabelPairs()
+    {
+        var enumType = Enum("""[{"code":"DRAFT","label":"Черновик"},{"code":"APPROVED","label":"Согласован"}]""");
+        var dt = Type($$"""{"fields":[{"key":"status","type":"enum","typeId":"{{enumType.Id}}"}]}""");
+
+        var fields = DocumentTypeSchemaReader.EffectiveFields(dt.Id, new Dictionary<Guid, DocumentType> { [dt.Id] = dt },
+            new Dictionary<Guid, EnumType> { [enumType.Id] = enumType });
+
+        var field = Assert.Single(fields);
+        Assert.NotNull(field.Options);
+        Assert.Equal(new EnumOptionInfo("DRAFT", "Черновик"), field.Options![0]);
+        Assert.Equal(new EnumOptionInfo("APPROVED", "Согласован"), field.Options[1]);
+    }
+
+    [Fact]
+    public void EffectiveFields_TypeIdWithoutEnumTypesById_OptionsIsNull()
+    {
+        // enumTypesById не передан вызывающим кодом (напр. call site, которому Options не нужен) —
+        // не должно падать, просто Options остаётся null.
+        var dt = Type($$"""{"fields":[{"key":"status","type":"enum","typeId":"{{Guid.NewGuid()}}"}]}""");
+        var fields = DocumentTypeSchemaReader.EffectiveFields(dt.Id, new Dictionary<Guid, DocumentType> { [dt.Id] = dt });
+
+        Assert.Null(Assert.Single(fields).Options);
+    }
+
+    [Fact]
+    public void EffectiveFields_NonEnumField_OptionsIsNull()
+    {
+        var dt = Type("""{"fields":[{"key":"name","type":"string"}]}""");
+        var fields = DocumentTypeSchemaReader.EffectiveFields(dt.Id, new Dictionary<Guid, DocumentType> { [dt.Id] = dt });
+
+        Assert.Null(Assert.Single(fields).Options);
+    }
+
+    [Fact]
+    public void ReferencesEnumType_MatchesFieldWithSameTypeId()
+    {
+        var enumTypeId = Guid.NewGuid();
+        var dt = Type($$"""{"fields":[{"key":"status","type":"enum","typeId":"{{enumTypeId}}"}]}""");
+
+        Assert.True(DocumentTypeSchemaReader.ReferencesEnumType(dt.Schema, enumTypeId));
+        Assert.False(DocumentTypeSchemaReader.ReferencesEnumType(dt.Schema, Guid.NewGuid()));
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.15.2</Version>
+    <Version>0.16.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Проблема

Варианты enum-поля (`options: string[]`) задавались инлайн в схеме каждого типа документа — при
повторяющемся списке (единицы измерения, статусы) приходилось набирать вручную в каждом типе,
правки расходились. Backend не парсил `options` вообще — вся семантика enum существовала только
во frontend-парсинге JSON, из-за чего уже была асимметрия: клиентское распознавание скана
документа качества знало enum-варианты (получало их с фронта), серверный pull-пайплайн
распознавания датасетов — нет.

## Консультация

Взял в работу по итогам консультации с Архитектором и Дизайнером (issue #59, agentId в памяти
проекта). Ключевые решения:
- Новый реестр `EnumType` по образцу `PrimitiveType` (не переиспользование `PrimitiveType` — разная
  природа: closed-choice UI vs validation-правила).
- Значения — **код + имя**, не плоский список строк: стабильный код хранится в реквизитах,
  переименование варианта в реестре не портит уже сохранённые документы.
- Резолв `typeId → Values` **внутри** `SchemaFieldInfo`/`EffectiveFields` — чинит корень асимметрии
  (не просто добавляет вторую точку использования, которую можно забыть обновить).
- Легаси инлайн `options` и новый `typeId` толерантно сосуществуют — без принудительной миграции
  (по прецеденту issue #19/#38/#42).
- UI — вкладка «Перечисления» **внутри** уже существующей страницы «Типы полей» (по образцу
  таб-переключателя `TemplatesPage.tsx`), без inline-создания типа из редактора схемы.

## Изменения

**Backend:**
- `EnumType` (Domain/Catalog) + EF-конфигурация + миграция `AddEnumTypes`.
- CRUD (`Application/Catalog/Commands.cs`/`Handlers.cs`, `Api/Endpoints/Catalog/EnumTypeEndpoints.cs`)
  по образцу `PrimitiveType`. Удаление проверяет использование в схеме (тот же класс защиты, что
  для `DocumentType` в issue #57).
- `DocumentTypeSchemaReader`: новый `EnumOptionInfo(Code, Label)`, `SchemaFieldInfo.Options`,
  `enumTypesById` протянут через `EffectiveFields`/`ParseSchema` (по аналогии с `byId`). Легаси
  инлайн `options` → `Code==Label`; `typeId` → резолв из `EnumType.Values`.
- `EntityResolver.ResolveEnumLabelsAsync` — **обязательная часть** (не опция): раз реквизиты хранят
  код, генерация PDF обязана резолвить код в имя, иначе документ показывал бы сырой код вместо
  текста. Вызывается во всех 3 генерационных пайплайнах (генерация/debug-bundle/валидация),
  толерантно к несовпадению кода.

**Frontend:**
- `shared/api/enumTypes.ts` + типы `EnumOptionDef`/`EnumTypeDef` — копия `primitiveTypes.ts`.
- `EnumTypesSection.tsx` — новая вкладка «Перечисления» в `PrimitiveTypesPage.tsx` (переиспользует
  `TypeGroupAccordion`/`GroupPicker`, форма — по образцу, не общий generic-компонент).
- `FieldBuilder.tsx` — dropdown выбора `EnumType` для новых enum-полей; легаси-поля (инлайн `options`,
  без `typeId`) продолжают редактироваться старым инлайн-списком без изменений.
- `PrimitiveInput.tsx` (+ дублирующая копия в `common-data/systemFields.tsx`) — новый проп
  `enumTypeDef`: показывает `label`, хранит `code`; без него — легаси-поведение по `options`.

## Осознанно вне scope (не вызывает регресс)

Enum-поля внутри табличного редактора composite/array-типов (`ComplexFields.tsx`/`ArrayTableModal`/
`TableCell`) и paste-mapping (`PasteMappingModal.tsx`) — эти компоненты уже сегодня не получают
`primitiveTypes`/типизацию вообще (существующий, не вызванный этой задачей пробел). Заводить туда
ещё и `enumTypes` непропорционально расширило бы этот PR. Легаси-поля там продолжают работать как
раньше; новые `typeId`-поля деградируют до "нет вариантов" без крэша.

## Test plan

- [x] `dotnet test` — 352/352 (14 новых тестов: CRUD, delete-usage-check, резолв Options легаси/typeId,
  `ResolveEnumLabelsAsync`)
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 106/106
- [x] Живой сценарий через реальный HTTP API: создан `EnumType` (код+имя) → тип документа с enum-полем
  через `typeId` → реквизиты хранят код `APPROVED` → `debug-bundle` `data.json` содержит резолвленное
  `"Согласован"`, не сырой код → тестовые сущности удалены (тестовое использование не мешает удалению
  сначала документа/шаблона, потом типа, потом EnumType — issue #57/#59 usage-checks отработали как надо)

🤖 Generated with [Claude Code](https://claude.com/claude-code)