### PR TITLE
refactor(fields): единый BaseCandidatePicker — 3 пикера базы → один (шаг 2 код-фазы)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -6,43 +6,13 @@ import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
 import { useListCommonData, useCreateCommonDataEntry, useUpdateCommonDataEntry, useDeleteCommonDataEntry } from '@/shared/api/commonData';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
-import type { CommonDataEntry, DocumentType, EnumTypeDef, PrimitiveTypeDef } from '@/shared/api/types';
+import type { DocumentType, EnumTypeDef, PrimitiveTypeDef, CommonDataEntry } from '@/shared/api/types';
+import { SCOPE_LABELS } from '@/shared/api/types';
 import { resolveEffectiveFields, groupEffectiveFields, parseSchemaFields, getDefaultValues, type SchemaField } from '@/shared/api/schema';
 import {
   PrimitiveInput, FileField, ImageField, ArrayFieldEditor, ComplexFieldGroup, DocRefCatalogPickerField,
+  BaseCandidatePicker, SCOPE_TIER, type BaseCandidate,
 } from '../document-sets/fields';
-
-// ─── Base entry picker (общие данные System-скопа) ────────────────────────────
-// Локальный пикер базового экземпляра (issue #73, шаг 1). Единый пикер — отдельный шаг (#73 п.2).
-function BaseEntryPickerModal({ open, onOpenChange, parentType, onSelect }: {
-  open: boolean; onOpenChange: (o: boolean) => void;
-  parentType: DocumentType; onSelect: (entry: CommonDataEntry) => void;
-}) {
-  const [search, setSearch] = useState('');
-  const { data: entries = [] } = useListCommonData({ scope: 'System', typeId: parentType.id, enabled: open });
-  const filtered = entries.filter(e => e.displayName.toLowerCase().includes(search.toLowerCase()));
-  return (
-    <Modal open={open} onOpenChange={onOpenChange} title={`Базовый экземпляр: ${parentType.name}`}>
-      <div className="space-y-4">
-        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
-          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        {filtered.length === 0 ? (
-          <p className="text-sm text-fg4 text-center py-4">Нет записей типа «{parentType.name}» в системном каталоге.</p>
-        ) : (
-          <div className="space-y-1 max-h-72 overflow-y-auto">
-            {filtered.map(entry => (
-              <button key={entry.id} type="button" onClick={() => { onSelect(entry); onOpenChange(false); }}
-                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                <Link2 size={13} className="text-brand shrink-0" />
-                <span className="flex-1 font-medium text-fg1 truncate">{entry.displayName}</span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </Modal>
-  );
-}
 
 // ─── Entry form (add / edit) ──────────────────────────────────────────────────
 
@@ -98,6 +68,11 @@ function EntryForm({
     enabled: !!parentType,
   });
   const baseEntry = parentEntries.find(e => e.id === baseRefId);
+  // Кандидаты базы для общего пикера (issue #73, шаг 2): записи родительского типа (System-скоп).
+  const baseCandidates: BaseCandidate[] = parentEntries.map(e => ({
+    kind: 'catalog' as const, id: e.id, name: e.displayName, typeId: e.compositeTypeId,
+    tier: SCOPE_TIER[e.scope], scopeLabel: SCOPE_LABELS[e.scope], dist: 0,
+  }));
 
   function setValue(key: string, v: unknown) {
     setValues(p => {
@@ -252,11 +227,11 @@ function EntryForm({
               Без базового экземпляра все {effectiveFields.length} полей заполняются вручную.
             </p>
           )}
-          <BaseEntryPickerModal
+          <BaseCandidatePicker
             open={basePickerOpen}
             onOpenChange={setBasePickerOpen}
-            parentType={parentType}
-            onSelect={e => setValue('_baseRef', e.id)}
+            candidates={baseCandidates}
+            onSelect={c => setValue('_baseRef', c.id)}
           />
         </div>
       )}

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -25,6 +25,7 @@ import { EntryDataSetBindings } from './EntryDataSetBindings';
 import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
   PrimitiveInput, FileField, ImageField,
+  BaseCandidatePicker, SCOPE_TIER, type BaseCandidate,
 } from '../fields';
 
 export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
@@ -159,54 +160,8 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
   );
 }
 
-// ─── Base entry picker for catalog entry form ─────────────────────────────────
-
-function CatalogBaseEntryPicker({ open, onOpenChange, parentType, setId, scope, scopeId, onSelect }: {
-  open: boolean; onOpenChange: (o: boolean) => void;
-  parentType: DocumentType; setId?: string;
-  scope: CatalogScope; scopeId: string | null;
-  onSelect: (entry: CommonDataEntry) => void;
-}) {
-  const [search, setSearch] = useState('');
-  const { data: setCatalogEntries = [] } = useCommonDataForSet({
-    setId: setId ?? '', typeId: parentType.id, enabled: open && !!setId,
-  });
-  const { data: scopeEntries = [] } = useListCommonData({
-    scope, scopeId: scopeId ?? undefined, typeId: parentType.id,
-    enabled: open && !setId && scope !== 'System',
-  });
-  const { data: systemEntries = [] } = useListCommonData({
-    scope: 'System', typeId: parentType.id, enabled: open,
-  });
-  const allEntries: CommonDataEntry[] = setId
-    ? setCatalogEntries
-    : [...scopeEntries, ...systemEntries.filter(e => !scopeEntries.some(s => s.id === e.id))];
-  const filtered = allEntries.filter(e => e.displayName.toLowerCase().includes(search.toLowerCase()));
-
-  return (
-    <Modal open={open} onOpenChange={onOpenChange} title={`Базовый экземпляр: ${parentType.name}`}>
-      <div className="space-y-4">
-        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
-          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        {filtered.length === 0 ? (
-          <p className="text-sm text-fg4 text-center py-4">
-            Нет записей типа «{parentType.name}».
-          </p>
-        ) : (
-          <div className="space-y-1 max-h-72 overflow-y-auto">
-            {filtered.map(entry => (
-              <button key={entry.id} type="button" onClick={() => { onSelect(entry); onOpenChange(false); }}
-                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                <Link2 size={13} className="text-brand shrink-0" />
-                <span className="flex-1 font-medium text-fg1 truncate">{entry.displayName}</span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </Modal>
-  );
-}
+// Базовый экземпляр каталога использует общий BaseCandidatePicker (issue #73, шаг 2) —
+// кандидаты (записи родительского типа по скопам) строятся ниже из parentEntries.
 
 // ─── Catalog entry form (create + edit, shared by ScopedCatalogPanel) ────────
 
@@ -266,6 +221,13 @@ function CatalogEntryForm({
     ? allParentEntries
     : [...scopeParentEntries, ...systemParentEntries.filter(e => !scopeParentEntries.some(s => s.id === e.id))];
   const baseEntry = parentEntries.find(e => e.id === baseRefId);
+  // Кандидаты базы для общего пикера (issue #73, шаг 2): записи родительского типа по скопам.
+  const baseCandidates: BaseCandidate[] = parentEntries
+    .map(e => ({
+      kind: 'catalog' as const, id: e.id, name: e.displayName, typeId: e.compositeTypeId,
+      tier: SCOPE_TIER[e.scope], scopeLabel: SCOPE_LABELS[e.scope], dist: 0,
+    }))
+    .sort((a, b) => a.tier - b.tier || a.name.localeCompare(b.name, 'ru'));
 
   // Наборы данных: биндинги существуют только у уже сохранённой записи (нужен id-владелец).
   const { data: bindings = [] } = useListDataSetBindings({ commonDataEntryId: entry?.id });
@@ -519,14 +481,11 @@ function CatalogEntryForm({
               Без базового экземпляра все {effectiveFields.length} полей заполняются вручную.
             </p>
           )}
-          <CatalogBaseEntryPicker
+          <BaseCandidatePicker
             open={basePickerOpen}
             onOpenChange={setBasePickerOpen}
-            parentType={parentType}
-            setId={setId}
-            scope={scope}
-            scopeId={scopeId}
-            onSelect={e => setValue('_baseRef', e.id)}
+            candidates={baseCandidates}
+            onSelect={c => setValue('_baseRef', c.id)}
           />
         </div>
       )}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/shared/api/documentSets';
 import { useListTemplates } from '@/shared/api/templates';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
-import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTypeDef, CommonDataEntry, CatalogScope } from '@/shared/api/types';
+import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTypeDef, CommonDataEntry } from '@/shared/api/types';
 import { SCOPE_LABELS } from '@/shared/api/types';
 import { useCommonDataForSet } from '@/shared/api/commonData';
 import {
@@ -23,6 +23,7 @@ import {
   STATUS_LABELS, STATUS_COLORS,
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
   DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup,
+  BaseCandidatePicker, SCOPE_TIER, ancestorTypeIds, parseBaseRef, type BaseCandidate,
 } from '../fields';
 import { DataSetsTab } from './DataSetsTab';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
@@ -79,75 +80,6 @@ function BoundStateHint({ loading, error }: { loading: boolean; error: boolean }
 // Документ дочернего типа может наследоваться от базы — документа комплекта ЛИБО записи общих данных.
 // Кандидаты берутся по всей цепочке типов-предков и по скоп-близости (комплект > раздел > стройка >
 // система), внутри уровня — по близости наследования. Ссылка хранится как _baseRef {kind,id}.
-
-type BaseCandidateKind = 'instance' | 'catalog';
-interface BaseCandidate {
-  kind: BaseCandidateKind;
-  id: string;
-  name: string;
-  typeId: string;
-  tier: number;        // скоп-уровень: 0 комплект, 1 раздел, 2 стройка, 3 система
-  scopeLabel: string;  // «Комплект»/«Раздел»/«Стройка»/«Система»
-  dist: number;        // дистанция наследования: 0 прямой родитель, дальше — больше
-}
-
-const SCOPE_TIER: Record<CatalogScope, number> = { Set: 0, Section: 1, Construction: 2, System: 3 };
-
-/// Идентификаторы типов-предков по цепочке parentId (по возрастанию дистанции: [родитель, дед, …]).
-function ancestorTypeIds(docType: DocumentType | undefined, allDocTypes: DocumentType[]): string[] {
-  const ids: string[] = [];
-  const seen = new Set<string>();
-  let cur = docType?.parentId ?? undefined;
-  while (cur && !seen.has(cur)) {
-    seen.add(cur); ids.push(cur);
-    cur = allDocTypes.find(dt => dt.id === cur)?.parentId ?? undefined;
-  }
-  return ids;
-}
-
-/// Толерантный разбор _baseRef: {kind,id} (issue #71) или голая строка-id (legacy = catalog/запись).
-function parseBaseRef(raw: unknown): { kind: BaseCandidateKind; id: string } | undefined {
-  if (typeof raw === 'string') return raw ? { kind: 'catalog', id: raw } : undefined;
-  if (raw && typeof raw === 'object' && 'id' in raw) {
-    const r = raw as { kind?: string; id?: string };
-    if (r.id) return { kind: r.kind === 'instance' ? 'instance' : 'catalog', id: r.id };
-  }
-  return undefined;
-}
-
-/// Пикер базового экземпляра (issue #71) — единый список кандидатов (документы + общие данные),
-/// уже отсортированный по близости; у каждого — бейдж уровня скопа.
-function BaseCandidatePicker({ open, onOpenChange, candidates, onSelect }: {
-  open: boolean; onOpenChange: (o: boolean) => void;
-  candidates: BaseCandidate[]; onSelect: (c: BaseCandidate) => void;
-}) {
-  const [search, setSearch] = useState('');
-  const filtered = candidates.filter(c => c.name.toLowerCase().includes(search.toLowerCase()));
-  return (
-    <Modal open={open} onOpenChange={onOpenChange} title="Базовый экземпляр">
-      <div className="space-y-4">
-        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
-          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        {filtered.length === 0 ? (
-          <p className="text-sm text-fg4 text-center py-4">Нет подходящих базовых экземпляров.</p>
-        ) : (
-          <div className="space-y-1 max-h-72 overflow-y-auto">
-            {filtered.map(c => (
-              <button key={`${c.kind}:${c.id}`} type="button" onClick={() => { onSelect(c); onOpenChange(false); }}
-                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                {c.kind === 'instance'
-                  ? <FileText size={13} className="text-brand shrink-0" />
-                  : <Database size={13} className="text-brand shrink-0" />}
-                <span className="flex-1 font-medium text-fg1 truncate">{c.name}</span>
-                <span className="text-[11px] text-fg4 shrink-0">{c.scopeLabel}</span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </Modal>
-  );
-}
 
 function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef, onGoToDataTab }: {
   instance: DocumentInstance; setId: string; schemaFields: SchemaField[];

--- a/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
+++ b/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { FileText, Database } from 'lucide-react';
+import { Modal } from '@/shared/ui/Modal';
+import type { CatalogScope, DocumentType } from '@/shared/api/types';
+
+// Базовый экземпляр (issue #71/#73): объект дочернего типа наследуется от базы — документа комплекта
+// ЛИБО записи общих данных (по цепочке типов-предков и скоп-близости). Единый пикер + общие хелперы
+// кандидатов — переиспользуются редактором документов, каталогом и системным каталогом (шаг 2 #73).
+
+export type BaseCandidateKind = 'instance' | 'catalog';
+
+export interface BaseCandidate {
+  kind: BaseCandidateKind;
+  id: string;
+  name: string;
+  typeId: string;
+  tier: number;        // скоп-уровень: 0 комплект, 1 раздел, 2 стройка, 3 система
+  scopeLabel: string;  // «Комплект»/«Раздел»/«Стройка»/«Система»
+  dist: number;        // дистанция наследования: 0 прямой родитель, дальше — больше
+}
+
+export const SCOPE_TIER: Record<CatalogScope, number> = { Set: 0, Section: 1, Construction: 2, System: 3 };
+
+/** Идентификаторы типов-предков по цепочке parentId (по возрастанию дистанции: [родитель, дед, …]). */
+export function ancestorTypeIds(docType: DocumentType | undefined, allDocTypes: DocumentType[]): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let cur = docType?.parentId ?? undefined;
+  while (cur && !seen.has(cur)) {
+    seen.add(cur); ids.push(cur);
+    cur = allDocTypes.find(dt => dt.id === cur)?.parentId ?? undefined;
+  }
+  return ids;
+}
+
+/** Толерантный разбор _baseRef: {kind,id} (issue #71) или голая строка-id (legacy = catalog/запись). */
+export function parseBaseRef(raw: unknown): { kind: BaseCandidateKind; id: string } | undefined {
+  if (typeof raw === 'string') return raw ? { kind: 'catalog', id: raw } : undefined;
+  if (raw && typeof raw === 'object' && 'id' in raw) {
+    const r = raw as { kind?: string; id?: string };
+    if (r.id) return { kind: r.kind === 'instance' ? 'instance' : 'catalog', id: r.id };
+  }
+  return undefined;
+}
+
+/**
+ * Единый пикер базового экземпляра — презентационный: получает уже готовый (обычно отсортированный
+ * по близости) список кандидатов и вызывает onSelect. Вычисление и формат хранения `_baseRef` —
+ * ответственность вызывающего (документ пишет {kind,id}; каталог/система — голый id).
+ */
+export function BaseCandidatePicker({ open, onOpenChange, candidates, onSelect }: {
+  open: boolean; onOpenChange: (o: boolean) => void;
+  candidates: BaseCandidate[]; onSelect: (c: BaseCandidate) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const filtered = candidates.filter(c => c.name.toLowerCase().includes(search.toLowerCase()));
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title="Базовый экземпляр">
+      <div className="space-y-4">
+        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
+          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
+        {filtered.length === 0 ? (
+          <p className="text-sm text-fg4 text-center py-4">Нет подходящих базовых экземпляров.</p>
+        ) : (
+          <div className="space-y-1 max-h-72 overflow-y-auto">
+            {filtered.map(c => (
+              <button key={`${c.kind}:${c.id}`} type="button" onClick={() => { onSelect(c); onOpenChange(false); }}
+                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
+                {c.kind === 'instance'
+                  ? <FileText size={13} className="text-brand shrink-0" />
+                  : <Database size={13} className="text-brand shrink-0" />}
+                <span className="flex-1 font-medium text-fg1 truncate">{c.name}</span>
+                <span className="text-[11px] text-fg4 shrink-0">{c.scopeLabel}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/client/src/features/document-sets/fields/index.ts
+++ b/src/client/src/features/document-sets/fields/index.ts
@@ -8,3 +8,4 @@ export * from './DocRefCatalogPickerField';
 export * from './DocRefField';
 export * from './PasteMappingModal';
 export * from './ComplexFields';
+export * from './BaseCandidatePicker';

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.19.2</Version>
+    <Version>0.19.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
UI-шаг код-фазы (Part of #73). Сводит три параллельных пикера базового экземпляра к одному.

## Что
Было **три** реализации пикера базы (различались только источником кандидатов):
- `CatalogBaseEntryPicker` (каталог),
- `BaseCandidatePicker` (редактор документов, issue #71),
- локальный `BaseEntryPickerModal` (системный каталог, временный из шага 1).

Стало — один презентационный `document-sets/fields/BaseCandidatePicker.tsx` (+ общие хелперы `BaseCandidate`/`SCOPE_TIER`/`ancestorTypeIds`/`parseBaseRef`), переиспользуемый всеми тремя.

## Разделение ответственности
Пикер только показывает готовый список `BaseCandidate[]` и вызывает `onSelect`. Вычисление кандидатов и **формат хранения `_baseRef`** — за вызывающим:
- документ: `{ kind, id }` (полиморфно, issue #71);
- каталог/система: голый `id` (legacy-catalog).

Поведение каждого экрана сохранено (те же источники кандидатов, тот же формат хранения).

## Test plan
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 115/115
- [x] HMR применил editor/catalog/system без ошибок
- [ ] Живой визуальный проход по трём экранам — не делал (экономный режим, скриншот по запросу)

Part of #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)