### PR TITLE
feat(schema): ограничение точности date-типа — «Год»/«Месяц Год»

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -6,9 +6,10 @@ import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
 import { useCommonDataForSet, useListCommonData } from '@/shared/api/commonData';
 import type {
-  CatalogScope, CommonDataEntry, DocumentInstance, DocumentType, FieldRef,
+  CatalogScope, CommonDataEntry, DocumentInstance, DocumentType, FieldRef, PrimitiveTypeDef,
 } from '@/shared/api/types';
 import { isFieldRef, SCOPE_LABELS } from '@/shared/api/types';
+import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import {
   resolveEffectiveFields, getDefaultValues, type SchemaField,
 } from '@/shared/api/schema';
@@ -59,11 +60,12 @@ export function ComplexCellPicker({ value, onChange, compositeType, setId, allDo
 
 // ─── Table cell ───────────────────────────────────────────────────────────────
 
-export function TableCell({ field, value, onChange, compositeType, setId, allDocTypes, scope, scopeId }: {
+export function TableCell({ field, value, onChange, compositeType, setId, allDocTypes, scope, scopeId, primitiveTypeDef }: {
   field: SchemaField; value: unknown; onChange: (v: unknown) => void;
   compositeType: DocumentType | null;
   setId?: string; allDocTypes: DocumentType[];
   scope?: CatalogScope; scopeId?: string | null;
+  primitiveTypeDef?: PrimitiveTypeDef;
 }) {
   const strVal = value == null ? '' : String(value);
   if (field.type === 'complex') {
@@ -94,6 +96,12 @@ export function TableCell({ field, value, onChange, compositeType, setId, allDoc
   }
   if (field.type === 'date') {
     return <DateInput value={strVal} onChange={v => onChange(v)}
+      className="w-full h-full flex items-center px-1.5 focus-within:bg-brand-subtle" />;
+  }
+  // primitive-тип на базе date (issue #60) — иначе рендерился обычным текст-инпутом без DateInput/точности
+  if (field.type === 'primitive' && primitiveTypeDef?.baseType === 'date') {
+    return <DateInput value={strVal} onChange={v => onChange(v)}
+      precision={primitiveTypeDef.constraints.datePrecision ?? 'day'}
       className="w-full h-full flex items-center px-1.5 focus-within:bg-brand-subtle" />;
   }
   return (
@@ -132,6 +140,8 @@ export function ArrayTableModal({
   const { data: cdForSet = [] } = useCommonDataForSet({ setId: setId ?? '', enabled: open && !!setId });
   const { data: cdSystem = [] } = useListCommonData({ scope: 'System', enabled: open && !setId });
   const commonDataEntries = (setId ? cdForSet : cdSystem) as CommonDataEntry[];
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
 
   const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
   const tableFields = subFields.filter(f => TABLE_SHOWN_TYPES.has(f.type));
@@ -241,7 +251,7 @@ export function ArrayTableModal({
                       style={{ border: BORDER, padding: 0, height: 26 }}>
                       <TableCell field={f} value={row[f.key]} onChange={v => updateCell(i, f.key, v)}
                         compositeType={compositeForField} setId={setId} allDocTypes={allDocTypes}
-                        scope={scope} scopeId={scopeId} />
+                        scope={scope} scopeId={scopeId} primitiveTypeDef={primDef(f)} />
                     </td>
                   );
                 })}
@@ -300,6 +310,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   const [catalogPickerOpen, setCatalogPickerOpen] = useState(false);
 
   const hasTableFields = subFields.some(f => TABLE_SHOWN_TYPES.has(f.type));
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
 
   function addRow() {
     const newRow = getDefaultValues(subFields);
@@ -440,7 +452,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                               otherInstances={otherInstances} setId={setId} />
                           ) : (
                             <PrimitiveInput field={sf} value={subVal}
-                              onChange={v => updateRow(i, { ...row, [sf.key]: v })} invalid={invalid} />
+                              onChange={v => updateRow(i, { ...row, [sf.key]: v })} invalid={invalid}
+                              primitiveTypeDef={primDef(sf)} />
                           )}
                           {invalid && <p className="text-xs text-danger mt-0.5">Обязательное поле</p>}
                         </div>
@@ -489,6 +502,7 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(true);
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
 
   if (isFieldRef(value)) {
@@ -512,6 +526,7 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
   const subValues = (value != null && typeof value === 'object' && !isFieldRef(value)
     ? value : {}) as Record<string, unknown>;
   const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
+  const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
 
   function setSubValue(key: string, val: unknown) {
     onChange({ ...subValues, [key]: val });
@@ -574,7 +589,8 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
                     setId={setId} otherInstances={otherInstances}
                     scope={scope} scopeId={scopeId} docRefMode={docRefMode} />
                 ) : (
-                  <PrimitiveInput field={sf} value={subVal} onChange={v => setSubValue(sf.key, v)} invalid={invalid} />
+                  <PrimitiveInput field={sf} value={subVal} onChange={v => setSubValue(sf.key, v)} invalid={invalid}
+                    primitiveTypeDef={primDef(sf)} />
                 )}
                 {invalid && <p className="text-xs text-danger mt-1">Обязательное поле</p>}
               </div>

--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -1,4 +1,4 @@
-import { isoToRu, ruToISO } from '@/shared/utils/date';
+import { formatDateRu, ruToISO } from '@/shared/utils/date';
 import { DateInput } from '@/shared/ui/DateInput';
 import type { SchemaField } from '@/shared/api/schema';
 import type { PrimitiveTypeDef, FieldConstraints, EnumTypeDef } from '@/shared/api/types';
@@ -34,8 +34,9 @@ export function validateConstraint(value: unknown, def: PrimitiveTypeDef): strin
     if (c.max != null && num > c.max) return `Макс. значение: ${c.max}`;
   } else if (def.baseType === 'date') {
     const iso = ruToISO(String(value));
-    if (c.minDate && iso < c.minDate) return `Дата не ранее ${isoToRu(c.minDate)}`;
-    if (c.maxDate && iso > c.maxDate) return `Дата не позднее ${isoToRu(c.maxDate)}`;
+    const prec = c.datePrecision ?? 'day';
+    if (c.minDate && iso < c.minDate) return `Дата не ранее ${formatDateRu(c.minDate, prec)}`;
+    if (c.maxDate && iso > c.maxDate) return `Дата не позднее ${formatDateRu(c.maxDate, prec)}`;
   }
   return null;
 }
@@ -77,7 +78,9 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
   if (field.type === 'primitive' && primitiveTypeDef) {
     const bt = primitiveTypeDef.baseType;
     if (bt === 'date') {
-      return <DateInput value={strVal} onChange={v => onChange(v)} className={cls} disabled={readOnly} />;
+      return <DateInput value={strVal} onChange={v => onChange(v)}
+        precision={primitiveTypeDef.constraints.datePrecision ?? 'day'}
+        className={cls} disabled={readOnly} />;
     }
     const step = bt === 'number' && primitiveTypeDef.constraints.integer ? 1 : undefined;
     return (

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -10,7 +10,8 @@ import {
   useSetPrimitiveTypeGroup,
   buildPrimitiveTypeDto,
 } from '@/shared/api/primitiveTypes';
-import type { FieldConstraints, PrimitiveTypeDef } from '@/shared/api/types';
+import type { FieldConstraints, PrimitiveTypeDef, DatePrecision } from '@/shared/api/types';
+import { formatDateRu } from '@/shared/utils/date';
 import { useTagRegistry, fieldTags } from '@/shared/api/tags';
 import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
 import { EnumTypesSection } from './EnumTypesSection';
@@ -22,6 +23,16 @@ const BASE_TYPES = [
   { value: 'number' as const, label: 'Число' },
   { value: 'date' as const, label: 'Дата' },
 ];
+
+const DATE_PRECISIONS: { value: DatePrecision; label: string }[] = [
+  { value: 'day', label: 'Полная (ДД.ММ.ГГГГ)' },
+  { value: 'month', label: 'Месяц и год (ММ.ГГГГ)' },
+  { value: 'year', label: 'Только год (ГГГГ)' },
+];
+
+const DATE_PRECISION_LABEL: Record<DatePrecision, string> = {
+  day: 'полная', month: 'месяц и год', year: 'только год',
+};
 
 // ─── Constraint editor ────────────────────────────────────────────────────────
 
@@ -128,23 +139,48 @@ function ConstraintEditor({ baseType, constraints, onChange }: ConstraintEditorP
 
   // date
   const dateCls = 'w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm';
+  const precision = constraints.datePrecision ?? 'day';
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="space-y-3">
       <div>
-        <label className="block text-sm font-medium text-fg1 mb-1">Минимальная дата</label>
-        <DateInput
-          value={constraints.minDate ?? ''}
-          onChange={v => v ? set('minDate', v) : unset('minDate')}
-          className={dateCls}
-        />
+        <label className="block text-sm font-medium text-fg1 mb-1">Точность</label>
+        <div className="flex gap-2">
+          {DATE_PRECISIONS.map(p => (
+            <button
+              key={p.value}
+              type="button"
+              onClick={() => p.value === 'day' ? unset('datePrecision') : set('datePrecision', p.value)}
+              className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                precision === p.value ? 'bg-brand text-white' : 'bg-base text-fg2 hover:bg-muted'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-xs text-fg3 mt-1">
+          Управляет форматом ввода и отображения. Значение хранится как полная дата.
+        </p>
       </div>
-      <div>
-        <label className="block text-sm font-medium text-fg1 mb-1">Максимальная дата</label>
-        <DateInput
-          value={constraints.maxDate ?? ''}
-          onChange={v => v ? set('maxDate', v) : unset('maxDate')}
-          className={dateCls}
-        />
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-sm font-medium text-fg1 mb-1">Минимальная дата</label>
+          <DateInput
+            value={constraints.minDate ?? ''}
+            onChange={v => v ? set('minDate', v) : unset('minDate')}
+            precision={precision}
+            className={dateCls}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-fg1 mb-1">Максимальная дата</label>
+          <DateInput
+            value={constraints.maxDate ?? ''}
+            onChange={v => v ? set('maxDate', v) : unset('maxDate')}
+            precision={precision}
+            className={dateCls}
+          />
+        </div>
       </div>
     </div>
   );
@@ -314,8 +350,10 @@ function ConstraintSummary({ baseType, c }: { baseType: string; c: FieldConstrai
     if (c.max != null) parts.push(`≤ ${c.max}`);
     if (c.integer) parts.push('целое');
   } else if (baseType === 'date') {
-    if (c.minDate) parts.push(`от ${c.minDate}`);
-    if (c.maxDate) parts.push(`до ${c.maxDate}`);
+    const prec = c.datePrecision ?? 'day';
+    if (prec !== 'day') parts.push(DATE_PRECISION_LABEL[prec]);
+    if (c.minDate) parts.push(`от ${formatDateRu(c.minDate, prec)}`);
+    if (c.maxDate) parts.push(`до ${formatDateRu(c.maxDate, prec)}`);
   }
   if (parts.length === 0) return <span className="text-fg4 italic">нет ограничений</span>;
   return <span>{parts.join(', ')}</span>;

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -166,6 +166,10 @@ export interface GeneratedFile {
 
 // ─── Primitive Types ─────────────────────────────────────────────────────────
 
+/** Точность ввода/отображения date-значения (issue #60). Хранение всегда полный ISO YYYY-MM-DD;
+ *  точность управляет только раскладкой ввода и отображением. Отсутствие ≡ 'day' (обратная совм.). */
+export type DatePrecision = 'day' | 'month' | 'year';
+
 export interface FieldConstraints {
   pattern?: string;
   patternMessage?: string;
@@ -176,6 +180,8 @@ export interface FieldConstraints {
   integer?: boolean;
   minDate?: string;
   maxDate?: string;
+  /** Точность date-типа (issue #60). Отсутствует ≡ 'day' — полная дата ДД.ММ.ГГГГ. */
+  datePrecision?: DatePrecision;
 }
 
 export interface PrimitiveTypeDef {

--- a/src/client/src/shared/ui/DateInput.tsx
+++ b/src/client/src/shared/ui/DateInput.tsx
@@ -1,20 +1,30 @@
 import { useEffect, useRef, useState } from 'react';
+import type { DatePrecision } from '@/shared/api/types';
 
 interface DateInputProps {
-  /** Stored value: ISO YYYY-MM-DD or '' */
+  /** Stored value: ISO YYYY-MM-DD or '' (always full ISO, независимо от точности) */
   value: string;
-  /** Emits ISO YYYY-MM-DD when complete, '' when explicitly cleared, nothing while partially typed */
+  /**
+   * Emits full ISO YYYY-MM-DD when the visible segments are complete, '' when explicitly cleared,
+   * nothing while partially typed. Скрытые точностью части допоняются '01' (issue #60):
+   * 'year' → YYYY-01-01, 'month' → YYYY-MM-01, 'day' → YYYY-MM-DD.
+   */
   onChange: (iso: string) => void;
+  /** Точность ввода: 'day' (ДД.ММ.ГГГГ, по умолч.), 'month' (ММ.ГГГГ), 'year' (ГГГГ). */
+  precision?: DatePrecision;
   /** Applied to the outer container div (border, bg, padding, focus-within:ring, width) */
   className?: string;
   disabled?: boolean;
 }
 
-export function DateInput({ value, onChange, className = '', disabled = false }: DateInputProps) {
+export function DateInput({ value, onChange, precision = 'day', className = '', disabled = false }: DateInputProps) {
   const [d, setD] = useState('');
   const [m, setM] = useState('');
   const [y, setY] = useState('');
   const [focused, setFocused] = useState(false);
+
+  const showMonth = precision !== 'year';
+  const showDay = precision === 'day';
 
   const dayRef = useRef<HTMLInputElement>(null);
   const monRef = useRef<HTMLInputElement>(null);
@@ -41,7 +51,18 @@ export function DateInput({ value, onChange, className = '', disabled = false }:
     blurTimer.current = setTimeout(() => setFocused(false), 120);
   }
 
+  // Emit полный ISO из видимых сегментов; скрытые части допоняем '01'. Пустой ввод — явная очистка.
   function emit(dd: string, mm: string, yyyy: string) {
+    if (precision === 'year') {
+      if (yyyy.length === 4) onChange(`${yyyy}-01-01`);
+      else if (!yyyy) onChange('');
+      return;
+    }
+    if (precision === 'month') {
+      if (mm.length === 2 && yyyy.length === 4) onChange(`${yyyy}-${mm}-01`);
+      else if (!mm && !yyyy) onChange('');
+      return;
+    }
     if (dd.length === 2 && mm.length === 2 && yyyy.length === 4) {
       onChange(`${yyyy}-${mm}-${dd}`);
     } else if (!dd && !mm && !yyyy) {
@@ -117,32 +138,40 @@ export function DateInput({ value, onChange, className = '', disabled = false }:
 
   return (
     <div className={`flex items-center ${className}`}>
-      <input
-        ref={dayRef} type="text" inputMode="numeric"
-        placeholder="ДД" maxLength={2}
-        style={{ width: '2.2ch' }}
-        value={d}
-        disabled={disabled}
-        onChange={e => handleD(e.target.value)}
-        onKeyDown={onDayKey}
-        onFocus={onFocus}
-        onBlur={() => { blurD(); onBlur(); }}
-        className={seg}
-      />
-      <span className="text-fg4 select-none">.</span>
-      <input
-        ref={monRef} type="text" inputMode="numeric"
-        placeholder="ММ" maxLength={2}
-        style={{ width: '2.2ch' }}
-        value={m}
-        disabled={disabled}
-        onChange={e => handleM(e.target.value)}
-        onKeyDown={onMonKey}
-        onFocus={onFocus}
-        onBlur={() => { blurM(); onBlur(); }}
-        className={seg}
-      />
-      <span className="text-fg4 select-none">.</span>
+      {showDay && (
+        <>
+          <input
+            ref={dayRef} type="text" inputMode="numeric"
+            placeholder="ДД" maxLength={2}
+            style={{ width: '2.2ch' }}
+            value={d}
+            disabled={disabled}
+            onChange={e => handleD(e.target.value)}
+            onKeyDown={onDayKey}
+            onFocus={onFocus}
+            onBlur={() => { blurD(); onBlur(); }}
+            className={seg}
+          />
+          <span className="text-fg4 select-none">.</span>
+        </>
+      )}
+      {showMonth && (
+        <>
+          <input
+            ref={monRef} type="text" inputMode="numeric"
+            placeholder="ММ" maxLength={2}
+            style={{ width: '2.2ch' }}
+            value={m}
+            disabled={disabled}
+            onChange={e => handleM(e.target.value)}
+            onKeyDown={onMonKey}
+            onFocus={onFocus}
+            onBlur={() => { blurM(); onBlur(); }}
+            className={seg}
+          />
+          <span className="text-fg4 select-none">.</span>
+        </>
+      )}
       <input
         ref={yrRef} type="text" inputMode="numeric"
         placeholder="ГГГГ" maxLength={4}

--- a/src/client/src/shared/utils/date.test.ts
+++ b/src/client/src/shared/utils/date.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { isoToRu, ruToISO, formatDateRu } from './date';
+
+describe('isoToRu', () => {
+  it('converts full ISO to RU', () => {
+    expect(isoToRu('2026-07-11')).toBe('11.07.2026');
+  });
+  it('passes through empty/other', () => {
+    expect(isoToRu('')).toBe('');
+    expect(isoToRu(null)).toBe('');
+    expect(isoToRu('не-дата')).toBe('не-дата');
+  });
+});
+
+describe('ruToISO', () => {
+  it('converts RU to ISO', () => {
+    expect(ruToISO('11.07.2026')).toBe('2026-07-11');
+  });
+  it('passes through incomplete', () => {
+    expect(ruToISO('11.07')).toBe('11.07');
+  });
+});
+
+describe('formatDateRu (issue #60)', () => {
+  const iso = '2026-07-11';
+  it('day precision (default) shows full date', () => {
+    expect(formatDateRu(iso)).toBe('11.07.2026');
+    expect(formatDateRu(iso, 'day')).toBe('11.07.2026');
+  });
+  it('month precision hides the day', () => {
+    expect(formatDateRu(iso, 'month')).toBe('07.2026');
+  });
+  it('year precision shows only the year', () => {
+    expect(formatDateRu(iso, 'year')).toBe('2026');
+  });
+  it('formats padded partial dates by precision (values stored full ISO)', () => {
+    // year-точность хранит YYYY-01-01, month — YYYY-MM-01; показываем только значимую часть
+    expect(formatDateRu('2026-01-01', 'year')).toBe('2026');
+    expect(formatDateRu('2026-07-01', 'month')).toBe('07.2026');
+  });
+  it('passes through empty/unparseable', () => {
+    expect(formatDateRu('')).toBe('');
+    expect(formatDateRu(null, 'year')).toBe('');
+    expect(formatDateRu('мусор', 'month')).toBe('мусор');
+  });
+});

--- a/src/client/src/shared/utils/date.ts
+++ b/src/client/src/shared/utils/date.ts
@@ -1,8 +1,25 @@
+import type { DatePrecision } from '@/shared/api/types';
+
 /** Converts ISO date (YYYY-MM-DD) → Russian display format (DD.MM.YYYY). Passes through anything else. */
 export function isoToRu(iso: string | null | undefined): string {
   if (!iso) return '';
   const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
   return m ? `${m[3]}.${m[2]}.${m[1]}` : iso;
+}
+
+/**
+ * Форматирует ISO-дату для показа человеку с учётом точности типа (issue #60):
+ * 'year' → «2026», 'month' → «07.2026», 'day'/по умолчанию → «01.07.2026».
+ * Хранение всегда полный ISO; здесь лишь скрываем допоненные части. Непонятный вход — как есть.
+ */
+export function formatDateRu(iso: string | null | undefined, precision: DatePrecision = 'day'): string {
+  if (!iso) return '';
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return iso;
+  const [, y, mo, d] = m;
+  if (precision === 'year') return y;
+  if (precision === 'month') return `${mo}.${y}`;
+  return `${d}.${mo}.${y}`;
 }
 
 /** Converts Russian format (DD.MM.YYYY) → ISO (YYYY-MM-DD). Passes through incomplete/other strings. */

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.17.1</Version>
+    <Version>0.18.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Summary
Примитивные типы на базе `date` теперь умеют ограничивать точность ввода/отображения: полная дата (ДД.ММ.ГГГГ), «месяц и год» (ММ.ГГГГ) или «только год» (ГГГГ).

Согласованное решение: **хранение не меняется** — значение всегда полный ISO `YYYY-MM-DD` (скрытые точностью части допоняются `01`). Точность — метаданные типа (`datePrecision` в `FieldConstraints`), управляют только форматом ввода-вывода **на экране**. Валидация `minDate/maxDate` и все потребители значения не затрагиваются. Про PDF заботится шаблон (backend даты не форматирует — как и до этого).

## Изменения (только фронтенд)
- `types.ts` — `datePrecision?: 'day'|'month'|'year'` в `FieldConstraints` (отсутствует ≡ `day`).
- `DateInput` — проп `precision`: рендерит 1/2/3 сегмента, при завершении допоняет скрытые части `01` (год → `2026-01-01`, месяц-год → `2026-07-01`). Хранение остаётся полным ISO.
- `date.ts` — `formatDateRu(iso, precision)` для precision-aware отображения (`2026` / `07.2026` / `01.07.2026`).
- `PrimitiveInput` — читает `datePrecision` из типа, прокидывает в `DateInput`; сообщения валидации min/max показывают границы в той же точности.
- `PrimitiveTypesPage` — селектор точности в `ConstraintEditor` (min/max тоже уважают точность); `ConstraintSummary` показывает точность и границы форматированно.
- `ComplexFields` — заодно закрыт смежный пробел: `primitive`+`date` в **табличных ячейках** и **составных под-полях** раньше рендерился обычным текст-инпутом без `DateInput`/точности; теперь резолвится тип и подставляется `DateInput`.

Миграций/бэкенда нет: непрозрачный `Constraints` JSONB просто везёт новый ключ; существующие даты валидны как `day`.

## Test plan
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 115/115 (добавлен `date.test.ts`: 9 тестов на `formatDateRu`/`isoToRu`/`ruToISO`)
- [x] Vite HMR применил все изменённые файлы без ошибок трансформации; app поднят (client 200, api 401)
- [ ] Визуальный проход по UI (создать year-precision тип, ввести/увидеть в форме, таблице, составном поле) — не делал (экономный режим, скриншоты по запросу); готов снять, если нужно

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)