### PR TITLE
feat(md3): фаза 1c — IconButton в шаблонах и качестве (#110)

### DIFF
--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, Fragment } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Plus, Pencil, Trash2, ShieldCheck, FileText, Search, Globe, ExternalLink, Download, Loader2, ChevronRight, ChevronDown } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -222,14 +222,13 @@ export function QualityDocsPage() {
                         </td>
                         <td className="px-4 py-2.5">
                           <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                            <button onClick={() => setEditDoc(d)} className="p-1.5 text-fg4 hover:text-fg2 rounded" title="Редактировать">
+                            <IconButton label="Редактировать" size="sm" onClick={() => setEditDoc(d)}>
                               <Pencil size={14} />
-                            </button>
-                            <button onClick={() => setDeleteTarget(d)}
-                              disabled={del.isPending}
-                              className="p-1.5 text-fg4 hover:text-danger rounded disabled:opacity-40" title="Удалить">
+                            </IconButton>
+                            <IconButton label="Удалить" size="sm" danger onClick={() => setDeleteTarget(d)}
+                              disabled={del.isPending}>
                               <Trash2 size={14} />
-                            </button>
+                            </IconButton>
                           </div>
                         </td>
                       </tr>

--- a/src/client/src/features/templates/TemplateAssetsPanel.tsx
+++ b/src/client/src/features/templates/TemplateAssetsPanel.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { ChevronDown, ChevronUp, Image as ImageIcon, Type as FontIcon, Upload, RefreshCw, Trash2 } from 'lucide-react';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { IconButton } from '@/shared/ui/Button';
 import {
   useListTemplateAssets, useUploadTemplateAsset, useReplaceTemplateAsset, useDeleteTemplateAsset,
   type TemplateAssetDto, type TemplateAssetScope,
@@ -41,18 +42,16 @@ function AssetRow({ asset }: { asset: TemplateAssetDto }) {
         {asset.fileName}{asset.fontFamilyName ? ` — ${asset.fontFamilyName}` : ''}
       </span>
       {error && <span className="text-xs text-danger shrink-0">{error}</span>}
-      <button type="button" onClick={() => replaceInputRef.current?.click()}
+      <IconButton label="Заменить файл" size="sm" onClick={() => replaceInputRef.current?.click()}
         disabled={replaceMutation.isPending}
-        title="Заменить файл"
-        className="p-1 text-fg4 hover:text-brand opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all shrink-0 disabled:opacity-30">
+        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 shrink-0">
         <RefreshCw size={12} />
-      </button>
+      </IconButton>
       <input ref={replaceInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleReplace} />
-      <button type="button" onClick={() => setConfirmDelete(true)}
-        title="Удалить"
-        className="p-1 text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all shrink-0">
+      <IconButton label="Удалить" size="sm" danger onClick={() => setConfirmDelete(true)}
+        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 shrink-0">
         <Trash2 size={12} />
-      </button>
+      </IconButton>
       <ConfirmDialog
         open={confirmDelete}
         onOpenChange={setConfirmDelete}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.9</Version>
+    <Version>0.23.10</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1c (IconButton-свип), область — **шаблоны + документы качества**.

## Что сделано
- **`TemplateAssetsPanel`**: заменить файл / удалить ассет → `IconButton`.
- **`QualityDocsPage`**: правка / удаление документа качества → `IconButton`.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed

Осталось в свипе: датасеты (SourcesExpander / ProcessingTemplatesDialog / DataSetsPage row-icons) — последняя область, затем Фаза 2.