### PR TITLE
feat(md3): фаза 1b — кнопки в шаблонах, качестве, пользователях (#110)

### DIFF
--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Loader2, ShieldCheck, Upload, Eye } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
 import {
   useCreateQualityDoc, useUpdateQualityDoc, useSetQualityDocScan, recognizeDocument,
   type QualityDocument, type RecognitionFieldReq,
@@ -219,11 +220,10 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
 
       {error && <p className="text-sm text-danger">{error}</p>}
       <div className="flex items-center gap-2 pt-1">
-        <button onClick={handleSave} disabled={busy || recognizing || !typeId}
-          className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-          {busy ? 'Сохранение...' : isEdit ? 'Сохранить' : 'Создать'}
-        </button>
-        <button onClick={onCancel} className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
+        <Button variant="filled" onClick={handleSave} loading={busy} disabled={busy || recognizing || !typeId}>
+          {busy ? 'Сохранение…' : isEdit ? 'Сохранить' : 'Создать'}
+        </Button>
+        <Button variant="text" onClick={onCancel}>Отмена</Button>
         {recognizing && (
           <span className="flex items-center gap-1.5 text-xs text-fg3">
             <Loader2 size={12} className="animate-spin" /> Идёт распознавание — дождитесь завершения перед сохранением…

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, Fragment } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Plus, Pencil, Trash2, ShieldCheck, FileText, Search, Globe, ExternalLink, Download, Loader2, ChevronRight, ChevronDown } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -111,10 +112,9 @@ export function QualityDocsPage() {
         <h1 className="text-xl font-semibold text-fg1 flex items-center gap-2">
           <ShieldCheck size={20} className="text-brand" /> Документы качества
         </h1>
-        <button onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
-          <Plus size={16} /> Добавить документ
-        </button>
+        <Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+          Добавить документ
+        </Button>
       </div>
 
       {/* Веб-поиск (ФГИС → производитель → веб) */}
@@ -128,10 +128,10 @@ export function QualityDocsPage() {
             onKeyDown={e => { if (e.key === 'Enter') void handleWebSearch(); }}
             placeholder="Напр.: Выключатель автоматический EKF AV-10"
             className="flex-1 min-w-[260px] border border-stroke-strong rounded-md px-3 py-2 text-sm bg-surface text-fg1" />
-          <button onClick={handleWebSearch} disabled={searching || !webQuery.trim()}
-            className="flex items-center gap-2 px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-            {searching ? <Loader2 size={14} className="animate-spin" /> : <Search size={14} />} Найти
-          </button>
+          <Button variant="filled" onClick={handleWebSearch} disabled={searching || !webQuery.trim()}
+            loading={searching} icon={<Search size={14} />}>
+            Найти
+          </Button>
         </div>
         {searchError && <p className="text-sm text-danger mt-2">{searchError}</p>}
         {candidates && (

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus, KeyRound, Trash2, ShieldCheck, User as UserIcon, Mail } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { SendMessageDialog } from '@/shared/ui/SendMessageDialog';
 import { useAuth, type UserRole } from '@/shared/hooks/useAuth';
@@ -42,14 +43,12 @@ export function UsersPage() {
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-semibold text-fg1">Пользователи</h1>
         <div className="flex items-center gap-2">
-          <button onClick={() => setSendOpen(true)}
-            className="flex items-center gap-2 border border-stroke hover:bg-base text-fg2 text-sm font-medium px-3 py-2 rounded-md transition-colors">
-            <Mail size={15} className="text-brand" /> Отправить сообщение
-          </button>
-          <button onClick={() => setCreateOpen(true)}
-            className="flex items-center gap-2 bg-brand hover:bg-brand-hover text-white text-sm font-medium px-4 py-2 rounded-md transition-colors">
-            <Plus size={16} /> Добавить пользователя
-          </button>
+          <Button variant="tonal" icon={<Mail size={15} />} onClick={() => setSendOpen(true)}>
+            Отправить сообщение
+          </Button>
+          <Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+            Добавить пользователя
+          </Button>
         </div>
       </div>
 
@@ -174,13 +173,11 @@ function CreateUserModal({ open, onClose }: { open: boolean; onClose: () => void
           </select>
         </div>
         {error && <p className="text-sm text-danger">{error}</p>}
-        <div className="flex justify-end gap-3 pt-1">
-          <button type="button" onClick={() => { reset(); onClose(); }}
-            className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-          <button type="submit" disabled={create.isPending}
-            className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-            {create.isPending ? 'Создание...' : 'Создать'}
-          </button>
+        <div className="flex justify-end gap-2 pt-1">
+          <Button type="button" variant="text" onClick={() => { reset(); onClose(); }}>Отмена</Button>
+          <Button type="submit" variant="filled" loading={create.isPending}>
+            {create.isPending ? 'Создание…' : 'Создать'}
+          </Button>
         </div>
       </form>
     </Modal>
@@ -213,13 +210,11 @@ function ResetPasswordModal({ user, onClose }: { user: AppUser | null; onClose: 
         </div>
         {error && <p className="text-sm text-danger">{error}</p>}
         {done && <p className="text-sm text-success">Пароль изменён</p>}
-        <div className="flex justify-end gap-3 pt-1">
-          <button type="button" onClick={onClose}
-            className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-          <button type="submit" disabled={reset.isPending}
-            className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-            {reset.isPending ? 'Сохранение...' : 'Сбросить пароль'}
-          </button>
+        <div className="flex justify-end gap-2 pt-1">
+          <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+          <Button type="submit" variant="filled" loading={reset.isPending}>
+            {reset.isPending ? 'Сохранение…' : 'Сбросить пароль'}
+          </Button>
         </div>
       </form>
     </Modal>

--- a/src/client/src/features/templates/EditorPanel.tsx
+++ b/src/client/src/features/templates/EditorPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
+import { Button } from '@/shared/ui/Button';
 import { BookOpen, Save, Star, CheckCircle } from 'lucide-react';
 import type { Template, DocumentType } from '@/shared/api/types';
 import { resolveEffectiveFields } from '@/shared/api/schema';
@@ -223,11 +224,10 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
           )}
           {savedMsg && <span className="text-xs text-success">Сохранено ✓</span>}
           {error && <span className="text-xs text-danger max-w-xs truncate">{error}</span>}
-          <button onClick={handleSave} disabled={saving}
-            title="Сохранить (Ctrl+S)"
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-brand hover:bg-brand-hover text-white rounded-md transition-colors disabled:opacity-50">
-            <Save size={12} /> {saving ? 'Сохранение...' : 'Сохранить'}
-          </button>
+          <Button variant="filled" size="sm" onClick={handleSave} loading={saving}
+            icon={<Save size={12} />} title="Сохранить (Ctrl+S)">
+            {saving ? 'Сохранение…' : 'Сохранить'}
+          </Button>
         </div>
       </div>
 

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Library } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -52,12 +53,11 @@ function NewTemplateForm({ documentTypeId, docType, allDocTypes, onClose, onCrea
         </p>
         {error && <p className="text-sm text-danger">{error}</p>}
       </div>
-      <div className="shrink-0 px-6 py-3 border-t border-stroke flex justify-end gap-3">
-        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-        <button type="submit" disabled={mutation.isPending}
-          className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-          {mutation.isPending ? 'Создание...' : 'Создать'}
-        </button>
+      <div className="shrink-0 px-6 py-3 border-t border-stroke flex justify-end gap-2">
+        <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+        <Button type="submit" variant="filled" loading={mutation.isPending}>
+          {mutation.isPending ? 'Создание…' : 'Создать'}
+        </Button>
       </div>
     </form>
   );

--- a/src/client/src/features/templates/UserLibPanel.tsx
+++ b/src/client/src/features/templates/UserLibPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
+import { Button } from '@/shared/ui/Button';
 import { Save } from 'lucide-react';
 import { useTypstUserLib, useSaveTypstUserLib } from '@/shared/api/typstUserLib';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
@@ -40,10 +41,10 @@ export function UserLibPanel() {
         <div className="flex items-center gap-2">
           {savedMsg && <span className="text-xs text-success">Сохранено</span>}
           {error && <span className="text-xs text-danger max-w-xs truncate">{error}</span>}
-          <button onClick={handleSave} disabled={saveMutation.isPending}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-brand hover:bg-brand-hover text-white rounded-md transition-colors disabled:opacity-50">
-            <Save size={12} /> {saveMutation.isPending ? 'Сохранение...' : 'Сохранить'}
-          </button>
+          <Button variant="filled" size="sm" onClick={handleSave} loading={saveMutation.isPending}
+            icon={<Save size={12} />}>
+            {saveMutation.isPending ? 'Сохранение…' : 'Сохранить'}
+          </Button>
         </div>
       </div>
       <div className="flex-1 overflow-hidden">

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.4</Version>
+    <Version>0.23.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1b, область 4 — **шаблоны + документы качества + пользователи** (экраны хендоффа 22-25, 17).

## Что сделано
- **Шаблоны** (`EditorPanel`, `UserLibPanel`, `TemplatesPage`): filled «Сохранить»/«Создать» (loading, иконка Save), text «Отмена».
- **Документы качества** (`QualityDocsPage`, `QualityDocForm`): filled «Добавить документ», «Найти» (веб-поиск), «Сохранить»/«Создать» (loading); text «Отмена».
- **Пользователи** (`UsersPage`): **tonal** «Отправить сообщение», filled «Добавить пользователя»/«Создать»/«Сбросить пароль» (loading); text «Отмена».

## Вне охвата
Row-action иконки — общий IconButton-свип. Датасет-панели — отдельно.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed