### PR TITLE
feat(proxy): кликабельная метка + глубокий резолв «наследует» (#92)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -122,8 +122,9 @@ export function SystemCommonDataPage() {
                           const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
                           const target = tid ? items.find(e => e.id === tid) : undefined;
                           if (!target) return null;
-                          return <span className="flex items-center gap-1 text-[11px] text-fg4 shrink-0 max-w-[180px] truncate" title="Роль — ссылка на реальный объект">
-                            <Link2 size={11} className="shrink-0" />→ {target.displayName}</span>;
+                          return <button type="button" onClick={e => { e.stopPropagation(); setEditEntry(target); }}
+                            title="Открыть реальный объект" className="flex items-center gap-1 text-[11px] text-fg4 hover:text-brand shrink-0 max-w-[180px] truncate transition-colors">
+                            <Link2 size={11} className="shrink-0" />→ {target.displayName}</button>;
                         })()}
                         {Object.keys(entry.data).length > 0 && (
                           <span className="text-xs text-fg4 truncate max-w-xs hidden sm:block">

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -70,8 +70,9 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
             const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
             const target = tid ? entries.find(e => e.id === tid) : undefined;
             if (!target || target.compositeTypeId !== entry.compositeTypeId) return null;
-            return <span className="flex items-center gap-1 text-[11px] text-fg4 shrink-0 max-w-[180px] truncate" title="Роль — ссылка на реальный объект">
-              <Link2 size={11} className="shrink-0" />→ {target.displayName}</span>;
+            return <button type="button" onClick={e => { e.stopPropagation(); setEditEntry(target); }}
+              title="Открыть реальный объект" className="flex items-center gap-1 text-[11px] text-fg4 hover:text-brand shrink-0 max-w-[180px] truncate transition-colors">
+              <Link2 size={11} className="shrink-0" />→ {target.displayName}</button>;
           })()}
           {isDocKind && <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>}
           <button onClick={() => setEditEntry(entry)}
@@ -278,9 +279,27 @@ export function CatalogEntryForm({
   const selectedBase = baseRefId ? allCandidates.find(c => c.id === baseRefId) : undefined;
   const isProxy = !!selectedBase?.proxy;
   const canHaveBase = !!parentType || !!selectedType?.allowsProxy;
-  // Данные выбранного реального объекта — для подсказки «наследует: …» в режиме прокси (issue #92).
-  const proxyTarget = isProxy && baseRefId ? proxyEntries.find(e => e.id === baseRefId) : undefined;
-  const realData = (proxyTarget?.data ?? {}) as Record<string, unknown>;
+  // Резолвнутые данные выбранного реального объекта — для подсказки «наследует: …» в режиме прокси
+  // (issue #92). Проходим цепочку _baseRef цели (прокси-на-прокси), мержим база→свои, без _baseRef.
+  const realData: Record<string, unknown> = (() => {
+    if (!isProxy || !baseRefId) return {};
+    const seen = new Set<string>();
+    const chain: CommonDataEntry[] = [];
+    let curId: string | undefined = baseRefId;
+    while (curId && !seen.has(curId)) {
+      seen.add(curId);
+      const e = proxyEntries.find(x => x.id === curId);
+      if (!e) break;
+      chain.push(e);
+      const br = (e.data as Record<string, unknown>)?._baseRef;
+      curId = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
+    }
+    const merged: Record<string, unknown> = {};
+    for (const e of chain.reverse())
+      for (const [k, v] of Object.entries(e.data as Record<string, unknown>))
+        if (k !== '_baseRef') merged[k] = v;
+    return merged;
+  })();
 
   // Поля формы: у прокси нет деления свои/родительские — все наследуются. Показываем «дельту»
   // (только переопределённые поля), с раскрытием всех для добавления переопределений (issue #89).

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.2</Version>
+    <Version>0.22.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #92 (хвосты #89).

## Что сделано
- **#4 Кликабельная метка** «→ реальный» в списках каталога и системного — открывает реальный объект в форме редактирования.
- **#2 (глубокий вариант)** Подсказка «наследует: …» теперь резолвит всю цепочку `_baseRef` цели (прокси-на-прокси), а не только immediate-объект.

## Проверка
tsc -b + vitest 115/115.

## Осталось в #92
Аффорданса прокси в редакторе документа (`editor/index.tsx`) — документ-прокси на документ того же типа. Нишевый кейс (основной — общие данные/организации). Рекомендую отдельно/по необходимости.

PATCH 0.22.3.