### PR TITLE
refactor(common-data): системный каталог переиспользует форму каталога (форм-ядро)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -3,246 +3,9 @@ import { Plus, Pencil, Trash2, Search, ChevronDown, ChevronUp } from 'lucide-rea
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
-import { useListEnumTypes } from '@/shared/api/enumTypes';
-import { useListCommonData, useCreateCommonDataEntry, useUpdateCommonDataEntry, useDeleteCommonDataEntry } from '@/shared/api/commonData';
-import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
-import type { DocumentType, EnumTypeDef, PrimitiveTypeDef, CommonDataEntry } from '@/shared/api/types';
-import { SCOPE_LABELS } from '@/shared/api/types';
-import { resolveEffectiveFields, groupEffectiveFields, parseSchemaFields, getDefaultValues, type SchemaField } from '@/shared/api/schema';
-import {
-  PrimitiveInput, FileField, ImageField, ArrayFieldEditor, ComplexFieldGroup, DocRefCatalogPickerField,
-  BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
-} from '../document-sets/fields';
-
-// ─── Entry form (add / edit) ──────────────────────────────────────────────────
-
-function EntryForm({
-  entry, compositeTypes, documentTypes, allDocTypes, enumTypes, onClose,
-}: {
-  entry: CommonDataEntry | null;
-  compositeTypes: DocumentType[];
-  documentTypes: DocumentType[];
-  allDocTypes: DocumentType[];
-  enumTypes: EnumTypeDef[];
-  onClose: () => void;
-}) {
-  const [displayName, setDisplayName] = useState(entry?.displayName ?? '');
-  const [typeId, setTypeId] = useState(entry?.compositeTypeId ?? '');
-  const [values, setValues] = useState<Record<string, unknown>>(() => entry?.data ?? {});
-  const [error, setError] = useState('');
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
-  const createMutation = useCreateCommonDataEntry();
-  const updateMutation = useUpdateCommonDataEntry();
-
-  const getPrimitiveDef = (f: SchemaField): PrimitiveTypeDef | undefined =>
-    f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
-  const getEnumDef = (f: SchemaField): EnumTypeDef | undefined =>
-    f.type === 'enum' ? enumTypes.find(et => et.id === f.typeId) : undefined;
-
-  const allSelectableTypes = [...compositeTypes, ...documentTypes];
-  const selectedType = allSelectableTypes.find(t => t.id === typeId) ?? null;
-
-  // Базовый тип (родитель) — для поддержки _baseRef
-  const parentType = selectedType?.parentId
-    ? allDocTypes.find(dt => dt.id === selectedType.parentId) ?? null
-    : null;
-
-  // Текущий _baseRef (ID базового экземпляра)
-  const baseRefId = typeof values._baseRef === 'string' ? values._baseRef : undefined;
-
-  // Когда _baseRef задан — показываем только собственные поля этого типа,
-  // наследуемые поля придут из базового экземпляра через EntityResolver
-  const ownFields = selectedType ? parseSchemaFields(selectedType.schema) : [];
-  const effectiveFields = selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : [];
-  const displayFields = (parentType && baseRefId) ? ownFields : effectiveFields;
-  const sections = selectedType
-    ? groupEffectiveFields(displayFields, selectedType.schema)
-    : [];
-
-  // Записи базового типа для пикера
-  const { data: parentEntries = [] } = useListCommonData({
-    scope: 'System',
-    typeId: parentType?.id,
-    enabled: !!parentType,
-  });
-  // Кандидаты базы для общего пикера (issue #73, шаг 2): записи родительского типа (System-скоп).
-  const baseCandidates: BaseCandidate[] = parentEntries.map(e => ({
-    kind: 'catalog' as const, id: e.id, name: e.displayName, typeId: e.compositeTypeId,
-    tier: SCOPE_TIER[e.scope], scopeLabel: SCOPE_LABELS[e.scope], dist: 0,
-  }));
-
-  function setValue(key: string, v: unknown) {
-    setValues(p => {
-      if (v === undefined) { const n = { ...p }; delete n[key]; return n; }
-      return { ...p, [key]: v };
-    });
-  }
-  function toggleGroup(key: string) {
-    setExpandedGroups(prev => { const n = new Set(prev); n.has(key) ? n.delete(key) : n.add(key); return n; });
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError('');
-    if (!displayName.trim() || !typeId) { setError('Укажите название и тип'); return; }
-    try {
-      if (entry) {
-        await updateMutation.mutateAsync({ id: entry.id, displayName, data: JSON.stringify(values) });
-      } else {
-        await createMutation.mutateAsync({ displayName, compositeTypeId: typeId, data: JSON.stringify(values), scope: 'System', scopeId: null });
-      }
-      onClose();
-    } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Ошибка'); }
-  }
-
-  function renderFields(sectionFields: SchemaField[]) {
-    return (
-      <div className="space-y-4">
-        {sectionFields.map(field => {
-          // doc-array links to multiple document instances — not applicable in catalog context
-          if (field.type === 'doc-array') return null;
-          return (
-          <div key={field.key}>
-            {field.type === 'complex' || field.type === 'array' ? (
-              <div>
-                <label className="block text-sm font-medium text-fg2 mb-1">
-                  {field.title}{field.required && <span className="ml-0.5 text-danger">*</span>}
-                </label>
-                {field.type === 'array' ? (
-                  <ArrayFieldEditor field={field} allDocTypes={allDocTypes}
-                    value={values[field.key]} onChange={v => setValue(field.key, v)}
-                    showValidation={false} scope="System" scopeId={null} />
-                ) : (
-                  <ComplexFieldGroup field={field} allDocTypes={allDocTypes}
-                    value={values[field.key]} onChange={v => setValue(field.key, v)}
-                    showValidation={false} scope="System" scopeId={null} />
-                )}
-              </div>
-            ) : field.type === 'doc-ref' ? (
-              <div>
-                <label className="block text-sm font-medium text-fg2 mb-1">
-                  {field.title}{field.required && <span className="ml-0.5 text-danger">*</span>}
-                </label>
-                <DocRefCatalogPickerField field={field} allDocTypes={allDocTypes}
-                  value={values[field.key]} onChange={v => setValue(field.key, v ?? undefined)}
-                  scope="System" scopeId={null} />
-              </div>
-            ) : (
-              <>
-                {field.type !== 'boolean' && (
-                  <label className="block text-sm font-medium text-fg2 mb-1">
-                    {field.title}{field.required && <span className="ml-0.5 text-danger">*</span>}
-                  </label>
-                )}
-                {field.type === 'image' ? (
-                  <ImageField value={values[field.key]} onChange={v => setValue(field.key, v)} />
-                ) : field.type === 'file' ? (
-                  <FileField value={values[field.key]} onChange={v => setValue(field.key, v)} />
-                ) : (
-                  <PrimitiveInput field={field} value={values[field.key]}
-                    onChange={v => setValue(field.key, v)} invalid={false}
-                    primitiveTypeDef={getPrimitiveDef(field)} enumTypeDef={getEnumDef(field)} />
-                )}
-              </>
-            )}
-          </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  const isPending = createMutation.isPending || updateMutation.isPending;
-
-  return (
-    <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
-      <div>
-        <label className="block text-sm font-medium text-fg2 mb-1">Наименование</label>
-        <input value={displayName} onChange={e => setDisplayName(e.target.value)} required autoFocus
-          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-      </div>
-      {!entry ? (
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Тип</label>
-          <select value={typeId} onChange={e => {
-              const newId = e.target.value;
-              setTypeId(newId);
-              const t = allSelectableTypes.find(c => c.id === newId);
-              setValues(t ? getDefaultValues(resolveEffectiveFields(t, allDocTypes)) : {});
-            }} required
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm text-fg1 bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-            <option value="">Выберите тип...</option>
-            {compositeTypes.length > 0 && (
-              <optgroup label="Составные типы">
-                {compositeTypes.map(ct => <option key={ct.id} value={ct.id}>{ct.name} ({ct.code})</option>)}
-              </optgroup>
-            )}
-            {documentTypes.length > 0 && (
-              <optgroup label="Типы документов (внешние)">
-                {documentTypes.map(dt => <option key={dt.id} value={dt.id}>{dt.name} ({dt.code})</option>)}
-              </optgroup>
-            )}
-          </select>
-        </div>
-      ) : (
-        <p className="text-sm text-fg3">
-          Тип: <span className="font-medium text-fg2">
-            {allSelectableTypes.find(t => t.id === entry.compositeTypeId)?.name ?? entry.compositeTypeId}
-          </span>
-          {allDocTypes.find(t => t.id === entry.compositeTypeId)?.kind === 'Document' && (
-            <span className="ml-2 text-xs bg-warning-subtle text-warning border border-warning-border px-1.5 py-0.5 rounded-full">внеш. документ</span>
-          )}
-        </p>
-      )}
-
-      {/* Базовый экземпляр — показываем, если тип имеет родителя */}
-      {parentType && (
-        <BaseInstancePanel
-          title={parentType.name}
-          candidates={baseCandidates}
-          selected={baseCandidates.find(c => c.id === baseRefId)}
-          missing={!!baseRefId && !baseCandidates.some(c => c.id === baseRefId)}
-          manualHint={ownFields.length < effectiveFields.length
-            ? `Без базового экземпляра все ${effectiveFields.length} полей заполняются вручную.` : undefined}
-          onSelect={c => setValue('_baseRef', c.id)}
-          onClear={() => setValue('_baseRef', undefined)}
-        />
-      )}
-
-      {selectedType && sections.length > 0 && displayFields.length > 0 && (
-        <div className="space-y-3 pt-1 border-t border-muted">
-          {sections.map(section => {
-            if (!section.title) return <div key={section.key}>{renderFields(section.fields)}</div>;
-            const isExpanded = expandedGroups.has(section.key);
-            return (
-              <div key={section.key} className="border border-stroke rounded-lg overflow-hidden">
-                <button type="button" onClick={() => toggleGroup(section.key)}
-                  className="w-full flex items-center gap-2 px-3 py-2.5 bg-base hover:bg-muted transition-colors text-left">
-                  {isExpanded ? <ChevronUp size={13} className="text-fg4 shrink-0" /> : <ChevronDown size={13} className="text-fg4 shrink-0" />}
-                  <span className="text-xs font-semibold uppercase tracking-wide text-fg2 flex-1">{section.title}</span>
-                  <span className="text-xs text-fg4">{section.fields.length} п.</span>
-                </button>
-                {isExpanded && <div className="px-3 py-3">{renderFields(section.fields)}</div>}
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {error && <p className="text-sm text-danger">{error}</p>}
-      </div>
-      <div className="shrink-0 px-6 py-3 border-t border-stroke flex justify-end gap-3">
-        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-        <button type="submit" disabled={isPending}
-          className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-          {isPending ? (entry ? 'Сохранение...' : 'Создание...') : (entry ? 'Сохранить' : 'Создать')}
-        </button>
-      </div>
-    </form>
-  );
-}
+import { useListCommonData, useDeleteCommonDataEntry } from '@/shared/api/commonData';
+import type { CommonDataEntry } from '@/shared/api/types';
+import { CatalogEntryForm } from '../document-sets/catalog';
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
@@ -259,7 +22,6 @@ export function SystemCommonDataPage() {
   }
 
   const { data: allDocTypes = [] } = useListDocumentTypes();
-  const { data: enumTypes = [] } = useListEnumTypes();
   const { data: entries = [], isLoading } = useListCommonData({ scope: 'System' });
   const deleteMutation = useDeleteCommonDataEntry();
 
@@ -413,12 +175,12 @@ export function SystemCommonDataPage() {
 
       <Modal open={addOpen} onOpenChange={setAddOpen} title="Новая запись" wide flushBody>
         {addOpen && (
-          <EntryForm entry={null} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} enumTypes={enumTypes} onClose={() => setAddOpen(false)} />
+          <CatalogEntryForm entry={null} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} scope="System" scopeId={null} onClose={() => setAddOpen(false)} />
         )}
       </Modal>
       <Modal open={!!editEntry} onOpenChange={o => { if (!o) setEditEntry(null); }} title="Редактировать запись" wide flushBody>
         {editEntry && (
-          <EntryForm entry={editEntry} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} enumTypes={enumTypes} onClose={() => setEditEntry(null)} />
+          <CatalogEntryForm entry={editEntry} compositeTypes={compositeTypes} documentTypes={documentTypes} allDocTypes={allDocTypes} scope="System" scopeId={null} onClose={() => setEditEntry(null)} />
         )}
       </Modal>
       <ConfirmDialog

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -167,7 +167,7 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
 
 // ─── Catalog entry form (create + edit, shared by ScopedCatalogPanel) ────────
 
-function CatalogEntryForm({
+export function CatalogEntryForm({
   entry, compositeTypes, documentTypes = [], allDocTypes, scope, scopeId, setId, onClose,
 }: {
   entry?: CommonDataEntry | null;

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.19.5</Version>
+    <Version>0.19.6</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Крупный шаг код-фазы (Part of #73) — форм-ядро объекта составного типа для общих данных.

## Что
`SystemCommonDataPage` держал собственную копию формы записи (`EntryForm`, ~230 строк), почти дословно дублируя `CatalogEntryForm` (обе редактируют `CommonDataEntry`). Системная страница теперь переиспользует общий `CatalogEntryForm` со `scope="System"`, `scopeId={null}`. Собственная `EntryForm` удалена — **−243 строки**.

## Поведенческое изменение (единообразие, согласовано)
Записи **системных** общих данных получили те же возможности, что и в остальном каталоге:
- привязка к наборам данных (биндинги) + «обновить из источника»;
- распознавание реквизитов из вложенного файла;
- бейдж скопа/приоритета.

Формат и скоп сохранения прежние (`System`/`null`). Пикер/панель базы — уже общие (#77/#78).

## Test plan
- [x] `npx tsc -b` — чисто
- [x] `npm test` — 115/115
- [x] HMR применил без ошибок
- [ ] Живой проход по системному каталогу (создание/редактирование записи, база, биндинги) — на этапе багханта

Part of #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)