### PR TITLE
fix(catalog): длинные псевдонимы обрезались в чипе

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -514,10 +514,10 @@ export function CatalogEntryForm({
         {aliases.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mb-1.5">
             {aliases.map(a => (
-              <span key={a} className="inline-flex items-center gap-1 text-xs bg-muted text-fg2 rounded-full pl-2.5 pr-1 py-0.5">
-                {a}
+              <span key={a} className="inline-flex items-center gap-1 text-xs bg-muted text-fg2 rounded-2xl pl-2.5 pr-1 py-0.5 max-w-full">
+                <span className="min-w-0 break-words">{a}</span>
                 <button type="button" onClick={() => setAliases(prev => prev.filter(x => x !== a))}
-                  className="text-fg4 hover:text-danger transition-colors" title="Удалить">
+                  className="text-fg4 hover:text-danger transition-colors shrink-0" title="Удалить">
                   <X size={11} />
                 </button>
               </span>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.5</Version>
+    <Version>0.22.6</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Длинные псевдонимы (напр. полное «Общество с ограниченной ответственностью …») не помещались: чип был `inline-flex` с сырым текстом без ограничения ширины — длиннее контейнера вылезал за правый край, обрезая крестик удаления.

**Фикс:** чип `max-w-full`, текст в `min-w-0 break-words` (переносится внутри чипа), крестик `shrink-0` всегда виден. Короткие остаются пилюлями, длинные переносятся и полностью читаются.

Живой прогон — за тобой (hot-reload на :5173). PATCH 0.22.6.