### PR TITLE
feat(md3): фаза 0 — токены MD3 + Roboto (#110)

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -8,6 +8,8 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/roboto": "^5.2.10",
+        "@fontsource/roboto-mono": "^5.2.9",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-dialog": "^1.1.17",
         "@radix-ui/react-dropdown-menu": "^2.1.18",
@@ -493,6 +495,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
+      "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/roboto-mono": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto-mono/-/roboto-mono-5.2.9.tgz",
+      "integrity": "sha512-iIeSyrRGoM15uIWqXslW1K9UFnUYfnCFNrNoWjXE0huO1L+hM0Jst0KNLuRc7P21xPpGL0bZouzYSX0Em9eyWg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -12,6 +12,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/roboto": "^5.2.10",
+    "@fontsource/roboto-mono": "^5.2.9",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-dropdown-menu": "^2.1.18",

--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -3,48 +3,54 @@
 /* ── Fluent 2 design tokens ────────────────────────────────────────────────── */
 
 :root {
-  /* Typography */
-  --f-font: 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  /* Typography — Roboto (MD3, issue #110 фаза 0) */
+  --f-font:      'Roboto', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --f-font-mono: 'Roboto Mono', ui-monospace, 'Cascadia Code', Consolas, monospace;
 
-  /* Surface layers */
-  --f-bg1: #ffffff;   /* card / panel */
-  --f-bg2: #f5f5f5;   /* page background */
-  --f-bg3: #f0f0f0;   /* input, subtle */
-  --f-bg4: #ebebeb;   /* selected, hover-deep */
+  /* Surface layers → MD3 surface / surface-container-* */
+  --f-bg1: #fdfbff;   /* card / panel        (surface)                 */
+  --f-bg2: #f4f2f7;   /* page background     (surface-container-low)   */
+  --f-bg3: #eef0f4;   /* input, subtle       (surface-container)       */
+  --f-bg4: #e9e7ee;   /* selected, hover-deep(surface-container-high)  */
 
-  /* Foregrounds */
-  --f-fg1: #242424;   /* primary text */
-  --f-fg2: #424242;   /* secondary text / labels */
-  --f-fg3: #616161;   /* tertiary / placeholder */
-  --f-fg4: #707070;   /* caption / disabled-light */
-  --f-fg-disabled: #bdbdbd;
+  /* Foregrounds → MD3 on-surface / on-surface-variant / outline */
+  --f-fg1: #1a1c1e;   /* primary text        (on-surface)              */
+  --f-fg2: #44474e;   /* secondary / labels  (on-surface-variant)      */
+  --f-fg3: #5b5f67;   /* tertiary / placeholder                        */
+  --f-fg4: #74777f;   /* caption             (outline)                 */
+  --f-fg-disabled: #a3a5ab;
 
-  /* Strokes */
-  --f-stroke1: #d1d1d1;  /* stronger border */
-  --f-stroke2: #e0e0e0;  /* default border */
-  --f-stroke3: #f0f0f0;  /* subtle separator */
+  /* Strokes → MD3 outline / outline-variant */
+  --f-stroke1: #74777f;  /* stronger border  (outline)                 */
+  --f-stroke2: #c4c6d0;  /* default border   (outline-variant)         */
+  --f-stroke3: #e3e1e6;  /* subtle separator (surface-container-highest)*/
 
-  /* Brand (Microsoft blue) */
-  --f-brand:         #0f6cbd;
-  --f-brand-hover:   #115ea3;
-  --f-brand-pressed: #0e4775;
-  --f-brand-bg2:     #cfe4fa;  /* subtle brand tint */
-  --f-brand-fg:      #0f6cbd;  /* brand-coloured text */
-  --f-brand-text:    #ffffff;  /* text on brand bg */
+  /* Brand → MD3 primary / primary-container */
+  --f-brand:         #1d5fb0;  /* primary            */
+  --f-brand-hover:   #17518f;
+  --f-brand-pressed: #124074;
+  --f-brand-bg2:     #d6e3ff;  /* primary-container  */
+  --f-brand-fg:      #1d5fb0;  /* brand-coloured text*/
+  --f-brand-text:    #ffffff;  /* on-primary         */
 
-  /* Status */
-  --f-success-bg: #f1faf1;
-  --f-success-fg: #107c10;
-  --f-warning-bg: #fff8e8;
-  --f-warning-fg: #835b00;
+  /* MD3 tonal / container roles (для фаз 1–3: filled-tonal, чипы, плашки) */
+  --f-secondary-container:    #dae2f9;
+  --f-on-secondary-container: #131c2b;
+  --f-on-primary-container:   #001b3c;
+
+  /* Status → MD3 error + производные контейнеры */
+  --f-success-bg: #d7f0e3;
+  --f-success-fg: #1b8a5b;
+  --f-warning-bg: #fbeecb;
+  --f-warning-fg: #7a5900;
   --f-warning-stroke: #c49500;
-  --f-danger-bg:  #fdf3f4;
-  --f-danger-fg:  #bc2f32;
+  --f-danger-bg:  #ffdad6;  /* error-container */
+  --f-danger-fg:  #ba1a1a;  /* error          */
 
-  /* Elevation shadows */
-  --f-shadow4:  0 2px 4px rgba(0,0,0,.14), 0 0 2px rgba(0,0,0,.12);
-  --f-shadow16: 0 8px 16px rgba(0,0,0,.14), 0 0 2px rgba(0,0,0,.12);
-  --f-shadow28: 0 14px 28px rgba(0,0,0,.16), 0 0 8px rgba(0,0,0,.10);
+  /* Elevation shadows → MD3 levels (тёплый сине-серый scrim-тон) */
+  --f-shadow4:  0 1px 2px rgba(16,35,63,.30), 0 1px 3px 1px rgba(16,35,63,.12);
+  --f-shadow16: 0 2px 8px rgba(16,35,63,.12), 0 1px 2px rgba(16,35,63,.10);
+  --f-shadow28: 0 8px 24px rgba(0,0,0,.28), 0 2px 6px rgba(0,0,0,.14);
 
   /* Border radii */
   --f-r-sm: 2px;
@@ -56,39 +62,44 @@
 /* ── Dark theme ──────────────────────────────────────────────────────────────── */
 
 :root[data-theme="dark"] {
-  --f-bg1: #1b1b1b;
-  --f-bg2: #141414;
-  --f-bg3: #292929;
-  --f-bg4: #333333;
+  /* MD3 dark surfaces */
+  --f-bg1: #111318;   /* surface                 */
+  --f-bg2: #191c20;   /* surface-container-low   */
+  --f-bg3: #1d2024;   /* surface-container       */
+  --f-bg4: #282a2f;   /* surface-container-high  */
 
-  --f-fg1: #ffffff;
-  --f-fg2: #d6d6d6;
-  --f-fg3: #adadad;
-  --f-fg4: #999999;
-  --f-fg-disabled: #5c5c5c;
+  --f-fg1: #e2e2e6;   /* on-surface          */
+  --f-fg2: #c4c6d0;   /* on-surface-variant  */
+  --f-fg3: #a8abb3;
+  --f-fg4: #8e9099;   /* outline             */
+  --f-fg-disabled: #5c5f66;
 
-  --f-stroke1: #424242;
-  --f-stroke2: #333333;
-  --f-stroke3: #1b1b1b;
+  --f-stroke1: #8e9099;  /* outline         */
+  --f-stroke2: #43474e;  /* outline-variant */
+  --f-stroke3: #282a2f;
 
-  --f-brand:         #479ef5;
-  --f-brand-hover:   #62abf5;
-  --f-brand-pressed: #1a6ca8;
-  --f-brand-bg2:     #00306e;
-  --f-brand-fg:      #62abf5;
-  --f-brand-text:    #003d6b;
+  --f-brand:         #a7c8ff;  /* primary           */
+  --f-brand-hover:   #bcd4ff;
+  --f-brand-pressed: #8bb3f0;
+  --f-brand-bg2:     #004787;  /* primary-container */
+  --f-brand-fg:      #a7c8ff;
+  --f-brand-text:    #00315f;  /* on-primary        */
 
-  --f-success-bg: #052505;
-  --f-success-fg: #54b054;
+  --f-secondary-container:    #3b4858;
+  --f-on-secondary-container: #dae2f9;
+  --f-on-primary-container:   #d6e3ff;
+
+  --f-success-bg: #06301f;
+  --f-success-fg: #5fd39a;
   --f-warning-bg: #3a2a00;
   --f-warning-fg: #fcba60;
   --f-warning-stroke: #5a3c00;
-  --f-danger-bg:  #3b0509;
-  --f-danger-fg:  #f1707b;
+  --f-danger-bg:  #5c1417;
+  --f-danger-fg:  #ffb4ab;  /* error */
 
-  --f-shadow4:  0 2px 4px rgba(0,0,0,.28), 0 0 2px rgba(0,0,0,.24);
-  --f-shadow16: 0 8px 16px rgba(0,0,0,.28), 0 0 2px rgba(0,0,0,.24);
-  --f-shadow28: 0 14px 28px rgba(0,0,0,.36), 0 0 8px rgba(0,0,0,.20);
+  --f-shadow4:  0 1px 2px rgba(0,0,0,.40), 0 1px 3px 1px rgba(0,0,0,.24);
+  --f-shadow16: 0 2px 8px rgba(0,0,0,.36), 0 1px 2px rgba(0,0,0,.24);
+  --f-shadow28: 0 8px 24px rgba(0,0,0,.48), 0 2px 6px rgba(0,0,0,.28);
 }
 
 /* ── Tailwind v4: map color scales to Fluent tokens ─────────────────────────── */
@@ -116,11 +127,19 @@
   --color-stroke-strong: var(--f-stroke1);
   --color-stroke-subtle: var(--f-stroke3);
 
+  /* Fonts */
+  --font-mono: var(--f-font-mono);   /* utility: font-mono → Roboto Mono (код, версия) */
+
   /* Brand */
   --color-brand:         var(--f-brand);
   --color-brand-hover:   var(--f-brand-hover);
   --color-brand-pressed: var(--f-brand-pressed);
-  --color-brand-subtle:  var(--f-brand-bg2);
+  --color-brand-subtle:  var(--f-brand-bg2);          /* primary-container      */
+  --color-on-brand-subtle: var(--f-on-primary-container);
+
+  /* Tonal (MD3 secondary-container) — для filled-tonal кнопок/чипов (фазы 1–3) */
+  --color-tonal:    var(--f-secondary-container);
+  --color-on-tonal: var(--f-on-secondary-container);
 
   /* Status */
   --color-success:         var(--f-success-fg);

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -1,5 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+// Roboto — семейство MD3 (issue #110, фаза 0). Self-hosted через @fontsource (офлайн, без Google Fonts/CSP).
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
+import '@fontsource/roboto-mono/400.css';
+import '@fontsource/roboto-mono/500.css';
 import './index.css';
 import App from './App.tsx';
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.22.14</Version>
+    <Version>0.23.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Первая фаза рестайла в **Material Design 3** (#110). **Token-first, без правок компонентов.**

## Почему так безопасно
Тема двухслойная: рантайм-токены `--f-*` (флипаются на dark) → `@theme inline` маппит семантические Tailwind-имена (`text-fg1`, `bg-surface`, `text-brand`, `border-stroke`…). Меняем значения `--f-*` — перекрашивается всё приложение, семантический маппинг не тронут → **ни одного изменения в компонентах**.

## Что сделано
- **Цвет** — `--f-*` ремапнуты на роли MD3 (источник: согласованный хендофф):
  - primary `#1d5fb0` (dark `#a7c8ff`), primary-container, on-primary;
  - surface / surface-container-low/high слои → `bg1..bg4`;
  - on-surface / on-surface-variant / outline / outline-variant → fg/stroke;
  - error `#ba1a1a` (dark `#ffb4ab`); success/warning производные.
  - light + dark.
- **Шрифт** — Roboto (400/500/700) + Roboto Mono (400/500), **self-hosted** через `@fontsource` (офлайн, без Google Fonts/CSP). Кириллица в бандле (проверено).
- **Тени** → уровни MD3; добавлены forward-роли (`secondary-container`/`tonal`, `on-primary-container`) + `font-mono`-утилита для фаз 1–3.
- **Компакт-плотность и радиусы сохранены** — форма (pill-кнопки, radius карточек/диалогов) идёт в фазах кнопок/карточек, чтобы не ломать раскладки на этом шаге.

## Область
Только `src/client/src/index.css` (токены) + `main.tsx` (импорт шрифтов) + `package.json` (шрифты). Компоненты не тронуты.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- `npm run build` — ок, Roboto (вкл. кириллицу) в бандле

## Дальше
Фаза 1 — кнопки (filled/tonal/outlined/text, pill-форма, иерархия), с APG-фокусом (#107 F3-задел).