### PR TITLE
feat(proxy): роль/прокси того же типа — бэкенд + admin-флаг + scope-guard (#89)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateDocumentTypeSchema,
   useDeleteDocumentType,
   useSetDocumentTypeAbstract,
+  useSetDocumentTypeAllowsProxy,
   useSetDocumentTypeGroup,
 } from '@/shared/api/documentTypes';
 import { TypeGroupAccordion, GroupPicker } from './TypeGroupAccordion';
@@ -614,6 +615,7 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
 }) {
   const deleteMutation = useDeleteDocumentType();
   const abstractMutation = useSetDocumentTypeAbstract();
+  const proxyMutation = useSetDocumentTypeAllowsProxy();
   const groupMutation = useSetDocumentTypeGroup();
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -661,6 +663,11 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
               ↑ {parentType.name}
             </span>
           )}
+          {docType.allowsProxy && (
+            <span className="text-[11px] bg-brand-subtle text-brand px-1.5 py-0.5 rounded-full shrink-0">
+              роль/прокси
+            </span>
+          )}
           <span className="flex-1" />
           {effectiveFields.length > 0 && (
             <span className="text-xs text-fg4 shrink-0">
@@ -677,6 +684,17 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
               {complexFields.length} сост.
             </span>
           )}
+        </button>
+        <button
+          onClick={e => { e.stopPropagation(); proxyMutation.mutate({ id: docType.id, allowsProxy: !docType.allowsProxy }); }}
+          disabled={proxyMutation.isPending}
+          className={`px-2 py-3 text-xs font-medium opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30 ${
+            docType.allowsProxy ? 'text-brand hover:text-brand-hover' : 'text-stroke-strong hover:text-brand'
+          }`}
+          title={docType.allowsProxy
+            ? 'Запретить роль/прокси'
+            : 'Разрешить роль/прокси: объект этого типа сможет ссылаться на реальный объект того же типа'}>
+          Прокси
         </button>
         {docType.kind === 'Document' && (
           <>

--- a/src/client/src/features/templates/templateBlank.test.ts
+++ b/src/client/src/features/templates/templateBlank.test.ts
@@ -8,7 +8,7 @@ function docType(overrides: Partial<DocumentType> & { schema: Record<string, unk
     name: overrides.name ?? 'Тест',
     code: overrides.code ?? 'TEST',
     kind: 'Document' as DocumentType['kind'],
-    isAbstract: false,
+    isAbstract: false, allowsProxy: false,
     parentId: overrides.parentId ?? null,
     schema: overrides.schema,
     pluginBindings: {},

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -45,6 +45,15 @@ export function useSetDocumentTypeAbstract() {
   });
 }
 
+export function useSetDocumentTypeAllowsProxy() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, allowsProxy }: { id: string; allowsProxy: boolean }) =>
+      apiClient.put<DocumentType>(`/document-types/${id}/allows-proxy`, { allowsProxy }).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['document-types'] }),
+  });
+}
+
 export function useSetDocumentTypeGroup() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/client/src/shared/api/schema.test.ts
+++ b/src/client/src/shared/api/schema.test.ts
@@ -17,7 +17,7 @@ let seq = 0;
 function dt(schema: Record<string, unknown>, parentId: string | null = null, id?: string): DocumentType {
   return {
     id: id ?? `dt${++seq}`,
-    name: 'T', code: 'C', kind: 'Document', isAbstract: false,
+    name: 'T', code: 'C', kind: 'Document', isAbstract: false, allowsProxy: false,
     parentId, schema, pluginBindings: {}, group: null,
     createdAt: '', updatedAt: '',
   };

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -67,6 +67,8 @@ export interface DocumentType {
   code: string;
   kind: DocumentTypeKind;
   isAbstract: boolean;
+  /** issue #89: объект этого типа может быть ролью/прокси — ссылаться (_baseRef) на реальный объект того же типа. */
+  allowsProxy: boolean;
   parentId: string | null;
   schema: Record<string, unknown>;
   pluginBindings: Record<string, unknown>;

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -53,6 +53,9 @@ public static class DocumentTypeEndpoints
         admin.MapPut("/{id:guid}/abstract", async (Guid id, SetAbstractRequest req, IMediator m)
             => Results.Ok(await m.Send(new SetDocumentTypeAbstractCommand(id, req.IsAbstract))));
 
+        admin.MapPut("/{id:guid}/allows-proxy", async (Guid id, SetAllowsProxyRequest req, IMediator m)
+            => Results.Ok(await m.Send(new SetDocumentTypeAllowsProxyCommand(id, req.AllowsProxy))));
+
         admin.MapPut("/{id:guid}/group", async (Guid id, SetGroupRequest req, IMediator m)
             => Results.Ok(await m.Send(new SetDocumentTypeGroupCommand(id, req.Group))));
 
@@ -67,5 +70,6 @@ public static class DocumentTypeEndpoints
     record UpdateTypeRequest(string Name, string Code, Guid? ParentId);
     record UpdateSchemaRequest(string Schema);
     record SetAbstractRequest(bool IsAbstract);
+    record SetAllowsProxyRequest(bool AllowsProxy);
     record SetGroupRequest(string? Group);
 }

--- a/src/server/BHS.CRG.Application/Backup/BackupModels.cs
+++ b/src/server/BHS.CRG.Application/Backup/BackupModels.cs
@@ -20,7 +20,7 @@ public record BackupPrimitiveType(
 public record BackupDocumentType(
     Guid Id, string Name, string Code, string Kind, Guid? ParentId, bool IsAbstract,
     JsonElement Schema, JsonElement PluginBindings,
-    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt, string? Group = null);
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt, string? Group = null, bool AllowsProxy = false);
 
 public record BackupTemplate(
     Guid Id, Guid DocumentTypeId, string Name, string Content, int Version,

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -11,6 +11,7 @@ public record CreateDocumentTypeCommand(string Name, string Code, DocumentTypeKi
 public record UpdateDocumentTypeCommand(Guid Id, string Name, string Code, Guid? ParentId) : IRequest<DocumentType>;
 public record UpdateDocumentTypeSchemaCommand(Guid Id, JsonDocument Schema) : IRequest<DocumentType>;
 public record SetDocumentTypeAbstractCommand(Guid Id, bool IsAbstract) : IRequest<DocumentType>;
+public record SetDocumentTypeAllowsProxyCommand(Guid Id, bool AllowsProxy) : IRequest<DocumentType>;
 public record SetDocumentTypeGroupCommand(Guid Id, string? Group) : IRequest<DocumentType>;
 public record DeleteDocumentTypeCommand(Guid Id) : IRequest;
 public record ListDocumentTypesQuery(DocumentTypeKind? Kind = null) : IRequest<IReadOnlyList<DocumentType>>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -20,6 +20,7 @@ public class DocumentTypeHandlers(
     IRequestHandler<UpdateDocumentTypeCommand, DocumentType>,
     IRequestHandler<UpdateDocumentTypeSchemaCommand, DocumentType>,
     IRequestHandler<SetDocumentTypeAbstractCommand, DocumentType>,
+    IRequestHandler<SetDocumentTypeAllowsProxyCommand, DocumentType>,
     IRequestHandler<SetDocumentTypeGroupCommand, DocumentType>,
     IRequestHandler<DeleteDocumentTypeCommand>,
     IRequestHandler<ListDocumentTypesQuery, IReadOnlyList<DocumentType>>,
@@ -98,6 +99,16 @@ public class DocumentTypeHandlers(
         var dt = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"DocumentType {cmd.Id} not found");
         dt.SetAbstract(cmd.IsAbstract);
+        repo.Update(dt);
+        await repo.SaveChangesAsync(ct);
+        return dt;
+    }
+
+    public async Task<DocumentType> Handle(SetDocumentTypeAllowsProxyCommand cmd, CancellationToken ct)
+    {
+        var dt = await repo.GetByIdAsync(cmd.Id, ct)
+            ?? throw new KeyNotFoundException($"DocumentType {cmd.Id} not found");
+        dt.SetAllowsProxy(cmd.AllowsProxy);
         repo.Update(dt);
         await repo.SaveChangesAsync(ct);
         return dt;

--- a/src/server/BHS.CRG.Domain/Documents/DocumentType.cs
+++ b/src/server/BHS.CRG.Domain/Documents/DocumentType.cs
@@ -15,6 +15,11 @@ public class DocumentType : Entity
     /// <summary>Абстрактный тип нельзя добавить в комплект напрямую — он используется как базовый.</summary>
     public bool IsAbstract { get; private set; }
 
+    /// <summary>Разрешает роль/прокси (issue #89): объект этого типа может ссылаться (`_baseRef`) на
+    /// ДРУГОЙ объект ТОГО ЖЕ типа как на реального носителя данных (делегирование, не наследование
+    /// по типам). Opt-in — по умолчанию выключено.</summary>
+    public bool AllowsProxy { get; private set; }
+
     /// <summary>Произвольная группа для отображения на странице типов (null — без группы).</summary>
     public string? Group { get; private set; }
 
@@ -32,12 +37,12 @@ public class DocumentType : Entity
     public static DocumentType Restore(
         Guid id, string name, string code, DocumentTypeKind kind, Guid? parentId,
         JsonDocument schema, JsonDocument pluginBindings, bool isAbstract,
-        DateTimeOffset createdAt, DateTimeOffset updatedAt, string? group = null)
+        DateTimeOffset createdAt, DateTimeOffset updatedAt, string? group = null, bool allowsProxy = false)
         => new()
         {
             Id = id, Name = name, Code = code, Kind = kind, ParentId = parentId,
             Schema = schema, PluginBindings = pluginBindings, IsAbstract = isAbstract,
-            CreatedAt = createdAt, UpdatedAt = updatedAt, Group = group,
+            CreatedAt = createdAt, UpdatedAt = updatedAt, Group = group, AllowsProxy = allowsProxy,
         };
 
     public void UpdateSchema(JsonDocument schema) { Schema = schema; TouchUpdatedAt(); }
@@ -45,5 +50,6 @@ public class DocumentType : Entity
     public void SetParent(Guid? parentId) { ParentId = parentId; TouchUpdatedAt(); }
     public void UpdatePluginBindings(JsonDocument bindings) { PluginBindings = bindings; TouchUpdatedAt(); }
     public void SetAbstract(bool isAbstract) { IsAbstract = isAbstract; TouchUpdatedAt(); }
+    public void SetAllowsProxy(bool allowsProxy) { AllowsProxy = allowsProxy; TouchUpdatedAt(); }
     public void SetGroup(string? group) { Group = string.IsNullOrWhiteSpace(group) ? null : group.Trim(); TouchUpdatedAt(); }
 }

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -74,7 +74,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             DocumentTypes: docTypes.Select(dt => new BackupDocumentType(
                 dt.Id, dt.Name, dt.Code, dt.Kind.ToString(), dt.ParentId, dt.IsAbstract,
                 dt.Schema.RootElement.Clone(), dt.PluginBindings.RootElement.Clone(),
-                dt.CreatedAt, dt.UpdatedAt, dt.Group)).ToArray(),
+                dt.CreatedAt, dt.UpdatedAt, dt.Group, dt.AllowsProxy)).ToArray(),
             Templates: templates.Select(t => new BackupTemplate(
                 t.Id, t.DocumentTypeId, t.Name, t.Content, t.Version,
                 t.IsActive, t.IsDefault,
@@ -260,7 +260,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
                 item.Id, item.Name, item.Code, kind, item.ParentId,
                 JsonDocument.Parse(item.Schema.GetRawText()),
                 JsonDocument.Parse(item.PluginBindings.GetRawText()),
-                item.IsAbstract, item.CreatedAt, item.UpdatedAt, item.Group);
+                item.IsAbstract, item.CreatedAt, item.UpdatedAt, item.Group, item.AllowsProxy);
             db.Entry(entity).State = existingIds.Contains(item.Id) ? EntityState.Modified : EntityState.Added;
             if (existingIds.Contains(item.Id)) stats.DocumentTypesUpdated++; else stats.DocumentTypesCreated++;
         }

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -45,10 +45,11 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
 
     public async Task ResolveContextRefsAsync(GenerationContext ctx, Guid documentSetId, CancellationToken ct = default)
     {
+        var scope = await ScopeChains.LoadAsync(db, documentSetId, ct);
         foreach (var key in ctx.Data.Keys.ToList())
         {
             if (ctx.Data[key] is not JsonElement el) continue;
-            ctx.Set(key, await ResolveNode(el, documentSetId, depth: 0, allowInstanceRefs: true, ct));
+            ctx.Set(key, await ResolveNode(el, scope, depth: 0, allowInstanceRefs: true, ct));
         }
     }
 
@@ -102,20 +103,20 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     /// instance-ссылки (становится false внутри уже развёрнутого instance — один переход по
     /// документу, защита от циклов A→B→C).
     /// </summary>
-    private async Task<JsonElement> ResolveNode(JsonElement node, Guid documentSetId, int depth, bool allowInstanceRefs, CancellationToken ct)
+    private async Task<JsonElement> ResolveNode(JsonElement node, ScopeChain scope, int depth, bool allowInstanceRefs, CancellationToken ct)
     {
         if (depth >= MaxRefDepth) return node.Clone();
 
         switch (node.ValueKind)
         {
             case JsonValueKind.Object when node.TryGetProperty("$ref", out var refTypeProp):
-                return await ResolveRefObject(node, refTypeProp.GetString(), documentSetId, depth, allowInstanceRefs, ct);
+                return await ResolveRefObject(node, refTypeProp.GetString(), scope, depth, allowInstanceRefs, ct);
 
             case JsonValueKind.Object:
             {
                 var dict = new Dictionary<string, JsonElement>();
                 foreach (var prop in node.EnumerateObject())
-                    dict[prop.Name] = await ResolveNode(prop.Value, documentSetId, depth + 1, allowInstanceRefs, ct);
+                    dict[prop.Name] = await ResolveNode(prop.Value, scope, depth + 1, allowInstanceRefs, ct);
                 return JsonSerializer.SerializeToElement(dict);
             }
 
@@ -123,7 +124,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
             {
                 var list = new List<JsonElement>();
                 foreach (var item in node.EnumerateArray())
-                    list.Add(await ResolveNode(item, documentSetId, depth + 1, allowInstanceRefs, ct));
+                    list.Add(await ResolveNode(item, scope, depth + 1, allowInstanceRefs, ct));
                 return JsonSerializer.SerializeToElement(list);
             }
 
@@ -132,7 +133,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         }
     }
 
-    private async Task<JsonElement> ResolveRefObject(JsonElement node, string? refType, Guid documentSetId, int depth, bool allowInstanceRefs, CancellationToken ct)
+    private async Task<JsonElement> ResolveRefObject(JsonElement node, string? refType, ScopeChain scope, int depth, bool allowInstanceRefs, CancellationToken ct)
     {
         switch (refType)
         {
@@ -140,10 +141,10 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
             case "catalog"
                 when node.TryGetProperty("entryId", out var entryIdProp) && Guid.TryParse(entryIdProp.GetString(), out var entryId):
             {
-                var resolved = await ResolveEntryByIdAsync(entryId, [], ct);
+                var resolved = await ResolveEntryByIdAsync(entryId, scope, [], ct);
                 return resolved.ValueKind == JsonValueKind.Undefined
                     ? node.Clone()
-                    : await ResolveNode(resolved, documentSetId, depth + 1, allowInstanceRefs, ct);
+                    : await ResolveNode(resolved, scope, depth + 1, allowInstanceRefs, ct);
             }
 
             // Протягивание одного поля из реквизитов другого документа — значение как есть, без рекурсии
@@ -154,7 +155,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
             {
                 var fieldKey = fieldKeyProp.GetString() ?? string.Empty;
                 var refObj = await db.DomainObjects.AsNoTracking()
-                    .FirstOrDefaultAsync(o => o.Id == instId && o.ScopeLevel == CatalogScope.Set && o.ScopeId == documentSetId, ct);
+                    .FirstOrDefaultAsync(o => o.Id == instId && o.ScopeLevel == CatalogScope.Set && o.ScopeId == scope.SetId, ct);
                 return refObj is not null && refObj.Data.RootElement.TryGetProperty(fieldKey, out var fieldVal)
                     ? fieldVal.Clone()
                     : node.Clone();
@@ -165,7 +166,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
                 when allowInstanceRefs
                      && node.TryGetProperty("instanceId", out var docInstIdProp) && Guid.TryParse(docInstIdProp.GetString(), out var docInstId):
             {
-                var resolved = await ResolveDocumentInstanceAsync(docInstId, documentSetId, depth, ct);
+                var resolved = await ResolveDocumentInstanceAsync(docInstId, scope, depth, ct);
                 return resolved.ValueKind != JsonValueKind.Undefined ? resolved : node.Clone();
             }
 
@@ -180,11 +181,11 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     /// <c>allowInstanceRefs: false</c> — вложенные instance-ссылки дальше не разворачиваются
     /// (защита от циклов), а массивы/таблицы внутри обрабатываются как везде (это чинит баг B).
     /// </summary>
-    private async Task<JsonElement> ResolveDocumentInstanceAsync(Guid instanceId, Guid documentSetId, int depth, CancellationToken ct)
+    private async Task<JsonElement> ResolveDocumentInstanceAsync(Guid instanceId, ScopeChain scope, int depth, CancellationToken ct)
     {
         var obj = await db.DomainObjects.AsNoTracking().Include(o => o.Facet)
             .FirstOrDefaultAsync(o => o.Id == instanceId && o.ScopeLevel == CatalogScope.Set
-                                      && o.ScopeId == documentSetId && o.Facet != null, ct);
+                                      && o.ScopeId == scope.SetId && o.Facet != null, ct);
 
         if (obj is null) return default;
 
@@ -192,7 +193,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         var dict = new Dictionary<string, JsonElement>();
         foreach (var (k, v) in subCtx.Data)
             if (v is JsonElement je)
-                dict[k] = await ResolveNode(je, documentSetId, depth + 1, allowInstanceRefs: false, ct);
+                dict[k] = await ResolveNode(je, scope, depth + 1, allowInstanceRefs: false, ct);
 
         return JsonSerializer.SerializeToElement(dict);
     }
@@ -200,9 +201,11 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     /// <summary>
     /// Рекурсивно разрешает объект общих данных по id с поддержкой _baseRef: если в data есть
     /// "_baseRef", подтягивает данные базового объекта и выполняет deep-merge (собственные поля
-    /// имеют приоритет). Цепочка entry→entry со своим <paramref name="visited"/>-guard.
+    /// имеют приоритет). Цель может быть того же типа — прокси/роль (issue #89). Guard: база обязана
+    /// быть в скоуп-поддереве документа (<paramref name="scope"/>) — вверх по оси/System да, вбок
+    /// (другая стройка/раздел/комплект) нет; иначе утечка чужих данных. Цикл — <paramref name="visited"/>.
     /// </summary>
-    private async Task<JsonElement> ResolveEntryByIdAsync(Guid id, HashSet<Guid> visited, CancellationToken ct)
+    private async Task<JsonElement> ResolveEntryByIdAsync(Guid id, ScopeChain scope, HashSet<Guid> visited, CancellationToken ct)
     {
         if (!visited.Add(id))
             return default; // защита от циклических ссылок
@@ -214,7 +217,12 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         if (!ownData.TryGetProperty("_baseRef", out var baseRefEl) || ParseBaseRef(baseRefEl) is not { } baseId)
             return ownData;
 
-        var baseData = await ResolveEntryByIdAsync(baseId, visited, ct);
+        // Scope-guard на цель базы/прокси (issue #89): вне скоуп-поддерева документа — не наследуем.
+        var baseObj = await db.DomainObjects.AsNoTracking().FirstOrDefaultAsync(o => o.Id == baseId, ct);
+        if (baseObj is null || !scope.Contains(baseObj.ScopeLevel, baseObj.ScopeId))
+            return ownData;
+
+        var baseData = await ResolveEntryByIdAsync(baseId, scope, visited, ct);
         return baseData.ValueKind == JsonValueKind.Object ? MergeBaseObjects(baseData, ownData) : ownData;
     }
 
@@ -246,7 +254,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         else // запись общих данных
         {
             if (!scope.Contains(baseObj.ScopeLevel, baseObj.ScopeId)) return ownData; // scope-subtree guard
-            baseData = await ResolveEntryByIdAsync(id, visited, ct); // entry→entry цепочка + свой visited.Add(id)
+            baseData = await ResolveEntryByIdAsync(id, scope, visited, ct); // entry→entry цепочка (guard на всю цепь) + свой visited.Add(id)
         }
 
         return baseData.ValueKind == JsonValueKind.Object ? MergeBaseObjects(baseData, ownData) : ownData;

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260713034408_AddDocumentTypeAllowsProxy.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260713034408_AddDocumentTypeAllowsProxy.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713034408_AddDocumentTypeAllowsProxy")]
+    partial class AddDocumentTypeAllowsProxy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260713034408_AddDocumentTypeAllowsProxy.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260713034408_AddDocumentTypeAllowsProxy.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentTypeAllowsProxy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AllowsProxy",
+                table: "document_types",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AllowsProxy",
+                table: "document_types");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -42,9 +42,12 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
     }
 
     private async Task<Guid> EntryAsync(Guid typeId, string data)
+        => await EntryScopedAsync(typeId, data, CatalogScope.System, null);
+
+    private async Task<Guid> EntryScopedAsync(Guid typeId, string data, CatalogScope scope, Guid? scopeId)
     {
-        using var scope = fixture.Services.CreateScope();
-        var e = await M(scope).Send(new CreateCommonDataEntryCommand("Запись", typeId, J(data), CatalogScope.System, null));
+        using var s = fixture.Services.CreateScope();
+        var e = await M(s).Send(new CreateCommonDataEntryCommand("Запись", typeId, J(data), scope, scopeId));
         return e.Id;
     }
 
@@ -250,5 +253,41 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
 
         // раньше catalog-ссылка внутри таблицы подмешанного instance оставалась неразрешённой
         Assert.Equal("ООО Ромашка", table[0].GetProperty("Поставщик").GetProperty("Наименование").GetString());
+    }
+
+    // ── Прокси/роль того же типа (issue #89) ─────────────────────────────────────
+
+    [Fact] // Прокси «Подрядчик» → реальная «Ромашка» (тот же тип): документ через $ref catalog получает данные реальной
+    public async Task Proxy_SameType_ChainMerged()
+    {
+        var setId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_PX");
+        var orgType = await TypeAsync(DocumentTypeKind.Composite, "ORG_PX");
+        var realId = await EntryAsync(orgType, "{'Наименование':'ООО Ромашка','ИНН':'123'}");        // реальная орг (System)
+        var proxyId = await EntryAsync(orgType, "{'_baseRef':'" + realId + "','Роль':'Подрядчик'}");   // прокси того же типа (System)
+        var docId = await DocAsync(setId, docType, "{'Орг':{'$ref':'catalog','entryId':'" + proxyId + "'}}");
+
+        var org = E(await ResolveAsync(docId), "Орг");
+
+        Assert.Equal("ООО Ромашка", org.GetProperty("Наименование").GetString()); // унаследовано от реальной через прокси
+        Assert.Equal("123", org.GetProperty("ИНН").GetString());
+        Assert.Equal("Подрядчик", org.GetProperty("Роль").GetString());           // собственное поле прокси
+    }
+
+    [Fact] // guard-фикс #89: прокси в скоупе, но его _baseRef — на орг ЧУЖОЙ стройки → чужие данные не подмешиваются
+    public async Task Proxy_ChainCrossScope_NotMerged()
+    {
+        var setId = await SetupSetAsync();
+        var otherSetId = await SetupSetAsync();  // другой комплект/стройка (SetupSet создаёт свою Construction)
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_PXX");
+        var orgType = await TypeAsync(DocumentTypeKind.Composite, "ORG_PXX");
+        var realOtherId = await EntryScopedAsync(orgType, "{'Наименование':'Чужая орг'}", CatalogScope.Set, otherSetId); // вне скоупа документа
+        var proxyId = await EntryAsync(orgType, "{'_baseRef':'" + realOtherId + "','Роль':'Подрядчик'}");                  // прокси видим (System)
+        var docId = await DocAsync(setId, docType, "{'Орг':{'$ref':'catalog','entryId':'" + proxyId + "'}}");
+
+        var org = E(await ResolveAsync(docId), "Орг");
+
+        Assert.False(org.TryGetProperty("Наименование", out _)); // scope-guard на цепочке: чужая орг не подмешана
+        Assert.Equal("Подрядчик", org.GetProperty("Роль").GetString()); // собственные поля прокси остаются
     }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.21.1</Version>
+    <Version>0.22.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #89. **Бэкенд + admin-флаг** (аффорданса в форме объекта — следующим PR в этот же issue).

## Кейс
Реальный объект «ООО Ромашка» (тип Organization) + прокси/роль «Подрядчик» (тот же тип), ссылающийся на реальный. В документах — «Подрядчик», данные берутся у «Ромашки»; смена ссылки в прокси = все документы подхватывают. Механически — `_baseRef`-merge того же типа.

## Что в этом PR
**Бэкенд:**
- `DocumentType.AllowsProxy` (opt-in флаг) + команда/эндпоинт `PUT /document-types/{id}/allows-proxy` + Backup (v2).
- 🔴 **Scope-guard на entry-цепочку `_baseRef`** (`EntityResolver.ResolveEntryByIdAsync`): раньше цепочка записей общих данных следовала `_baseRef` **без** scope-guard — латентная дыра (наследование/прокси на объект чужой стройки = утечка). Теперь база обязана быть в скоуп-поддереве документа (вверх по оси/System — да, вбок — нет). `ScopeChain` протянут через `ResolveNode`/`ResolveRefObject`.
- Тип цели по-прежнему НЕ проверяется (merge = key-union) → same-type база (прокси) валидна.

**Фронт (admin):**
- `DocumentType.allowsProxy` в клиентском типе + хук `useSetDocumentTypeAllowsProxy`.
- На странице типов — hover-тумблер «Прокси» + бейдж «роль/прокси».

## Проверка
- Backend `dotnet build` + **379/379 тестов** (`Proxy_SameType_ChainMerged`, `Proxy_ChainCrossScope_NotMerged`).
- Фронт `tsc -b` + **vitest 115/115**.

## Дальше (отдельный PR, этот же issue)
Аффорданса в форме объекта — по разбору Архитектора + Дизайнера (§16): одна `BaseInstancePanel` с двумя группами кандидатов («Роль на реальный объект» / «Базовый тип»), режим «переопределений» для полей прокси, метка `→ реальный` в списке, warning прокси-на-прокси.

MINOR 0.22.0.
