### PR TITLE
fix(catalog): резолв primitive/enum-типов в форме записи каталога

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -9,8 +9,10 @@ import {
   useListCommonData, useCommonDataForSet, useCreateCommonDataEntry,
   useUpdateCommonDataEntry, useDeleteCommonDataEntry,
 } from '@/shared/api/commonData';
-import type { CommonDataEntry, CatalogScope, DocumentType } from '@/shared/api/types';
+import type { CommonDataEntry, CatalogScope, DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import { SCOPE_LABELS, SCOPE_PRIORITY } from '@/shared/api/types';
+import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
 import {
   resolveEffectiveFields, parseSchemaFields, groupEffectiveFields,
   getDefaultValues, findTaggedFieldPath, type SchemaField,
@@ -185,6 +187,13 @@ function CatalogEntryForm({
   const [recognizing, setRecognizing] = useState(false);
   const createMutation = useCreateCommonDataEntry();
   const updateMutation = useUpdateCommonDataEntry();
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
+
+  const getPrimitiveDef = (f: SchemaField): PrimitiveTypeDef | undefined =>
+    f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
+  const getEnumDef = (f: SchemaField): EnumTypeDef | undefined =>
+    f.type === 'enum' ? enumTypes.find(et => et.id === f.typeId) : undefined;
 
   const allSelectableTypes = [...compositeTypes, ...documentTypes];
   const selectedType = allSelectableTypes.find(t => t.id === typeId) ?? null;
@@ -392,7 +401,8 @@ function CatalogEntryForm({
                   ) : field.type === 'file' ? (
                     <FileField value={val} onChange={v => setValue(field.key, v)} />
                   ) : (
-                    <PrimitiveInput field={field} value={val} onChange={v => setValue(field.key, v)} invalid={false} />
+                    <PrimitiveInput field={field} value={val} onChange={v => setValue(field.key, v)} invalid={false}
+                      primitiveTypeDef={getPrimitiveDef(field)} enumTypeDef={getEnumDef(field)} />
                   )}
                 </>
               )}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.19.4</Version>
+    <Version>0.19.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Небольшой шаг код-фазы (Part of #73) — устраняет реальный дрейф поведения между тремя формами объекта составного типа.

## Что
Форма записи каталога (`CatalogEntryForm`) передавала в общий `PrimitiveInput` пустые `primitiveTypeDef`/`enumTypeDef`:
- поля на основе примитивного типа рендерились как обычный текст (без ограничений/спец-инпута);
- enum-метки не резолвились по `typeId` (issue #59) — показывался сырой код/легаси-поведение.

Системный каталог и редактор документов это уже делают (System — с шага 1 #73; документ — исходно). Теперь и каталог резолвит `primitiveTypeDef`/`enumTypeDef` через `useListPrimitiveTypes`/`useListEnumTypes`.

Это и bugfix, и пререквизит: убирает асимметрию, которая мешала бы чистому слиянию трёх форм в одно ядро (следующий крупный шаг #73).

## Test plan
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 115/115
- [ ] Живой проход по форме каталога с primitive/enum-полями — по запросу

Part of #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)