### PR TITLE
refactor(generation): read-seam DocumentView под резолверы (PR-1 Фазы 1)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/DocumentView.cs
+++ b/src/server/BHS.CRG.Application/Generation/DocumentView.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Read-model генерации: минимальная проекция объекта, которую потребляют резолверы
+/// (<see cref="IEntityResolver"/>, <see cref="IDataSetResolver"/>, <see cref="IQualityLinkResolver"/>).
+/// Отвязывает hot-path генерации (merge/ref-логику) от конкретной сущности хранения
+/// (issue #84, Фаза 1): после слияния CommonDataEntry+DocumentInstance в DomainObject
+/// сменится лишь источник проекции — логика резолва останется прежней.
+/// </summary>
+public sealed record DocumentView(
+    Guid Id,
+    Guid DocumentSetId,
+    Guid DocumentTypeId,
+    JsonDocument Requisites,
+    JsonDocument PluginData)
+{
+    public static DocumentView From(DocumentInstance instance) => new(
+        instance.Id, instance.DocumentSetId, instance.DocumentTypeId,
+        instance.Requisites, instance.PluginData);
+}

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -67,15 +67,16 @@ public class GenerateDocumentHandler(
 
             var allDocTypes = await docTypeRepo.GetAllAsync(ct);
             var diagnostics = new List<ResolutionDiagnostic>();
-            var context = await entityResolver.ResolveAsync(instance, ct);
-            await dataSetResolver.InjectAsync(context, instance, diagnostics, ct);
+            var view = DocumentView.From(instance);
+            var context = await entityResolver.ResolveAsync(view, ct);
+            await dataSetResolver.InjectAsync(context, view, diagnostics, ct);
             // Значения по умолчанию из схемы типа (issue #53) — для полей, оставшихся без значения
             // после реквизитов инстанса и биндингов (самый низкий приоритет).
-            await entityResolver.ApplyDefaultsAsync(context, instance, ct);
+            await entityResolver.ApplyDefaultsAsync(context, view, ct);
             // Enum-поля: код → отображаемое имя (issue #59) — иначе в PDF попадёт сырой код.
-            await entityResolver.ResolveEnumLabelsAsync(context, instance, ct);
+            await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
             // Подмешиваем документы качества по идентичности материала (артикул/наименование).
-            await qualityLinkResolver.InjectAsync(context, instance, ct);
+            await qualityLinkResolver.InjectAsync(context, view, ct);
             // Наборы данных могли добавить ссылки на каталог ($ref) в составные поля —
             // разрешаем их вторым проходом (для уже разрешённых данных идемпотентно).
             await entityResolver.ResolveContextRefsAsync(context, instance.DocumentSetId, ct);
@@ -119,7 +120,7 @@ public class GenerateDocumentHandler(
                     : null;
 
                 var generator = generatorFactory.Create(cmd.Format);
-                var request = new GenerationRequest(instance, template.Content, cmd.Format, context,
+                var request = new GenerationRequest(template.Content, cmd.Format, context,
                     TypeBlocksContent: typeBlocksContent, UserLibContent: userLibContent,
                     ImageOptions: imageOptions, TemplateAssets: templateAssets);
                 var bytes = await generator.GenerateAsync(request, ct);

--- a/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
+++ b/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
@@ -59,11 +59,12 @@ public class GetGenerationDebugBundleHandler(
             ?? throw new InvalidOperationException($"No active template for DocumentType {instance.DocumentTypeId}");
 
         var allDocTypes = await docTypeRepo.GetAllAsync(ct);
-        var context = await entityResolver.ResolveAsync(instance, ct);
-        await dataSetResolver.InjectAsync(context, instance, null, ct);
-        await entityResolver.ApplyDefaultsAsync(context, instance, ct);
-        await entityResolver.ResolveEnumLabelsAsync(context, instance, ct);
-        await qualityLinkResolver.InjectAsync(context, instance, ct);
+        var view = DocumentView.From(instance);
+        var context = await entityResolver.ResolveAsync(view, ct);
+        await dataSetResolver.InjectAsync(context, view, null, ct);
+        await entityResolver.ApplyDefaultsAsync(context, view, ct);
+        await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
+        await qualityLinkResolver.InjectAsync(context, view, ct);
         // Тот же второй проход, что и при генерации — разрешаем $ref, добавленные наборами данных.
         await entityResolver.ResolveContextRefsAsync(context, instance.DocumentSetId, ct);
         context.Set("params", TemplateParams.Effective(template.Parameters,

--- a/src/server/BHS.CRG.Application/Generation/IDataSetResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/IDataSetResolver.cs
@@ -1,5 +1,3 @@
-using BHS.CRG.Domain.Documents;
-
 namespace BHS.CRG.Application.Generation;
 
 public interface IDataSetResolver
@@ -8,6 +6,6 @@ public interface IDataSetResolver
     /// Подмешивает данные наборов в контекст. Если передан <paramref name="diagnostics"/>,
     /// в него записываются проблемы маппинга (например, значение колонки не найдено в каталоге).
     /// </summary>
-    Task InjectAsync(GenerationContext ctx, DocumentInstance instance,
+    Task InjectAsync(GenerationContext ctx, DocumentView instance,
         List<ResolutionDiagnostic>? diagnostics = null, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Application/Generation/IDocumentGenerator.cs
+++ b/src/server/BHS.CRG.Application/Generation/IDocumentGenerator.cs
@@ -10,7 +10,6 @@ public interface IDocumentGenerator
 }
 
 public record GenerationRequest(
-    DocumentInstance Instance,
     string TemplateContent,
     OutputFormat Format,
     GenerationContext Context,

--- a/src/server/BHS.CRG.Application/Generation/IEntityResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/IEntityResolver.cs
@@ -1,15 +1,13 @@
-using BHS.CRG.Domain.Documents;
-
 namespace BHS.CRG.Application.Generation;
 
 /// <summary>
 /// C#-аналог ref/merge механизма из NewElementResolverStyles.xsl старой системы.
-/// Принимает DocumentInstance, разрешает ссылки на сущности каталога,
+/// Принимает <see cref="DocumentView"/>, разрешает ссылки на сущности каталога,
 /// возвращает собранный GenerationContext.
 /// </summary>
 public interface IEntityResolver
 {
-    Task<GenerationContext> ResolveAsync(DocumentInstance instance, CancellationToken ct = default);
+    Task<GenerationContext> ResolveAsync(DocumentView instance, CancellationToken ct = default);
 
     /// <summary>
     /// Повторно разрешает $ref-ссылки в уже собранном контексте. Применяется после
@@ -26,7 +24,7 @@ public interface IEntityResolver
     /// IDataSetResolver.InjectAsync (иначе биндинг не успеет "победить"). Только скалярные поля —
     /// составные/табличные (complex/array/doc-ref/doc-array/file/image) не трогает.
     /// </summary>
-    Task ApplyDefaultsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default);
+    Task ApplyDefaultsAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default);
 
     /// <summary>
     /// Резолвит enum-поля реквизитов из кода (хранится в контексте) в отображаемое имя EnumType
@@ -34,5 +32,5 @@ public interface IEntityResolver
     /// ApplyDefaultsAsync (иначе default-значение enum-поля не получит резолва). Толерантно: код без
     /// совпадения в реестре остаётся как есть. Только верхнеуровневые скалярные поля.
     /// </summary>
-    Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default);
+    Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Application/Generation/IQualityLinkResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/IQualityLinkResolver.cs
@@ -1,5 +1,3 @@
-using BHS.CRG.Domain.Documents;
-
 namespace BHS.CRG.Application.Generation;
 
 /// <summary>
@@ -9,5 +7,5 @@ namespace BHS.CRG.Application.Generation;
 /// </summary>
 public interface IQualityLinkResolver
 {
-    Task InjectAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default);
+    Task InjectAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
@@ -23,10 +23,11 @@ public class ValidateInstanceResolutionHandler(
             ?? throw new KeyNotFoundException($"DocumentInstance {q.InstanceId} not found");
 
         var diagnostics = new List<ResolutionDiagnostic>();
-        var context = await entityResolver.ResolveAsync(instance, ct);
-        await dataSetResolver.InjectAsync(context, instance, diagnostics, ct);
-        await entityResolver.ApplyDefaultsAsync(context, instance, ct);
-        await entityResolver.ResolveEnumLabelsAsync(context, instance, ct);
+        var view = DocumentView.From(instance);
+        var context = await entityResolver.ResolveAsync(view, ct);
+        await dataSetResolver.InjectAsync(context, view, diagnostics, ct);
+        await entityResolver.ApplyDefaultsAsync(context, view, ct);
+        await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
         await entityResolver.ResolveContextRefsAsync(context, instance.DocumentSetId, ct);
         ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
         return diagnostics;

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -20,7 +20,7 @@ public class DataSetResolver(
     ILogger<DataSetResolver> logger
 ) : IDataSetResolver
 {
-    public async Task InjectAsync(GenerationContext ctx, DocumentInstance instance,
+    public async Task InjectAsync(GenerationContext ctx, DocumentView instance,
         List<ResolutionDiagnostic>? diagnostics = null, CancellationToken ct = default)
     {
         var bindings = await db.DataSetBindings
@@ -149,7 +149,7 @@ public class DataSetResolver(
     private async Task<object?> MapValueAsync(
         string mapVal,
         IReadOnlyDictionary<string, string?> row,
-        DocumentInstance instance,
+        DocumentView instance,
         Func<Task<ScopeChain>> scopeChainAccessor,
         Dictionary<Guid, List<CommonDataEntry>> entryCache,
         List<ResolutionDiagnostic>? diagnostics,

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -19,7 +19,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     // глубоких структур). Ортогональна allowInstanceRefs (защита от циклов по документам).
     private const int MaxRefDepth = 8;
 
-    public async Task<GenerationContext> ResolveAsync(DocumentInstance instance, CancellationToken ct = default)
+    public async Task<GenerationContext> ResolveAsync(DocumentView instance, CancellationToken ct = default)
     {
         // Наследование от базового экземпляра (issue #71): если реквизиты несут "_baseRef", подмешиваем
         // реквизиты базы — документа комплекта ЛИБО записи общих данных (полиморфно, по скоп-близости) —
@@ -52,7 +52,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         }
     }
 
-    public async Task ApplyDefaultsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default)
+    public async Task ApplyDefaultsAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default)
     {
         var allDocTypes = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
         var fields = DocumentTypeSchemaReader.EffectiveFields(instance.DocumentTypeId, allDocTypes);
@@ -72,7 +72,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     /// что уже есть у ApplyDefaultsAsync (не резолвит внутрь строк array/complex полей). Толерантно:
     /// код без совпадения в Options остаётся как есть (та же философия, что и везде в резолвере).
     /// </summary>
-    public async Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default)
+    public async Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default)
     {
         var allDocTypes = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
         var enumTypesById = await db.EnumTypes.AsNoTracking().ToDictionaryAsync(e => e.Id, ct);

--- a/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
@@ -12,7 +12,7 @@ namespace BHS.CRG.Infrastructure.Generation;
 
 public class QualityLinkResolver(AppDbContext db) : IQualityLinkResolver
 {
-    public async Task InjectAsync(GenerationContext ctx, DocumentInstance instance, CancellationToken ct = default)
+    public async Task InjectAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default)
     {
         // Поля идентичности материала и целевое поле ссылки берём по функциональным тэгам
         // (material.identity / material.qualityDocLink) из составных типов, а не по именам.

--- a/src/server/BHS.CRG.Tests/Integration/DataSetResolverDefaultsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetResolverDefaultsTests.cs
@@ -61,8 +61,9 @@ public class DataSetResolverDefaultsTests(IntegrationTestFixture fixture) : IAsy
         var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
         var dataSetResolver = scope.ServiceProvider.GetRequiredService<IDataSetResolver>();
 
-        var ctx = await resolver.ResolveAsync(inst!, default);
-        await dataSetResolver.InjectAsync(ctx, inst!, null, default);
+        var view = DocumentView.From(inst!);
+        var ctx = await resolver.ResolveAsync(view, default);
+        await dataSetResolver.InjectAsync(ctx, view, null, default);
 
         var rows = (JsonElement)ctx.Data["Строки"]!;
         Assert.Equal(JsonValueKind.Array, rows.ValueKind);
@@ -104,8 +105,9 @@ public class DataSetResolverDefaultsTests(IntegrationTestFixture fixture) : IAsy
         var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
         var dataSetResolver = scope.ServiceProvider.GetRequiredService<IDataSetResolver>();
 
-        var ctx = await resolver.ResolveAsync(inst!, default);
-        await dataSetResolver.InjectAsync(ctx, inst!, null, default);
+        var view = DocumentView.From(inst!);
+        var ctx = await resolver.ResolveAsync(view, default);
+        await dataSetResolver.InjectAsync(ctx, view, null, default);
 
         var rows = (JsonElement)ctx.Data["Строки"]!;
         Assert.Equal("2", rows[0].GetProperty("ВидДокумента").GetString()); // из колонки B, не "дефолт"

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverDefaultsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverDefaultsTests.cs
@@ -53,7 +53,7 @@ public class EntityResolverDefaultsTests(IntegrationTestFixture fixture) : IAsyn
         using var scope = fixture.Services.CreateScope();
         var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
         var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
-        await resolver.ApplyDefaultsAsync(ctx, inst!, default);
+        await resolver.ApplyDefaultsAsync(ctx, DocumentView.From(inst!), default);
     }
 
     [Fact]

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverEnumLabelsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverEnumLabelsTests.cs
@@ -44,7 +44,7 @@ public class EntityResolverEnumLabelsTests(IntegrationTestFixture fixture) : IAs
         using var scope = fixture.Services.CreateScope();
         var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
         var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
-        await resolver.ResolveEnumLabelsAsync(ctx, inst!, default);
+        await resolver.ResolveEnumLabelsAsync(ctx, DocumentView.From(inst!), default);
     }
 
     [Fact]

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -61,7 +61,7 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         using var scope = fixture.Services.CreateScope();
         var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
         var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
-        return await resolver.ResolveAsync(inst!);
+        return await resolver.ResolveAsync(DocumentView.From(inst!));
     }
 
     private static JsonElement E(GenerationContext ctx, string key) => (JsonElement)ctx.Data[key]!;

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.20.0</Version>
+    <Version>0.20.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Part of #84 (Фаза 1, часть #73). **PR-1 — read-seam генерации.**

Первый (зелёный, безопасный) шаг слияния `CommonDataEntry`+`DocumentInstance` → `DomainObject`: отвязываем hot-path генерации от конкретной сущности хранения, чтобы будущий цутовер менял лишь *источник* данных, а merge/ref-логику не трогал.

## Что сделано
- Новый read-model **`DocumentView(Id, DocumentSetId, DocumentTypeId, Requisites, PluginData)`** — ровно те поля, что резолверы реально читают (подтверждено: другого от инстанса они не берут).
- Резолверы переведены на `DocumentView` вместо `DocumentInstance`:
  - `IEntityResolver.ResolveAsync/ApplyDefaultsAsync/ResolveEnumLabelsAsync`
  - `IDataSetResolver.InjectAsync`
  - `IQualityLinkResolver.InjectAsync`
- Хендлеры (`GenerateDocumentHandler`, `ValidateInstanceResolutionHandler`, `GetGenerationDebugBundle`) строят `DocumentView.From(instance)` и передают его резолверам; **конкретный инстанс остаётся** для мутаций (статус, файлы, обратная запись метаданных, выбор шаблонов).
- Удалено мёртвое поле `GenerationRequest.Instance` (генераторы им не пользовались).

## Почему это де-риск цутовера
После слияния `DomainObject`→`DocumentView` строится так же ⇒ сигнатуры и логика резолва (в т.ч. коллапс `_baseRef`/`$ref`) не меняются в цутовер-PR — там сменится только загрузка сущности и мутации.

## Проверка
- `dotnet build BHS.CRG.slnx` — зелёно.
- `dotnet test` — **376/376** (резолверные интеграционные тесты обновлены на `DocumentView.From`).
- Приложение перезапущено, стартует и обслуживает запросы.

Поведение не меняется — чистый рефактор (PATCH 0.20.1).
