### PR TITLE
fix(common-data): @@ref-привязки хранят $ref, а не строку «🔗» (#99, PR-1)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 import {
   ChevronDown, ChevronUp, Plus, Database, ShieldCheck, Loader2,
-  DatabaseZap, RefreshCw, X, CornerUpLeft,
+  DatabaseZap, RefreshCw, X, CornerUpLeft, Link2,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import {
   useListCommonData, useCommonDataForSet, useCreateCommonDataEntry,
-  useUpdateCommonDataEntry, useDeleteCommonDataEntry,
+  useUpdateCommonDataEntry, useDeleteCommonDataEntry, useCommonDataEntry,
 } from '@/shared/api/commonData';
 import type { CommonDataEntry, CatalogScope, DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import { SCOPE_LABELS, SCOPE_PRIORITY } from '@/shared/api/types';
@@ -30,6 +30,17 @@ import {
   PrimitiveInput, FileField, ImageField,
   BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
 } from '../fields';
+
+/** Показ резолвнутой $ref-ссылки в связанном поле (issue #99): резолвит запись каталога по id → имя. */
+function BoundRefValue({ entryId }: { entryId: string }) {
+  const { data: entry } = useCommonDataEntry(entryId);
+  return (
+    <span className="inline-flex items-center gap-1 text-brand">
+      <Link2 size={12} className="shrink-0" />
+      {entry ? entry.displayName : <span className="text-fg4">запись каталога…</span>}
+    </span>
+  );
+}
 
 export function ScopedCatalogPanel({ scope, scopeId, allDocTypes, setId }: {
   scope: CatalogScope; scopeId: string | null; allDocTypes: DocumentType[];
@@ -393,6 +404,11 @@ export function CatalogEntryForm({
           }
 
           if (isBoundScalar) {
+            // Резолвнутая ссылка на запись каталога (@@ref, issue #99): показываем связанную запись,
+            // а не сырой JSON. Составное поле теперь хранит {$ref:catalog, entryId}, а не строку «🔗 …».
+            const refId = val && typeof val === 'object'
+              && (val as { $ref?: string }).$ref === 'catalog'
+              ? (val as { entryId?: string }).entryId : undefined;
             const display = val === undefined || val === null || val === ''
               ? null
               : isFileAttachment(val)
@@ -405,7 +421,7 @@ export function CatalogEntryForm({
                   <span title="Значение подставляется из источника данных"><DatabaseZap size={12} className="text-brand" /></span>
                 </label>
                 <div className="w-full border border-stroke rounded-md px-3 py-2 text-sm bg-muted text-fg2">
-                  {display ?? <em className="text-fg4">нет данных</em>}
+                  {refId ? <BoundRefValue entryId={refId} /> : (display ?? <em className="text-fg4">нет данных</em>)}
                 </div>
               </div>
             );

--- a/src/client/src/shared/api/commonData.ts
+++ b/src/client/src/shared/api/commonData.ts
@@ -72,6 +72,16 @@ export function useCommonDataForScope({
   });
 }
 
+/** Одна запись каталога по id — для показа резолвнутой $ref-ссылки в связанном поле (issue #99). */
+export function useCommonDataEntry(id: string | undefined) {
+  return useQuery({
+    queryKey: [QK, 'by-id', id],
+    queryFn: () => apiClient.get<CommonDataEntry>(`/common-data/${id}`).then(r => r.data),
+    enabled: !!id,
+    staleTime: 60_000,
+  });
+}
+
 export function useCreateCommonDataEntry() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Application/Documents/CommonDataBindingMerge.cs
+++ b/src/server/BHS.CRG.Application/Documents/CommonDataBindingMerge.cs
@@ -1,45 +1,29 @@
 using System.Text.Json;
-using BHS.CRG.Application.DataSets;
 
 namespace BHS.CRG.Application.Documents;
 
 /// <summary>
-/// Мёрджит результаты резолва DataSetBinding (см. IDataSetService.PreviewBindingsAsync) в текущие
-/// данные записи каталога перед сохранением — CommonDataEntry.Data читается EntityResolver
-/// живьём из БД при каждом $ref без отдельного кэша, поэтому синхронизация происходит здесь,
-/// на момент сохранения записи, а не при чтении.
+/// Мёрджит РЕЗОЛВНУТЫЕ значения привязок (см. IDataSetResolver.ResolveOwnerBindingsAsync) в данные
+/// объекта общих данных перед сохранением (sync-on-save). Ключевое (issue #99): значения приходят
+/// уже как ЗНАЧЕНИЯ резолва — скаляр = строка, @@ref = {$ref:catalog, entryId} (настоящая ссылка),
+/// — а не как display-превью «🔗 …». Data читается EntityResolver живьём при каждом $ref, поэтому
+/// синхронизация — на момент сохранения.
 /// </summary>
 public static class CommonDataBindingMerge
 {
-    public static JsonDocument Merge(JsonDocument current, IReadOnlyList<BindingPreviewDto> previews)
+    public static JsonDocument Merge(JsonDocument current, IReadOnlyDictionary<string, object?> resolved)
     {
         var dict = new Dictionary<string, JsonElement>();
         foreach (var prop in current.RootElement.EnumerateObject())
             dict[prop.Name] = prop.Value.Clone();
 
-        foreach (var preview in previews)
+        foreach (var (key, value) in resolved)
         {
-            if (preview.Error is not null) continue;
-
-            if (preview.Mode == "scalar" && preview.Data is Dictionary<string, object?> scalarData)
-            {
-                foreach (var (key, value) in scalarData)
-                {
-                    // Пустое строковое значение колонки не затирает ранее сохранённое (или введённое
-                    // вручную до создания биндинга) — источник мог временно не дать данных по этой
-                    // строке. Не-строковое значение (напр. файловый объект от @@file-маппинга)
-                    // пишем всегда, если оно не null.
-                    if (value is string s && string.IsNullOrEmpty(s)) continue;
-                    if (value is null) continue;
-                    dict[key] = JsonSerializer.SerializeToElement(value);
-                }
-            }
-            else if (preview.Mode == "tabular" && preview.TargetFieldKey is { } targetKey
-                     && preview.Data is List<Dictionary<string, object?>> rows)
-            {
-                // Табличное поле целиком управляется источником — пишем как есть, включая [].
-                dict[targetKey] = JsonSerializer.SerializeToElement(rows);
-            }
+            // Пустое строковое значение колонки не затирает ранее введённое вручную (источник мог
+            // временно не дать данных). Нет-матч @@ref сюда не попадает (резолвер его пропускает).
+            if (value is null) continue;
+            if (value is string s && string.IsNullOrEmpty(s)) continue;
+            dict[key] = value is JsonElement je ? je.Clone() : JsonSerializer.SerializeToElement(value);
         }
 
         return JsonDocument.Parse(JsonSerializer.Serialize(dict));

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Generation;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
@@ -417,7 +418,7 @@ public class CommonDataHandlers(
     IRepository<DomainObject> repo,
     IRepository<DocumentSet> setRepo,
     IRepository<Section> sectionRepo,
-    IDataSetService dataSetService) :
+    IDataSetResolver dataSetResolver) :
     IRequestHandler<CreateCommonDataEntryCommand, DomainObject>,
     IRequestHandler<UpdateCommonDataEntryCommand, DomainObject>,
     IRequestHandler<DeleteCommonDataEntryCommand>,
@@ -437,8 +438,11 @@ public class CommonDataHandlers(
     public async Task<DomainObject> Handle(UpdateCommonDataEntryCommand cmd, CancellationToken ct)
     {
         var entry = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
-        var previews = await dataSetService.PreviewBindingsAsync(cmd.Id, ct);
-        var data = previews.Count == 0 ? cmd.Data : CommonDataBindingMerge.Merge(cmd.Data, previews);
+        // Резолв-путь (issue #99): @@ref → {$ref:catalog, entryId}, а не display-строка «🔗 …».
+        // Scope — из расположения объекта. Нет матча → поле не пишется (резолвер пропускает).
+        var resolved = await dataSetResolver.ResolveOwnerBindingsAsync(
+            cmd.Id, entry.CompositeTypeId, entry.ScopeLevel, entry.ScopeId, null, ct);
+        var data = resolved.Count == 0 ? cmd.Data : CommonDataBindingMerge.Merge(cmd.Data, resolved);
         entry.Update(cmd.DisplayName, data, cmd.Aliases);
         repo.Update(entry);
         await repo.SaveChangesAsync(ct);

--- a/src/server/BHS.CRG.Application/Generation/IDataSetResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/IDataSetResolver.cs
@@ -1,3 +1,5 @@
+using BHS.CRG.Domain.Catalog;
+
 namespace BHS.CRG.Application.Generation;
 
 public interface IDataSetResolver
@@ -7,5 +9,15 @@ public interface IDataSetResolver
     /// в него записываются проблемы маппинга (например, значение колонки не найдено в каталоге).
     /// </summary>
     Task InjectAsync(GenerationContext ctx, DocumentView instance,
+        List<ResolutionDiagnostic>? diagnostics = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Резолвит привязки объекта для ПЕРСИСТА (issue #99): @@ref → {$ref:catalog, entryId} (нет матча —
+    /// пропуск + WARNING в <paramref name="diagnostics"/>). Scope берётся из расположения объекта.
+    /// Используется sync-on-save общих данных вместо display-превью — чтобы составное поле хранило
+    /// настоящую ссылку, а не строку «🔗 …».
+    /// </summary>
+    Task<IReadOnlyDictionary<string, object?>> ResolveOwnerBindingsAsync(
+        Guid ownerId, Guid typeId, CatalogScope scopeLevel, Guid? scopeId,
         List<ResolutionDiagnostic>? diagnostics = null, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Infrastructure/Common/ScopeChain.cs
+++ b/src/server/BHS.CRG.Infrastructure/Common/ScopeChain.cs
@@ -37,4 +37,25 @@ public static class ScopeChains
             : await db.Sections.AsNoTracking().FirstOrDefaultAsync(s => s.Id == sectionId, ct);
         return new ScopeChain(setId, sectionId, section?.ConstructionId ?? Guid.Empty);
     }
+
+    /// <summary>
+    /// Скоп-цепочка для объекта на произвольном уровне оси (issue #99): от его расположения
+    /// (ScopeLevel, ScopeId) резолвит родителей вверх (Section→Construction). Неразрешённые уровни —
+    /// Guid.Empty. Нужна для резолва @@ref-привязок общих данных (у них нет комплекта-владельца).
+    /// </summary>
+    public static async Task<ScopeChain> LoadForScopeAsync(AppDbContext db, CatalogScope scopeLevel, Guid? scopeId, CancellationToken ct)
+    {
+        switch (scopeLevel)
+        {
+            case CatalogScope.Set when scopeId is { } sid:
+                return await LoadAsync(db, sid, ct);
+            case CatalogScope.Section when scopeId is { } secId:
+                var section = await db.Sections.AsNoTracking().FirstOrDefaultAsync(s => s.Id == secId, ct);
+                return new ScopeChain(Guid.Empty, secId, section?.ConstructionId ?? Guid.Empty);
+            case CatalogScope.Construction when scopeId is { } cid:
+                return new ScopeChain(Guid.Empty, Guid.Empty, cid);
+            default: // System — родителей нет
+                return new ScopeChain(Guid.Empty, Guid.Empty, Guid.Empty);
+        }
+    }
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -21,21 +21,43 @@ public class DataSetResolver(
     ILogger<DataSetResolver> logger
 ) : IDataSetResolver
 {
-    public async Task InjectAsync(GenerationContext ctx, DocumentView instance,
+    /// <summary>Генерация документа: резолвит привязки владельца в контекст (scope — из комплекта документа).</summary>
+    public Task InjectAsync(GenerationContext ctx, DocumentView instance,
         List<ResolutionDiagnostic>? diagnostics = null, CancellationToken ct = default)
+        => ResolveBindingsCoreAsync(ctx, instance.Id, instance.DocumentTypeId,
+            () => ScopeChains.LoadAsync(db, instance.DocumentSetId, ct), diagnostics, ct);
+
+    /// <summary>
+    /// Резолв привязок для ПЕРСИСТА (issue #99): sync-on-save общих данных. Прогоняет тот же резолв-путь,
+    /// что и генерация (@@ref → {$ref:catalog, entryId}, нет матча → пропуск + WARNING), но scope берётся
+    /// из расположения объекта (ScopeLevel, ScopeId), а результат отдаётся значениями для слияния в Data.
+    /// Ключевое отличие от превью: здесь резолвится ЗНАЧЕНИЕ (ссылка), а не display-строка «🔗 …».
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, object?>> ResolveOwnerBindingsAsync(
+        Guid ownerId, Guid typeId, CatalogScope scopeLevel, Guid? scopeId,
+        List<ResolutionDiagnostic>? diagnostics = null, CancellationToken ct = default)
+    {
+        var ctx = new GenerationContext();
+        await ResolveBindingsCoreAsync(ctx, ownerId, typeId,
+            () => ScopeChains.LoadForScopeAsync(db, scopeLevel, scopeId, ct), diagnostics, ct);
+        return ctx.Data;
+    }
+
+    private async Task ResolveBindingsCoreAsync(GenerationContext ctx, Guid ownerId, Guid typeId,
+        Func<Task<ScopeChain>> chainProvider, List<ResolutionDiagnostic>? diagnostics, CancellationToken ct)
     {
         var bindings = await db.DataSetBindings
             .Include(b => b.Source).ThenInclude(s => s.File)
-            .Where(b => b.OwnerId == instance.Id)
+            .Where(b => b.OwnerId == ownerId)
             .AsNoTracking()
             .ToListAsync(ct);
 
         if (bindings.Count == 0) return;
 
-        // Цепочка scope каталога (Set → Section → Construction → System) и кэш записей
-        // по составному типу — строятся лениво, только если встретится ссылочный маппинг.
+        // Цепочка scope каталога и кэш записей по составному типу — строятся лениво, только если
+        // встретится ссылочный маппинг. Источник scope-цепочки — параметр (комплект vs расположение объекта).
         Task<ScopeChain>? scopeChainTask = null;
-        Task<ScopeChain> ChainAsync() => scopeChainTask ??= ScopeChains.LoadAsync(db, instance.DocumentSetId, ct);
+        Task<ScopeChain> ChainAsync() => scopeChainTask ??= chainProvider();
         var entryCache = new Dictionary<Guid, List<DomainObject>>();
 
         // Схема типов (для кардинальности целевого поля материализации/табличной связки) — лениво, один раз.
@@ -65,7 +87,7 @@ public class DataSetResolver(
                         var row = rows[0];
                         foreach (var (fieldKey, mapVal) in mapping)
                         {
-                            var value = await MapValueAsync(mapVal, row, instance, ChainAsync, entryCache, diagnostics, fieldKey, ct);
+                            var value = await MapValueAsync(mapVal, row, ownerId, ChainAsync, entryCache, diagnostics, fieldKey, ct);
                             if (value is not null)
                                 ctx.Set(fieldKey, value);
                         }
@@ -76,7 +98,7 @@ public class DataSetResolver(
                     // Кардинальность решает ТИП целевого поля: complex/doc-ref ← первая сущность;
                     // array/doc-array (и всё прочее) ← весь поток. Вычисляем ДО построения строк —
                     // нужен и для кардинальности, и для defaultValue (issue #53, часть 2).
-                    var field = DocumentTypeSchemaReader.Field(instance.DocumentTypeId, binding.TargetFieldKey, await TypesAsync());
+                    var field = DocumentTypeSchemaReader.Field(typeId, binding.TargetFieldKey, await TypesAsync());
 
                     // defaultValue незамапленных полей ТИПА СТРОКИ (issue #53, часть 2): для табличных
                     // биндингов маппинг покрывает только явно перечисленные ключи (свои — binding.Mapping,
@@ -103,7 +125,7 @@ public class DataSetResolver(
                         foreach (var (fieldKey, mapVal) in mapping)
                         {
                             var path = $"{binding.TargetFieldKey}[{rowIndex}].{fieldKey}";
-                            var value = await MapValueAsync(mapVal, row, instance, ChainAsync, entryCache, diagnostics, path, ct);
+                            var value = await MapValueAsync(mapVal, row, ownerId, ChainAsync, entryCache, diagnostics, path, ct);
                             if (value is not null)
                                 obj[fieldKey] = value;
                         }
@@ -131,8 +153,8 @@ public class DataSetResolver(
                 // Пропускаем невалидные привязки, чтобы не блокировать генерацию,
                 // но фиксируем причину — иначе "пустые" поля невозможно отладить.
                 logger.LogWarning(ex,
-                    "Привязка набора данных пропущена при генерации. BindingId={BindingId}, SourceId={SourceId}, Instance={InstanceId}",
-                    binding.Id, binding.SourceId, instance.Id);
+                    "Привязка набора данных пропущена. BindingId={BindingId}, SourceId={SourceId}, Owner={OwnerId}",
+                    binding.Id, binding.SourceId, ownerId);
                 // Иначе поле просто исчезает без следа — поднимаем причину в диагностику.
                 diagnostics?.Add(new ResolutionDiagnostic(
                     DiagnosticSeverity.Error,
@@ -150,7 +172,7 @@ public class DataSetResolver(
     private async Task<object?> MapValueAsync(
         string mapVal,
         IReadOnlyDictionary<string, string?> row,
-        DocumentView instance,
+        Guid ownerId,
         Func<Task<ScopeChain>> scopeChainAccessor,
         Dictionary<Guid, List<DomainObject>> entryCache,
         List<ResolutionDiagnostic>? diagnostics,
@@ -174,8 +196,8 @@ public class DataSetResolver(
         if (entryId is null)
         {
             logger.LogWarning(
-                "Запись каталога не найдена при маппинге набора данных. TypeId={TypeId}, Match={Match}, Value={Value}, Instance={InstanceId}",
-                refMap.TypeId, refMap.Match, lookup, instance.Id);
+                "Запись каталога не найдена при маппинге набора данных. TypeId={TypeId}, Match={Match}, Value={Value}, Owner={OwnerId}",
+                refMap.TypeId, refMap.Match, lookup, ownerId);
             diagnostics?.Add(new ResolutionDiagnostic(
                 DiagnosticSeverity.Warning, path,
                 $"Значение «{lookup}» не найдено в каталоге — ссылка не подставлена."));

--- a/src/server/BHS.CRG.Tests/Documents/CommonDataBindingMergeTests.cs
+++ b/src/server/BHS.CRG.Tests/Documents/CommonDataBindingMergeTests.cs
@@ -1,29 +1,20 @@
 using System.Text.Json;
-using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
 
 namespace BHS.CRG.Tests.Documents;
 
+// issue #99: Merge принимает РЕЗОЛВНУТЫЕ значения (скаляр=строка, @@ref={$ref,entryId}), а не превью.
 public class CommonDataBindingMergeTests
 {
     private static JsonDocument Json(string json) => JsonDocument.Parse(json);
-
-    private static BindingPreviewDto Scalar(Dictionary<string, object?> data) =>
-        new(Guid.NewGuid(), "Источник", "Файл", "scalar", null, 1, data, null);
-
-    private static BindingPreviewDto Tabular(string targetFieldKey, List<Dictionary<string, object?>> rows) =>
-        new(Guid.NewGuid(), "Источник", "Файл", "tabular", targetFieldKey, rows.Count, rows, null);
-
-    private static BindingPreviewDto Error() =>
-        new(Guid.NewGuid(), "Источник", "Файл", "error", null, 0, new { }, "Источник недоступен");
+    private static Dictionary<string, object?> Resolved(params (string k, object? v)[] items) =>
+        items.ToDictionary(x => x.k, x => x.v);
 
     [Fact]
     public void Scalar_OverwritesMatchingKey()
     {
         var current = Json("""{"inn":"старое","name":"Не трогать"}""");
-        var previews = new[] { Scalar(new Dictionary<string, object?> { ["inn"] = "новое" }) };
-
-        var merged = CommonDataBindingMerge.Merge(current, previews);
+        var merged = CommonDataBindingMerge.Merge(current, Resolved(("inn", "новое")));
 
         Assert.Equal("новое", merged.RootElement.GetProperty("inn").GetString());
         Assert.Equal("Не трогать", merged.RootElement.GetProperty("name").GetString());
@@ -33,38 +24,48 @@ public class CommonDataBindingMergeTests
     public void Scalar_EmptyValue_DoesNotOverwriteExisting()
     {
         var current = Json("""{"inn":"ручное значение"}""");
-        var previews = new[] { Scalar(new Dictionary<string, object?> { ["inn"] = "" }) };
-
-        var merged = CommonDataBindingMerge.Merge(current, previews);
+        var merged = CommonDataBindingMerge.Merge(current, Resolved(("inn", "")));
 
         Assert.Equal("ручное значение", merged.RootElement.GetProperty("inn").GetString());
+    }
+
+    [Fact]
+    public void RefValue_WritesRefObject_NotDisplayString()
+    {
+        // Ключевой инвариант #99: составное поле хранит {$ref:catalog, entryId}, а не «🔗 …».
+        var id = Guid.NewGuid();
+        var current = Json("{}");
+        var refVal = new Dictionary<string, object?> { ["$ref"] = "catalog", ["entryId"] = id.ToString() };
+        var merged = CommonDataBindingMerge.Merge(current, Resolved(("Орг", refVal)));
+
+        var org = merged.RootElement.GetProperty("Орг");
+        Assert.Equal(JsonValueKind.Object, org.ValueKind);
+        Assert.Equal("catalog", org.GetProperty("$ref").GetString());
+        Assert.Equal(id.ToString(), org.GetProperty("entryId").GetString());
     }
 
     [Fact]
     public void Tabular_WritesArrayIntoTargetFieldKey_EvenWhenEmpty()
     {
         var current = Json("""{"Чертежи":[{"old":true}]}""");
-        var previews = new[] { Tabular("Чертежи", new List<Dictionary<string, object?>>()) };
-
-        var merged = CommonDataBindingMerge.Merge(current, previews);
+        var merged = CommonDataBindingMerge.Merge(current, Resolved(("Чертежи", new List<Dictionary<string, object?>>())));
 
         Assert.Equal(JsonValueKind.Array, merged.RootElement.GetProperty("Чертежи").ValueKind);
         Assert.Equal(0, merged.RootElement.GetProperty("Чертежи").GetArrayLength());
     }
 
     [Fact]
-    public void ErrorBinding_LeavesExistingValueUntouched()
+    public void AbsentKey_LeavesExistingValueUntouched()
     {
+        // Нет матча / ошибка источника → ключа нет в резолве → прежнее значение не трогаем.
         var current = Json("""{"inn":"прежнее"}""");
-        var previews = new[] { Error() };
-
-        var merged = CommonDataBindingMerge.Merge(current, previews);
+        var merged = CommonDataBindingMerge.Merge(current, Resolved());
 
         Assert.Equal("прежнее", merged.RootElement.GetProperty("inn").GetString());
     }
 
     [Fact]
-    public void Scalar_FileValue_WritesNestedObjectNotString()
+    public void FileValue_WritesNestedObjectNotString()
     {
         var current = Json("{}");
         var fileValue = new Dictionary<string, object?>
@@ -72,9 +73,7 @@ public class CommonDataBindingMergeTests
             ["$type"] = "file", ["blobPath"] = "bhs-crg/x_report.pdf",
             ["fileName"] = "report.pdf", ["mimeType"] = "application/pdf", ["size"] = 123L,
         };
-        var previews = new[] { Scalar(new Dictionary<string, object?> { ["Чертёж"] = fileValue }) };
-
-        var merged = CommonDataBindingMerge.Merge(current, previews);
+        var merged = CommonDataBindingMerge.Merge(current, Resolved(("Чертёж", fileValue)));
 
         var chertezh = merged.RootElement.GetProperty("Чертёж");
         Assert.Equal(JsonValueKind.Object, chertezh.ValueKind);
@@ -83,16 +82,12 @@ public class CommonDataBindingMergeTests
     }
 
     [Fact]
-    public void MultipleBindings_MergeWithoutClobberingEachOther()
+    public void MultipleValues_MergeWithoutClobberingEachOther()
     {
         var current = Json("{}");
-        var previews = new[]
-        {
-            Scalar(new Dictionary<string, object?> { ["inn"] = "123" }),
-            Tabular("Листы", new List<Dictionary<string, object?>> { new() { ["НомерЛиста"] = "1" } }),
-        };
-
-        var merged = CommonDataBindingMerge.Merge(current, previews);
+        var merged = CommonDataBindingMerge.Merge(current, Resolved(
+            ("inn", "123"),
+            ("Листы", new List<Dictionary<string, object?>> { new() { ["НомерЛиста"] = "1" } })));
 
         Assert.Equal("123", merged.RootElement.GetProperty("inn").GetString());
         Assert.Equal(1, merged.RootElement.GetProperty("Листы").GetArrayLength());

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.6</Version>
+    <Version>0.22.7</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #99 (PR-1 — ядро). PR-2 (диагностика «Проверить связки») — отдельно.

## Баг
Привязка набора данных к СОСТАВНОМУ полю общих данных (@@ref, по имени) сохраняла в `Data` display-строку `"🔗 {значение}"` вместо `{$ref:catalog, entryId}`. Поле по факту не связано с каталогом; при генерации «🔗 name» — строка, не резолвится.

## Корень
`PreviewCell` смешивал формат-для-показа (`$"🔗 {v}"`) и ЗНАЧЕНИЕ. sync-on-save общих данных переиспользовал **preview-путь как persist-value**. У документов не видно — резолв живой при генерации.

## Фикс (Архитектор + синтез): развести resolve-for-persist и format-for-display
- `ScopeChains.LoadForScopeAsync` — scope-цепочка из расположения объекта (общие данные не привязаны к комплекту).
- `DataSetResolver`: общий `ResolveBindingsCoreAsync` (параметризован источником scope-цепочки); публичный `ResolveOwnerBindingsAsync` возвращает ЗНАЧЕНИЯ (@@ref → `{$ref,entryId}`, нет матча → пропуск + WARNING). `PreviewCell` остаётся чисто display.
- `CommonDataHandlers.Update` идёт резолв-путём; `CommonDataBindingMerge` мёрджит резолвнутые значения. **🔗 исчезает по построению.**
- Фронт: связанное поле со значением `{$ref}` показывает запись каталога (имя + ссылка), а не сырой JSON.

## Проверка
- `dotnet build` + **380 тестов** (CommonDataBindingMerge переписаны под резолвнутые значения, +`RefValue_WritesRefObject_NotDisplayString`). `tsc -b` + vitest 115.
- Живой PUT общих данных → 200 (резолв-путь без ошибок). Полный live-repro @@ref заблокирован: **привязки стёрты цутовером #84** (`DELETE FROM dataset_bindings`), `🔗`-данные — наследие; пользователь пересоздаёт данные.

## Не в PR-1
- Диагностика «Проверить связки» (matched / не найдено / dangling / drift) — PR-2.
- Чистка старых «🔗…» — пользователь пересоздаёт (миграции нет).

PATCH 0.22.7.