### PR TITLE
refactor(catalog): единый ObjectRow/группировка для списков объектов (#88)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { Plus, Pencil, Trash2, Search, ChevronDown, ChevronUp, Link2 } from 'lucide-react';
+import { Plus, Search, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useListCommonData, useDeleteCommonDataEntry } from '@/shared/api/commonData';
 import type { CommonDataEntry } from '@/shared/api/types';
 import { CatalogEntryForm } from '../document-sets/catalog';
+import { groupObjectsByType, ObjectRow } from '../document-sets/catalog/ObjectsByTypeList';
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
@@ -39,11 +40,8 @@ export function SystemCommonDataPage() {
     return typeCmp !== 0 ? typeCmp : a.displayName.localeCompare(b.displayName);
   });
 
-  // Group by type
-  const grouped = allSelectableTypes
-    .map(t => ({ t, items: filtered.filter(e => e.compositeTypeId === t.id) }))
-    .filter(g => g.items.length > 0);
-  const noType = filtered.filter(e => !allSelectableTypes.find(t => t.id === e.compositeTypeId));
+  // Группировка по типу — общий хелпер (issue #88)
+  const { groups, noType } = groupObjectsByType(filtered, allSelectableTypes);
 
   return (
     <div className="px-6 py-4 max-w-4xl mx-auto">
@@ -95,7 +93,7 @@ export function SystemCommonDataPage() {
         <div className="text-center py-10 text-fg4 text-sm">Ничего не найдено</div>
       ) : (
         <div className="space-y-2">
-          {grouped.map(({ t, items }) => {
+          {groups.map(({ type: t, items }) => {
             const isOpen = expandedTypes.has(t.id);
             return (
               <div key={t.id} className="border border-stroke rounded-xl overflow-hidden">
@@ -114,36 +112,9 @@ export function SystemCommonDataPage() {
                 {isOpen && (
                   <div className="border-t border-stroke">
                     {items.map((entry, idx) => (
-                      <div key={entry.id}
-                        className={`flex items-center gap-4 px-4 py-3 group hover:bg-base transition-colors ${idx > 0 ? 'border-t border-muted' : ''}`}>
-                        <span className="flex-1 text-sm font-medium text-fg1 truncate">{entry.displayName}</span>
-                        {(() => { // issue #89: пометка роли/прокси (цель того же типа — в этой же группе)
-                          const br = (entry.data as Record<string, unknown>)?._baseRef;
-                          const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
-                          const target = tid ? items.find(e => e.id === tid) : undefined;
-                          if (!target) return null;
-                          return <button type="button" onClick={e => { e.stopPropagation(); setEditEntry(target); }}
-                            title="Открыть реальный объект" className="flex items-center gap-1 text-[11px] text-fg4 hover:text-brand shrink-0 max-w-[180px] truncate transition-colors">
-                            <Link2 size={11} className="shrink-0" />→ {target.displayName}</button>;
-                        })()}
-                        {Object.keys(entry.data).length > 0 && (
-                          <span className="text-xs text-fg4 truncate max-w-xs hidden sm:block">
-                            {Object.entries(entry.data).filter(([, v]) => v != null && v !== '').slice(0, 3).map(([k, v]) => `${k}: ${v}`).join(' · ')}
-                          </span>
-                        )}
-                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-                          <button onClick={() => setEditEntry(entry)}
-                            className="p-1.5 text-fg4 hover:text-fg2 rounded transition-colors" title="Редактировать">
-                            <Pencil size={13} />
-                          </button>
-                          <button
-                            onClick={() => setDeleteTarget(entry)}
-                            disabled={deleteMutation.isPending}
-                            className="p-1.5 text-fg4 hover:text-danger rounded transition-colors disabled:opacity-30" title="Удалить">
-                            <Trash2 size={13} />
-                          </button>
-                        </div>
-                      </div>
+                      <ObjectRow key={entry.id} entry={entry} siblings={items}
+                        onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
+                        showPreview className={idx > 0 ? 'border-t border-muted' : ''} />
                     ))}
                   </div>
                 )}
@@ -165,14 +136,9 @@ export function SystemCommonDataPage() {
                 {isOpen && (
                   <div className="border-t border-stroke">
                     {noType.map((entry, idx) => (
-                      <div key={entry.id}
-                        className={`flex items-center gap-4 px-4 py-3 group hover:bg-base ${idx > 0 ? 'border-t border-muted' : ''}`}>
-                        <span className="flex-1 text-sm font-medium text-fg1">{entry.displayName}</span>
-                        <div className="flex gap-1 opacity-0 group-hover:opacity-100 shrink-0">
-                          <button onClick={() => setEditEntry(entry)} className="p-1.5 text-fg4 hover:text-fg2 rounded"><Pencil size={13} /></button>
-                          <button onClick={() => setDeleteTarget(entry)} className="p-1.5 text-fg4 hover:text-danger rounded"><Trash2 size={13} /></button>
-                        </div>
-                      </div>
+                      <ObjectRow key={entry.id} entry={entry} siblings={noType}
+                        onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
+                        className={idx > 0 ? 'border-t border-muted' : ''} />
                     ))}
                   </div>
                 )}

--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -1,0 +1,81 @@
+import { Pencil, Trash2, Link2, FileText } from 'lucide-react';
+import type { CommonDataEntry, DocumentType } from '@/shared/api/types';
+
+// Общие презентационные части списка «объекты по типу» (issue #88) — устраняют дублирование между
+// системным каталогом (SystemCommonDataPage) и скоуп-панелью каталога (ScopedCatalogPanel). Обёртки
+// групп (карточка-страница vs рейл-панель) намеренно разные (issue #8, три канала иерархии) и остаются
+// на стороне страниц; здесь — группировка, строка объекта и метка роли/прокси.
+
+/** Группировка записей по составному типу (+ «без типа»). Порядок внутри группы — как во входе. */
+export function groupObjectsByType(entries: CommonDataEntry[], types: DocumentType[]) {
+  const groups = types
+    .map(type => ({ type, items: entries.filter(e => e.compositeTypeId === type.id) }))
+    .filter(g => g.items.length > 0);
+  const noType = entries.filter(e => !types.some(t => t.id === e.compositeTypeId));
+  return { groups, noType };
+}
+
+/** Метка роли/прокси (issue #89): если запись ссылается (`_baseRef`) на объект ТОГО ЖЕ типа —
+ *  показываем «→ реальный» и открываем его по клику. Цель ищется среди siblings. */
+export function ProxyRoleMarker({ entry, siblings, onOpen }: {
+  entry: CommonDataEntry;
+  siblings: CommonDataEntry[];
+  onOpen: (e: CommonDataEntry) => void;
+}) {
+  const br = (entry.data as Record<string, unknown>)?._baseRef;
+  const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
+  const target = tid ? siblings.find(e => e.id === tid) : undefined;
+  if (!target || target.compositeTypeId !== entry.compositeTypeId) return null;
+  return (
+    <button type="button" onClick={e => { e.stopPropagation(); onOpen(target); }}
+      title="Открыть реальный объект"
+      className="flex items-center gap-1 text-[11px] text-fg4 hover:text-brand shrink-0 max-w-[180px] truncate transition-colors">
+      <Link2 size={11} className="shrink-0" />→ {target.displayName}
+    </button>
+  );
+}
+
+/** Строка объекта: имя + метка роли + (превью полей / бейдж внеш.документа) + скрытые hover-действия.
+ *  <paramref name="dense"/> — компактный вид (панель) vs просторный (страница). Разделитель/фон —
+ *  через <paramref name="className"/> на стороне вызывающего. */
+export function ObjectRow({
+  entry, siblings, onEdit, onDelete, deleteDisabled = false,
+  dense = false, showPreview = false, docKind = false, className = '',
+}: {
+  entry: CommonDataEntry;
+  siblings: CommonDataEntry[];
+  onEdit: (e: CommonDataEntry) => void;
+  onDelete: (e: CommonDataEntry) => void;
+  deleteDisabled?: boolean;
+  dense?: boolean;
+  showPreview?: boolean;
+  docKind?: boolean;   // тип-документ во внешнем каталоге — иконка + бейдж (в плотном виде панели)
+  className?: string;
+}) {
+  const icon = dense ? 12 : 13;
+  const preview = Object.entries(entry.data).filter(([, v]) => v != null && v !== '')
+    .slice(0, 3).map(([k, v]) => `${k}: ${v}`).join(' · ');
+  return (
+    <div className={`group flex items-center transition-colors ${dense ? 'gap-3 px-3 py-2 hover:bg-muted' : 'gap-4 px-4 py-3 hover:bg-base'} ${className}`}>
+      {docKind && dense && <FileText size={12} className="text-warning shrink-0" />}
+      <span className={`flex-1 text-sm truncate ${dense ? 'text-fg1' : 'font-medium text-fg1'}`}>{entry.displayName}</span>
+      <ProxyRoleMarker entry={entry} siblings={siblings} onOpen={onEdit} />
+      {docKind && dense && (
+        <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>
+      )}
+      {showPreview && preview && (
+        <span className="text-xs text-fg4 truncate max-w-xs hidden sm:block">{preview}</span>
+      )}
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+        <button type="button" onClick={() => onEdit(entry)} title="Редактировать"
+          className={`rounded transition-colors ${dense ? 'p-1 text-stroke-strong hover:text-fg2' : 'p-1.5 text-fg4 hover:text-fg2'}`}>
+          <Pencil size={icon} />
+        </button>
+        <button type="button" onClick={() => onDelete(entry)} disabled={deleteDisabled} title="Удалить"
+          className={`rounded transition-colors disabled:opacity-30 ${dense ? 'p-1 text-stroke-strong hover:text-danger' : 'p-1.5 text-fg4 hover:text-danger'}`}>
+          <Trash2 size={icon} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
-  ChevronDown, ChevronUp, Plus, Pencil, Trash2, FileText, Database, ShieldCheck, Loader2,
-  DatabaseZap, RefreshCw, X, Link2, CornerUpLeft,
+  ChevronDown, ChevronUp, Plus, Database, ShieldCheck, Loader2,
+  DatabaseZap, RefreshCw, X, CornerUpLeft,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -24,6 +24,7 @@ import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
 import { computeBoundFieldKeys, mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
 import { EntryDataSetBindings } from './EntryDataSetBindings';
+import { groupObjectsByType, ObjectRow } from './ObjectsByTypeList';
 import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
   PrimitiveInput, FileField, ImageField,
@@ -48,46 +49,20 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
   const allSelectableTypes = [...compositeTypes, ...documentTypes];
   const deleteMutation = useDeleteCommonDataEntry();
 
-  const grouped = allSelectableTypes
-    .map(ct => ({ ct, items: [...entries].filter(e => e.compositeTypeId === ct.id).sort((a, b) => a.displayName.localeCompare(b.displayName)) }))
-    .filter(g => g.items.length > 0);
-  const noType = [...entries].filter(e => !allSelectableTypes.find(ct => ct.id === e.compositeTypeId)).sort((a, b) => a.displayName.localeCompare(b.displayName));
+  const sorted = [...entries].sort((a, b) => a.displayName.localeCompare(b.displayName));
+  const { groups, noType } = groupObjectsByType(sorted, allSelectableTypes);
 
   function toggleType(id: string) {
     setExpandedTypes(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
   }
 
   function renderEntries(items: CommonDataEntry[]) {
-    return items.map((entry, idx) => {
-      const isDocKind = documentTypes.some(dt => dt.id === entry.compositeTypeId);
-      return (
-        <div key={entry.id}
-          className={`flex items-center gap-3 pl-3 pr-3 py-2 group hover:bg-muted transition-colors ${idx > 0 ? 'border-t border-stroke' : ''}`}>
-          {isDocKind && <FileText size={12} className="text-warning shrink-0" />}
-          <span className="flex-1 text-sm text-fg1 truncate">{entry.displayName}</span>
-          {(() => { // issue #89: пометка роли/прокси — тот же тип, ссылка на реальный объект
-            const br = (entry.data as Record<string, unknown>)?._baseRef;
-            const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
-            const target = tid ? entries.find(e => e.id === tid) : undefined;
-            if (!target || target.compositeTypeId !== entry.compositeTypeId) return null;
-            return <button type="button" onClick={e => { e.stopPropagation(); setEditEntry(target); }}
-              title="Открыть реальный объект" className="flex items-center gap-1 text-[11px] text-fg4 hover:text-brand shrink-0 max-w-[180px] truncate transition-colors">
-              <Link2 size={11} className="shrink-0" />→ {target.displayName}</button>;
-          })()}
-          {isDocKind && <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>}
-          <button onClick={() => setEditEntry(entry)}
-            className="p-1 text-stroke-strong hover:text-fg2 opacity-0 group-hover:opacity-100 transition-all">
-            <Pencil size={12} />
-          </button>
-          <button
-            onClick={() => setDeleteTarget(entry)}
-            disabled={deleteMutation.isPending}
-            className="p-1 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30">
-            <Trash2 size={12} />
-          </button>
-        </div>
-      );
-    });
+    return items.map((entry, idx) => (
+      <ObjectRow key={entry.id} entry={entry} siblings={entries}
+        onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
+        dense docKind={documentTypes.some(dt => dt.id === entry.compositeTypeId)}
+        className={idx > 0 ? 'border-t border-stroke' : ''} />
+    ));
   }
 
   // Группа типа: uppercase-микрозаголовок на заливке bg-base (сильный «заголовочный» сигнал),
@@ -138,7 +113,7 @@ export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
             <p className="text-sm text-fg4 text-center py-2">Записей нет</p>
           ) : (
             <div className="space-y-1">
-              {grouped.map(({ ct, items }) => renderGroup(ct.id, ct.name, items))}
+              {groups.map(({ type, items }) => renderGroup(type.id, type.name, items))}
               {noType.length > 0 && renderGroup('__no_type__', 'Без типа', noType, true)}
             </div>
           )}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.3</Version>
+    <Version>0.22.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #88 (хвост код-фазы #73).

## Что сделано
Устранена вторая вёрстка списка «объекты по типу». Общие презентационные части — в новом `document-sets/catalog/ObjectsByTypeList.tsx`:
- **`groupObjectsByType()`** — группировка по составному типу (+ «без типа»).
- **`ProxyRoleMarker`** — метка роли «→ реальный» (была скопирована в обе страницы после #89).
- **`ObjectRow`** — строка объекта: имя + метка роли + превью полей / бейдж «внеш. документ» + скрытые hover edit/delete. Параметры `dense`/`showPreview`/`docKind`.

`SystemCommonDataPage` (страница) и `ScopedCatalogPanel` (панель) теперь используют общие части. **Оболочки групп** (карточка-страница vs рейл-панель со скоуп-бейджем) намеренно оставлены разными — это осознанная визуальная иерархия (issue #8), не дубль.

## Проверка
Поведение не меняется (чистый рефактор). `tsc -b` + **vitest 115/115**. Живой прогон — за тобой (системный каталог + скоуп-панель в дереве комплекта: списки, hover-действия, метка роли).

PATCH 0.22.4.