### PR TITLE
feat(md3): фаза 1c — IconButton в настройках/типах (#110)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -5,7 +5,7 @@ import {
 } from 'lucide-react';
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { apiError } from '@/shared/utils/apiError';
 import {
@@ -717,11 +717,11 @@ function TypeRow({ docType, allDocTypes, allGroups, expanded, onToggle }: {
           <GroupPicker groups={allGroups} value={docType.group}
             onChange={group => groupMutation.mutate({ id: docType.id, group })} />
         </span>
-        <button onClick={handleDelete} disabled={deleteMutation.isPending}
-          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
+        <IconButton label="Удалить" size="sm" danger onClick={handleDelete} disabled={deleteMutation.isPending}
+          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
           title={hasChildren ? 'Нельзя удалить: есть дочерние типы' : 'Удалить'}>
           <Trash2 size={14} />
-        </button>
+        </IconButton>
       </div>
       {expanded && (
         <div className="px-4 pb-5 pt-3 border-t border-stroke bg-base">

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
 import {
   useListEnumTypes,
   useCreateEnumType,
@@ -196,11 +196,10 @@ function EnumTypeRow({ type, allGroups, expanded, onToggle }: {
           <GroupPicker groups={allGroups} value={type.group}
             onChange={group => groupMutation.mutate({ id: type.id, group })} />
         </span>
-        <button onClick={handleDelete} disabled={deleteMutation.isPending}
-          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
-          title="Удалить">
+        <IconButton label="Удалить" size="sm" danger onClick={handleDelete} disabled={deleteMutation.isPending}
+          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
           <Trash2 size={14} />
-        </button>
+        </IconButton>
       </div>
       {expanded && (
         <div className="px-4 pb-5 pt-3 border-t border-stroke bg-base">

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
 import { DateInput } from '@/shared/ui/DateInput';
 import {
   useListPrimitiveTypes,
@@ -394,11 +394,10 @@ function FieldTypeRow({ type, allGroups, expanded, onToggle }: {
           <GroupPicker groups={allGroups} value={type.group}
             onChange={group => groupMutation.mutate({ id: type.id, group })} />
         </span>
-        <button onClick={handleDelete} disabled={deleteMutation.isPending}
-          className="px-3 py-3 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all disabled:opacity-30"
-          title="Удалить">
+        <IconButton label="Удалить" size="sm" danger onClick={handleDelete} disabled={deleteMutation.isPending}
+          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
           <Trash2 size={14} />
-        </button>
+        </IconButton>
       </div>
       {expanded && (
         <div className="px-4 pb-5 pt-3 border-t border-stroke bg-base">

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Plus, KeyRound, Trash2, ShieldCheck, User as UserIcon, Mail } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { SendMessageDialog } from '@/shared/ui/SendMessageDialog';
 import { useAuth, type UserRole } from '@/shared/hooks/useAuth';
@@ -93,11 +93,14 @@ export function UsersPage() {
                     </td>
                     <td className="px-4 py-2.5">
                       <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                        <button onClick={() => setResetFor(u)} title="Сбросить пароль"
-                          className="p-1.5 text-fg4 hover:text-brand rounded"><KeyRound size={14} /></button>
-                        <button onClick={() => setDeleteTarget(u)} disabled={isSelf || del.isPending}
-                          title={isSelf ? 'Нельзя удалить себя' : 'Удалить'}
-                          className="p-1.5 text-fg4 hover:text-danger rounded disabled:opacity-30 disabled:hover:text-fg4"><Trash2 size={14} /></button>
+                        <IconButton label="Сбросить пароль" size="sm" onClick={() => setResetFor(u)}>
+                          <KeyRound size={14} />
+                        </IconButton>
+                        <IconButton label="Удалить" size="sm" danger onClick={() => setDeleteTarget(u)}
+                          disabled={isSelf || del.isPending}
+                          title={isSelf ? 'Нельзя удалить себя' : 'Удалить'}>
+                          <Trash2 size={14} />
+                        </IconButton>
                       </div>
                     </td>
                   </tr>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.8</Version>
+    <Version>0.23.9</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1c (IconButton-свип), область — **Настройка системы / типы**.

## Что сделано
- Удаление строки типа → `IconButton` (danger, hover-reveal): `DocumentTypesPage`, `EnumTypesSection`, `PrimitiveTypesPage`.
- **`UsersPage`**: сброс пароля / удаление пользователя → `IconButton`.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed