### PR TITLE
fix(a11y): семантика rail разделов + закрытие структурного трека #107

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -570,12 +570,13 @@ export function CatalogEntryForm({
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
       <div className={showRail ? 'flex gap-5 items-start' : ''}>
       {showRail && (
-        <nav className="hidden lg:block sticky top-0 w-52 shrink-0 self-start space-y-0.5">
+        <nav aria-label="Разделы" className="hidden lg:block sticky top-0 w-52 shrink-0 self-start space-y-0.5">
           <div className="text-[10px] font-semibold uppercase tracking-wide text-fg4 px-2 pb-1">Разделы</div>
           {titledSections.map(section => {
             const expanded = expandedGroups.has(section.key);
             return (
               <button key={section.key} type="button" onClick={() => goToSection(section.key)}
+                aria-current={expanded ? 'true' : undefined}
                 className={`w-full flex items-center gap-1.5 text-left text-xs px-2 py-1 rounded transition-colors
                   ${expanded ? 'bg-base text-fg1 font-medium' : 'text-fg3 hover:bg-base hover:text-fg1'}`}>
                 <span className="flex-1 truncate">{section.title}</span>

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -383,17 +383,21 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
       <div className={showRail ? 'flex gap-5 items-start' : ''}>
       {showRail && (
-        <nav className="hidden lg:block sticky top-0 w-52 shrink-0 self-start space-y-0.5">
+        <nav aria-label="Разделы" className="hidden lg:block sticky top-0 w-52 shrink-0 self-start space-y-0.5">
           <div className="text-[10px] font-semibold uppercase tracking-wide text-fg4 px-2 pb-1">Разделы</div>
           {titledSections.map(section => {
             const expanded = expandedGroups.has(section.key);
             const missing = showValidation && section.fields.some(f => isFieldMissing(f, values[f.key]));
             return (
               <button key={section.key} type="button" onClick={() => goToSection(section.key)}
+                aria-current={expanded ? 'true' : undefined}
                 className={`w-full flex items-center gap-1.5 text-left text-xs px-2 py-1 rounded transition-colors
                   ${expanded ? 'bg-base text-fg1 font-medium' : 'text-fg3 hover:bg-base hover:text-fg1'}`}>
                 <span className="flex-1 truncate">{section.title}</span>
-                {missing && <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" title="Не заполнено" />}
+                {missing && <>
+                  <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" aria-hidden="true" />
+                  <span className="sr-only">не заполнено</span>
+                </>}
                 <span className="text-[10px] text-fg4 shrink-0">{section.fields.length}</span>
               </button>
             );

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.13</Version>
+    <Version>0.22.14</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Part of #107. Завершает **структурный (не-MD3) клавиатурный трек**.

## Изменение
Rail разделов (#102 P3) получил ARIA-семантику:
- `aria-label="Разделы"` на `<nav>` — именованный landmark;
- `aria-current="true"` на активном (раскрытом) разделе;
- `sr-only` «не заполнено» рядом с красной точкой валидации (точка — `aria-hidden`).
- В обоих редакторах (документа комплекта и записи каталога).

Этот пункт F4 откладывался «за #106» (rail был там) — теперь #106 в master, закрыто.

## Заодно: F6 проверен — уже сделан
Инспекция показала, что оверлеи, которые аудит помечал как самодельные (guard смены вкладки `pendingTab`, `SaveAsTemplate`), **уже рендерятся через общий `<Modal>`** (Radix — focus-trap/Esc/возврат фокуса); `fixed inset-0` есть только у `Modal`/`ConfirmDialog`. Оставшиеся инлайн-«Удалить?» (`ProcessingTemplatesDialog`, `BindingTemplatesDialog`) — настоящие `<button>` в потоке, с клавиатуры доступны, overlay нет → не a11y-дыра. **Для клавиатуры F6 закрывать нечего** (правки были сделаны в более раннем §6.5/§15).

## Итог трека #107 (структурный пас)
Закрыты: **F1** (фокус hover-действий), **F2** (заголовок групп качества), **F4** (aria-expanded аккордеонов + rail-семантика), **F8a** (↑↓ в таблице), **F6** (оказался уже сделан).
Остаётся только MD3-gated: **F3** (табы→APG), **F5** (пикеры→listbox), **F8b** (полный APG grid) — в фазы рестайла MD3.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed