### PR TITLE
feat(proxy): режим дельты — «наследует: …» + per-field «↩ наследовать» (#92)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
   ChevronDown, ChevronUp, Plus, Pencil, Trash2, FileText, Database, ShieldCheck, Loader2,
-  DatabaseZap, RefreshCw, X, Link2,
+  DatabaseZap, RefreshCw, X, Link2, CornerUpLeft,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -278,6 +278,9 @@ export function CatalogEntryForm({
   const selectedBase = baseRefId ? allCandidates.find(c => c.id === baseRefId) : undefined;
   const isProxy = !!selectedBase?.proxy;
   const canHaveBase = !!parentType || !!selectedType?.allowsProxy;
+  // Данные выбранного реального объекта — для подсказки «наследует: …» в режиме прокси (issue #92).
+  const proxyTarget = isProxy && baseRefId ? proxyEntries.find(e => e.id === baseRefId) : undefined;
+  const realData = (proxyTarget?.data ?? {}) as Record<string, unknown>;
 
   // Поля формы: у прокси нет деления свои/родительские — все наследуются. Показываем «дельту»
   // (только переопределённые поля), с раскрытием всех для добавления переопределений (issue #89).
@@ -406,8 +409,28 @@ export function CatalogEntryForm({
             );
           }
 
+          const proxyOverridden = isProxy && values[field.key] !== undefined;
+          const proxyReal = realData[field.key];
+          const proxyRealHint = isProxy && (typeof proxyReal === 'string' || typeof proxyReal === 'number') && proxyReal !== ''
+            ? String(proxyReal) : undefined;
           return (
             <div key={field.key}>
+              {isProxy && (
+                <div className="flex items-center justify-between gap-2 mb-0.5 min-h-[16px]">
+                  <span className="text-[11px] text-fg4 truncate">
+                    {proxyOverridden ? 'переопределено'
+                      : proxyRealHint ? `наследует: ${proxyRealHint}`
+                      : 'наследуется от реального'}
+                  </span>
+                  {proxyOverridden && (
+                    <button type="button" onClick={() => setValue(field.key, undefined)}
+                      title="Вернуть к наследованию от реального объекта"
+                      className="text-[11px] text-brand hover:text-brand-hover flex items-center gap-0.5 shrink-0">
+                      <CornerUpLeft size={11} /> наследовать
+                    </button>
+                  )}
+                </div>
+              )}
               {field.type === 'complex' || field.type === 'array' ? (
                 <div>
                   <label className="block text-sm font-medium text-fg2 mb-1">

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.1</Version>
+    <Version>0.22.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #92 (хвосты #89). Доводка режима «дельты» переопределений прокси в форме объекта.

## Что сделано
- **«наследует: {значение реального}»** на каждом поле в режиме прокси — пользователь видит, что именно наследуется (раньше пустой инпут не подсказывал). Данные берутся у выбранного реального объекта (#92 п.2).
- **«↩ наследовать»** на переопределённом поле → `setValue(key, undefined)`: удаляет ключ ⇒ поле снова наследуется (а не остаётся переопределённым пустым `''`). Чинит реальный пробел режима дельты (#92 п.3).

## Проверка
- `tsc -b` + **vitest 115/115**. Живой прогон — за тобой (роль «Подрядчик» → видно «наследует: ООО Ромашка» на полях; «↩ наследовать» возвращает поле к наследованию).

## Осталось в #92
- Placeholder-из-реального сейчас по **immediate**-цели (без глубокого резолва прокси-на-прокси).
- Аффорданса в редакторе документа; кликабельная метка «→ реальный» (P3).

PATCH 0.22.2.