### PR TITLE
fix(a11y): клавиатурные quick-wins — фокус hover-действий + заголовок групп качества (#107 F1,F2)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -97,7 +97,7 @@ export function SystemCommonDataPage() {
             const isOpen = expandedTypes.has(t.id);
             return (
               <div key={t.id} className="border border-stroke rounded-xl overflow-hidden">
-                <button onClick={() => toggleType(t.id)}
+                <button type="button" onClick={() => toggleType(t.id)} aria-expanded={isOpen}
                   className="w-full flex items-center gap-2 px-4 py-3 bg-surface hover:bg-base transition-colors text-left">
                   {isOpen
                     ? <ChevronUp size={14} className="text-fg4 shrink-0" />
@@ -125,7 +125,7 @@ export function SystemCommonDataPage() {
             const isOpen = expandedTypes.has('__no_type__');
             return (
               <div className="border border-stroke rounded-xl overflow-hidden">
-                <button onClick={() => toggleType('__no_type__')}
+                <button type="button" onClick={() => toggleType('__no_type__')} aria-expanded={isOpen}
                   className="w-full flex items-center gap-2 px-4 py-3 bg-surface hover:bg-base transition-colors text-left">
                   {isOpen
                     ? <ChevronUp size={14} className="text-fg4 shrink-0" />

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -241,7 +241,7 @@ function SetDetail() {
                       <button
                         onClick={e => { e.stopPropagation(); setDeleteTarget(inst); }}
                         disabled={deleteMutation.isPending}
-                        className="p-1 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30"
+                        className="p-1 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
                         title="Удалить документ">
                         <Trash2 size={14} />
                       </button>
@@ -495,10 +495,10 @@ function DocumentSetRow({ ds, section: _section, construction: _construction, on
         </button>
       )}
       <span className="text-xs text-fg4 shrink-0">{ds.instances?.length ?? 0} doc</span>
-      <button onClick={() => setEditing(true)} className="p-1 text-stroke-strong hover:text-fg2 opacity-0 group-hover:opacity-100 transition-all" title="Переименовать">
+      <button onClick={() => setEditing(true)} className="p-1 text-stroke-strong hover:text-fg2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all" title="Переименовать">
         <Pencil size={12} />
       </button>
-      <button onClick={onDelete} className="p-1 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all" title="Удалить">
+      <button onClick={onDelete} className="p-1 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all" title="Удалить">
         <Trash2 size={12} />
       </button>
       <ChevronRight size={13} className="text-stroke-strong shrink-0" />
@@ -733,7 +733,7 @@ function ConstructionsList() {
                   ) : (
                     <h3 className="text-base font-semibold text-fg1 flex-1">{c.name}</h3>
                   )}
-                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0">
                     <button onClick={e => { e.stopPropagation(); setEditId(c.id); setEditName(c.name); }}
                       className="p-1.5 text-fg4 hover:text-fg2 rounded transition-colors" title="Переименовать">
                       <Pencil size={13} />

--- a/src/client/src/features/document-sets/SubscribersPanel.tsx
+++ b/src/client/src/features/document-sets/SubscribersPanel.tsx
@@ -76,7 +76,7 @@ export function SubscribersPanel({ scope, scopeId }: { scope: SubscriptionScope;
                   )}
                   {isAdmin && (
                     <button onClick={() => remove.mutate({ id: s.id, scope, scopeId })}
-                      className="p-0.5 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all" title="Убрать из подписчиков">
+                      className="p-0.5 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all" title="Убрать из подписчиков">
                       <Trash2 size={13} />
                     </button>
                   )}

--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -66,7 +66,7 @@ export function ObjectRow({
       {showPreview && preview && (
         <span className="text-xs text-fg4 truncate max-w-xs hidden sm:block">{preview}</span>
       )}
-      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0">
         <button type="button" onClick={() => onEdit(entry)} title="Редактировать"
           className={`rounded transition-colors ${dense ? 'p-1 text-stroke-strong hover:text-fg2' : 'p-1.5 text-fg4 hover:text-fg2'}`}>
           <Pencil size={icon} />

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type ReactNode } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
   Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, Link2, Pencil, Plus, Trash2, Unlink, X,
 } from 'lucide-react';
@@ -178,6 +178,28 @@ export function ArrayTableModal({
     setPasteOpen(true);
   }
 
+  // ↑↓-навигация между ячейками ОДНОЙ колонки (issue #107, F8a). Полный APG grid (←→, роли,
+  // выделение строк, ресайз с клавиатуры) отложен в фазу таблиц MD3. <select> не трогаем — там
+  // ↑↓ выбирают опцию; для остальных (text/number/date/checkbox/пикер) нативное ↑↓ — no-op либо
+  // нежелательный инкремент, так что перехват безопасен и полезен при вводе столбца сверху вниз.
+  const tableRef = useRef<HTMLTableElement>(null);
+  function onGridKey(e: React.KeyboardEvent) {
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+    const el = e.target as HTMLElement;
+    if (el.tagName === 'SELECT') return;
+    const td = el.closest('td[data-r]') as HTMLElement | null;
+    if (!td) return;
+    const r = Number(td.dataset.r), c = Number(td.dataset.c);
+    const nr = e.key === 'ArrowUp' ? r - 1 : r + 1;
+    if (nr < 0 || nr >= rows.length) return;
+    const target = tableRef.current?.querySelector<HTMLElement>(`td[data-r="${nr}"][data-c="${c}"]`);
+    const focusable = target?.querySelector<HTMLElement>('input, select, textarea, button');
+    if (!focusable) return;
+    e.preventDefault();
+    focusable.focus();
+    if (focusable instanceof HTMLInputElement && focusable.type !== 'checkbox') focusable.select();
+  }
+
   const BORDER = '1px solid #d1d5db';
   const TH_BG = '#f3f4f6';
   const IDX_BG = '#f9fafb';
@@ -212,7 +234,8 @@ export function ArrayTableModal({
         </div>
       }>
       <div className="overflow-x-auto -mx-6 px-6">
-        <table style={{ tableLayout: 'fixed', borderCollapse: 'collapse', width: 'max-content', minWidth: '100%' }}>
+        <table ref={tableRef} onKeyDown={onGridKey}
+          style={{ tableLayout: 'fixed', borderCollapse: 'collapse', width: 'max-content', minWidth: '100%' }}>
           <colgroup>
             <col style={{ width: 32 }} />
             {tableFields.map(f => <col key={f.key} style={{ width: getW(f) }} />)}
@@ -243,11 +266,11 @@ export function ArrayTableModal({
                 <td style={{ border: BORDER, background: IDX_BG, padding: 0, textAlign: 'center' }}>
                   <span className="flex items-center justify-center text-xs text-fg4 font-mono" style={{ height: 26 }}>{i + 1}</span>
                 </td>
-                {tableFields.map(f => {
+                {tableFields.map((f, ci) => {
                   const compositeForField = f.type === 'complex'
                     ? allDocTypes.find(dt => dt.id === f.typeId) ?? null : null;
                   return (
-                    <td key={f.key}
+                    <td key={f.key} data-r={i} data-c={ci}
                       className="focus-within:bg-brand-subtle transition-colors"
                       style={{ border: BORDER, padding: 0, height: 26 }}>
                       <TableCell field={f} value={row[f.key]} onChange={v => updateCell(i, f.key, v)}

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -531,7 +531,7 @@ export function AutoFieldsSection({ count, children }: { count: number; children
   const [open, setOpen] = useState(false);
   return (
     <div className="border border-dashed border-stroke rounded-lg overflow-hidden">
-      <button type="button" onClick={() => setOpen(v => !v)}
+      <button type="button" onClick={() => setOpen(v => !v)} aria-expanded={open}
         className="w-full flex items-center gap-2 px-3 py-2 bg-base/40 hover:bg-base transition-colors text-left">
         {open ? <ChevronUp size={12} className="text-fg4 shrink-0" /> : <ChevronDown size={12} className="text-fg4 shrink-0" />}
         <Database size={11} className="text-brand shrink-0" />

--- a/src/client/src/features/notifications/NotificationsCenter.tsx
+++ b/src/client/src/features/notifications/NotificationsCenter.tsx
@@ -89,7 +89,7 @@ function NotificationRow({ n }: { n: NotificationDto }) {
           type="button"
           onClick={() => dismiss.mutate(n.id)}
           title="Удалить"
-          className="text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+          className="text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
         >
           <X size={14} />
         </button>

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -196,13 +196,14 @@ export function QualityDocsPage() {
                 const open = openGroups.has(manuf);
                 return (
                   <Fragment key={manuf}>
-                    <tr className="bg-base/60 cursor-pointer select-none hover:bg-base" onClick={() => toggleGroup(manuf)}>
-                      <td colSpan={5} className="px-3 py-2">
-                        <span className="flex items-center gap-2 text-sm font-medium text-fg2">
+                    <tr className="bg-base/60 hover:bg-base">
+                      <td colSpan={5} className="p-0">
+                        <button type="button" onClick={() => toggleGroup(manuf)} aria-expanded={open}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-sm font-medium text-fg2 text-left select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand">
                           {open ? <ChevronDown size={14} className="text-fg4 shrink-0" /> : <ChevronRight size={14} className="text-fg4 shrink-0" />}
                           <span className="truncate">{manuf}</span>
                           <span className="text-xs text-fg4 font-normal">({items.length})</span>
-                        </span>
+                        </button>
                       </td>
                     </tr>
                     {open && items.map(d => (
@@ -220,7 +221,7 @@ export function QualityDocsPage() {
                             : <span className="text-fg4">—</span>}
                         </td>
                         <td className="px-4 py-2.5">
-                          <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                             <button onClick={() => setEditDoc(d)} className="p-1.5 text-fg4 hover:text-fg2 rounded" title="Редактировать">
                               <Pencil size={14} />
                             </button>

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -646,7 +646,7 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
   return (
     <div className={`overflow-hidden group ${expanded ? 'bg-base' : ''}`}>
       <div className="flex items-center hover:bg-base transition-colors">
-        <button onClick={onToggle}
+        <button type="button" onClick={onToggle} aria-expanded={expanded}
           className="flex-1 min-w-0 flex items-center gap-2 px-4 py-2.5 text-left">
           {expanded
             ? <ChevronUp size={15} className="text-fg4 shrink-0" />

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -688,7 +688,7 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
         <button
           onClick={e => { e.stopPropagation(); proxyMutation.mutate({ id: docType.id, allowsProxy: !docType.allowsProxy }); }}
           disabled={proxyMutation.isPending}
-          className={`px-2 py-3 text-xs font-medium opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30 ${
+          className={`px-2 py-3 text-xs font-medium opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30 ${
             docType.allowsProxy ? 'text-brand hover:text-brand-hover' : 'text-stroke-strong hover:text-brand'
           }`}
           title={docType.allowsProxy
@@ -700,7 +700,7 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
           <>
             <button
               onClick={e => { e.stopPropagation(); setTemplatesOpen(true); }}
-              className="px-2 py-3 opacity-0 group-hover:opacity-100 transition-all text-brand"
+              className="px-2 py-3 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all text-brand"
               title="Шаблоны данных"
             >
               <Database size={14} />
@@ -708,7 +708,7 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
             <button
               onClick={e => { e.stopPropagation(); abstractMutation.mutate({ id: docType.id, isAbstract: !docType.isAbstract }); }}
               disabled={abstractMutation.isPending}
-              className={`px-2 py-3 text-xs font-medium opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30 ${
+              className={`px-2 py-3 text-xs font-medium opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30 ${
                 docType.isAbstract
                   ? 'text-warning hover:text-orange-700'
                   : 'text-stroke-strong hover:text-warning'
@@ -723,7 +723,7 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
             onChange={group => groupMutation.mutate({ id: docType.id, group })} />
         </span>
         <button onClick={handleDelete} disabled={deleteMutation.isPending}
-          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30"
+          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
           title={hasChildren ? 'Нельзя удалить: есть дочерние типы' : 'Удалить'}>
           <Trash2 size={14} />
         </button>

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -181,7 +181,7 @@ function EnumTypeRow({ type, allGroups, expanded, onToggle }: {
   return (
     <div className={`overflow-hidden group ${expanded ? 'bg-base' : ''}`}>
       <div className="flex items-center hover:bg-base transition-colors">
-        <button onClick={onToggle}
+        <button type="button" onClick={onToggle} aria-expanded={expanded}
           className="flex-1 min-w-0 flex items-center gap-2 px-4 py-2.5 text-left">
           {expanded
             ? <ChevronUp size={15} className="text-fg4 shrink-0" />

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -200,7 +200,7 @@ function EnumTypeRow({ type, allGroups, expanded, onToggle }: {
             onChange={group => groupMutation.mutate({ id: type.id, group })} />
         </span>
         <button onClick={handleDelete} disabled={deleteMutation.isPending}
-          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30"
+          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
           title="Удалить">
           <Trash2 size={14} />
         </button>

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -398,7 +398,7 @@ function FieldTypeRow({ type, allGroups, expanded, onToggle }: {
             onChange={group => groupMutation.mutate({ id: type.id, group })} />
         </span>
         <button onClick={handleDelete} disabled={deleteMutation.isPending}
-          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 transition-all disabled:opacity-30"
+          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
           title="Удалить">
           <Trash2 size={14} />
         </button>

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -378,7 +378,7 @@ function FieldTypeRow({ type, allGroups, expanded, onToggle }: {
   return (
     <div className={`overflow-hidden group ${expanded ? 'bg-base' : ''}`}>
       <div className="flex items-center hover:bg-base transition-colors">
-        <button onClick={onToggle}
+        <button type="button" onClick={onToggle} aria-expanded={expanded}
           className="flex-1 min-w-0 flex items-center gap-2 px-4 py-2.5 text-left">
           {expanded
             ? <ChevronUp size={15} className="text-fg4 shrink-0" />

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -93,7 +93,7 @@ export function UsersPage() {
                       </select>
                     </td>
                     <td className="px-4 py-2.5">
-                      <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                         <button onClick={() => setResetFor(u)} title="Сбросить пароль"
                           className="p-1.5 text-fg4 hover:text-brand rounded"><KeyRound size={14} /></button>
                         <button onClick={() => setDeleteTarget(u)} disabled={isSelf || del.isPending}

--- a/src/client/src/features/templates/TemplateAssetsPanel.tsx
+++ b/src/client/src/features/templates/TemplateAssetsPanel.tsx
@@ -44,13 +44,13 @@ function AssetRow({ asset }: { asset: TemplateAssetDto }) {
       <button type="button" onClick={() => replaceInputRef.current?.click()}
         disabled={replaceMutation.isPending}
         title="Заменить файл"
-        className="p-1 text-fg4 hover:text-brand opacity-0 group-hover:opacity-100 transition-all shrink-0 disabled:opacity-30">
+        className="p-1 text-fg4 hover:text-brand opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all shrink-0 disabled:opacity-30">
         <RefreshCw size={12} />
       </button>
       <input ref={replaceInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleReplace} />
       <button type="button" onClick={() => setConfirmDelete(true)}
         title="Удалить"
-        className="p-1 text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 transition-all shrink-0">
+        className="p-1 text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all shrink-0">
         <Trash2 size={12} />
       </button>
       <ConfirmDialog

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.11</Version>
+    <Version>0.22.13</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Part of #107 (структурный проход — не выбрасывается рестайлом MD3).

Реализованы два дешёвых, широких по охвату пункта из клавиатурного аудита Дизайнера.

## F1 — hover-действия невидимы при фокусе с клавиатуры
Иконочные кнопки «переименовать/удалить» и подобные (`opacity-0 group-hover:opacity-100`) фокусируются с Tab, но остаются **невидимыми** — пользователь не понимает, где фокус. Добавлен `group-focus-within:opacity-100` во все `.group`-контейнеры: как только любой контрол внутри группы получает фокус, действия проявляются (как при hover).

**17 мест в 10 файлах:** карточки/строки комплектов, каталог общих данных (`ObjectsByTypeList`), документы качества, подписчики, типы документов, перечисления, примитивные типы, пользователи, ассеты шаблонов, уведомления.

## F2 — заголовок группы «Документы качества» не открывался с клавиатуры
Был `<tr onClick>` без `tabindex`/`role`/обработчика клавиш. Заменён на настоящую `<button>` во всю ширину ячейки: нативные Enter/Space, `aria-expanded`, видимое кольцо фокуса (`focus-visible:ring-inset`).

## Вне охвата (осознанно)
F3 (табы→APG), F4 (aria-expanded аккордеонов, aria-current rail), F5 (listbox в пикерах), F6 (самокатные оверлеи→ConfirmDialog), F7 (Enter=submit) — уходят в per-component фазы рестайла MD3 либо отдельными задачами (см. чек-лист #107).

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed