### PR TITLE
fix(catalog): пикер объектов резолвит всю цепочку скопов (for-scope)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -4,9 +4,9 @@ import {
 } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
-import { useCommonDataForSet, useListCommonData } from '@/shared/api/commonData';
+import { useCommonDataForScope } from '@/shared/api/commonData';
 import type {
-  CatalogScope, CommonDataEntry, DocumentInstance, DocumentType, FieldRef, PrimitiveTypeDef,
+  CatalogScope, DocumentInstance, DocumentType, FieldRef, PrimitiveTypeDef,
 } from '@/shared/api/types';
 import { isFieldRef, SCOPE_LABELS } from '@/shared/api/types';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
@@ -137,9 +137,10 @@ export function ArrayTableModal({
     if (open) setRows(items.map(r => ({ ...r })));
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { data: cdForSet = [] } = useCommonDataForSet({ setId: setId ?? '', enabled: open && !!setId });
-  const { data: cdSystem = [] } = useListCommonData({ scope: 'System', enabled: open && !setId });
-  const commonDataEntries = (setId ? cdForSet : cdSystem) as CommonDataEntry[];
+  // Единая цепочка скопов (issue #82): комплект → (Set, setId), иначе (scope, scopeId) — с подъёмом по родителям.
+  const { data: commonDataEntries = [] } = useCommonDataForScope({
+    scope: setId ? 'Set' : scope, scopeId: setId ?? scopeId, enabled: open && (!!setId || !!scope),
+  });
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
 

--- a/src/client/src/features/document-sets/fields/RefPickerModal.tsx
+++ b/src/client/src/features/document-sets/fields/RefPickerModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { FileText, ChevronDown, ChevronRight } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { useCommonDataForSet, useListCommonData } from '@/shared/api/commonData';
+import { useCommonDataForScope } from '@/shared/api/commonData';
 import type {
   CommonDataEntry, DocumentInstance, DocumentType, FieldRef, CatalogScope,
 } from '@/shared/api/types';
@@ -26,23 +26,14 @@ export function RefPickerModal({
 }) {
   const [search, setSearch] = useState('');
 
-  const { data: setCatalogEntries = [] } = useCommonDataForSet({
-    setId: setId ?? '',
-    enabled: open && !!setId,
+  // Единый резолв всей цепочки скопов (issue #82): комплект-контекст → (Set, setId), иначе (scope, scopeId).
+  // for-scope сам поднимается по родителям (Раздел→Стройка→Система), поэтому объекты более широких
+  // уровней видны из раздел/строечных контекстов (раньше запасной путь их пропускал).
+  const effScope: CatalogScope | undefined = setId ? 'Set' : scope;
+  const effScopeId = setId ?? scopeId;
+  const { data: catalogEntries = [] } = useCommonDataForScope({
+    scope: effScope, scopeId: effScopeId, enabled: open && !!effScope,
   });
-
-  const { data: scopeEntries = [] } = useListCommonData({
-    scope, scopeId: scopeId ?? undefined,
-    enabled: open && !setId && !!scope && scope !== 'System',
-  });
-  const { data: systemFallback = [] } = useListCommonData({
-    scope: 'System',
-    enabled: open && !setId,
-  });
-
-  const catalogEntries: CommonDataEntry[] = setId
-    ? setCatalogEntries
-    : [...scopeEntries, ...systemFallback.filter(e => !scopeEntries.some(s => s.id === e.id))];
 
   const filtered = catalogEntries.filter(e => {
     if (compositeType && !isSubtypeOf(e.compositeTypeId, compositeType.id, allDocTypes)) return false;

--- a/src/client/src/shared/api/commonData.ts
+++ b/src/client/src/shared/api/commonData.ts
@@ -45,6 +45,33 @@ export function useCommonDataForSet({
   });
 }
 
+/**
+ * Записи, видимые из ЛЮБОГО скопа (issue #82): резолвит родительскую цепочку
+ * (Раздел→Стройка→Система и т.д.) — в отличие от useCommonDataForSet, который стартует с комплекта.
+ */
+export function useCommonDataForScope({
+  scope,
+  scopeId,
+  typeId,
+  enabled = true,
+}: {
+  scope: CatalogScope | undefined;
+  scopeId?: string | null;
+  typeId?: string;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: [QK, 'for-scope', scope ?? null, scopeId ?? null, typeId ?? null],
+    queryFn: () =>
+      apiClient
+        .get<CommonDataEntryWithScope[]>('/common-data/for-scope', {
+          params: { scope, scopeId: scopeId ?? undefined, typeId },
+        })
+        .then(r => r.data),
+    enabled: enabled && !!scope,
+  });
+}
+
 export function useCreateCommonDataEntry() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
@@ -35,6 +35,21 @@ public static class CommonDataEndpoints
             catch (KeyNotFoundException ex) { return Results.NotFound(ex.Message); }
         });
 
+        // Resolve entries visible from ANY scope level, walking the parent chain (issue #82).
+        g.MapGet("/for-scope", async (string scope, Guid? scopeId, Guid? typeId, IMediator m) =>
+        {
+            CatalogScope? parsed = scope switch
+            {
+                "Set"          => CatalogScope.Set,
+                "Section"      => CatalogScope.Section,
+                "Construction" => CatalogScope.Construction,
+                "System"       => CatalogScope.System,
+                _              => null,
+            };
+            if (parsed is null) return Results.BadRequest($"Unknown scope '{scope}'.");
+            return Results.Ok(await m.Send(new ResolveCommonDataForScopeQuery(parsed.Value, scopeId, typeId)));
+        });
+
         g.MapGet("/{id:guid}", async (Guid id, IMediator m) =>
         {
             var all = await m.Send(new ListCommonDataEntriesQuery());

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -72,6 +72,15 @@ public record ListCommonDataEntriesQuery(
 public record ResolveCommonDataForSetQuery(Guid SetId, Guid? CompositeTypeId = null)
     : IRequest<IReadOnlyList<CommonDataEntryWithScope>>;
 
+/// <summary>
+/// Записи общих данных, видимые из ЛЮБОГО скопа (issue #82): резолвит полную родительскую цепочку
+/// (Set→Section→Construction→System) — в отличие от <see cref="ResolveCommonDataForSetQuery"/>,
+/// который стартует только с комплекта. Нужен, чтобы из раздел/строечного объекта ссылаться на
+/// объекты более широких уровней.
+/// </summary>
+public record ResolveCommonDataForScopeQuery(CatalogScope Scope, Guid? ScopeId, Guid? CompositeTypeId = null)
+    : IRequest<IReadOnlyList<CommonDataEntryWithScope>>;
+
 public record CommonDataEntryWithScope(
     Guid Id,
     string DisplayName,

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -412,7 +412,8 @@ public class CommonDataHandlers(
     IRequestHandler<UpdateCommonDataEntryCommand, CommonDataEntry>,
     IRequestHandler<DeleteCommonDataEntryCommand>,
     IRequestHandler<ListCommonDataEntriesQuery, IReadOnlyList<CommonDataEntry>>,
-    IRequestHandler<ResolveCommonDataForSetQuery, IReadOnlyList<CommonDataEntryWithScope>>
+    IRequestHandler<ResolveCommonDataForSetQuery, IReadOnlyList<CommonDataEntryWithScope>>,
+    IRequestHandler<ResolveCommonDataForScopeQuery, IReadOnlyList<CommonDataEntryWithScope>>
 {
     public async Task<CommonDataEntry> Handle(CreateCommonDataEntryCommand cmd, CancellationToken ct)
     {
@@ -465,6 +466,53 @@ public class CommonDataHandlers(
             ((e.Scope == CatalogScope.Set         && e.ScopeId == setId) ||
              (e.Scope == CatalogScope.Section     && e.ScopeId == sectionId) ||
              (e.Scope == CatalogScope.Construction && e.ScopeId == constructionId) ||
+             e.Scope == CatalogScope.System) &&
+            (!typeId.HasValue || e.CompositeTypeId == typeId.Value), ct);
+
+        return relevant
+            .Select(e => new CommonDataEntryWithScope(
+                e.Id, e.DisplayName, e.CompositeTypeId, e.Data,
+                e.Scope, e.ScopeId, (int)e.Scope,
+                e.CreatedAt, e.UpdatedAt))
+            .OrderBy(e => e.Priority)
+            .ThenBy(e => e.DisplayName)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<CommonDataEntryWithScope>> Handle(
+        ResolveCommonDataForScopeQuery q, CancellationToken ct)
+    {
+        // Разрешаем родительскую цепочку скопа: Set→Section→Construction→System (issue #82).
+        // Неразрешённые уровни — Guid.Empty: ни одна запись со ScopeId==Empty не совпадёт.
+        Guid setId = Guid.Empty, sectionId = Guid.Empty, constructionId = Guid.Empty;
+        switch (q.Scope)
+        {
+            case CatalogScope.Set when q.ScopeId is { } sid:
+                setId = sid;
+                var set = await setRepo.GetByIdAsync(sid, ct);
+                if (set is not null)
+                {
+                    sectionId = set.SectionId;
+                    var sec = await sectionRepo.GetByIdAsync(set.SectionId, ct);
+                    if (sec is not null) constructionId = sec.ConstructionId;
+                }
+                break;
+            case CatalogScope.Section when q.ScopeId is { } secId:
+                sectionId = secId;
+                var section = await sectionRepo.GetByIdAsync(secId, ct);
+                if (section is not null) constructionId = section.ConstructionId;
+                break;
+            case CatalogScope.Construction when q.ScopeId is { } cid:
+                constructionId = cid;
+                break;
+            // System — родителей нет.
+        }
+        var typeId = q.CompositeTypeId;
+
+        var relevant = await repo.FindAsync(e =>
+            ((e.Scope == CatalogScope.Set          && e.ScopeId == setId) ||
+             (e.Scope == CatalogScope.Section       && e.ScopeId == sectionId) ||
+             (e.Scope == CatalogScope.Construction  && e.ScopeId == constructionId) ||
              e.Scope == CatalogScope.System) &&
             (!typeId.HasValue || e.CompositeTypeId == typeId.Value), ct);
 

--- a/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
@@ -101,6 +101,29 @@ public class CommonDataHandlerTests(IntegrationTestFixture fixture) : IAsyncLife
         }
     }
 
+    // ── for-scope: резолв родительской цепочки (issue #82) ──────────────────────
+
+    [Fact]
+    public async Task ForScope_Section_IncludesConstructionAndSystem_NotForeign()
+    {
+        var typeId = await CreateCompositeTypeAsync("ORG_FS");
+        var (_, sectionId, constructionId) = await CreateHierarchyAsync();
+        using var scope = fixture.Services.CreateScope();
+        var m = Mediator(scope);
+        var c = await m.Send(new CreateCommonDataEntryCommand("Стройка", typeId, Json("{}"), CatalogScope.Construction, constructionId));
+        var s = await m.Send(new CreateCommonDataEntryCommand("Раздел", typeId, Json("{}"), CatalogScope.Section, sectionId));
+        var sys = await m.Send(new CreateCommonDataEntryCommand("Система", typeId, Json("{}"), CatalogScope.System, null));
+        var foreign = await m.Send(new CreateCommonDataEntryCommand("Чужая стройка", typeId, Json("{}"), CatalogScope.Construction, Guid.NewGuid()));
+
+        var ids = (await m.Send(new ResolveCommonDataForScopeQuery(CatalogScope.Section, sectionId, null)))
+            .Select(e => e.Id).ToHashSet();
+
+        Assert.Contains(c.Id, ids);       // стройка — родитель раздела (раньше пикер её не показывал)
+        Assert.Contains(s.Id, ids);       // сам раздел
+        Assert.Contains(sys.Id, ids);     // система
+        Assert.DoesNotContain(foreign.Id, ids); // объект чужой стройки не виден
+    }
+
     // ── Update ────────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.20.0</Version>
+    <Version>0.20.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #82. Из объекта уровня Раздел/Стройка нельзя было сослаться полем на объект более широкого уровня — пикер показывал только записи точного скопа + системные.

## Причина
Полную цепочку скопов (Комплект→Раздел→Стройка→Система) резолвил только путь `for-set` по `setId`. Панели каталога уровня Раздел/Стройка `setId` не передают, и запасной путь пикера (`useListCommonData(точный скоп) + Система`) вверх по родителям не поднимался. Подтверждено на данных: «Проект ЭОМ (РД)» (Раздел) не видел «ЕЦДМ» (Стройка), хотя по типу они совпадают.

## Фикс
- **Backend**: `ResolveCommonDataForScopeQuery(scope, scopeId, typeId?)` — резолвит родительскую цепочку для любого уровня (Section→Construction→System и т.д.); эндпоинт `GET /common-data/for-scope`.
- **Frontend**: хук `useCommonDataForScope`; `RefPickerModal` и `ArrayTableModal` переведены на него, эффективный скоп = `setId ? (Set,setId) : (scope,scopeId)`. Урезанные fallback-запросы удалены.

## Test plan
- [x] `dotnet build` + `dotnet test` — **377/377** (новый тест: for-scope из Раздела включает Стройку+Систему, исключает чужую стройку)
- [x] `npx tsc -b` — чисто; `npm test` — 115/115
- [ ] Живой сценарий: «Проект ЭОМ (РД)» (Раздел) → поле «Объект» → в пикере видна «ЕЦДМ» (Стройка) — на этапе багханта

## Отдельно (данные)
16 записей уровня Стройка ссылаются на удалённую стройку `0fdc980e` — осиротели, невидимы (не этот баг).

Closes #82
🤖 Generated with [Claude Code](https://claude.com/claude-code)