### PR TITLE
feat(forms): продвижение $ref + свёртка авто-полей (#102, P2)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -28,7 +28,7 @@ import { EntryDataSetBindings } from './EntryDataSetBindings';
 import { groupObjectsByType, ObjectRow } from './ObjectsByTypeList';
 import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
-  PrimitiveInput, FileField, ImageField,
+  PrimitiveInput, FileField, ImageField, AutoFieldsSection,
   BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
 } from '../fields';
 
@@ -394,10 +394,11 @@ export function CatalogEntryForm({
     } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Ошибка'); }
   }
 
-  function renderFields(sectionFields: SchemaField[]) {
-    return (
-      <div className="space-y-4">
-        {sectionFields.map(field => {
+    const isAuto = (f: SchemaField) =>
+      (f.type === 'array' && boundArrayKeys.has(f.key)) ||
+      (f.type !== 'array' && boundFieldKeys.has(f.key));
+
+    function renderCell(field: SchemaField) {
           const val = values[field.key];
           const isBoundArray = field.type === 'array' && boundArrayKeys.has(field.key);
           const isBoundScalar = field.type !== 'array' && boundFieldKeys.has(field.key);
@@ -533,10 +534,25 @@ export function CatalogEntryForm({
               )}
             </div>
           );
-        })}
-      </div>
-    );
-  }
+    }
+
+    function fieldStack(fields: SchemaField[]) {
+      return <div className="space-y-4">{fields.map(renderCell)}</div>;
+    }
+
+    // Поля из источника данных (read-only) — под сворачиваемую секцию «Заполняются автоматически»
+    // (issue #102, P2), чтобы форма записи каталога не растягивалась в «портянку».
+    function renderFields(sectionFields: SchemaField[]) {
+      const auto = sectionFields.filter(isAuto);
+      if (auto.length === 0) return fieldStack(sectionFields);
+      const normal = sectionFields.filter(f => !isAuto(f));
+      return (
+        <div className="space-y-4">
+          {normal.length > 0 && fieldStack(normal)}
+          <AutoFieldsSection count={auto.length}>{fieldStack(auto)}</AutoFieldsSection>
+        </div>
+      );
+    }
 
   const isPending = createMutation.isPending || updateMutation.isPending;
 

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -22,7 +22,7 @@ import {
 import {
   STATUS_LABELS, STATUS_COLORS,
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
-  DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup,
+  DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup, AutoFieldsSection,
   BaseInstancePanel, SCOPE_TIER, ancestorTypeIds, parseBaseRef, type BaseCandidate,
 } from '../fields';
 import { DataSetsTab } from './DataSetsTab';
@@ -252,14 +252,11 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
 
   const sections = groupEffectiveFields(displayFields, docType?.schema ?? {});
 
-  function renderFields(fields: SchemaField[]) {
     const isWide = (f: SchemaField) =>
       f.type === 'complex' || f.type === 'array' || f.type === 'doc-ref' ||
       f.type === 'doc-array' || f.type === 'image' || f.type === 'file' || f.type === 'text';
 
-    return (
-      <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
-        {fields.map(field => {
+    function renderCell(field: SchemaField) {
           const raw = values[field.key];
           const missing = showValidation && isFieldMissing(field, raw);
           const bound = sourceBoundFields.has(field.key);
@@ -351,10 +348,25 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
               {!missing && constraintError && <p className="text-[11px] text-danger mt-0.5">{constraintError}</p>}
             </div>
           );
-        })}
-      </div>
-    );
-  }
+    }
+
+    function fieldGrid(fields: SchemaField[]) {
+      return <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">{fields.map(renderCell)}</div>;
+    }
+
+    // Поля, заполняемые из источника данных (read-only), прячем под сворачиваемую секцию
+    // «Заполняются автоматически» — чтобы форма не превращалась в «портянку» (issue #102, P2).
+    function renderFields(fields: SchemaField[]) {
+      const auto = fields.filter(f => sourceBoundFields.has(f.key));
+      if (auto.length === 0) return fieldGrid(fields);
+      const normal = fields.filter(f => !sourceBoundFields.has(f.key));
+      return (
+        <div className="space-y-2.5">
+          {normal.length > 0 && fieldGrid(normal)}
+          <AutoFieldsSection count={auto.length}>{fieldGrid(auto)}</AutoFieldsSection>
+        </div>
+      );
+    }
 
   return (
     <div className="flex flex-col min-h-0 flex-1">

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import {
-  Clipboard, ChevronDown, ChevronUp, FileSpreadsheet, Link2, Pencil, Plus, Trash2, Unlink, X,
+  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, Link2, Pencil, Plus, Trash2, Unlink, X,
 } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
@@ -502,6 +502,24 @@ export function objectSummary(values: Record<string, unknown>, fields: SchemaFie
   return parts.length ? parts.join(' · ') : '(пусто)';
 }
 
+/** Сворачиваемая секция «Заполняются автоматически» (issue #102, P2): read-only поля из источника
+ *  прячем по умолчанию, чтобы длинная форма не выглядела «портянкой» одинаковых боксов. */
+export function AutoFieldsSection({ count, children }: { count: number; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-dashed border-stroke rounded-lg overflow-hidden">
+      <button type="button" onClick={() => setOpen(v => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2 bg-base/40 hover:bg-base transition-colors text-left">
+        {open ? <ChevronUp size={12} className="text-fg4 shrink-0" /> : <ChevronDown size={12} className="text-fg4 shrink-0" />}
+        <Database size={11} className="text-brand shrink-0" />
+        <span className="text-xs text-fg3 flex-1">Заполняются автоматически</span>
+        <span className="text-xs text-fg4">{count} п.</span>
+      </button>
+      {open && <div className="px-3 py-3 border-t border-stroke">{children}</div>}
+    </div>
+  );
+}
+
 export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showValidation,
   setId, otherInstances = [],
   scope, scopeId, docRefMode = 'catalog', nested = false,
@@ -645,6 +663,27 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
         </Modal>
         {picker}
       </>
+    );
+  }
+
+  // Пустое составное (верхний уровень): продвигаем ВЫБОР между «из каталога» (ссылка-объект) и ручным
+  // заполнением как равноправные действия, а не прячем «из каталога» в мелкую ссылку (issue #102, P2).
+  if (isEmpty && collapsed) {
+    return (
+      <div className="border border-dashed border-stroke rounded-lg px-3 py-3 bg-base/40">
+        <div className="text-sm text-fg3 mb-2">{compositeType ? compositeType.name : 'Составной тип'}</div>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={() => setPickerOpen(true)}
+            className="flex items-center gap-1.5 text-sm bg-brand hover:bg-brand-hover text-white px-3 py-1.5 rounded-md transition-colors">
+            <Link2 size={13} /> Выбрать из каталога
+          </button>
+          <button type="button" onClick={() => setCollapsed(false)}
+            className="flex items-center gap-1.5 text-sm text-fg2 hover:text-fg1 border border-stroke hover:border-fg4 px-3 py-1.5 rounded-md transition-colors">
+            <Pencil size={13} /> Заполнить вручную
+          </button>
+        </div>
+        {picker}
+      </div>
     );
   }
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.10</Version>
+    <Version>0.22.11</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Part of #102 (P2).

## Что
Две меры против «портянки» больших форм с составными типами:

### 1. Продвижение $ref у пустого составного поля
Пустое составное поле верхнего уровня раньше показывало приглушённый свёрнутый заголовок с типом + мелкую ссылку «Выбрать из каталога». Теперь — явный выбор из **двух равноправных действий**:
- **Выбрать из каталога** (основная кнопка) — сделать поле ссылкой на объект каталога (`$ref`), заполнять только собственные поля;
- **Заполнить вручную** (вторичная) — раскрыть редактор подполей.

### 2. Свёртка авто-заполняемых полей
Поля, значение которых приходит из привязанного источника данных (read-only), сворачиваются в секцию **«Заполняются автоматически»** (по умолчанию свёрнута):
- в редакторе документа комплекта (`editor/index.tsx`, `sourceBoundFields`);
- в редакторе записи каталога (`catalog/index.tsx`, `boundFieldKeys`/`boundArrayKeys`).

Base-covered поля в редакторе документа уже отфильтровываются раньше (#71), `defaultValue`-поля НЕ прячем (они редактируемые). Общий компонент `AutoFieldsSection` вынесен в `fields/ComplexFields.tsx`.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed