### PR TITLE
feat(md3): фаза 1c — IconButton в датасет-панелях (#110)

### DIFF
--- a/src/client/src/features/datasets/DataSetsPage.tsx
+++ b/src/client/src/features/datasets/DataSetsPage.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
 import { Upload, Trash2, Database, RefreshCw, Download, Layers } from 'lucide-react';
 import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
 import type { DataSetFile } from '@/shared/api/types';
@@ -24,29 +24,16 @@ function FileRow({ file }: { file: DataSetFile }) {
           <div className="text-xs mt-0.5 text-fg4">{DATA_SET_FORMAT_LABELS[file.format]}</div>
         </div>
         <input ref={updateInputRef} type="file" accept=".csv,.txt,.xlsx,.xls,.xml,.json,.zip,.gsfx,.pdf" className="hidden" onChange={handleReplace} />
-        <button
-          onClick={handleDownload}
-          disabled={downloading}
-          className="p-1.5 rounded transition-colors disabled:opacity-40 text-fg4 hover:text-brand"
-          title="Скачать оригинальный файл"
-        >
+        <IconButton label="Скачать оригинальный файл" size="sm" onClick={handleDownload} disabled={downloading}>
           <Download size={14} className={downloading ? 'opacity-50' : ''} />
-        </button>
-        <button
-          onClick={() => updateInputRef.current?.click()}
-          disabled={update.isPending}
-          className="p-1.5 rounded transition-colors disabled:opacity-40 text-fg4 hover:text-brand"
-          title="Обновить файл (привязки сохранятся)"
-        >
+        </IconButton>
+        <IconButton label="Обновить файл (привязки сохранятся)" size="sm"
+          onClick={() => updateInputRef.current?.click()} disabled={update.isPending}>
           <RefreshCw size={14} className={update.isPending ? 'animate-spin' : ''} />
-        </button>
-        <button
-          onClick={() => setConfirming(true)}
-          className="p-1.5 rounded transition-colors text-fg4 hover:text-danger"
-          title="Удалить"
-        >
+        </IconButton>
+        <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
           <Trash2 size={14} />
-        </button>
+        </IconButton>
       </div>
       <div className="pl-7">
         <SourcesExpander file={file} />

--- a/src/client/src/features/datasets/ProcessingTemplatesDialog.tsx
+++ b/src/client/src/features/datasets/ProcessingTemplatesDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus, Trash2, Pencil, Check, Layers, Filter, FunctionSquare, ArrowUpDown, Route } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { IconButton } from '@/shared/ui/Button';
 import {
   useListProcessingTemplates, useCreateProcessingTemplate,
   useUpdateProcessingTemplate, useDeleteProcessingTemplate,
@@ -221,13 +222,13 @@ function TemplateRow({ template }: { template: DataSetProcessingTemplate }) {
             )}
           </div>
         </div>
-        <button onClick={() => setEditing(e => !e)} className="p-1.5 rounded text-fg3" title="Редактировать">
+        <IconButton label="Редактировать" size="sm" onClick={() => setEditing(e => !e)}>
           <Pencil size={13} />
-        </button>
+        </IconButton>
         {!confirming ? (
-          <button onClick={() => setConfirming(true)} className="p-1.5 rounded text-fg4 hover:text-danger transition-colors" title="Удалить">
+          <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
             <Trash2 size={13} />
-          </button>
+          </IconButton>
         ) : (
           <div className="flex items-center gap-1.5 text-xs">
             <span className="text-fg3">Удалить?</span>

--- a/src/client/src/features/datasets/ScopedDataSetsPanel.tsx
+++ b/src/client/src/features/datasets/ScopedDataSetsPanel.tsx
@@ -10,6 +10,7 @@ import { SCOPE_COLORS } from '@/features/document-sets/fields/constants';
 import { SourcesExpander } from './SourcesExpander';
 import { useDataSetFileActions } from './useDataSetFileActions';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { IconButton } from '@/shared/ui/Button';
 
 function FileRow({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogScope; scopeId?: string }) {
   const {
@@ -26,29 +27,16 @@ function FileRow({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogSc
           <span className="ml-2 text-xs text-fg4">{DATA_SET_FORMAT_LABELS[file.format]}</span>
         </div>
         <input ref={updateInputRef} type="file" accept=".csv,.txt,.xlsx,.xls,.xml,.json,.zip,.gsfx,.pdf" className="hidden" onChange={handleReplace} />
-        <button
-          onClick={handleDownload}
-          disabled={downloading}
-          className="p-1 rounded transition-colors disabled:opacity-40 text-fg4 hover:text-brand"
-          title="Скачать оригинальный файл"
-        >
+        <IconButton label="Скачать оригинальный файл" size="sm" onClick={handleDownload} disabled={downloading}>
           <Download size={13} className={downloading ? 'opacity-50' : ''} />
-        </button>
-        <button
-          onClick={() => updateInputRef.current?.click()}
-          disabled={update.isPending}
-          className="p-1 rounded transition-colors disabled:opacity-40 text-fg4 hover:text-brand"
-          title="Обновить файл (привязки сохранятся)"
-        >
+        </IconButton>
+        <IconButton label="Обновить файл (привязки сохранятся)" size="sm"
+          onClick={() => updateInputRef.current?.click()} disabled={update.isPending}>
           <RefreshCw size={13} className={update.isPending ? 'animate-spin' : ''} />
-        </button>
-        <button
-          onClick={() => setConfirming(true)}
-          className="p-1 rounded transition-colors text-fg4 hover:text-danger"
-          title="Удалить"
-        >
+        </IconButton>
+        <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
           <Trash2 size={13} />
-        </button>
+        </IconButton>
       </div>
       <div className="pl-5">
         <SourcesExpander file={file} maxColumns={6} />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.10</Version>
+    <Version>0.23.11</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1c (IconButton-свип), **последняя область — наборы данных**.

## Что сделано
- `ScopedDataSetsPanel`, `DataSetsPage` (строка файла): скачать / обновить / удалить → `IconButton`.
- `ProcessingTemplatesDialog` (строка шаблона): правка / удаление → `IconButton`.

## Вне охвата (осознанно)
Плотные builder-контролы (условия фильтра, строки сортировки, computed-колонки, миниатюры страниц PDF) — field-level элементы в плотных редакторах, не под 32px круглый таргет; оставлены.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed

## Итог IconButton-свипа
Покрыты row-action иконки во всех областях (комплекты, каталог, настройки/типы, шаблоны/качество, датасеты). **Фаза 1 (кнопки) завершена.** Дальше — **Фаза 2** (контролы форм + Select).