### PR TITLE
fix(templates): пришпилить «Системные ассеты» под редактором на вкладке «Общие функции Typst»

### DIFF
--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -176,7 +176,9 @@ export function TemplatesPage() {
 
       {/* ── Content ── */}
       {mode === 'userlib' ? (
-        <UserLibPanel />
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <UserLibPanel />
+        </div>
       ) : !selectedTypeId ? (
         <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Выберите тип документа</div>
       ) : templatesLoading ? (

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.18.1</Version>
+    <Version>0.18.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Summary
На вкладке «Общие функции Typst» блок «Системные ассеты» уходил ниже вьюпорта и скроллился вместе с редактором вместо того, чтобы быть пришпиленным снизу.

Причина: `UserLibPanel` вставлялся в `TemplatesPage` голым прямым потомком колонки `flex flex-col h-full` — **без** `flex-1`/`min-h-0` (в отличие от симметричной ветки «Шаблоны документов»). Его `h-full` считался от высоты страницы, header добавлялся сверху → переполнение вьюпорта, пришпиленный блок ассетов выпадал за сгиб.

Фикс: обёрнут в `<div className="flex-1 min-h-0 overflow-hidden">` — высота ограничена, `UserLibPanel` заполняет её, «Системные ассеты» пришпилены снизу (как задумано в issue #62). Чисто layout, логику не трогал.

## Test plan
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 115/115
- [x] Vite HMR применил `TemplatesPage.tsx` без ошибок
- [ ] Визуальная сверка вкладки (скриншот по запросу — экономный режим)

Closes #69
🤖 Generated with [Claude Code](https://claude.com/claude-code)