### PR TITLE
fix(catalog): пикер базы протекал объектами чужих типов (регрессия #89)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -215,9 +215,14 @@ export function CatalogEntryForm({
   const { data: systemParentEntries = [] } = useListCommonData({
     scope: 'System', typeId: parentType?.id, enabled: !!parentType,
   });
-  const parentEntries: CommonDataEntry[] = setId
-    ? allParentEntries
-    : [...scopeParentEntries, ...systemParentEntries.filter(e => !scopeParentEntries.some(s => s.id === e.id))];
+  // ВАЖНО: клиентский фильтр по типу обязателен — useQuery с typeId:undefined (когда parentType нет)
+  // возвращает закешированные данные по совпадающему ключу (нефильтрованный список каталога),
+  // даже при enabled:false. Без этого фильтра в пикер протекают объекты чужих типов.
+  const parentEntries: CommonDataEntry[] = !parentType ? [] :
+    (setId
+      ? allParentEntries
+      : [...scopeParentEntries, ...systemParentEntries.filter(e => !scopeParentEntries.some(s => s.id === e.id))]
+    ).filter(e => e.compositeTypeId === parentType.id);
   // Кандидаты базы для общего пикера (issue #73, шаг 2): записи родительского типа по скопам.
   const baseCandidates: BaseCandidate[] = parentEntries
     .map(e => ({
@@ -238,9 +243,12 @@ export function CatalogEntryForm({
   const { data: systemProxyEntries = [] } = useListCommonData({
     scope: 'System', typeId: proxyTypeId, enabled: !!proxyTypeId,
   });
-  const proxyEntries: CommonDataEntry[] = setId
-    ? allProxyEntries
-    : [...scopeProxyEntries, ...systemProxyEntries.filter(e => !scopeProxyEntries.some(s => s.id === e.id))];
+  // Тот же клиентский фильтр по типу (иммунно к cache-collision по ключу typeId:undefined).
+  const proxyEntries: CommonDataEntry[] = !proxyTypeId ? [] :
+    (setId
+      ? allProxyEntries
+      : [...scopeProxyEntries, ...systemProxyEntries.filter(e => !scopeProxyEntries.some(s => s.id === e.id))]
+    ).filter(e => e.compositeTypeId === proxyTypeId);
   const proxyCandidates: BaseCandidate[] = proxyEntries
     .filter(e => e.id !== entry?.id) // не сам на себя
     .map(e => ({

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.4</Version>
+    <Version>0.22.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #96.

## Баг
В форме объекта (`CatalogEntryForm`) пикер «Базовый экземпляр» показывал объекты **всех типов** вместо родительского/того же типа. Пример: «Подписант» (наследник «Персона») → пикер базы показывает всё по оси.

## Причина
React Query cache-collision: proxy-запросы (#89) при `allowsProxy=off` идут с `typeId: undefined`. `enabled:false` не мешает `useQuery` вернуть **закешированные** данные по совпадающему ключу `{scope, scopeId, typeId: undefined}`, а он заполнен нефильтрованным списком каталога (`ScopedCatalogPanel`). → `proxyEntries` = все типы.

Бэкенд-фильтр корректен (проверено эмпирически: list/for-set с `typeId` возвращают только нужный тип).

## Фикс
Клиентский фильтр кандидатов базы/роли по типу (иммунно к кешу) + прокси-список строится только при заданном `proxyTypeId`.

## Проверка
tsc -b + vitest 115/115. Живой прогон: у «Подписант» пикер базы теперь показывает только «Персона»; у типа с прокси — только тот же тип.

PATCH 0.22.5.