### PR TITLE
feat(md3): фаза 1a — система кнопок MD3 + адопция в shared/login (#110)

### DIFF
--- a/src/client/src/features/catalog/LoginPage.tsx
+++ b/src/client/src/features/catalog/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { FileCheck2 } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useAppVersion } from '@/shared/api/version';
+import { Button } from '@/shared/ui/Button';
 
 export function LoginPage() {
   const { login } = useAuth();
@@ -71,13 +72,9 @@ export function LoginPage() {
             />
           </div>
           {error && <p className="text-sm text-danger">{error}</p>}
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-brand hover:bg-brand-hover text-white font-medium py-2 px-4 rounded-md text-sm transition-colors disabled:opacity-50 mt-2"
-          >
-            {loading ? 'Вход...' : 'Войти'}
-          </button>
+          <Button type="submit" variant="filled" size="lg" fullWidth loading={loading} className="mt-2">
+            {loading ? 'Вход…' : 'Войти'}
+          </Button>
         </form>
         {version && (
           <p className="mt-6 text-center text-[11px] text-fg4"

--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -135,6 +135,7 @@
   --color-brand-hover:   var(--f-brand-hover);
   --color-brand-pressed: var(--f-brand-pressed);
   --color-brand-subtle:  var(--f-brand-bg2);          /* primary-container      */
+  --color-on-brand:        var(--f-brand-text);       /* on-primary (текст на filled) */
   --color-on-brand-subtle: var(--f-on-primary-container);
 
   /* Tonal (MD3 secondary-container) — для filled-tonal кнопок/чипов (фазы 1–3) */

--- a/src/client/src/shared/ui/Button.tsx
+++ b/src/client/src/shared/ui/Button.tsx
@@ -1,0 +1,119 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+
+/**
+ * MD3-кнопки (issue #110, фаза 1). Форма — пилюля (rounded-full), label-large (500),
+ * state-layer на hover/active, видимое кольцо фокуса. Иерархия: **максимум одна filled
+ * на экран/модалку**; заметное вторичное — tonal; обрамлённое — outlined; третичное — text.
+ * Плотность компактная (по умолчанию md=36px), spec-высота 40px доступна как lg.
+ */
+export type ButtonVariant = 'filled' | 'tonal' | 'outlined' | 'text';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+const BASE =
+  'inline-flex items-center justify-center gap-2 rounded-full font-medium whitespace-nowrap select-none ' +
+  'transition-[background-color,box-shadow,filter,color,border-color] duration-150 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 ' +
+  'focus-visible:ring-offset-base disabled:opacity-40 disabled:pointer-events-none';
+
+const SIZE: Record<ButtonSize, string> = {
+  sm: 'h-8 px-3 text-xs',
+  md: 'h-9 px-4 text-sm',
+  lg: 'h-10 px-6 text-sm',
+};
+// text-вариант живёт без заливки → чуть плотнее по горизонтали.
+const TEXT_SIZE: Record<ButtonSize, string> = {
+  sm: 'h-8 px-2 text-xs',
+  md: 'h-9 px-3 text-sm',
+  lg: 'h-10 px-4 text-sm',
+};
+
+function variantClass(variant: ButtonVariant, danger: boolean): string {
+  switch (variant) {
+    case 'filled':
+      return danger
+        ? 'bg-danger text-white shadow-[var(--f-shadow4)] hover:brightness-95 active:brightness-90'
+        : 'bg-brand text-on-brand shadow-[var(--f-shadow4)] hover:bg-brand-hover active:bg-brand-pressed';
+    case 'tonal':
+      return 'bg-tonal text-on-tonal hover:brightness-[.97] active:brightness-95';
+    case 'outlined':
+      return danger
+        ? 'border border-stroke-strong text-danger hover:bg-danger/10 active:bg-danger/15'
+        : 'border border-stroke-strong text-brand hover:bg-brand/10 active:bg-brand/15';
+    case 'text':
+      return danger
+        ? 'text-danger hover:bg-danger/10 active:bg-danger/15'
+        : 'text-brand hover:bg-brand/10 active:bg-brand/15';
+  }
+}
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  danger?: boolean;
+  loading?: boolean;
+  /** Ведущая иконка (слева). При loading заменяется спиннером. */
+  icon?: ReactNode;
+  trailingIcon?: ReactNode;
+  fullWidth?: boolean;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'text', size = 'md', danger = false, loading = false,
+    icon, trailingIcon, fullWidth, className = '', type, disabled, children, ...rest },
+  ref,
+) {
+  const sizes = variant === 'text' ? TEXT_SIZE : SIZE;
+  return (
+    <button
+      ref={ref}
+      type={type ?? 'button'}
+      disabled={disabled || loading}
+      className={`${BASE} ${sizes[size]} ${variantClass(variant, danger)} ${fullWidth ? 'w-full' : ''} ${className}`}
+      {...rest}
+    >
+      {loading ? <Loader2 size={16} className="animate-spin shrink-0" /> : icon}
+      {children}
+      {trailingIcon}
+    </button>
+  );
+});
+
+const ICON_SIZE: Record<ButtonSize, string> = {
+  sm: 'h-8 w-8',
+  md: 'h-9 w-9',
+  lg: 'h-10 w-10',
+};
+
+export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Обязательная доступная подпись (иконка сама по себе непрозрачна для скринридера). */
+  label: string;
+  size?: ButtonSize;
+  danger?: boolean;
+}
+
+/** Круглая icon-кнопка MD3: state-layer на hover, кольцо фокуса, обязательный aria-label. */
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(
+  { label, size = 'md', danger = false, className = '', type, children, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type ?? 'button'}
+      aria-label={label}
+      title={rest.title ?? label}
+      className={`inline-flex items-center justify-center rounded-full shrink-0 ${ICON_SIZE[size]} ` +
+        'transition-[background-color,color] duration-150 focus-visible:outline-none focus-visible:ring-2 ' +
+        'focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-base ' +
+        'disabled:opacity-40 disabled:pointer-events-none ' +
+        (danger
+          ? 'text-fg3 hover:text-danger hover:bg-danger/10'
+          : 'text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10') +
+        ` ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+});

--- a/src/client/src/shared/ui/ChangePasswordModal.tsx
+++ b/src/client/src/shared/ui/ChangePasswordModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { useChangeMyPassword } from '@/shared/api/users';
 
 function apiError(e: unknown): string {
@@ -50,13 +51,11 @@ export function ChangePasswordModal({ open, onClose }: { open: boolean; onClose:
         </div>
         {error && <p className="text-sm text-danger">{error}</p>}
         {done && <p className="text-sm text-success">Пароль изменён</p>}
-        <div className="flex justify-end gap-3 pt-1">
-          <button type="button" onClick={() => { reset(); onClose(); }}
-            className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-          <button type="submit" disabled={change.isPending}
-            className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-            {change.isPending ? 'Сохранение...' : 'Сменить'}
-          </button>
+        <div className="flex justify-end gap-2 pt-1">
+          <Button variant="text" onClick={() => { reset(); onClose(); }}>Отмена</Button>
+          <Button type="submit" variant="filled" loading={change.isPending}>
+            {change.isPending ? 'Сохранение…' : 'Сменить'}
+          </Button>
         </div>
       </form>
     </Modal>

--- a/src/client/src/shared/ui/ConfirmDialog.tsx
+++ b/src/client/src/shared/ui/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useState, type ReactNode } from 'react';
+import { Button } from './Button';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -70,21 +71,15 @@ export function ConfirmDialog({
 
           <div className={`flex gap-2 justify-end ${!requireCheckbox ? 'mt-4' : ''}`}>
             <Dialog.Close asChild>
-              <button
-                type="button"
-                className="px-3 py-1.5 text-sm rounded-md transition-colors border border-stroke text-fg2 hover:bg-muted"
-              >
-                {cancelLabel}
-              </button>
+              <Button variant="text" size="sm">{cancelLabel}</Button>
             </Dialog.Close>
-            <button
-              type="button"
+            <Button
+              variant="filled" danger size="sm"
               disabled={!canConfirm}
               onClick={() => { onConfirm(); onOpenChange(false); }}
-              className="px-3 py-1.5 text-sm rounded-md bg-danger text-white transition-colors disabled:opacity-40"
             >
               {confirmLabel}
-            </button>
+            </Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/src/client/src/shared/ui/SendMessageDialog.tsx
+++ b/src/client/src/shared/ui/SendMessageDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
 import { Modal } from './Modal';
+import { Button } from './Button';
 import { useSendEmail } from '@/shared/api/users';
 import { apiError } from '@/shared/utils/apiError';
 
@@ -43,12 +44,11 @@ export function SendMessageDialog({ open, onClose, candidates, title = 'Отпр
   return (
     <Modal open={open} onOpenChange={o => { if (!o) { onClose(); setResult(null); } }} title={title}
       footer={
-        <div className="flex justify-end gap-3">
-          <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Закрыть</button>
-          <button type="button" onClick={handleSend} disabled={!canSend}
-            className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-            {sendEmail.isPending ? 'Отправка...' : `Отправить (${selected.size})`}
-          </button>
+        <div className="flex justify-end gap-2">
+          <Button variant="text" onClick={onClose}>Закрыть</Button>
+          <Button variant="filled" onClick={handleSend} disabled={!canSend} loading={sendEmail.isPending}>
+            {sendEmail.isPending ? 'Отправка…' : `Отправить (${selected.size})`}
+          </Button>
         </div>
       }>
       <div className="space-y-4">

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.0</Version>
+    <Version>0.23.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1 рестайла MD3 (#110) — **кнопки**. Часть 1a: строим систему + адоптируем в общих поверхностях; фич-экраны — 1b.

## Новый компонент `shared/ui/Button` (+ `IconButton`)
- Варианты: **filled** (основное), **tonal** (заметное вторичное, MD3 secondary-container), **outlined**, **text**.
- Pill-форма (`rounded-full`), label-large (500), MD3 **state-layer** на hover/active (для outlined/text — полупрозрачный primary-оверлей `bg-brand/10`; для filled — brand-hover/pressed).
- **Видимое кольцо фокуса** (`focus-visible:ring-2 ring-brand ring-offset`), `type="button"` по умолчанию.
- Размеры sm/md/lg (компактный **md=36** по умолчанию; spec-высота 40 = lg), `danger`, `loading` (спиннер), слоты иконок, `fullWidth`.
- `IconButton` — круглая, state-layer, **обязательный `aria-label`**.

## Адопция (широкий охват без правки всех фич-экранов)
- **`ConfirmDialog`** — достаёт **каждое подтверждение удаления** в приложении: text «Отмена» + filled `danger` подтверждение (MD3 dialog: одна filled + text).
- **`LoginPage`** — filled lg fullWidth «Войти» (экран №1 хендоффа).
- **`ChangePasswordModal`**, **`SendMessageDialog`** — text + filled в футерах.

## Токены
Добавлен `--color-on-brand` (on-primary) — корректный цвет текста filled-кнопки в light и dark.

## Область
`Button.tsx` (новый) + 4 shared-компонента + LoginPage + `index.css` (1 токен) + версия. Фич-экранные кнопки (34 файла с primary-паттерном, row-action иконки → `IconButton`) — **фаза 1b**, отдельным PR, чтобы ревью оставалось обозримым.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- `npm run build` — ок (новые утилиты в CSS)

## Дальше
Фаза 1b — адопция кнопок на фич-экранах (primary «Добавить/Сохранить/Создать», row-action → IconButton), затем фаза 2 (контролы форм + Select).