### PR TITLE
feat(md3): фаза 1b — кнопки в настройках и типах (#110)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { apiError } from '@/shared/utils/apiError';
 import {
@@ -219,10 +220,9 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
       </div>
       {error && <p className="text-xs text-danger">{error}</p>}
       <div className="flex items-center gap-3">
-        <button type="submit" disabled={!dirty || mutation.isPending}
-          className="px-3 py-1.5 text-xs bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-40 transition-colors">
-          {mutation.isPending ? 'Сохранение...' : 'Сохранить параметры'}
-        </button>
+        <Button type="submit" variant="filled" size="sm" disabled={!dirty} loading={mutation.isPending}>
+          {mutation.isPending ? 'Сохранение…' : 'Сохранить параметры'}
+        </Button>
         {saved && <span className="text-xs text-success">Сохранено</span>}
         {dirty && !saved && <span className="text-xs text-warning">Есть несохранённые изменения</span>}
       </div>
@@ -371,14 +371,10 @@ function CreateForm({
       {error && <p className="text-sm text-danger">{error}</p>}
       </div>
       <div className="shrink-0 px-6 py-3 border-t border-stroke flex justify-end gap-3">
-        <button type="button" onClick={onClose}
-          className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">
-          Отмена
-        </button>
-        <button type="submit" disabled={mutation.isPending}
-          className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-          {mutation.isPending ? 'Создание...' : 'Создать'}
-        </button>
+        <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+        <Button type="submit" variant="filled" loading={mutation.isPending}>
+          {mutation.isPending ? 'Создание…' : 'Создать'}
+        </Button>
       </div>
     </form>
   );
@@ -595,10 +591,9 @@ function SchemaEditor({ docType, allDocTypes }: {
         <>
           {error && <p className="text-xs text-danger">{error}</p>}
           <div className="flex items-center gap-3 pt-1">
-            <button onClick={handleSave} disabled={mutation.isPending}
-              className="px-3 py-1.5 text-xs bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-              {mutation.isPending ? 'Сохранение...' : 'Сохранить схему'}
-            </button>
+            <Button variant="filled" size="sm" onClick={handleSave} loading={mutation.isPending}>
+              {mutation.isPending ? 'Сохранение…' : 'Сохранить схему'}
+            </Button>
             {saved && <span className="text-xs text-success">Сохранено</span>}
           </div>
         </>
@@ -791,10 +786,9 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
             </p>
           )}
         </div>
-        <button onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
-          <Plus size={16} /> {addLabel}
-        </button>
+        <Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+          {addLabel}
+        </Button>
       </div>
 
       {isLoading ? (

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import {
   useListEnumTypes,
   useCreateEnumType,
@@ -149,14 +150,10 @@ function EnumForm({ initial, onSaved, onCancel }: {
       {error && <p className="text-sm text-danger">{error}</p>}
 
       <div className="flex justify-end gap-2 border-t border-stroke pt-3">
-        <button type="button" onClick={onCancel}
-          className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">
-          Отмена
-        </button>
-        <button type="button" onClick={handleSave} disabled={isPending}
-          className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+        <Button type="button" variant="text" onClick={onCancel}>Отмена</Button>
+        <Button type="button" variant="filled" onClick={handleSave} loading={isPending}>
           {isPending ? 'Сохранение…' : 'Сохранить'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -270,10 +267,9 @@ export function EnumTypesSection() {
         <p className="text-xs text-fg3">
           Переиспользуемые списки вариантов (код + отображаемое имя) для полей типа «Перечисление»
         </p>
-        <button onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
-          <Plus size={16} /> Добавить тип
-        </button>
+        <Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+          Добавить тип
+        </Button>
       </div>
 
       {isLoading ? (

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { DateInput } from '@/shared/ui/DateInput';
 import {
   useListPrimitiveTypes,
@@ -324,14 +325,10 @@ function TypeForm({ initial, onSaved, onCancel }: TypeFormProps) {
       {error && <p className="text-sm text-danger">{error}</p>}
 
       <div className="flex justify-end gap-2 border-t border-stroke pt-3">
-        <button type="button" onClick={onCancel}
-          className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">
-          Отмена
-        </button>
-        <button type="button" onClick={handleSave} disabled={isPending}
-          className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+        <Button type="button" variant="text" onClick={onCancel}>Отмена</Button>
+        <Button type="button" variant="filled" onClick={handleSave} loading={isPending}>
           {isPending ? 'Сохранение…' : 'Сохранить'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -462,10 +459,9 @@ function PrimitiveTypesSection() {
         <p className="text-xs text-fg3">
           Пользовательские типы реквизитов на основе строки, числа или даты с ограничениями
         </p>
-        <button onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
-          <Plus size={16} /> Добавить тип
-        </button>
+        <Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+          Добавить тип
+        </Button>
       </div>
 
       {isLoading ? (

--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { Download, Upload, CheckCircle, XCircle, AlertTriangle, Info } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { downloadBackup, restoreBackup } from '@/shared/api/backup';
 import type { RestoreReport } from '@/shared/api/types';
 import {
@@ -59,14 +60,8 @@ function RestoreConfirmModal({ file, onConfirm, onCancel }: {
       </div>
       </div>
       <div className="shrink-0 px-6 py-3 border-t border-stroke flex justify-end gap-3">
-        <button type="button" onClick={onCancel}
-          className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md transition-colors">
-          Отмена
-        </button>
-        <button type="button" onClick={onConfirm}
-          className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors">
-          Восстановить
-        </button>
+        <Button variant="text" onClick={onCancel}>Отмена</Button>
+        <Button variant="filled" onClick={onConfirm}>Восстановить</Button>
       </div>
     </div>
   );
@@ -362,10 +357,7 @@ export function SettingsPage() {
             />
           </div>
           <div className="flex items-center gap-3">
-            <button type="submit"
-              className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors">
-              Сохранить
-            </button>
+            <Button type="submit" variant="filled">Сохранить</Button>
             {saved && <span className="text-sm text-success">Сохранено</span>}
           </div>
         </CollapsibleSection>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.3</Version>
+    <Version>0.23.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1b, область 3 — **Настройка системы** (экраны хендоффа 18-21, 26).

## Что сделано
- **`DocumentTypesPage`**: filled «Добавить тип», «Создать», «Сохранить схему», «Сохранить параметры» (loading); text «Отмена».
- **`PrimitiveTypesPage`**, **`EnumTypesSection`**: filled «Добавить тип» / «Сохранить» (loading); text «Отмена».
- **`SettingsPage`**: filled «Сохранить» / «Восстановить»; text «Отмена».

## Вне охвата
Сегмент-переключатели (точность даты; Примитивные/Перечисления) не тронуты — уйдут в MD3 segmented control (позже). Row-action иконки — общий IconButton-свип.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed