### PR TITLE
feat(md3): фаза 1b — кнопки в датасет-панелях (#110)

### DIFF
--- a/src/client/src/features/datasets/DataSetsPage.tsx
+++ b/src/client/src/features/datasets/DataSetsPage.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { Button } from '@/shared/ui/Button';
 import { Upload, Trash2, Database, RefreshCw, Download, Layers } from 'lucide-react';
 import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
 import type { DataSetFile } from '@/shared/api/types';
@@ -112,14 +113,10 @@ export function DataSetsPage() {
               className="hidden"
               onChange={handleFileInput}
             />
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading}
-              className="flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-md transition-colors disabled:opacity-40 bg-brand text-white"
-            >
-              <Upload size={14} />
-              {uploading ? 'Загрузка...' : 'Загрузить файл'}
-            </button>
+            <Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
+              loading={uploading} icon={<Upload size={14} />}>
+              {uploading ? 'Загрузка…' : 'Загрузить файл'}
+            </Button>
           </div>
         </div>
 

--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useSetMaterialization, useMaterializePreview } from '@/shared/api/datasets';
 import { MappingEditor } from '@/features/document-sets/editor/DataSetsTab';
@@ -38,12 +39,10 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
     <Modal open onOpenChange={o => { if (!o) onClose(); }} title={`Материализация источника «${source.name}»`} wide
       footer={
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onClose}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">Отмена</button>
-          <button type="button" onClick={handleSave} disabled={save.isPending}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+          <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+          <Button type="button" variant="filled" onClick={handleSave} loading={save.isPending}>
             {save.isPending ? 'Сохранение…' : 'Сохранить'}
-          </button>
+          </Button>
         </div>
       }>
       <div className="space-y-4 min-w-[560px]">

--- a/src/client/src/features/datasets/PdfGroupingEditor.tsx
+++ b/src/client/src/features/datasets/PdfGroupingEditor.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/shared/api/datasets';
 import type { GostGroupingGroup, GostGroupKind } from '@/shared/api/types';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 
 const DEFAULT_CODE = '(без шифра)';
 /** Тэги типа таблицы документа (спецификация / кабельный журнал) — распознаются и выгружаются. */
@@ -476,11 +477,10 @@ export function PdfGroupingEditor() {
               <AlertTriangle size={12} /> {suspiciousOnly ? 'Показать все' : `⚠ ${suspiciousPageCount} подозрительных`}
             </button>
           )}
-          <button onClick={handleSave} disabled={!dirty || applyMutation.isPending}
-            className="flex items-center gap-2 px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors disabled:opacity-50">
-            {applyMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+          <Button variant="filled" onClick={handleSave} disabled={!dirty} loading={applyMutation.isPending}
+            icon={<Save size={14} />}>
             Сохранить
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/client/src/features/datasets/PdfSourceDialog.tsx
+++ b/src/client/src/features/datasets/PdfSourceDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { useCreatePdfSource, useRecognizeFile } from '@/shared/api/datasets';
 import { useTagRegistry, datasetTags } from '@/shared/api/tags';
 
@@ -44,14 +45,10 @@ export function PdfSourceDialog({ fileId, onClose }: { fileId: string; onClose: 
     <Modal open onOpenChange={open => { if (!open) onClose(); }} title="Распознать PDF (профиль)"
       footer={
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onClose}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">
-            Отмена
-          </button>
-          <button type="button" onClick={handleSave} disabled={create.isPending}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+          <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+          <Button type="button" variant="filled" onClick={handleSave} loading={create.isPending}>
             {create.isPending ? 'Создание…' : 'Создать и распознать'}
-          </button>
+          </Button>
         </div>
       }>
       <div className="space-y-4 min-w-[420px]">

--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { useCreateDataSetSource, useUpdateDataSetSource, useListZipXmlEntries, useSourceCandidates } from '@/shared/api/datasets';
 import { XPathBuilder } from './xpath/XPathBuilder';
 import { JsonPathBuilder } from './jsonpath/JsonPathBuilder';
@@ -141,14 +142,10 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
     <Modal open onOpenChange={open => { if (!open) onClose(); }} title={dialogTitle} wide
       footer={
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onClose}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">
-            Отмена
-          </button>
-          <button type="button" onClick={handleSave} disabled={isPending}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+          <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+          <Button type="button" variant="filled" onClick={handleSave} loading={isPending}>
             {isPending ? 'Сохранение…' : 'Сохранить'}
-          </button>
+          </Button>
         </div>
       }>
       <div className="space-y-4 min-w-[520px]">

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/shared/api/datasets';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { RowActionsMenu, type RowAction } from '@/shared/ui/RowActionsMenu';
 import { SourceEditorDialog } from './SourceEditorDialog';
 import { MaterializationDialog } from './MaterializationDialog';
@@ -40,14 +41,11 @@ function SaveAsTemplateDialog({ defaultName, isPending, onSave, onClose }: {
       title="Сохранить как шаблон"
       footer={
         <div className="flex gap-2 justify-end">
-          <button onClick={onClose} disabled={isPending}
-            className="px-3 py-1.5 text-sm rounded-md border border-stroke text-fg2 hover:bg-muted disabled:opacity-50">
-            Отмена
-          </button>
-          <button onClick={() => canSave && onSave(name.trim())} disabled={!canSave}
-            className="px-3 py-1.5 text-sm rounded-md bg-brand text-white disabled:opacity-50">
+          <Button variant="text" size="sm" onClick={onClose} disabled={isPending}>Отмена</Button>
+          <Button variant="filled" size="sm" onClick={() => canSave && onSave(name.trim())}
+            disabled={!canSave} loading={isPending}>
             {isPending ? 'Сохранение…' : 'Сохранить'}
-          </button>
+          </Button>
         </div>
       }>
       <p className="text-xs mb-3 text-fg3">
@@ -215,13 +213,11 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
         <Modal open onOpenChange={o => { if (!o) setRenaming(false); }} title="Переименовать источник"
           footer={
             <div className="flex justify-end gap-2">
-              <button type="button" onClick={() => setRenaming(false)}
-                className="px-4 py-2 rounded-lg text-sm font-medium bg-base text-fg2 hover:bg-muted">Отмена</button>
-              <button type="button" disabled={!renameVal.trim() || renameMutation.isPending}
-                onClick={() => renameMutation.mutateAsync({ id: src.id, name: renameVal.trim() }).then(() => setRenaming(false))}
-                className="px-4 py-2 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover disabled:opacity-50">
+              <Button type="button" variant="text" onClick={() => setRenaming(false)}>Отмена</Button>
+              <Button type="button" variant="filled" disabled={!renameVal.trim()} loading={renameMutation.isPending}
+                onClick={() => renameMutation.mutateAsync({ id: src.id, name: renameVal.trim() }).then(() => setRenaming(false))}>
                 {renameMutation.isPending ? 'Сохранение…' : 'Сохранить'}
-              </button>
+              </Button>
             </div>
           }>
           <div className="min-w-[380px]">

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.5</Version>
+    <Version>0.23.6</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1b, область 5 — **наборы данных** (диалоги источников/материализации/PDF). Завершает **action-кнопки** фазы 1b.

## Что сделано
- Футеры **MaterializationDialog**, **PdfSourceDialog**, **SourceEditorDialog**, **SourcesExpander** (SaveAsTemplate + переименование): text «Отмена» + filled submit (loading).
- **PdfGroupingEditor**: filled «Сохранить» (loading, иконка Save).
- **DataSetsPage**: filled «Загрузить файл» (loading, иконка Upload).

## Вне охвата
Сегмент-переключатели (RowFilterDialog / SortSpecDialog / XPathBuilder) — уйдут в MD3 segmented control. Row-action иконки — общий IconButton-свип.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed

## Статус фазы 1b
Action-кнопки покрыты во всех областях (комплекты, каталог, настройки/типы, шаблоны/качество/пользователи, датасеты). **Дальше:** единый `IconButton`-свип row-action иконок → затем Фаза 2 (контролы форм + Select).