### PR TITLE
feat(documents): базовый экземпляр для документов комплекта

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -205,8 +205,6 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   }, [hasBase, ancestorIds, otherInstances, commonData]);
 
   const selectedBase = baseRef ? baseCandidates.find(c => c.id === baseRef.id) : undefined;
-  const ownFields = docType ? parseSchemaFields(docType.schema) : schemaFields;
-  const displayFields = (hasBase && baseRef) ? ownFields : schemaFields;
   // Поля, покрытые базовым экземпляром (его собственные ключи), не требуются к заполнению здесь —
   // придут наследованием при генерации (тот же класс, что sourceBoundFields из #55).
   const baseCoveredFields = useMemo(() => {
@@ -218,6 +216,14 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     const entry = (commonData as CommonDataEntry[]).find(e => e.id === baseRef.id);
     return new Set(entry ? Object.keys(entry.data) : []);
   }, [baseRef, otherInstances, commonData]);
+  const ownFields = docType ? parseSchemaFields(docType.schema) : schemaFields;
+  const ownFieldKeys = new Set(ownFields.map(f => f.key));
+  // При выбранной базе скрываем ТОЛЬКО поля, реально покрытые ею; собственные (можно переопределить)
+  // и унаследованные, но НЕ покрытые базой (напр. база — дед/запись общих данных, часть полей не даёт),
+  // показываем — их нужно заполнить вручную (issue #71).
+  const displayFields = (hasBase && baseRef)
+    ? schemaFields.filter(f => ownFieldKeys.has(f.key) || !baseCoveredFields.has(f.key))
+    : schemaFields;
   function selectBase(c: BaseCandidate) { setValue('_baseRef', { kind: c.kind, id: c.id }); }
   function clearBaseRef() {
     setValues(p => { const n = { ...p }; delete n._baseRef; return n; });

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database } from 'lucide-react';
+import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database, Link2, Unlink } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
 import { EmailSendDialog } from '../EmailSendDialog';
@@ -15,7 +15,7 @@ import { useListTemplates } from '@/shared/api/templates';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import {
-  groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, type SchemaField,
+  groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, parseSchemaFields, type SchemaField,
 } from '@/shared/api/schema';
 import {
   STATUS_LABELS, STATUS_COLORS,
@@ -73,6 +73,40 @@ function BoundStateHint({ loading, error }: { loading: boolean; error: boolean }
   return <p className="text-[11px] text-fg4 mt-0.5 italic">{text}</p>;
 }
 
+/// Пикер базового экземпляра (issue #71) — порт CatalogBaseEntryPicker для документов комплекта:
+/// выбор документа родительского типа из ТОГО ЖЕ комплекта (кандидаты уже под рукой в otherInstances).
+function BaseInstancePicker({ open, onOpenChange, parentType, candidates, onSelect }: {
+  open: boolean; onOpenChange: (o: boolean) => void;
+  parentType: DocumentType; candidates: DocumentInstance[];
+  onSelect: (inst: DocumentInstance) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const filtered = candidates.filter(i => (i.name ?? '').toLowerCase().includes(search.toLowerCase()));
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title={`Базовый экземпляр: ${parentType.name}`}>
+      <div className="space-y-4">
+        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
+          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
+        {filtered.length === 0 ? (
+          <p className="text-sm text-fg4 text-center py-4">
+            Нет документов типа «{parentType.name}» в комплекте.
+          </p>
+        ) : (
+          <div className="space-y-1 max-h-72 overflow-y-auto">
+            {filtered.map(inst => (
+              <button key={inst.id} type="button" onClick={() => { onSelect(inst); onOpenChange(false); }}
+                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
+                <Link2 size={13} className="text-brand shrink-0" />
+                <span className="flex-1 font-medium text-fg1 truncate">{inst.name ?? '(без имени)'}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
 function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef, onGoToDataTab }: {
   instance: DocumentInstance; setId: string; schemaFields: SchemaField[];
   allDocTypes: DocumentType[]; docType: DocumentType | undefined;
@@ -103,9 +137,30 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     }
     return s;
   }, [dsBindings]);
-  // Обязательное поле, покрытое активной привязкой, не блокирует сохранение реквизитов —
-  // значение подставится при генерации (DataSetResolver.InjectAsync), форма его не хранит.
-  const isFieldMissing = (f: SchemaField, val: unknown) => isMissing(f, val) && !sourceBoundFields.has(f.key);
+  // Базовый экземпляр (issue #71): документ дочернего типа можно связать с документом РОДИТЕЛЬСКОГО
+  // типа в том же комплекте — при связке наследуются его реквизиты (мердж при генерации), а вручную
+  // заполняются только собственные поля дочернего типа. Ссылка хранится как `_baseRef` в реквизитах.
+  const [basePickerOpen, setBasePickerOpen] = useState(false);
+  const parentType = docType?.parentId ? allDocTypes.find(dt => dt.id === docType.parentId) ?? null : null;
+  const baseRefId = typeof values._baseRef === 'string' ? values._baseRef : undefined;
+  const baseCandidates = parentType ? otherInstances.filter(i => i.documentTypeId === parentType.id) : [];
+  const baseInstance = baseRefId ? baseCandidates.find(i => i.id === baseRefId) : undefined;
+  const ownFields = docType ? parseSchemaFields(docType.schema) : schemaFields;
+  const displayFields = (parentType && baseRefId) ? ownFields : schemaFields;
+  // Поля, покрытые базовым экземпляром, не требуются к заполнению здесь — придут наследованием при
+  // генерации (тот же класс, что sourceBoundFields из #55).
+  const baseCoveredFields = useMemo(
+    () => new Set(baseInstance ? Object.keys(baseInstance.requisites) : []),
+    [baseInstance]);
+  function clearBaseRef() {
+    setValues(p => { const n = { ...p }; delete n._baseRef; return n; });
+    onDirty(true);
+  }
+
+  // Обязательное поле, покрытое активной привязкой ИЛИ базовым экземпляром, не блокирует сохранение
+  // реквизитов — значение подставится при генерации, форма его не хранит.
+  const isFieldMissing = (f: SchemaField, val: unknown) =>
+    isMissing(f, val) && !sourceBoundFields.has(f.key) && !baseCoveredFields.has(f.key);
 
   // Предпросмотр значений привязок (issue #67): скалярный биндинг не пишет значение в реквизиты —
   // оно резолвится только при генерации. Тот же preview-эндпоинт, что и на вкладке «Данные»,
@@ -191,7 +246,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   if (schemaFields.length === 0)
     return <div className="text-sm text-fg4 py-4 text-center">Схема полей не задана.</div>;
 
-  const sections = groupEffectiveFields(schemaFields, docType?.schema ?? {});
+  const sections = groupEffectiveFields(displayFields, docType?.schema ?? {});
 
   function renderFields(fields: SchemaField[]) {
     const isWide = (f: SchemaField) =>
@@ -300,6 +355,50 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
+      {parentType && (
+        <div className="rounded-lg border border-stroke p-3 space-y-2">
+          <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
+            Базовый экземпляр
+            <span className="normal-case font-normal ml-1 text-fg4">({parentType.name})</span>
+          </p>
+          {baseRefId && baseInstance ? (
+            <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
+              <Link2 size={14} className="text-brand shrink-0" />
+              <span className="flex-1 text-sm font-medium text-brand-hover truncate">{baseInstance.name ?? '(без имени)'}</span>
+              <button type="button" onClick={clearBaseRef}
+                className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
+                <Unlink size={13} />
+              </button>
+            </div>
+          ) : baseRefId && !baseInstance ? (
+            <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2">
+              <span className="flex-1 text-sm text-warning truncate">Базовый экземпляр не найден в комплекте</span>
+              <button type="button" onClick={clearBaseRef}
+                className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
+                <Unlink size={13} />
+              </button>
+            </div>
+          ) : (
+            <button type="button" onClick={() => setBasePickerOpen(true)}
+              className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
+              <Link2 size={14} />
+              Выбрать из «{parentType.name}»...
+            </button>
+          )}
+          {!baseRefId && ownFields.length < schemaFields.length && (
+            <p className="text-xs text-fg4">
+              Без базового экземпляра все {schemaFields.length} полей заполняются вручную.
+            </p>
+          )}
+          <BaseInstancePicker
+            open={basePickerOpen}
+            onOpenChange={setBasePickerOpen}
+            parentType={parentType}
+            candidates={baseCandidates}
+            onSelect={inst => setValue('_baseRef', inst.id)}
+          />
+        </div>
+      )}
       {sections.map(section => {
         if (!section.title) {
           // Ungrouped fields — always visible, no header

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -13,7 +13,9 @@ import {
 } from '@/shared/api/documentSets';
 import { useListTemplates } from '@/shared/api/templates';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
-import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
+import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTypeDef, CommonDataEntry, CatalogScope } from '@/shared/api/types';
+import { SCOPE_LABELS } from '@/shared/api/types';
+import { useCommonDataForSet } from '@/shared/api/commonData';
 import {
   groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, parseSchemaFields, type SchemaField,
 } from '@/shared/api/schema';
@@ -73,31 +75,71 @@ function BoundStateHint({ loading, error }: { loading: boolean; error: boolean }
   return <p className="text-[11px] text-fg4 mt-0.5 italic">{text}</p>;
 }
 
-/// Пикер базового экземпляра (issue #71) — порт CatalogBaseEntryPicker для документов комплекта:
-/// выбор документа родительского типа из ТОГО ЖЕ комплекта (кандидаты уже под рукой в otherInstances).
-function BaseInstancePicker({ open, onOpenChange, parentType, candidates, onSelect }: {
+// ─── Базовый экземпляр (issue #71) ────────────────────────────────────────────
+// Документ дочернего типа может наследоваться от базы — документа комплекта ЛИБО записи общих данных.
+// Кандидаты берутся по всей цепочке типов-предков и по скоп-близости (комплект > раздел > стройка >
+// система), внутри уровня — по близости наследования. Ссылка хранится как _baseRef {kind,id}.
+
+type BaseCandidateKind = 'instance' | 'catalog';
+interface BaseCandidate {
+  kind: BaseCandidateKind;
+  id: string;
+  name: string;
+  typeId: string;
+  tier: number;        // скоп-уровень: 0 комплект, 1 раздел, 2 стройка, 3 система
+  scopeLabel: string;  // «Комплект»/«Раздел»/«Стройка»/«Система»
+  dist: number;        // дистанция наследования: 0 прямой родитель, дальше — больше
+}
+
+const SCOPE_TIER: Record<CatalogScope, number> = { Set: 0, Section: 1, Construction: 2, System: 3 };
+
+/// Идентификаторы типов-предков по цепочке parentId (по возрастанию дистанции: [родитель, дед, …]).
+function ancestorTypeIds(docType: DocumentType | undefined, allDocTypes: DocumentType[]): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let cur = docType?.parentId ?? undefined;
+  while (cur && !seen.has(cur)) {
+    seen.add(cur); ids.push(cur);
+    cur = allDocTypes.find(dt => dt.id === cur)?.parentId ?? undefined;
+  }
+  return ids;
+}
+
+/// Толерантный разбор _baseRef: {kind,id} (issue #71) или голая строка-id (legacy = catalog/запись).
+function parseBaseRef(raw: unknown): { kind: BaseCandidateKind; id: string } | undefined {
+  if (typeof raw === 'string') return raw ? { kind: 'catalog', id: raw } : undefined;
+  if (raw && typeof raw === 'object' && 'id' in raw) {
+    const r = raw as { kind?: string; id?: string };
+    if (r.id) return { kind: r.kind === 'instance' ? 'instance' : 'catalog', id: r.id };
+  }
+  return undefined;
+}
+
+/// Пикер базового экземпляра (issue #71) — единый список кандидатов (документы + общие данные),
+/// уже отсортированный по близости; у каждого — бейдж уровня скопа.
+function BaseCandidatePicker({ open, onOpenChange, candidates, onSelect }: {
   open: boolean; onOpenChange: (o: boolean) => void;
-  parentType: DocumentType; candidates: DocumentInstance[];
-  onSelect: (inst: DocumentInstance) => void;
+  candidates: BaseCandidate[]; onSelect: (c: BaseCandidate) => void;
 }) {
   const [search, setSearch] = useState('');
-  const filtered = candidates.filter(i => (i.name ?? '').toLowerCase().includes(search.toLowerCase()));
+  const filtered = candidates.filter(c => c.name.toLowerCase().includes(search.toLowerCase()));
   return (
-    <Modal open={open} onOpenChange={onOpenChange} title={`Базовый экземпляр: ${parentType.name}`}>
+    <Modal open={open} onOpenChange={onOpenChange} title="Базовый экземпляр">
       <div className="space-y-4">
         <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
           className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
         {filtered.length === 0 ? (
-          <p className="text-sm text-fg4 text-center py-4">
-            Нет документов типа «{parentType.name}» в комплекте.
-          </p>
+          <p className="text-sm text-fg4 text-center py-4">Нет подходящих базовых экземпляров.</p>
         ) : (
           <div className="space-y-1 max-h-72 overflow-y-auto">
-            {filtered.map(inst => (
-              <button key={inst.id} type="button" onClick={() => { onSelect(inst); onOpenChange(false); }}
+            {filtered.map(c => (
+              <button key={`${c.kind}:${c.id}`} type="button" onClick={() => { onSelect(c); onOpenChange(false); }}
                 className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                <Link2 size={13} className="text-brand shrink-0" />
-                <span className="flex-1 font-medium text-fg1 truncate">{inst.name ?? '(без имени)'}</span>
+                {c.kind === 'instance'
+                  ? <FileText size={13} className="text-brand shrink-0" />
+                  : <Database size={13} className="text-brand shrink-0" />}
+                <span className="flex-1 font-medium text-fg1 truncate">{c.name}</span>
+                <span className="text-[11px] text-fg4 shrink-0">{c.scopeLabel}</span>
               </button>
             ))}
           </div>
@@ -137,21 +179,46 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     }
     return s;
   }, [dsBindings]);
-  // Базовый экземпляр (issue #71): документ дочернего типа можно связать с документом РОДИТЕЛЬСКОГО
-  // типа в том же комплекте — при связке наследуются его реквизиты (мердж при генерации), а вручную
-  // заполняются только собственные поля дочернего типа. Ссылка хранится как `_baseRef` в реквизитах.
+  // Базовый экземпляр (issue #71): документ дочернего типа наследуется от базы — документа комплекта
+  // ЛИБО записи общих данных (по цепочке типов-предков и скоп-близости). При связке наследуются её
+  // данные (мердж при генерации), вручную заполняются только собственные поля. Ссылка — `_baseRef` {kind,id}.
   const [basePickerOpen, setBasePickerOpen] = useState(false);
-  const parentType = docType?.parentId ? allDocTypes.find(dt => dt.id === docType.parentId) ?? null : null;
-  const baseRefId = typeof values._baseRef === 'string' ? values._baseRef : undefined;
-  const baseCandidates = parentType ? otherInstances.filter(i => i.documentTypeId === parentType.id) : [];
-  const baseInstance = baseRefId ? baseCandidates.find(i => i.id === baseRefId) : undefined;
+  const ancestorIds = useMemo(() => ancestorTypeIds(docType, allDocTypes), [docType, allDocTypes]);
+  const hasBase = ancestorIds.length > 0;
+  // Общие данные всех уровней скопа комплекта (Set/Section/Construction/System) — кандидаты-записи.
+  const { data: commonData = [] } = useCommonDataForSet({ setId, enabled: hasBase });
+  const baseRef = useMemo(() => parseBaseRef(values._baseRef), [values._baseRef]);
+
+  const baseCandidates = useMemo<BaseCandidate[]>(() => {
+    if (!hasBase) return [];
+    const ancestorSet = new Set(ancestorIds);
+    const distOf = (typeId: string) => { const i = ancestorIds.indexOf(typeId); return i < 0 ? 999 : i; };
+    const docs: BaseCandidate[] = otherInstances
+      .filter(i => ancestorSet.has(i.documentTypeId))
+      .map(i => ({ kind: 'instance', id: i.id, name: i.name ?? '(без имени)', typeId: i.documentTypeId,
+        tier: 0, scopeLabel: 'Комплект', dist: distOf(i.documentTypeId) }));
+    const entries: BaseCandidate[] = (commonData as CommonDataEntry[])
+      .filter(e => ancestorSet.has(e.compositeTypeId))
+      .map(e => ({ kind: 'catalog', id: e.id, name: e.displayName, typeId: e.compositeTypeId,
+        tier: SCOPE_TIER[e.scope], scopeLabel: SCOPE_LABELS[e.scope], dist: distOf(e.compositeTypeId) }));
+    return [...docs, ...entries].sort((a, b) => a.tier - b.tier || a.dist - b.dist || a.name.localeCompare(b.name, 'ru'));
+  }, [hasBase, ancestorIds, otherInstances, commonData]);
+
+  const selectedBase = baseRef ? baseCandidates.find(c => c.id === baseRef.id) : undefined;
   const ownFields = docType ? parseSchemaFields(docType.schema) : schemaFields;
-  const displayFields = (parentType && baseRefId) ? ownFields : schemaFields;
-  // Поля, покрытые базовым экземпляром, не требуются к заполнению здесь — придут наследованием при
-  // генерации (тот же класс, что sourceBoundFields из #55).
-  const baseCoveredFields = useMemo(
-    () => new Set(baseInstance ? Object.keys(baseInstance.requisites) : []),
-    [baseInstance]);
+  const displayFields = (hasBase && baseRef) ? ownFields : schemaFields;
+  // Поля, покрытые базовым экземпляром (его собственные ключи), не требуются к заполнению здесь —
+  // придут наследованием при генерации (тот же класс, что sourceBoundFields из #55).
+  const baseCoveredFields = useMemo(() => {
+    if (!baseRef) return new Set<string>();
+    if (baseRef.kind === 'instance') {
+      const inst = otherInstances.find(i => i.id === baseRef.id);
+      return new Set(inst ? Object.keys(inst.requisites) : []);
+    }
+    const entry = (commonData as CommonDataEntry[]).find(e => e.id === baseRef.id);
+    return new Set(entry ? Object.keys(entry.data) : []);
+  }, [baseRef, otherInstances, commonData]);
+  function selectBase(c: BaseCandidate) { setValue('_baseRef', { kind: c.kind, id: c.id }); }
   function clearBaseRef() {
     setValues(p => { const n = { ...p }; delete n._baseRef; return n; });
     onDirty(true);
@@ -355,24 +422,24 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
-      {parentType && (
+      {hasBase && (
         <div className="rounded-lg border border-stroke p-3 space-y-2">
-          <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
-            Базовый экземпляр
-            <span className="normal-case font-normal ml-1 text-fg4">({parentType.name})</span>
-          </p>
-          {baseRefId && baseInstance ? (
+          <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">Базовый экземпляр</p>
+          {baseRef && selectedBase ? (
             <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
-              <Link2 size={14} className="text-brand shrink-0" />
-              <span className="flex-1 text-sm font-medium text-brand-hover truncate">{baseInstance.name ?? '(без имени)'}</span>
+              {selectedBase.kind === 'instance'
+                ? <FileText size={14} className="text-brand shrink-0" />
+                : <Database size={14} className="text-brand shrink-0" />}
+              <span className="flex-1 text-sm font-medium text-brand-hover truncate">{selectedBase.name}</span>
+              <span className="text-[11px] text-fg4 shrink-0">{selectedBase.scopeLabel}</span>
               <button type="button" onClick={clearBaseRef}
                 className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
                 <Unlink size={13} />
               </button>
             </div>
-          ) : baseRefId && !baseInstance ? (
+          ) : baseRef && !selectedBase ? (
             <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2">
-              <span className="flex-1 text-sm text-warning truncate">Базовый экземпляр не найден в комплекте</span>
+              <span className="flex-1 text-sm text-warning truncate">Базовый экземпляр недоступен (удалён или вне области видимости)</span>
               <button type="button" onClick={clearBaseRef}
                 className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
                 <Unlink size={13} />
@@ -382,20 +449,19 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
             <button type="button" onClick={() => setBasePickerOpen(true)}
               className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
               <Link2 size={14} />
-              Выбрать из «{parentType.name}»...
+              Выбрать базовый экземпляр...
             </button>
           )}
-          {!baseRefId && ownFields.length < schemaFields.length && (
+          {!baseRef && ownFields.length < schemaFields.length && (
             <p className="text-xs text-fg4">
               Без базового экземпляра все {schemaFields.length} полей заполняются вручную.
             </p>
           )}
-          <BaseInstancePicker
+          <BaseCandidatePicker
             open={basePickerOpen}
             onOpenChange={setBasePickerOpen}
-            parentType={parentType}
             candidates={baseCandidates}
-            onSelect={inst => setValue('_baseRef', inst.id)}
+            onSelect={selectBase}
           />
         </div>
       )}

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BHS.CRG.Application.Generation;
 using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -19,15 +20,24 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
 
     public async Task<GenerationContext> ResolveAsync(DocumentInstance instance, CancellationToken ct = default)
     {
-        // Наследование от базового экземпляра (issue #71): если реквизиты несут "_baseRef",
-        // подмешиваем реквизиты базового инстанса ТОГО ЖЕ комплекта (собственные поля
-        // переопределяют). Только Requisites; PluginData (per-instance кэш плагинов) не наследуется.
-        // Резолв-тайм — ничего не персистим. visited стартует с текущего инстанса (обрыв самоссылки/цикла).
-        var effReq = await ResolveInstanceBaseRefAsync(
-            instance.Requisites.RootElement, instance.DocumentSetId, [instance.Id], ct);
-        using var effReqDoc = JsonSerializer.SerializeToDocument(effReq);
+        // Наследование от базового экземпляра (issue #71): если реквизиты несут "_baseRef", подмешиваем
+        // реквизиты базы — документа комплекта ЛИБО записи общих данных (полиморфно, по скоп-близости) —
+        // собственные поля переопределяют. Только Requisites; PluginData (per-instance кэш плагинов)
+        // не наследуется. Резолв-тайм — ничего не персистим. visited стартует с текущего инстанса.
+        GenerationContext ctx;
+        var reqRoot = instance.Requisites.RootElement;
+        if (reqRoot.ValueKind == JsonValueKind.Object && reqRoot.TryGetProperty("_baseRef", out _))
+        {
+            var scope = await LoadScopeChainAsync(instance.DocumentSetId, ct);
+            var effReq = await ResolveDocumentBaseRefAsync(reqRoot, scope, [instance.Id], ct);
+            using var effReqDoc = JsonSerializer.SerializeToDocument(effReq);
+            ctx = GenerationContext.FromJson(effReqDoc, instance.PluginData);
+        }
+        else
+        {
+            ctx = GenerationContext.FromJson(instance.Requisites, instance.PluginData);
+        }
 
-        var ctx = GenerationContext.FromJson(effReqDoc, instance.PluginData);
         await ResolveContextRefsAsync(ctx, instance.DocumentSetId, ct);
         return ctx;
     }
@@ -216,34 +226,78 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     }
 
     /// <summary>
-    /// Наследование от базового экземпляра для документов комплекта (issue #71): если в реквизитах
-    /// инстанса есть "_baseRef": "&lt;instanceId&gt;", подмешивает реквизиты базового инстанса
-    /// (собственные поля переопределяют). Рекурсивно (у базового может быть свой _baseRef),
-    /// cycle-guard через <paramref name="visited"/>. По образцу <see cref="ResolveCommonDataEntryAsync"/>,
-    /// но с двумя расхождениями: (1) грузит DocumentInstance, а не CommonDataEntry; (2) жёсткий
-    /// set-guard — базовый инстанс обязан быть в ТОМ ЖЕ комплекте (cross-set наследование = утечка
-    /// между комплектами). Тип базового НЕ проверяем — merge это key-union, лишние ключи безвредны.
+    /// Полиморфное наследование от базового экземпляра для документов комплекта (issue #71): реквизиты
+    /// документа могут нести "_baseRef" на ДРУГОЙ документ комплекта ЛИБО на запись общих данных.
+    /// Формат — дискриминированный <c>{"kind":"instance"|"catalog","id":"&lt;guid&gt;"}</c>; голый id
+    /// читается толерантно как legacy = "catalog"/запись. Собственные поля переопределяют
+    /// унаследованные (<see cref="MergeBaseObjects"/>). Guard по типу цели: instance — тот же комплект;
+    /// catalog — запись обязана быть в скоп-поддереве документа (System / его Set / Section /
+    /// Construction), иначе cross-subtree = утечка чужих данных. Cycle-guard — общий
+    /// <paramref name="visited"/> (id глобально уникальны; связи instance→catalog однонаправленны).
     /// </summary>
-    private async Task<JsonElement> ResolveInstanceBaseRefAsync(
-        JsonElement ownData, Guid documentSetId, HashSet<Guid> visited, CancellationToken ct)
+    private async Task<JsonElement> ResolveDocumentBaseRefAsync(
+        JsonElement ownData, (Guid setId, Guid sectionId, Guid constructionId) scope,
+        HashSet<Guid> visited, CancellationToken ct)
     {
         if (ownData.ValueKind != JsonValueKind.Object) return ownData;
-        if (!ownData.TryGetProperty("_baseRef", out var baseRefEl) ||
-            !Guid.TryParse(baseRefEl.GetString(), out var baseInstanceId))
-            return ownData;
+        if (!ownData.TryGetProperty("_baseRef", out var baseRefEl)) return ownData;
+        var (kind, baseId) = ParseBaseRef(baseRefEl);
+        if (baseId is not { } id) return ownData;
 
-        if (!visited.Add(baseInstanceId)) return ownData; // цикл/самоссылка → без наследования
+        JsonElement baseData;
+        if (kind == "instance")
+        {
+            if (!visited.Add(id)) return ownData; // цикл/самоссылка → без наследования
+            var baseInstance = await db.DocumentInstances.AsNoTracking()
+                .FirstOrDefaultAsync(i => i.Id == id && i.DocumentSetId == scope.setId, ct); // same-set guard
+            if (baseInstance is null) return ownData; // не найден / другой комплект
+            baseData = await ResolveDocumentBaseRefAsync(baseInstance.Requisites.RootElement, scope, visited, ct);
+        }
+        else // catalog — запись общих данных
+        {
+            var entry = await db.CommonDataEntries.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id, ct);
+            if (entry is null || !IsEntryInScopeSubtree(entry, scope)) return ownData; // scope-subtree guard
+            baseData = await ResolveCommonDataEntryAsync(id, visited, ct); // entry→entry цепочка + свой visited
+        }
 
-        var baseInstance = await db.DocumentInstances
-            .AsNoTracking()
-            .FirstOrDefaultAsync(i => i.Id == baseInstanceId && i.DocumentSetId == documentSetId, ct);
-        if (baseInstance is null) return ownData; // не найден / другой комплект → без наследования
+        return baseData.ValueKind == JsonValueKind.Object ? MergeBaseObjects(baseData, ownData) : ownData;
+    }
 
-        var baseData = await ResolveInstanceBaseRefAsync(
-            baseInstance.Requisites.RootElement, documentSetId, visited, ct);
-        if (baseData.ValueKind != JsonValueKind.Object) return ownData;
+    /// Разбор "_baseRef": дискриминированный объект {kind,id} (issue #71) или голый id-строка
+    /// (legacy = "catalog"/запись). Возвращает (kind, id|null); неизвестный kind → "catalog".
+    private static (string kind, Guid? id) ParseBaseRef(JsonElement el)
+    {
+        if (el.ValueKind == JsonValueKind.String)
+            return ("catalog", Guid.TryParse(el.GetString(), out var g) ? g : null);
+        if (el.ValueKind == JsonValueKind.Object
+            && el.TryGetProperty("id", out var idEl) && Guid.TryParse(idEl.GetString(), out var gid))
+        {
+            var kind = el.TryGetProperty("kind", out var kEl) ? kEl.GetString() : null;
+            return (kind == "instance" ? "instance" : "catalog", gid);
+        }
+        return ("catalog", null);
+    }
 
-        return MergeBaseObjects(baseData, ownData);
+    /// Запись общих данных в скоп-поддереве документа: System, либо её (Scope,ScopeId) совпадает
+    /// с комплектом/разделом/стройкой документа (иначе — чужое поддерево, не наследуем).
+    private static bool IsEntryInScopeSubtree(CommonDataEntry entry, (Guid setId, Guid sectionId, Guid constructionId) scope)
+        => entry.Scope switch
+        {
+            CatalogScope.System => true,
+            CatalogScope.Set => entry.ScopeId == scope.setId,
+            CatalogScope.Section => entry.ScopeId == scope.sectionId,
+            CatalogScope.Construction => entry.ScopeId == scope.constructionId,
+            _ => false,
+        };
+
+    /// Скоп-цепочка документа: (комплект, раздел, стройка) — для scope-subtree guard entry-базы.
+    private async Task<(Guid setId, Guid sectionId, Guid constructionId)> LoadScopeChainAsync(Guid setId, CancellationToken ct)
+    {
+        var set = await db.DocumentSets.AsNoTracking().FirstOrDefaultAsync(s => s.Id == setId, ct);
+        var sectionId = set?.SectionId ?? Guid.Empty;
+        var section = sectionId == Guid.Empty ? null
+            : await db.Sections.AsNoTracking().FirstOrDefaultAsync(s => s.Id == sectionId, ct);
+        return (setId, sectionId, section?.ConstructionId ?? Guid.Empty);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -19,7 +19,15 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
 
     public async Task<GenerationContext> ResolveAsync(DocumentInstance instance, CancellationToken ct = default)
     {
-        var ctx = GenerationContext.FromJson(instance.Requisites, instance.PluginData);
+        // Наследование от базового экземпляра (issue #71): если реквизиты несут "_baseRef",
+        // подмешиваем реквизиты базового инстанса ТОГО ЖЕ комплекта (собственные поля
+        // переопределяют). Только Requisites; PluginData (per-instance кэш плагинов) не наследуется.
+        // Резолв-тайм — ничего не персистим. visited стартует с текущего инстанса (обрыв самоссылки/цикла).
+        var effReq = await ResolveInstanceBaseRefAsync(
+            instance.Requisites.RootElement, instance.DocumentSetId, [instance.Id], ct);
+        using var effReqDoc = JsonSerializer.SerializeToDocument(effReq);
+
+        var ctx = GenerationContext.FromJson(effReqDoc, instance.PluginData);
         await ResolveContextRefsAsync(ctx, instance.DocumentSetId, ct);
         return ctx;
     }
@@ -204,7 +212,47 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         if (baseData.ValueKind != JsonValueKind.Object)
             return ownData;
 
-        // Merge: базовые поля первыми, собственные поля переопределяют их
+        return MergeBaseObjects(baseData, ownData);
+    }
+
+    /// <summary>
+    /// Наследование от базового экземпляра для документов комплекта (issue #71): если в реквизитах
+    /// инстанса есть "_baseRef": "&lt;instanceId&gt;", подмешивает реквизиты базового инстанса
+    /// (собственные поля переопределяют). Рекурсивно (у базового может быть свой _baseRef),
+    /// cycle-guard через <paramref name="visited"/>. По образцу <see cref="ResolveCommonDataEntryAsync"/>,
+    /// но с двумя расхождениями: (1) грузит DocumentInstance, а не CommonDataEntry; (2) жёсткий
+    /// set-guard — базовый инстанс обязан быть в ТОМ ЖЕ комплекте (cross-set наследование = утечка
+    /// между комплектами). Тип базового НЕ проверяем — merge это key-union, лишние ключи безвредны.
+    /// </summary>
+    private async Task<JsonElement> ResolveInstanceBaseRefAsync(
+        JsonElement ownData, Guid documentSetId, HashSet<Guid> visited, CancellationToken ct)
+    {
+        if (ownData.ValueKind != JsonValueKind.Object) return ownData;
+        if (!ownData.TryGetProperty("_baseRef", out var baseRefEl) ||
+            !Guid.TryParse(baseRefEl.GetString(), out var baseInstanceId))
+            return ownData;
+
+        if (!visited.Add(baseInstanceId)) return ownData; // цикл/самоссылка → без наследования
+
+        var baseInstance = await db.DocumentInstances
+            .AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Id == baseInstanceId && i.DocumentSetId == documentSetId, ct);
+        if (baseInstance is null) return ownData; // не найден / другой комплект → без наследования
+
+        var baseData = await ResolveInstanceBaseRefAsync(
+            baseInstance.Requisites.RootElement, documentSetId, visited, ct);
+        if (baseData.ValueKind != JsonValueKind.Object) return ownData;
+
+        return MergeBaseObjects(baseData, ownData);
+    }
+
+    /// <summary>
+    /// Слияние двух JSON-объектов для _baseRef-наследования: базовые поля первыми, собственные
+    /// переопределяют их на верхнем уровне; ключ "_baseRef" исключается. Чистая функция —
+    /// общая для наследования записей каталога и инстансов документов (issue #71).
+    /// </summary>
+    private static JsonElement MergeBaseObjects(JsonElement baseData, JsonElement ownData)
+    {
         var merged = new Dictionary<string, JsonElement>();
         foreach (var p in baseData.EnumerateObject())
             if (p.Name != "_baseRef") merged[p.Name] = p.Value.Clone();
@@ -213,5 +261,4 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
 
         return JsonSerializer.SerializeToElement(merged);
     }
-
 }

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -98,6 +98,55 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Assert.Equal("Ромашка", org.GetProperty("Наименование").GetString());  // переопределено
     }
 
+    // ── Базовый экземпляр документа комплекта (issue #71) ────────────────────────
+
+    [Fact]
+    public async Task InstanceBaseRef_Merged()
+    {
+        var setId = await SetupSetAsync();
+        var baseType = await TypeAsync(DocumentTypeKind.Document, "DOC_BASE");
+        var childType = await TypeAsync(DocumentTypeKind.Document, "DOC_CHILD");
+        var baseId = await DocAsync(setId, baseType, "{'Город':'Владивосток','Номер':'B-1'}");
+        var childId = await DocAsync(setId, childType, "{'_baseRef':'" + baseId + "','Номер':'C-1'}");
+
+        var ctx = await ResolveAsync(childId);
+
+        Assert.Equal("Владивосток", E(ctx, "Город").GetString()); // унаследовано от базового
+        Assert.Equal("C-1", E(ctx, "Номер").GetString());         // собственное переопределяет
+        Assert.False(ctx.Data.ContainsKey("_baseRef"));           // служебный ключ не протекает в контекст
+    }
+
+    [Fact]
+    public async Task InstanceBaseRef_CrossSet_NotMerged()
+    {
+        var setId = await SetupSetAsync();
+        var otherSetId = await SetupSetAsync();
+        var type = await TypeAsync(DocumentTypeKind.Document, "DOC_XSET");
+        var baseId = await DocAsync(otherSetId, type, "{'Город':'Владивосток'}"); // база в ДРУГОМ комплекте
+        var childId = await DocAsync(setId, type, "{'_baseRef':'" + baseId + "','Номер':'C-1'}");
+
+        var ctx = await ResolveAsync(childId);
+
+        Assert.False(ctx.Data.ContainsKey("Город"));      // set-guard: чужой комплект не подмешивается
+        Assert.Equal("C-1", E(ctx, "Номер").GetString());
+    }
+
+    [Fact]
+    public async Task InstanceBaseRef_Cycle_Breaks()
+    {
+        var setId = await SetupSetAsync();
+        var type = await TypeAsync(DocumentTypeKind.Document, "DOC_CYC");
+        var aId = await DocAsync(setId, type, "{'Поле':'A'}");
+        var bId = await DocAsync(setId, type, "{'_baseRef':'" + aId + "','Поле':'B'}");
+        // Замыкаем цикл: A._baseRef → B, B._baseRef → A.
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new UpdateRequisitesCommand(aId, J("{'_baseRef':'" + bId + "','Поле':'A'}")));
+
+        var ctx = await ResolveAsync(aId); // не должно зациклиться
+
+        Assert.Equal("A", E(ctx, "Поле").GetString()); // собственное значение, цикл оборван через visited
+    }
+
     [Fact]
     public async Task DocumentRef_TopLevel_Resolved()
     {

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -107,7 +107,8 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         var baseType = await TypeAsync(DocumentTypeKind.Document, "DOC_BASE");
         var childType = await TypeAsync(DocumentTypeKind.Document, "DOC_CHILD");
         var baseId = await DocAsync(setId, baseType, "{'Город':'Владивосток','Номер':'B-1'}");
-        var childId = await DocAsync(setId, childType, "{'_baseRef':'" + baseId + "','Номер':'C-1'}");
+        var childId = await DocAsync(setId, childType,
+            "{'_baseRef':{'kind':'instance','id':'" + baseId + "'},'Номер':'C-1'}");
 
         var ctx = await ResolveAsync(childId);
 
@@ -123,7 +124,8 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         var otherSetId = await SetupSetAsync();
         var type = await TypeAsync(DocumentTypeKind.Document, "DOC_XSET");
         var baseId = await DocAsync(otherSetId, type, "{'Город':'Владивосток'}"); // база в ДРУГОМ комплекте
-        var childId = await DocAsync(setId, type, "{'_baseRef':'" + baseId + "','Номер':'C-1'}");
+        var childId = await DocAsync(setId, type,
+            "{'_baseRef':{'kind':'instance','id':'" + baseId + "'},'Номер':'C-1'}");
 
         var ctx = await ResolveAsync(childId);
 
@@ -137,14 +139,54 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         var setId = await SetupSetAsync();
         var type = await TypeAsync(DocumentTypeKind.Document, "DOC_CYC");
         var aId = await DocAsync(setId, type, "{'Поле':'A'}");
-        var bId = await DocAsync(setId, type, "{'_baseRef':'" + aId + "','Поле':'B'}");
+        var bId = await DocAsync(setId, type, "{'_baseRef':{'kind':'instance','id':'" + aId + "'},'Поле':'B'}");
         // Замыкаем цикл: A._baseRef → B, B._baseRef → A.
         using (var scope = fixture.Services.CreateScope())
-            await M(scope).Send(new UpdateRequisitesCommand(aId, J("{'_baseRef':'" + bId + "','Поле':'A'}")));
+            await M(scope).Send(new UpdateRequisitesCommand(aId, J("{'_baseRef':{'kind':'instance','id':'" + bId + "'},'Поле':'A'}")));
 
         var ctx = await ResolveAsync(aId); // не должно зациклиться
 
         Assert.Equal("A", E(ctx, "Поле").GetString()); // собственное значение, цикл оборван через visited
+    }
+
+    [Fact]
+    public async Task CatalogEntryBaseRef_Merged()
+    {
+        var setId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_CB");
+        var entryType = await TypeAsync(DocumentTypeKind.Composite, "CMP_CB");
+        var entryId = await EntryAsync(entryType, "{'Город':'Москва','Орг':'База-СРО'}"); // System scope → в поддереве
+        var childId = await DocAsync(setId, docType,
+            "{'_baseRef':{'kind':'catalog','id':'" + entryId + "'},'Орг':'Своя'}");
+
+        var ctx = await ResolveAsync(childId);
+
+        Assert.Equal("Москва", E(ctx, "Город").GetString()); // унаследовано из записи общих данных
+        Assert.Equal("Своя", E(ctx, "Орг").GetString());     // собственное переопределяет
+    }
+
+    [Fact]
+    public async Task CatalogEntryBaseRef_OutOfScope_NotMerged()
+    {
+        var setId = await SetupSetAsync();
+        var otherSetId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_CBO");
+        var entryType = await TypeAsync(DocumentTypeKind.Composite, "CMP_CBO");
+        // Запись общих данных, привязанная к ДРУГОМУ комплекту (чужое скоп-поддерево).
+        Guid entryId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var e = await M(scope).Send(new CreateCommonDataEntryCommand(
+                "Чужая", entryType, J("{'Город':'Чужой'}"), CatalogScope.Set, otherSetId));
+            entryId = e.Id;
+        }
+        var childId = await DocAsync(setId, docType,
+            "{'_baseRef':{'kind':'catalog','id':'" + entryId + "'},'Номер':'C-1'}");
+
+        var ctx = await ResolveAsync(childId);
+
+        Assert.False(ctx.Data.ContainsKey("Город"));      // scope-subtree guard: чужой комплект не наследуется
+        Assert.Equal("C-1", E(ctx, "Номер").GetString());
     }
 
     [Fact]

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.18.2</Version>
+    <Version>0.19.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Summary
Документ дочернего типа можно связать с **базовым экземпляром** и унаследовать его данные (мердж при генерации), заполняя вручную только собственные поля. База берётся по всей цепочке **типов-предков** (не только прямой родитель) и по **скоп-близости** — кандидаты полиморфны:

- **Документы комплекта** (уровень комплекта) — другой документ типа-предка в том же комплекте;
- **Записи общих данных** уровней Set → Section → Construction → System.

Сортировка кандидатов: скоп-уровень (комплект > раздел > стройка > система) — приоритет, затем дистанция наследования. Перенос механизма «базовый экземпляр» из «Общих данных» в документы комплекта + расширение на иерархию/скоп. Closes #71. Дизайн согласован с Архитектором.

## Backend (`EntityResolver.cs`)
- `_baseRef` **дискриминирован**: `{kind:"instance"|"catalog", id}` (голый id читается толерантно как legacy `catalog` — миграция каталога не нужна).
- Merge в `ResolveAsync` **до** `FromJson`, resolve-time; наследуется только `Requisites`, не `PluginData`.
- Диспетчеризация: instance → `ResolveDocumentBaseRefAsync` (**same-set guard**); catalog → существующий `ResolveCommonDataEntryAsync` с **scope-subtree guard** (entry обязан быть System / Set / Section / Construction документа — иначе чужое поддерево не наследуется = защита от утечки).
- Тип базы НЕ проверяем (merge = key-union). Cycle-guard — общий `visited`, без `MaxRefDepth`.
- Общий чистый `MergeBaseObjects`.

## Frontend (`editor/index.tsx` RequisitesTab)
- Цепочка предков по `parentId`; кандидаты = документы (`otherInstances`) + общие данные всех скопов (`useCommonDataForSet` уже агрегирует Set/Section/Construction/System), фильтр по типам-предкам.
- Единый пикер, отсортированный по (скоп-уровень, дистанция наследования), с бейджем уровня у каждого кандидата.
- `_baseRef` хранится `{kind,id}`; при связке — только собственные поля; required, покрытые базой (`baseCoveredFields`), не блокируют сохранение (паттерн #55).

Миграций нет — `_baseRef` живёт в Requisites JSON.

## Test plan
- [x] `dotnet build` + `dotnet test` — **374/374** (5 интеграционных тестов `EntityResolverTests`: instance merge, cross-set guard, цикл, catalog-entry merge, entry out-of-scope guard — против реальной Postgres)
- [x] `npx tsc -b` — чисто; `npm test` — 115/115
- [x] API перезапущен и поднят; editor HMR применён без ошибок
- [ ] Живой UI-проход — не делал (экономный режим, скриншот по запросу)

🤖 Generated with [Claude Code](https://claude.com/claude-code)