### PR TITLE
feat(md3): фаза 1c — IconButton в каталоге общих данных (#110)

### DIFF
--- a/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
+++ b/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Database, Pencil, Trash2, Plus } from 'lucide-react';
+import { IconButton } from '@/shared/ui/Button';
 import {
   useListDataSetFiles, useAvailableDataSetFiles,
   useCreateDataSetBinding, useUpdateDataSetBinding, useDeleteDataSetBinding, useAutoMapDataSetSource,
@@ -163,13 +164,13 @@ function EntryBindingRow({
             {targetFieldKey && ` · таблица: ${targetFieldKey}`}
           </div>
         </div>
-        <button type="button" onClick={() => setEditing(e => !e)} className="p-1.5 rounded text-xs text-fg3" title="Редактировать маппинг">
+        <IconButton label="Редактировать маппинг" size="sm" onClick={() => setEditing(e => !e)}>
           <Pencil size={13} />
-        </button>
+        </IconButton>
         {!confirming ? (
-          <button type="button" onClick={() => setConfirming(true)} className="p-1.5 rounded text-fg4 hover:text-danger transition-colors" title="Удалить">
+          <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
             <Trash2 size={13} />
-          </button>
+          </IconButton>
         ) : (
           <div className="flex items-center gap-1.5 text-xs">
             <button type="button" onClick={handleDelete} disabled={del.isPending} className="px-2 py-0.5 rounded text-white text-xs bg-danger">Да</button>

--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -1,4 +1,5 @@
 import { Pencil, Trash2, Link2, FileText } from 'lucide-react';
+import { IconButton } from '@/shared/ui/Button';
 import type { CommonDataEntry, DocumentType } from '@/shared/api/types';
 
 // Общие презентационные части списка «объекты по типу» (issue #88) — устраняют дублирование между
@@ -67,14 +68,12 @@ export function ObjectRow({
         <span className="text-xs text-fg4 truncate max-w-xs hidden sm:block">{preview}</span>
       )}
       <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0">
-        <button type="button" onClick={() => onEdit(entry)} title="Редактировать"
-          className={`rounded transition-colors ${dense ? 'p-1 text-stroke-strong hover:text-fg2' : 'p-1.5 text-fg4 hover:text-fg2'}`}>
+        <IconButton label="Редактировать" size="sm" onClick={() => onEdit(entry)}>
           <Pencil size={icon} />
-        </button>
-        <button type="button" onClick={() => onDelete(entry)} disabled={deleteDisabled} title="Удалить"
-          className={`rounded transition-colors disabled:opacity-30 ${dense ? 'p-1 text-stroke-strong hover:text-danger' : 'p-1.5 text-fg4 hover:text-danger'}`}>
+        </IconButton>
+        <IconButton label="Удалить" size="sm" danger onClick={() => onDelete(entry)} disabled={deleteDisabled}>
           <Trash2 size={icon} />
-        </button>
+        </IconButton>
       </div>
     </div>
   );

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.7</Version>
+    <Version>0.23.8</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1c (IconButton-свип), область — **Каталог общих данных**.

## Что сделано
- **`ObjectRow`** (`ObjectsByTypeList`, используется и в `ScopedCatalogPanel`, и в системном каталоге): правка / удаление записи → `IconButton`.
- **`EntryDataSetBindings`**: правка маппинга / удаление привязки → `IconButton` (inline-confirm Да/Нет оставлен).

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed