### PR TITLE
feat(catalog): псевдонимы (aliases) для записей общих данных

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
   ChevronDown, ChevronUp, Plus, Pencil, Trash2, FileText, Database, ShieldCheck, Loader2,
-  DatabaseZap, RefreshCw,
+  DatabaseZap, RefreshCw, X,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -180,6 +180,13 @@ export function CatalogEntryForm({
   onClose: () => void;
 }) {
   const [displayName, setDisplayName] = useState(entry?.displayName ?? '');
+  const [aliases, setAliases] = useState<string[]>(entry?.aliases ?? []);
+  const [aliasDraft, setAliasDraft] = useState('');
+  function addAlias() {
+    const t = aliasDraft.trim();
+    if (t && !aliases.some(a => a.toLowerCase() === t.toLowerCase())) setAliases(prev => [...prev, t]);
+    setAliasDraft('');
+  }
   const [typeId, setTypeId] = useState(entry?.compositeTypeId ?? '');
   const [values, setValues] = useState<Record<string, unknown>>(() => entry?.data ?? {});
   const [error, setError] = useState('');
@@ -286,9 +293,9 @@ export function CatalogEntryForm({
     if (!displayName.trim() || !typeId) { setError('Укажите название и тип'); return; }
     try {
       if (entry) {
-        await updateMutation.mutateAsync({ id: entry.id, displayName, data: JSON.stringify(values) });
+        await updateMutation.mutateAsync({ id: entry.id, displayName, data: JSON.stringify(values), aliases });
       } else {
-        await createMutation.mutateAsync({ displayName, compositeTypeId: typeId, data: JSON.stringify(values), scope, scopeId });
+        await createMutation.mutateAsync({ displayName, compositeTypeId: typeId, data: JSON.stringify(values), scope, scopeId, aliases });
       }
       onClose();
     } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Ошибка'); }
@@ -428,6 +435,31 @@ export function CatalogEntryForm({
       <div>
         <label className="block text-sm font-medium text-fg2 mb-1">Наименование</label>
         <input value={displayName} onChange={e => setDisplayName(e.target.value)} required autoFocus
+          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
+      </div>
+
+      {/* Алиасы (issue #74) — доп. имена для поиска записи при связывании с источниками */}
+      <div>
+        <label className="block text-sm font-medium text-fg2 mb-1">
+          Псевдонимы <span className="text-xs text-fg4 font-normal">(для поиска при связывании с источниками)</span>
+        </label>
+        {aliases.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-1.5">
+            {aliases.map(a => (
+              <span key={a} className="inline-flex items-center gap-1 text-xs bg-muted text-fg2 rounded-full pl-2.5 pr-1 py-0.5">
+                {a}
+                <button type="button" onClick={() => setAliases(prev => prev.filter(x => x !== a))}
+                  className="text-fg4 hover:text-danger transition-colors" title="Удалить">
+                  <X size={11} />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <input value={aliasDraft} onChange={e => setAliasDraft(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); addAlias(); } }}
+          onBlur={addAlias}
+          placeholder="Добавить псевдоним и Enter..."
           className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
       </div>
 

--- a/src/client/src/shared/api/commonData.ts
+++ b/src/client/src/shared/api/commonData.ts
@@ -54,6 +54,7 @@ export function useCreateCommonDataEntry() {
       data: string;
       scope: CatalogScope;
       scopeId?: string | null;
+      aliases?: string[];
     }) => apiClient.post<CommonDataEntry>('/common-data', payload).then(r => r.data),
     onSuccess: () => qc.invalidateQueries({ queryKey: [QK] }),
   });
@@ -62,8 +63,8 @@ export function useCreateCommonDataEntry() {
 export function useUpdateCommonDataEntry() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, displayName, data }: { id: string; displayName: string; data: string }) =>
-      apiClient.put<CommonDataEntry>(`/common-data/${id}`, { displayName, data }).then(r => r.data),
+    mutationFn: ({ id, displayName, data, aliases }: { id: string; displayName: string; data: string; aliases?: string[] }) =>
+      apiClient.put<CommonDataEntry>(`/common-data/${id}`, { displayName, data, aliases }).then(r => r.data),
     onSuccess: () => qc.invalidateQueries({ queryKey: [QK] }),
   });
 }

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -13,6 +13,8 @@ export const SCOPE_LABELS: Record<CatalogScope, string> = {
 export interface CommonDataEntry {
   id: string;
   displayName: string;
+  /** Альтернативные имена (issue #74) — для поиска записи при связывании с источниками данных. */
+  aliases: string[];
   compositeTypeId: string;
   data: Record<string, unknown>;
   scope: CatalogScope;

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
@@ -53,12 +53,12 @@ public static class CommonDataEndpoints
             };
             return Results.Ok(await m.Send(new CreateCommonDataEntryCommand(
                 req.DisplayName, req.CompositeTypeId,
-                JsonDocument.Parse(req.Data), scope, req.ScopeId)));
+                JsonDocument.Parse(req.Data), scope, req.ScopeId, req.Aliases)));
         });
 
         g.MapPut("/{id:guid}", async (Guid id, UpdateRequest req, IMediator m) =>
             Results.Ok(await m.Send(new UpdateCommonDataEntryCommand(
-                id, req.DisplayName, JsonDocument.Parse(req.Data)))));
+                id, req.DisplayName, JsonDocument.Parse(req.Data), req.Aliases))));
 
         g.MapDelete("/{id:guid}", async (Guid id, IMediator m) =>
         {
@@ -67,6 +67,6 @@ public static class CommonDataEndpoints
         });
     }
 
-    record CreateRequest(string DisplayName, Guid CompositeTypeId, string Data, string Scope, Guid? ScopeId);
-    record UpdateRequest(string DisplayName, string Data);
+    record CreateRequest(string DisplayName, Guid CompositeTypeId, string Data, string Scope, Guid? ScopeId, string[]? Aliases);
+    record UpdateRequest(string DisplayName, string Data, string[]? Aliases);
 }

--- a/src/server/BHS.CRG.Application/Backup/BackupModels.cs
+++ b/src/server/BHS.CRG.Application/Backup/BackupModels.cs
@@ -34,7 +34,8 @@ public record BackupCatalogEntity(
 public record BackupCommonDataEntry(
     Guid Id, string DisplayName, Guid CompositeTypeId, JsonElement Data,
     string Scope, Guid? ScopeId,
-    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt,
+    string[]? Aliases = null);
 
 public record RestoreReport(
     bool Success,

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -53,10 +53,10 @@ public record SetDocumentTemplateParamsCommand(Guid InstanceId, string? Params) 
 // --- CommonDataEntry ---
 public record CreateCommonDataEntryCommand(
     string DisplayName, Guid CompositeTypeId, JsonDocument Data,
-    CatalogScope Scope, Guid? ScopeId) : IRequest<CommonDataEntry>;
+    CatalogScope Scope, Guid? ScopeId, IReadOnlyList<string>? Aliases = null) : IRequest<CommonDataEntry>;
 
-public record UpdateCommonDataEntryCommand(Guid Id, string DisplayName, JsonDocument Data)
-    : IRequest<CommonDataEntry>;
+public record UpdateCommonDataEntryCommand(Guid Id, string DisplayName, JsonDocument Data,
+    IReadOnlyList<string>? Aliases = null) : IRequest<CommonDataEntry>;
 
 public record DeleteCommonDataEntryCommand(Guid Id) : IRequest;
 

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -416,7 +416,7 @@ public class CommonDataHandlers(
 {
     public async Task<CommonDataEntry> Handle(CreateCommonDataEntryCommand cmd, CancellationToken ct)
     {
-        var entry = CommonDataEntry.Create(cmd.DisplayName, cmd.CompositeTypeId, cmd.Data, cmd.Scope, cmd.ScopeId);
+        var entry = CommonDataEntry.Create(cmd.DisplayName, cmd.CompositeTypeId, cmd.Data, cmd.Scope, cmd.ScopeId, cmd.Aliases);
         await repo.AddAsync(entry, ct);
         await repo.SaveChangesAsync(ct);
         return entry;
@@ -427,7 +427,7 @@ public class CommonDataHandlers(
         var entry = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
         var previews = await dataSetService.PreviewBindingsAsync(null, cmd.Id, ct);
         var data = previews.Count == 0 ? cmd.Data : CommonDataBindingMerge.Merge(cmd.Data, previews);
-        entry.Update(cmd.DisplayName, data);
+        entry.Update(cmd.DisplayName, data, cmd.Aliases);
         repo.Update(entry);
         await repo.SaveChangesAsync(ct);
         return entry;

--- a/src/server/BHS.CRG.Domain/Catalog/CommonDataEntry.cs
+++ b/src/server/BHS.CRG.Domain/Catalog/CommonDataEntry.cs
@@ -16,6 +16,10 @@ public class CommonDataEntry : Entity
 {
     public string DisplayName { get; private set; } = null!;
 
+    /// <summary>Альтернативные имена (issue #74) — используются при сопоставлении записи со значением
+    /// колонки источника данных наравне с <see cref="DisplayName"/> (когда матч идёт по имени).</summary>
+    public List<string> Aliases { get; private set; } = [];
+
     /// <summary>ID составного типа документа (DocumentType.Kind == Composite).</summary>
     public Guid CompositeTypeId { get; private set; }
 
@@ -31,10 +35,11 @@ public class CommonDataEntry : Entity
 
     public static CommonDataEntry Create(
         string displayName, Guid compositeTypeId, JsonDocument data,
-        CatalogScope scope, Guid? scopeId)
+        CatalogScope scope, Guid? scopeId, IReadOnlyList<string>? aliases = null)
         => new()
         {
             DisplayName = displayName,
+            Aliases = NormalizeAliases(aliases),
             CompositeTypeId = compositeTypeId,
             Data = data,
             Scope = scope,
@@ -43,18 +48,35 @@ public class CommonDataEntry : Entity
 
     public static CommonDataEntry Restore(
         Guid id, string displayName, Guid compositeTypeId, JsonDocument data,
-        CatalogScope scope, Guid? scopeId, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        CatalogScope scope, Guid? scopeId, DateTimeOffset createdAt, DateTimeOffset updatedAt,
+        IReadOnlyList<string>? aliases = null)
         => new()
         {
-            Id = id, DisplayName = displayName, CompositeTypeId = compositeTypeId,
+            Id = id, DisplayName = displayName, Aliases = NormalizeAliases(aliases),
+            CompositeTypeId = compositeTypeId,
             Data = data, Scope = scope, ScopeId = scopeId,
             CreatedAt = createdAt, UpdatedAt = updatedAt,
         };
 
-    public void Update(string displayName, JsonDocument data)
+    public void Update(string displayName, JsonDocument data, IReadOnlyList<string>? aliases = null)
     {
         DisplayName = displayName;
+        Aliases = NormalizeAliases(aliases);
         Data = data;
         TouchUpdatedAt();
+    }
+
+    /// Убираем пустые/дублирующиеся алиасы (без учёта регистра), сохраняя порядок.
+    private static List<string> NormalizeAliases(IReadOnlyList<string>? aliases)
+    {
+        if (aliases is null) return [];
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (var a in aliases)
+        {
+            var t = a?.Trim();
+            if (!string.IsNullOrEmpty(t) && seen.Add(t)) result.Add(t);
+        }
+        return result;
     }
 }

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -82,7 +82,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             CommonDataEntries: commonDataEntries.Select(e => new BackupCommonDataEntry(
                 e.Id, e.DisplayName, e.CompositeTypeId, e.Data.RootElement.Clone(),
                 e.Scope.ToString(), e.ScopeId,
-                e.CreatedAt, e.UpdatedAt)).ToArray(),
+                e.CreatedAt, e.UpdatedAt, e.Aliases.ToArray())).ToArray(),
             PrimitiveTypes: primitiveTypes.Select(p => new BackupPrimitiveType(
                 p.Id, p.Name, p.Code, p.BaseType, p.Description,
                 p.Constraints.RootElement.Clone(),
@@ -326,7 +326,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             var entity = CommonDataEntry.Restore(
                 item.Id, item.DisplayName, item.CompositeTypeId,
                 JsonDocument.Parse(item.Data.GetRawText()),
-                scope, item.ScopeId, item.CreatedAt, item.UpdatedAt);
+                scope, item.ScopeId, item.CreatedAt, item.UpdatedAt, item.Aliases);
             db.Entry(entity).State = existingIds.Contains(item.Id) ? EntityState.Modified : EntityState.Added;
             if (existingIds.Contains(item.Id)) stats.CommonDataEntriesUpdated++; else stats.CommonDataEntriesCreated++;
         }

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -207,11 +207,16 @@ public class DataSetResolver(
         if (needle.Length == 0) return null; // пустое значение ни с чем не сопоставляем
         foreach (var entry in candidates)
         {
-            var hay = string.IsNullOrEmpty(match)
-                ? entry.DisplayName
-                : ReadDataField(entry.Data, match);
-            if (hay is not null && Normalize(hay) == needle)
-                return entry.Id;
+            if (!string.IsNullOrEmpty(match))
+            {
+                // Матч по конкретному полю данных — алиасы (это про имя) не участвуют.
+                var hay = ReadDataField(entry.Data, match);
+                if (hay is not null && Normalize(hay) == needle) return entry.Id;
+                continue;
+            }
+            // Матч по имени: DisplayName ИЛИ любой из алиасов (issue #74).
+            if (Normalize(entry.DisplayName) == needle) return entry.Id;
+            if (entry.Aliases.Any(a => Normalize(a) == needle)) return entry.Id;
         }
         return null;
     }

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260712211512_AddCommonDataEntryAliases.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260712211512_AddCommonDataEntryAliases.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712211512_AddCommonDataEntryAliases")]
+    partial class AddCommonDataEntryAliases
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260712211512_AddCommonDataEntryAliases.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260712211512_AddCommonDataEntryAliases.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommonDataEntryAliases : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "Aliases",
+                table: "common_data_entries",
+                type: "text[]",
+                nullable: false,
+                defaultValueSql: "'{}'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Aliases",
+                table: "common_data_entries");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/CommonDataEntryConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/CommonDataEntryConfiguration.cs
@@ -11,6 +11,8 @@ public class CommonDataEntryConfiguration : IEntityTypeConfiguration<CommonDataE
         b.ToTable("common_data_entries");
         b.HasKey(e => e.Id);
         b.Property(e => e.DisplayName).HasMaxLength(512).IsRequired();
+        // Алиасы (issue #74) — Postgres text[]; сопоставление идёт в памяти, индексация не требуется.
+        b.Property(e => e.Aliases).HasColumnType("text[]").IsRequired();
         b.Property(e => e.CompositeTypeId).IsRequired();
         b.Property(e => e.Data).HasColumnType("jsonb").IsRequired();
         b.Property(e => e.Scope)

--- a/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
@@ -54,6 +55,50 @@ public class CommonDataHandlerTests(IntegrationTestFixture fixture) : IAsyncLife
         Assert.Equal("ООО Тест", entry.DisplayName);
         Assert.Equal(CatalogScope.System, entry.Scope);
         Assert.Null(entry.ScopeId);
+    }
+
+    // ── Aliases (issue #74) ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_NormalizesAndPersistsAliases()
+    {
+        var typeId = await CreateCompositeTypeAsync("ORG_AL");
+        Guid id;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var entry = await Mediator(scope).Send(new CreateCommonDataEntryCommand(
+                "ООО Ромашка", typeId, Json("{}"), CatalogScope.System, null,
+                new[] { "Ромашка", " Ромашка ", "ромашка", "", "  ", "РМШ" }));
+            id = entry.Id;
+            // trim + dedup (без учёта регистра) + отбрасывание пустых → остаются "Ромашка", "РМШ"
+            Assert.Equal(new[] { "Ромашка", "РМШ" }, entry.Aliases);
+        }
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IRepository<CommonDataEntry>>();
+            var reloaded = await repo.GetByIdAsync(id, default);
+            Assert.NotNull(reloaded);
+            Assert.Equal(new[] { "Ромашка", "РМШ" }, reloaded!.Aliases); // персистентно (text[])
+        }
+    }
+
+    [Fact]
+    public async Task Update_ReplacesAliases()
+    {
+        var typeId = await CreateCompositeTypeAsync("ORG_AU");
+        Guid id;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var e = await Mediator(scope).Send(new CreateCommonDataEntryCommand(
+                "X", typeId, Json("{}"), CatalogScope.System, null, new[] { "старый" }));
+            id = e.Id;
+        }
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var e = await Mediator(scope).Send(new UpdateCommonDataEntryCommand(
+                id, "X", Json("{}"), new[] { "новый1", "новый2" }));
+            Assert.Equal(new[] { "новый1", "новый2" }, e.Aliases);
+        }
     }
 
     // ── Update ────────────────────────────────────────────────────────────────

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.19.6</Version>
+    <Version>0.20.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Summary
Записи общих данных (инстансы составных типов) получили список **псевдонимов** (альтернативных имён). При связывании с источником данных, когда сопоставление идёт по имени (`@@ref` без указания match-поля), значение колонки источника матчится с `DisplayName` **ИЛИ любым псевдонимом**. Closes #74.

## Backend
- **Домен** `CommonDataEntry.Aliases` (`List<string>`); нормализация при Create/Update/Restore — trim, дедуп без учёта регистра, отбрасывание пустых, сохранение порядка.
- **EF**: колонка `text[]`; миграция `AddCommonDataEntryAliases` с `defaultValueSql '{}'` (безопасно на существующих строках).
- **Резолв** (`DataSetResolver.FindCatalogEntryIdAsync`): матч по имени теперь = `DisplayName` ∪ `Aliases`; матч по конкретному полю данных (`match` задан) — как прежде, псевдонимы не участвуют (они про имя).
- **Команды / эндпоинты / Backup** — сквозная передача `aliases`.

## Frontend
- Тип `CommonDataEntry.aliases`, хуки create/update передают `aliases`.
- Редактор псевдонимов в форме записи каталога (единой для всех скопов): чипы с удалением + ввод по Enter/запятой.

## Scope
Фича — для `CommonDataEntry` (именно эти инстансы составных типов сопоставляются по имени при биндинге). Документные инстансы по имени в биндингах не матчатся, поэтому не затронуты.

## Test plan
- [x] `dotnet build` + `dotnet test` — **376/376** (2 новых: нормализация псевдонимов + `text[]` round-trip)
- [x] `npx tsc -b` — чисто; `npm test` — 115/115
- [ ] Живой: добавить псевдоним записи → биндинг источника, где колонка = псевдоним → проверить, что запись подтянулась (на этапе багханта)

Closes #74
🤖 Generated with [Claude Code](https://claude.com/claude-code)