### PR TITLE
refactor(fields): единая панель «Базовый экземпляр» — блок ×3 → один (шаг 3 код-фазы)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Plus, Pencil, Trash2, Search, Link2, Unlink, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Pencil, Trash2, Search, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -11,7 +11,7 @@ import { SCOPE_LABELS } from '@/shared/api/types';
 import { resolveEffectiveFields, groupEffectiveFields, parseSchemaFields, getDefaultValues, type SchemaField } from '@/shared/api/schema';
 import {
   PrimitiveInput, FileField, ImageField, ArrayFieldEditor, ComplexFieldGroup, DocRefCatalogPickerField,
-  BaseCandidatePicker, SCOPE_TIER, type BaseCandidate,
+  BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
 } from '../document-sets/fields';
 
 // ─── Entry form (add / edit) ──────────────────────────────────────────────────
@@ -31,7 +31,6 @@ function EntryForm({
   const [values, setValues] = useState<Record<string, unknown>>(() => entry?.data ?? {});
   const [error, setError] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const [basePickerOpen, setBasePickerOpen] = useState(false);
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const createMutation = useCreateCommonDataEntry();
   const updateMutation = useUpdateCommonDataEntry();
@@ -67,7 +66,6 @@ function EntryForm({
     typeId: parentType?.id,
     enabled: !!parentType,
   });
-  const baseEntry = parentEntries.find(e => e.id === baseRefId);
   // Кандидаты базы для общего пикера (issue #73, шаг 2): записи родительского типа (System-скоп).
   const baseCandidates: BaseCandidate[] = parentEntries.map(e => ({
     kind: 'catalog' as const, id: e.id, name: e.displayName, typeId: e.compositeTypeId,
@@ -201,39 +199,16 @@ function EntryForm({
 
       {/* Базовый экземпляр — показываем, если тип имеет родителя */}
       {parentType && (
-        <div className="rounded-lg border border-stroke p-3 space-y-2">
-          <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
-            Базовый экземпляр
-            <span className="normal-case font-normal ml-1 text-fg4">({parentType.name})</span>
-          </p>
-          {baseRefId && baseEntry ? (
-            <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
-              <Link2 size={14} className="text-brand shrink-0" />
-              <span className="flex-1 text-sm font-medium text-brand-hover truncate">{baseEntry.displayName}</span>
-              <button type="button" onClick={() => setValue('_baseRef', undefined)}
-                className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
-                <Unlink size={13} />
-              </button>
-            </div>
-          ) : (
-            <button type="button" onClick={() => setBasePickerOpen(true)}
-              className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
-              <Link2 size={14} />
-              Выбрать из «{parentType.name}»...
-            </button>
-          )}
-          {!baseRefId && ownFields.length < effectiveFields.length && (
-            <p className="text-xs text-fg4">
-              Без базового экземпляра все {effectiveFields.length} полей заполняются вручную.
-            </p>
-          )}
-          <BaseCandidatePicker
-            open={basePickerOpen}
-            onOpenChange={setBasePickerOpen}
-            candidates={baseCandidates}
-            onSelect={c => setValue('_baseRef', c.id)}
-          />
-        </div>
+        <BaseInstancePanel
+          title={parentType.name}
+          candidates={baseCandidates}
+          selected={baseCandidates.find(c => c.id === baseRefId)}
+          missing={!!baseRefId && !baseCandidates.some(c => c.id === baseRefId)}
+          manualHint={ownFields.length < effectiveFields.length
+            ? `Без базового экземпляра все ${effectiveFields.length} полей заполняются вручную.` : undefined}
+          onSelect={c => setValue('_baseRef', c.id)}
+          onClear={() => setValue('_baseRef', undefined)}
+        />
       )}
 
       {selectedType && sections.length > 0 && displayFields.length > 0 && (

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import {
-  Link2, Unlink, ChevronDown, ChevronUp, Plus, Pencil, Trash2, FileText, Database, ShieldCheck, Loader2,
+  ChevronDown, ChevronUp, Plus, Pencil, Trash2, FileText, Database, ShieldCheck, Loader2,
   DatabaseZap, RefreshCw,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
@@ -25,7 +25,7 @@ import { EntryDataSetBindings } from './EntryDataSetBindings';
 import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
   PrimitiveInput, FileField, ImageField,
-  BaseCandidatePicker, SCOPE_TIER, type BaseCandidate,
+  BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
 } from '../fields';
 
 export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
@@ -182,7 +182,6 @@ function CatalogEntryForm({
   const [values, setValues] = useState<Record<string, unknown>>(() => entry?.data ?? {});
   const [error, setError] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const [basePickerOpen, setBasePickerOpen] = useState(false);
   const [recognizing, setRecognizing] = useState(false);
   const createMutation = useCreateCommonDataEntry();
   const updateMutation = useUpdateCommonDataEntry();
@@ -220,7 +219,6 @@ function CatalogEntryForm({
   const parentEntries: CommonDataEntry[] = setId
     ? allParentEntries
     : [...scopeParentEntries, ...systemParentEntries.filter(e => !scopeParentEntries.some(s => s.id === e.id))];
-  const baseEntry = parentEntries.find(e => e.id === baseRefId);
   // Кандидаты базы для общего пикера (issue #73, шаг 2): записи родительского типа по скопам.
   const baseCandidates: BaseCandidate[] = parentEntries
     .map(e => ({
@@ -455,39 +453,16 @@ function CatalogEntryForm({
       )}
 
       {parentType && (
-        <div className="rounded-lg border border-stroke p-3 space-y-2">
-          <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
-            Базовый экземпляр
-            <span className="normal-case font-normal ml-1 text-fg4">({parentType.name})</span>
-          </p>
-          {baseRefId && baseEntry ? (
-            <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
-              <Link2 size={14} className="text-brand shrink-0" />
-              <span className="flex-1 text-sm font-medium text-brand-hover truncate">{baseEntry.displayName}</span>
-              <button type="button" onClick={() => setValue('_baseRef', undefined)}
-                className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
-                <Unlink size={13} />
-              </button>
-            </div>
-          ) : (
-            <button type="button" onClick={() => setBasePickerOpen(true)}
-              className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
-              <Link2 size={14} />
-              Выбрать из «{parentType.name}»...
-            </button>
-          )}
-          {!baseRefId && ownFields.length < effectiveFields.length && (
-            <p className="text-xs text-fg4">
-              Без базового экземпляра все {effectiveFields.length} полей заполняются вручную.
-            </p>
-          )}
-          <BaseCandidatePicker
-            open={basePickerOpen}
-            onOpenChange={setBasePickerOpen}
-            candidates={baseCandidates}
-            onSelect={c => setValue('_baseRef', c.id)}
-          />
-        </div>
+        <BaseInstancePanel
+          title={parentType.name}
+          candidates={baseCandidates}
+          selected={baseCandidates.find(c => c.id === baseRefId)}
+          missing={!!baseRefId && !baseCandidates.some(c => c.id === baseRefId)}
+          manualHint={ownFields.length < effectiveFields.length
+            ? `Без базового экземпляра все ${effectiveFields.length} полей заполняются вручную.` : undefined}
+          onSelect={c => setValue('_baseRef', c.id)}
+          onClear={() => setValue('_baseRef', undefined)}
+        />
       )}
 
       {attachment && (

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database, Link2, Unlink } from 'lucide-react';
+import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
 import { EmailSendDialog } from '../EmailSendDialog';
@@ -23,7 +23,7 @@ import {
   STATUS_LABELS, STATUS_COLORS,
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
   DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup,
-  BaseCandidatePicker, SCOPE_TIER, ancestorTypeIds, parseBaseRef, type BaseCandidate,
+  BaseInstancePanel, SCOPE_TIER, ancestorTypeIds, parseBaseRef, type BaseCandidate,
 } from '../fields';
 import { DataSetsTab } from './DataSetsTab';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
@@ -114,7 +114,6 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   // Базовый экземпляр (issue #71): документ дочернего типа наследуется от базы — документа комплекта
   // ЛИБО записи общих данных (по цепочке типов-предков и скоп-близости). При связке наследуются её
   // данные (мердж при генерации), вручную заполняются только собственные поля. Ссылка — `_baseRef` {kind,id}.
-  const [basePickerOpen, setBasePickerOpen] = useState(false);
   const ancestorIds = useMemo(() => ancestorTypeIds(docType, allDocTypes), [docType, allDocTypes]);
   const hasBase = ancestorIds.length > 0;
   // Общие данные всех уровней скопа комплекта (Set/Section/Construction/System) — кандидаты-записи.
@@ -361,47 +360,15 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     <div className="flex flex-col min-h-0 flex-1">
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
       {hasBase && (
-        <div className="rounded-lg border border-stroke p-3 space-y-2">
-          <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">Базовый экземпляр</p>
-          {baseRef && selectedBase ? (
-            <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
-              {selectedBase.kind === 'instance'
-                ? <FileText size={14} className="text-brand shrink-0" />
-                : <Database size={14} className="text-brand shrink-0" />}
-              <span className="flex-1 text-sm font-medium text-brand-hover truncate">{selectedBase.name}</span>
-              <span className="text-[11px] text-fg4 shrink-0">{selectedBase.scopeLabel}</span>
-              <button type="button" onClick={clearBaseRef}
-                className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
-                <Unlink size={13} />
-              </button>
-            </div>
-          ) : baseRef && !selectedBase ? (
-            <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2">
-              <span className="flex-1 text-sm text-warning truncate">Базовый экземпляр недоступен (удалён или вне области видимости)</span>
-              <button type="button" onClick={clearBaseRef}
-                className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
-                <Unlink size={13} />
-              </button>
-            </div>
-          ) : (
-            <button type="button" onClick={() => setBasePickerOpen(true)}
-              className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
-              <Link2 size={14} />
-              Выбрать базовый экземпляр...
-            </button>
-          )}
-          {!baseRef && ownFields.length < schemaFields.length && (
-            <p className="text-xs text-fg4">
-              Без базового экземпляра все {schemaFields.length} полей заполняются вручную.
-            </p>
-          )}
-          <BaseCandidatePicker
-            open={basePickerOpen}
-            onOpenChange={setBasePickerOpen}
-            candidates={baseCandidates}
-            onSelect={selectBase}
-          />
-        </div>
+        <BaseInstancePanel
+          candidates={baseCandidates}
+          selected={selectedBase}
+          missing={!!baseRef && !selectedBase}
+          manualHint={ownFields.length < schemaFields.length
+            ? `Без базового экземпляра все ${schemaFields.length} полей заполняются вручную.` : undefined}
+          onSelect={selectBase}
+          onClear={clearBaseRef}
+        />
       )}
       {sections.map(section => {
         if (!section.title) {

--- a/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
+++ b/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FileText, Database } from 'lucide-react';
+import { FileText, Database, Link2, Unlink } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import type { CatalogScope, DocumentType } from '@/shared/api/types';
 
@@ -77,5 +77,58 @@ export function BaseCandidatePicker({ open, onOpenChange, candidates, onSelect }
         )}
       </div>
     </Modal>
+  );
+}
+
+/**
+ * Панель «Базовый экземпляр» (issue #73, шаг 3) — единый блок для всех форм объекта составного типа
+ * (редактор документов, каталог, системный каталог). Показывает выбранную базу / кнопку выбора /
+ * состояние «недоступна», содержит пикер. Вычисление кандидатов и формат хранения `_baseRef` —
+ * ответственность вызывающего (см. BaseCandidatePicker).
+ */
+export function BaseInstancePanel({ title, candidates, selected, missing = false, manualHint, onSelect, onClear }: {
+  title?: string;                       // напр. имя родительского типа — в подзаголовок
+  candidates: BaseCandidate[];
+  selected: BaseCandidate | undefined;  // выбранная база (по _baseRef), если найдена среди кандидатов
+  missing?: boolean;                    // ссылка задана, но кандидат не найден (удалён/вне видимости)
+  manualHint?: string;                  // подсказка «без базы все N полей вручную»
+  onSelect: (c: BaseCandidate) => void;
+  onClear: () => void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  return (
+    <div className="rounded-lg border border-stroke p-3 space-y-2">
+      <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
+        Базовый экземпляр
+        {title && <span className="normal-case font-normal ml-1 text-fg4">({title})</span>}
+      </p>
+      {selected ? (
+        <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
+          {selected.kind === 'instance'
+            ? <FileText size={14} className="text-brand shrink-0" />
+            : <Database size={14} className="text-brand shrink-0" />}
+          <span className="flex-1 text-sm font-medium text-brand-hover truncate">{selected.name}</span>
+          <span className="text-[11px] text-fg4 shrink-0">{selected.scopeLabel}</span>
+          <button type="button" onClick={onClear} className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
+            <Unlink size={13} />
+          </button>
+        </div>
+      ) : missing ? (
+        <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2">
+          <span className="flex-1 text-sm text-warning truncate">Базовый экземпляр недоступен (удалён или вне области видимости)</span>
+          <button type="button" onClick={onClear} className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
+            <Unlink size={13} />
+          </button>
+        </div>
+      ) : (
+        <button type="button" onClick={() => setPickerOpen(true)}
+          className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
+          <Link2 size={14} />
+          Выбрать базовый экземпляр...
+        </button>
+      )}
+      {!selected && !missing && manualHint && <p className="text-xs text-fg4">{manualHint}</p>}
+      <BaseCandidatePicker open={pickerOpen} onOpenChange={setPickerOpen} candidates={candidates} onSelect={onSelect} />
+    </div>
   );
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.19.3</Version>
+    <Version>0.19.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
UI-шаг код-фазы (Part of #73). Завершает унификацию UI связывания с базой (после пикера в #77).

## Что
Блок «Базовый экземпляр» (подзаголовок → выбранная база / кнопка выбора / состояние «недоступна» → пикер → подсказка «без базы N полей вручную») дублировался почти дословно в трёх формах объекта составного типа:
- редактор документов (`editor/index.tsx`),
- каталог (`catalog/index.tsx`),
- системный каталог (`SystemCommonDataPage.tsx`).

Сведён к общему `BaseInstancePanel` в `document-sets/fields/BaseCandidatePicker.tsx` (панель владеет состоянием пикера). Вызывающий передаёт `candidates` / `selected` / `missing` / `manualHint` / `onSelect` / `onClear` — формат хранения `_baseRef` прежний (документ `{kind,id}`; каталог/система голый `id`).

Побочно (улучшение без регресса): каталог и системный каталог получили состояние «база недоступна (удалена/вне видимости)», которое раньше было только у редактора документов.

## Test plan
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 115/115
- [x] HMR применил все три экрана без ошибок
- [ ] Живой визуальный проход — не делал (экономный режим, скриншот по запросу)

Part of #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)