### PR TITLE
feat(proxy): аффорданса роли/прокси в форме объекта (#89)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Plus, Pencil, Trash2, Search, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Pencil, Trash2, Search, ChevronDown, ChevronUp, Link2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -117,6 +117,14 @@ export function SystemCommonDataPage() {
                       <div key={entry.id}
                         className={`flex items-center gap-4 px-4 py-3 group hover:bg-base transition-colors ${idx > 0 ? 'border-t border-muted' : ''}`}>
                         <span className="flex-1 text-sm font-medium text-fg1 truncate">{entry.displayName}</span>
+                        {(() => { // issue #89: пометка роли/прокси (цель того же типа — в этой же группе)
+                          const br = (entry.data as Record<string, unknown>)?._baseRef;
+                          const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
+                          const target = tid ? items.find(e => e.id === tid) : undefined;
+                          if (!target) return null;
+                          return <span className="flex items-center gap-1 text-[11px] text-fg4 shrink-0 max-w-[180px] truncate" title="Роль — ссылка на реальный объект">
+                            <Link2 size={11} className="shrink-0" />→ {target.displayName}</span>;
+                        })()}
                         {Object.keys(entry.data).length > 0 && (
                           <span className="text-xs text-fg4 truncate max-w-xs hidden sm:block">
                             {Object.entries(entry.data).filter(([, v]) => v != null && v !== '').slice(0, 3).map(([k, v]) => `${k}: ${v}`).join(' · ')}

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
   ChevronDown, ChevronUp, Plus, Pencil, Trash2, FileText, Database, ShieldCheck, Loader2,
-  DatabaseZap, RefreshCw, X,
+  DatabaseZap, RefreshCw, X, Link2,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -65,6 +65,14 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
           className={`flex items-center gap-3 pl-3 pr-3 py-2 group hover:bg-muted transition-colors ${idx > 0 ? 'border-t border-stroke' : ''}`}>
           {isDocKind && <FileText size={12} className="text-warning shrink-0" />}
           <span className="flex-1 text-sm text-fg1 truncate">{entry.displayName}</span>
+          {(() => { // issue #89: пометка роли/прокси — тот же тип, ссылка на реальный объект
+            const br = (entry.data as Record<string, unknown>)?._baseRef;
+            const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
+            const target = tid ? entries.find(e => e.id === tid) : undefined;
+            if (!target || target.compositeTypeId !== entry.compositeTypeId) return null;
+            return <span className="flex items-center gap-1 text-[11px] text-fg4 shrink-0 max-w-[180px] truncate" title="Роль — ссылка на реальный объект">
+              <Link2 size={11} className="shrink-0" />→ {target.displayName}</span>;
+          })()}
           {isDocKind && <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>}
           <button onClick={() => setEditEntry(entry)}
             className="p-1 text-stroke-strong hover:text-fg2 opacity-0 group-hover:opacity-100 transition-all">
@@ -192,6 +200,7 @@ export function CatalogEntryForm({
   const [error, setError] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [recognizing, setRecognizing] = useState(false);
+  const [showAllProxyFields, setShowAllProxyFields] = useState(false); // прокси: раскрыть все поля для переопределения (issue #89)
   const createMutation = useCreateCommonDataEntry();
   const updateMutation = useUpdateCommonDataEntry();
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
@@ -211,8 +220,6 @@ export function CatalogEntryForm({
   const baseRefId = typeof values._baseRef === 'string' ? values._baseRef : undefined;
   const ownFields = selectedType ? parseSchemaFields(selectedType.schema) : [];
   const effectiveFields = selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : [];
-  const displayFields = (parentType && baseRefId) ? ownFields : effectiveFields;
-  const sections = selectedType ? groupEffectiveFields(displayFields, selectedType.schema) : [];
 
   // Распознавание: берём первое поле-файл с загруженным вложением (обычно единственное —
   // "Файл"). Заполняет только простые поля (flattenLeaves пропускает array/doc-ref/complex-с-
@@ -242,6 +249,42 @@ export function CatalogEntryForm({
       tier: SCOPE_TIER[e.scope], scopeLabel: SCOPE_LABELS[e.scope], dist: 0,
     }))
     .sort((a, b) => a.tier - b.tier || a.name.localeCompare(b.name, 'ru'));
+
+  // Кандидаты роли/прокси (issue #89): объекты ТОГО ЖЕ типа, видимые в скоупе (кроме самого себя).
+  const proxyTypeId = selectedType?.allowsProxy ? selectedType.id : undefined;
+  const { data: allProxyEntries = [] } = useCommonDataForSet({
+    setId: setId ?? '', typeId: proxyTypeId, enabled: !!proxyTypeId && !!setId,
+  });
+  const { data: scopeProxyEntries = [] } = useListCommonData({
+    scope, scopeId: scopeId ?? undefined, typeId: proxyTypeId,
+    enabled: !!proxyTypeId && !setId && scope !== 'System',
+  });
+  const { data: systemProxyEntries = [] } = useListCommonData({
+    scope: 'System', typeId: proxyTypeId, enabled: !!proxyTypeId,
+  });
+  const proxyEntries: CommonDataEntry[] = setId
+    ? allProxyEntries
+    : [...scopeProxyEntries, ...systemProxyEntries.filter(e => !scopeProxyEntries.some(s => s.id === e.id))];
+  const proxyCandidates: BaseCandidate[] = proxyEntries
+    .filter(e => e.id !== entry?.id) // не сам на себя
+    .map(e => ({
+      kind: 'catalog' as const, id: e.id, name: e.displayName, typeId: e.compositeTypeId,
+      tier: SCOPE_TIER[e.scope], scopeLabel: SCOPE_LABELS[e.scope], dist: 0, proxy: true,
+      targetIsProxy: !!(e.data as Record<string, unknown>)?._baseRef,
+    }))
+    .sort((a, b) => a.tier - b.tier || a.name.localeCompare(b.name, 'ru'));
+
+  const allCandidates = [...proxyCandidates, ...baseCandidates];
+  const selectedBase = baseRefId ? allCandidates.find(c => c.id === baseRefId) : undefined;
+  const isProxy = !!selectedBase?.proxy;
+  const canHaveBase = !!parentType || !!selectedType?.allowsProxy;
+
+  // Поля формы: у прокси нет деления свои/родительские — все наследуются. Показываем «дельту»
+  // (только переопределённые поля), с раскрытием всех для добавления переопределений (issue #89).
+  const displayFields = isProxy
+    ? (showAllProxyFields ? effectiveFields : effectiveFields.filter(f => values[f.key] !== undefined && values[f.key] !== ''))
+    : (parentType && baseRefId) ? ownFields : effectiveFields;
+  const sections = selectedType ? groupEffectiveFields(displayFields, selectedType.schema) : [];
 
   // Наборы данных: биндинги существуют только у уже сохранённой записи (нужен id-владелец).
   const { data: bindings = [] } = useListDataSetBindings({ ownerId: entry?.id });
@@ -494,16 +537,16 @@ export function CatalogEntryForm({
         </p>
       )}
 
-      {parentType && (
+      {canHaveBase && (
         <BaseInstancePanel
-          title={parentType.name}
-          candidates={baseCandidates}
-          selected={baseCandidates.find(c => c.id === baseRefId)}
-          missing={!!baseRefId && !baseCandidates.some(c => c.id === baseRefId)}
-          manualHint={ownFields.length < effectiveFields.length
+          title={parentType?.name}
+          candidates={allCandidates}
+          selected={selectedBase}
+          missing={!!baseRefId && !allCandidates.some(c => c.id === baseRefId)}
+          manualHint={!isProxy && ownFields.length < effectiveFields.length
             ? `Без базового экземпляра все ${effectiveFields.length} полей заполняются вручную.` : undefined}
-          onSelect={c => setValue('_baseRef', c.id)}
-          onClear={() => setValue('_baseRef', undefined)}
+          onSelect={c => { setValue('_baseRef', c.id); setShowAllProxyFields(false); }}
+          onClear={() => { setValue('_baseRef', undefined); setShowAllProxyFields(false); }}
         />
       )}
 
@@ -544,6 +587,16 @@ export function CatalogEntryForm({
         </div>
       ) : (
         <p className="text-xs text-fg4">Сохраните запись, чтобы привязать источники данных.</p>
+      )}
+
+      {isProxy && (
+        <div className="rounded-md bg-brand-subtle/40 px-3 py-2 text-xs text-fg3 flex items-center justify-between gap-2">
+          <span>Роль наследует все поля реального объекта — заполните только переопределяемые, пустые берутся у реального.</span>
+          {!showAllProxyFields && (
+            <button type="button" onClick={() => setShowAllProxyFields(true)}
+              className="text-brand hover:text-brand-hover font-medium shrink-0">Переопределить ещё…</button>
+          )}
+        </div>
       )}
 
       {selectedType && sections.length > 0 && (

--- a/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
+++ b/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FileText, Database, Link2, Unlink } from 'lucide-react';
+import { FileText, Database, Link2, Unlink, AlertTriangle } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import type { CatalogScope, DocumentType } from '@/shared/api/types';
 
@@ -17,6 +17,8 @@ export interface BaseCandidate {
   tier: number;        // скоп-уровень: 0 комплект, 1 раздел, 2 стройка, 3 система
   scopeLabel: string;  // «Комплект»/«Раздел»/«Стройка»/«Система»
   dist: number;        // дистанция наследования: 0 прямой родитель, дальше — больше
+  proxy?: boolean;     // issue #89: кандидат того же типа — «роль на реальный объект», а не наследование от родителя
+  targetIsProxy?: boolean; // выбранный «реальный» сам является прокси (цепочка ссылок — data-smell)
 }
 
 export const SCOPE_TIER: Record<CatalogScope, number> = { Set: 0, Section: 1, Construction: 2, System: 3 };
@@ -54,25 +56,45 @@ export function BaseCandidatePicker({ open, onOpenChange, candidates, onSelect }
 }) {
   const [search, setSearch] = useState('');
   const filtered = candidates.filter(c => c.name.toLowerCase().includes(search.toLowerCase()));
+  // issue #89: две именованные группы — «роль на реальный объект того же типа» и наследование от базового типа.
+  const proxyCands = filtered.filter(c => c.proxy);
+  const baseCands = filtered.filter(c => !c.proxy);
+
+  const row = (c: BaseCandidate) => (
+    <button key={`${c.kind}:${c.id}`} type="button" onClick={() => { onSelect(c); onOpenChange(false); }}
+      className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
+      {c.proxy
+        ? <Link2 size={13} className="text-brand shrink-0" />
+        : c.kind === 'instance'
+          ? <FileText size={13} className="text-brand shrink-0" />
+          : <Database size={13} className="text-brand shrink-0" />}
+      <span className="flex-1 font-medium text-fg1 truncate">{c.name}</span>
+      {c.targetIsProxy && <span className="text-[10px] text-warning shrink-0">роль</span>}
+      <span className="text-[11px] text-fg4 shrink-0">{c.scopeLabel}</span>
+    </button>
+  );
+
   return (
-    <Modal open={open} onOpenChange={onOpenChange} title="Базовый экземпляр">
+    <Modal open={open} onOpenChange={onOpenChange} title="Базовый экземпляр / роль">
       <div className="space-y-4">
         <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск..." autoFocus
           className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
         {filtered.length === 0 ? (
-          <p className="text-sm text-fg4 text-center py-4">Нет подходящих базовых экземпляров.</p>
+          <p className="text-sm text-fg4 text-center py-4">Нет подходящих кандидатов.</p>
         ) : (
-          <div className="space-y-1 max-h-72 overflow-y-auto">
-            {filtered.map(c => (
-              <button key={`${c.kind}:${c.id}`} type="button" onClick={() => { onSelect(c); onOpenChange(false); }}
-                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                {c.kind === 'instance'
-                  ? <FileText size={13} className="text-brand shrink-0" />
-                  : <Database size={13} className="text-brand shrink-0" />}
-                <span className="flex-1 font-medium text-fg1 truncate">{c.name}</span>
-                <span className="text-[11px] text-fg4 shrink-0">{c.scopeLabel}</span>
-              </button>
-            ))}
+          <div className="space-y-3 max-h-72 overflow-y-auto">
+            {proxyCands.length > 0 && (
+              <div className="space-y-1">
+                <p className="text-[11px] font-semibold text-fg3 uppercase tracking-wide px-1">Роль на реальный объект (тот же тип)</p>
+                {proxyCands.map(row)}
+              </div>
+            )}
+            {baseCands.length > 0 && (
+              <div className="space-y-1">
+                {proxyCands.length > 0 && <p className="text-[11px] font-semibold text-fg3 uppercase tracking-wide px-1">Базовый тип</p>}
+                {baseCands.map(row)}
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -99,20 +121,32 @@ export function BaseInstancePanel({ title, candidates, selected, missing = false
   return (
     <div className="rounded-lg border border-stroke p-3 space-y-2">
       <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
-        Базовый экземпляр
-        {title && <span className="normal-case font-normal ml-1 text-fg4">({title})</span>}
+        {selected?.proxy ? 'Роль — ссылка на реальный объект' : 'Базовый экземпляр'}
+        {title && !selected?.proxy && <span className="normal-case font-normal ml-1 text-fg4">({title})</span>}
       </p>
       {selected ? (
+        <>
         <div className="flex items-center gap-2 rounded-md border border-brand-subtle bg-brand-subtle px-3 py-2">
-          {selected.kind === 'instance'
-            ? <FileText size={14} className="text-brand shrink-0" />
-            : <Database size={14} className="text-brand shrink-0" />}
-          <span className="flex-1 text-sm font-medium text-brand-hover truncate">{selected.name}</span>
+          {selected.proxy
+            ? <Link2 size={14} className="text-brand shrink-0" />
+            : selected.kind === 'instance'
+              ? <FileText size={14} className="text-brand shrink-0" />
+              : <Database size={14} className="text-brand shrink-0" />}
+          <span className="flex-1 text-sm font-medium text-brand-hover truncate">
+            {selected.proxy && <span className="text-fg4 font-normal">→ </span>}{selected.name}
+          </span>
           <span className="text-[11px] text-fg4 shrink-0">{selected.scopeLabel}</span>
           <button type="button" onClick={onClear} className="text-brand hover:text-danger transition-colors" title="Снять ссылку">
             <Unlink size={13} />
           </button>
         </div>
+        {selected.targetIsProxy && (
+          <p className="text-[11px] text-warning flex items-center gap-1">
+            <AlertTriangle size={11} className="shrink-0" />
+            «{selected.name}» — тоже роль. Цепочка ссылок усложняет прослеживание данных.
+          </p>
+        )}
+        </>
       ) : missing ? (
         <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2">
           <span className="flex-1 text-sm text-warning truncate">Базовый экземпляр недоступен (удалён или вне области видимости)</span>
@@ -124,7 +158,7 @@ export function BaseInstancePanel({ title, candidates, selected, missing = false
         <button type="button" onClick={() => setPickerOpen(true)}
           className="flex items-center gap-2 text-sm text-brand hover:text-brand-hover border border-dashed border-brand-subtle rounded-md px-3 py-2 w-full hover:bg-brand-subtle transition-colors">
           <Link2 size={14} />
-          Выбрать базовый экземпляр...
+          Выбрать базовый экземпляр или роль...
         </button>
       )}
       {!selected && !missing && manualHint && <p className="text-xs text-fg4">{manualHint}</p>}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.0</Version>
+    <Version>0.22.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #89 (продолжение #90). Аффорданса в форме объекта — по разбору Архитектора + Дизайнера (§16).

## Что сделано
- **Пикер базы — две именованные группы**: «Роль на реальный объект (тот же тип)» / «Базовый тип» (одна `BaseInstancePanel`, слот `_baseRef` один).
- **Кандидаты-прокси**: объекты того же типа, видимые в скоупе (кроме самого себя); панель показывается и когда у типа нет родителя, но есть `allowsProxy`.
- **Поля прокси — режим «дельты»**: показываются только переопределённые + «Переопределить ещё…» (у прокси все поля наследуются, пустые берутся у реального — не «стена пустых инпутов»).
- **Метка в списках** (каталог + системный): `Link2` «→ {реальный}» для объектов-ролей (цель того же типа).
- **Прокси-на-прокси**: мягкий warning (не запрет) в пикере/панели.

## Проверка
- `tsc -b` + **vitest 115/115**. (Живой прогон — за тобой: включить `allowsProxy` типу Organization, создать реальную орг + роль «Подрядчик» → сослать → проверить документ.)

## Отложено (follow-up, этот же issue)
- Аффорданса в редакторе документа (`editor/index.tsx`) — документы-прокси того же типа (реже; основной кейс — общие данные).
- Placeholder «сейчас: …» из значений реального; per-field «↩ наследовать».

PATCH 0.22.1.