### PR TITLE
feat(common-data): «Проверить связки» — диагностика @@ref-полей (#99, PR-2)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -7,7 +7,8 @@ import { Modal } from '@/shared/ui/Modal';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import {
   useListCommonData, useCommonDataForSet, useCreateCommonDataEntry,
-  useUpdateCommonDataEntry, useDeleteCommonDataEntry, useCommonDataEntry,
+  useUpdateCommonDataEntry, useDeleteCommonDataEntry, useCommonDataEntry, useCheckBindings,
+  type BindingCheckItem,
 } from '@/shared/api/commonData';
 import type { CommonDataEntry, CatalogScope, DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import { SCOPE_LABELS, SCOPE_PRIORITY } from '@/shared/api/types';
@@ -30,6 +31,37 @@ import {
   PrimitiveInput, FileField, ImageField,
   BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
 } from '../fields';
+
+// Отчёт «Проверить связки» (issue #99): статус каждого @@ref-поля.
+const CHECK_STATUS: Record<string, { label: string; cls: string }> = {
+  matched: { label: 'связано', cls: 'bg-green-50 text-green-700 border-green-200' },
+  'not-found': { label: 'не найдено', cls: 'bg-warning-subtle text-warning border-warning-border' },
+  dangling: { label: 'запись удалена', cls: 'bg-red-50 text-danger border-red-200' },
+  drift: { label: 'устарело', cls: 'bg-warning-subtle text-warning border-warning-border' },
+  stale: { label: 'пересохранить', cls: 'bg-warning-subtle text-warning border-warning-border' },
+};
+
+function BindingCheckReport({ items }: { items: BindingCheckItem[] }) {
+  if (items.length === 0)
+    return <p className="text-xs text-fg4 px-1">Ссылочных связок нет — проверять нечего.</p>;
+  return (
+    <div className="rounded-lg border border-stroke divide-y divide-muted">
+      {items.map(it => {
+        const s = CHECK_STATUS[it.status] ?? { label: it.status, cls: 'bg-muted text-fg3 border-stroke' };
+        return (
+          <div key={it.fieldKey} className="flex items-start gap-2 px-3 py-2 text-sm">
+            <span className="flex-1 min-w-0">
+              <span className="font-medium text-fg1">{it.fieldTitle}</span>
+              {it.linkedName && <span className="text-fg4"> → {it.linkedName}</span>}
+              {it.detail && <span className="block text-[11px] text-fg4">{it.detail}</span>}
+            </span>
+            <span className={`shrink-0 text-[11px] px-1.5 py-0.5 rounded-full border font-medium ${s.cls}`}>{s.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 /** Показ резолвнутой $ref-ссылки в связанном поле (issue #99): резолвит запись каталога по id → имя. */
 function BoundRefValue({ entryId }: { entryId: string }) {
@@ -307,6 +339,8 @@ export function CatalogEntryForm({
   const { scalarKeys: boundFieldKeys, arrayKeys: boundArrayKeys } = computeBoundFieldKeys(bindings);
   const { refetch: refetchBindingPreview, isFetching: refreshingFromSource } =
     usePreviewDataSetBindings({ ownerId: entry?.id });
+  // Проверка связок (issue #99) — по требованию.
+  const { data: bindingCheck, refetch: runBindingCheck, isFetching: checkingBindings } = useCheckBindings(entry?.id);
 
   async function handleRefreshFromSource() {
     const { data: previews } = await refetchBindingPreview();
@@ -619,12 +653,20 @@ export function CatalogEntryForm({
             scopeId={scopeId}
           />
           {bindings.length > 0 && (
-            <button type="button" onClick={handleRefreshFromSource} disabled={refreshingFromSource}
-              className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md bg-muted text-fg2 hover:bg-stroke disabled:opacity-50">
-              {refreshingFromSource ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
-              Обновить из источника
-            </button>
+            <div className="flex items-center gap-2">
+              <button type="button" onClick={handleRefreshFromSource} disabled={refreshingFromSource}
+                className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md bg-muted text-fg2 hover:bg-stroke disabled:opacity-50">
+                {refreshingFromSource ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+                Обновить из источника
+              </button>
+              <button type="button" onClick={() => runBindingCheck()} disabled={checkingBindings}
+                className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md bg-muted text-fg2 hover:bg-stroke disabled:opacity-50">
+                {checkingBindings ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
+                Проверить связки
+              </button>
+            </div>
           )}
+          {bindingCheck && <BindingCheckReport items={bindingCheck.items} />}
         </div>
       ) : (
         <p className="text-xs text-fg4">Сохраните запись, чтобы привязать источники данных.</p>

--- a/src/client/src/shared/api/commonData.ts
+++ b/src/client/src/shared/api/commonData.ts
@@ -82,6 +82,24 @@ export function useCommonDataEntry(id: string | undefined) {
   });
 }
 
+/** Проверка связок (issue #99): статус каждого @@ref-поля. */
+export interface BindingCheckItem {
+  fieldKey: string;
+  fieldTitle: string;
+  status: 'matched' | 'not-found' | 'dangling' | 'drift' | 'stale';
+  linkedName: string | null;
+  detail: string | null;
+}
+
+/** По требованию (кнопка «Проверить связки») — enabled:false, дёргается через refetch. */
+export function useCheckBindings(id: string | undefined) {
+  return useQuery({
+    queryKey: [QK, 'binding-check', id],
+    queryFn: () => apiClient.get<{ items: BindingCheckItem[] }>(`/common-data/${id}/binding-check`).then(r => r.data),
+    enabled: false,
+  });
+}
+
 export function useCreateCommonDataEntry() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
@@ -58,6 +58,13 @@ public static class CommonDataEndpoints
             return entry is null ? Results.NotFound() : Results.Ok(CommonDataEntryDto.From(entry));
         });
 
+        // Проверка связок (issue #99): сверка снимка $ref-ссылок со свежим резолвом источника.
+        g.MapGet("/{id:guid}/binding-check", async (Guid id, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new CheckCommonDataBindingsQuery(id))); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
         g.MapPost("/", async (CreateRequest req, IMediator m) =>
         {
             var scope = req.Scope switch

--- a/src/server/BHS.CRG.Application/Documents/CommonDataBindingCheck.cs
+++ b/src/server/BHS.CRG.Application/Documents/CommonDataBindingCheck.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
+using MediatR;
+
+namespace BHS.CRG.Application.Documents;
+
+/// <summary>
+/// Проверка связок наборов данных объекта общих данных (issue #99, PR-2). Сверяет СНИМОК ссылок в Data
+/// со СВЕЖИМ резолвом источника по каждому составному (@@ref) полю. Статусы:
+/// matched (снимок = свежий и запись жива), not-found (значение источника не сматчилось),
+/// dangling (запись каталога удалена), drift (источник теперь указывает на ДРУГУЮ запись — снимок id устарел),
+/// stale (снимок не {$ref} — легаси «🔗…» — но источник матчится: пересохранить).
+/// </summary>
+public record BindingCheckItem(string FieldKey, string FieldTitle, string Status, string? LinkedName, string? Detail);
+public record BindingCheckResult(IReadOnlyList<BindingCheckItem> Items);
+
+public record CheckCommonDataBindingsQuery(Guid Id) : IRequest<BindingCheckResult>;
+
+public class CheckCommonDataBindingsHandler(
+    IRepository<DomainObject> repo,
+    IRepository<DocumentType> docTypeRepo,
+    IDataSetResolver dataSetResolver) : IRequestHandler<CheckCommonDataBindingsQuery, BindingCheckResult>
+{
+    public async Task<BindingCheckResult> Handle(CheckCommonDataBindingsQuery q, CancellationToken ct)
+    {
+        var entry = await repo.GetByIdAsync(q.Id, ct) ?? throw new KeyNotFoundException();
+
+        var diag = new List<ResolutionDiagnostic>();
+        var fresh = await dataSetResolver.ResolveOwnerBindingsAsync(
+            q.Id, entry.CompositeTypeId, entry.ScopeLevel, entry.ScopeId, diag, ct);
+
+        var allTypes = (await docTypeRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+        var titles = DocumentTypeSchemaReader.EffectiveFields(entry.CompositeTypeId, allTypes)
+            .ToDictionary(f => f.Key, f => f.Title ?? f.Key);
+        string Title(string key) => titles.TryGetValue(key, out var t) ? t : key;
+
+        var nameCache = new Dictionary<string, string?>();
+        async Task<string?> NameAsync(string entryId)
+        {
+            if (nameCache.TryGetValue(entryId, out var cached)) return cached;
+            var e = Guid.TryParse(entryId, out var g) ? await repo.GetByIdAsync(g, ct) : null;
+            return nameCache[entryId] = e?.DisplayName;
+        }
+
+        var items = new List<BindingCheckItem>();
+        var handled = new HashSet<string>();
+        var stored = entry.Data.RootElement;
+
+        // 1) not-found — значение источника не нашлось в каталоге (из диагностики резолва).
+        foreach (var d in diag.Where(d => d.Severity == DiagnosticSeverity.Warning))
+            if (handled.Add(d.Path))
+                items.Add(new BindingCheckItem(d.Path, Title(d.Path), "not-found", null, d.Message));
+
+        // 2) свежие ссылки → сравнить со снимком.
+        foreach (var (field, value) in fresh)
+        {
+            var freshId = RefId(value);
+            if (freshId is null || !handled.Add(field)) continue;
+
+            var freshName = await NameAsync(freshId);
+            var storedId = stored.TryGetProperty(field, out var sv) ? RefIdJson(sv) : null;
+
+            if (storedId == freshId)
+                items.Add(freshName is null
+                    ? new BindingCheckItem(field, Title(field), "dangling", null, "Целевая запись каталога удалена.")
+                    : new BindingCheckItem(field, Title(field), "matched", freshName, null));
+            else if (storedId is not null)
+                items.Add(new BindingCheckItem(field, Title(field), "drift", await NameAsync(storedId),
+                    $"Источник теперь указывает на «{freshName ?? "(удалена)"}» — пересохраните для обновления."));
+            else
+                items.Add(new BindingCheckItem(field, Title(field), "stale", freshName,
+                    "Сохранённое значение устарело (нет структурной ссылки) — пересохраните."));
+        }
+
+        // 3) dangling: снимок несёт {$ref}, а свежий резолв его не дал (источник убран / поле вне маппинга).
+        foreach (var prop in stored.EnumerateObject())
+        {
+            var storedId = RefIdJson(prop.Value);
+            if (storedId is null || !handled.Add(prop.Name)) continue;
+            var name = await NameAsync(storedId);
+            items.Add(name is null
+                ? new BindingCheckItem(prop.Name, Title(prop.Name), "dangling", null, "Целевая запись каталога удалена.")
+                : new BindingCheckItem(prop.Name, Title(prop.Name), "matched", name, null));
+        }
+
+        return new BindingCheckResult(items.OrderBy(i => i.FieldTitle).ToList());
+    }
+
+    private static string? RefId(object? v) =>
+        v is IDictionary<string, object?> d && d.TryGetValue("$ref", out var r) && r as string == "catalog"
+            && d.TryGetValue("entryId", out var e) ? e as string : null;
+
+    private static string? RefIdJson(JsonElement el) =>
+        el.ValueKind == JsonValueKind.Object && el.TryGetProperty("$ref", out var r) && r.GetString() == "catalog"
+            && el.TryGetProperty("entryId", out var e) ? e.GetString() : null;
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.7</Version>
+    <Version>0.22.8</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #99 (PR-2 — диагностика; PR-1 #100 влит). Закрывает запрос пользователя «дать возможность проверить связки и увидеть диагностику».

## Что сделано
Кнопка **«Проверить связки»** в форме объекта общих данных (рядом с «Обновить из источника»). Сверяет СНИМОК `$ref`-ссылок в `Data` со СВЕЖИМ резолвом источника и показывает статус по каждому составному (@@ref) полю:
- **matched** — снимок = свежий и запись жива (+ имя связанной записи);
- **not-found** — значение источника не сматчилось в каталоге;
- **dangling** — целевая запись каталога удалена;
- **drift** — источник теперь указывает на ДРУГУЮ запись (снимок id устарел, пересохранить);
- **stale** — легаси-значение (нет структурной ссылки), пересохранить.

- **Backend:** `CheckCommonDataBindingsQuery`/Handler (переиспользует `ResolveOwnerBindingsAsync` + сверка со снимком + проверка существования записи); `GET /common-data/{id}/binding-check`.
- **Фронт:** `useCheckBindings` (по требованию, enabled:false) + панель отчёта со статус-бейджами.

## Проверка
- `dotnet build` + **380 тестов**; `tsc -b` + vitest 115.
- Живой прогон отчёта требует пересозданной привязки (все стёрты цутовером #84) — за пользователем.

## После этого #99 закрывается
PR-1 (персист `$ref`) + PR-2 (диагностика) покрывают обе части. Чистку старых «🔗…» пользователь делает пересозданием.

PATCH 0.22.8.