### PR TITLE
feat(md3): фаза 2a — MD3 Select (Radix) + первые адопции (#110)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -2,6 +2,10 @@ import { useState } from 'react';
 import { Plus, Search, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
+
+/** Sentinel для «Все типы» — Radix Select запрещает пустую строку как value. */
+const ALL_TYPES = '__all__';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useListCommonData, useDeleteCommonDataEntry } from '@/shared/api/commonData';
@@ -65,20 +69,21 @@ export function SystemCommonDataPage() {
             className="w-full border border-stroke-strong rounded-md pl-9 pr-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
         </div>
         {allSelectableTypes.length > 0 && (
-          <select value={filterTypeId} onChange={e => setFilterTypeId(e.target.value)}
-            className="border border-stroke-strong rounded-md px-3 py-2 text-sm text-fg1 bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-            <option value="">Все типы</option>
+          <Select value={filterTypeId || ALL_TYPES}
+            onValueChange={v => setFilterTypeId(v === ALL_TYPES ? '' : v)}
+            aria-label="Фильтр по типу" className="w-56">
+            <SelectItem value={ALL_TYPES}>Все типы</SelectItem>
             {compositeTypes.length > 0 && (
-              <optgroup label="Составные типы">
-                {compositeTypes.map(ct => <option key={ct.id} value={ct.id}>{ct.name}</option>)}
-              </optgroup>
+              <SelectGroup label="Составные типы">
+                {compositeTypes.map(ct => <SelectItem key={ct.id} value={ct.id}>{ct.name}</SelectItem>)}
+              </SelectGroup>
             )}
             {documentTypes.length > 0 && (
-              <optgroup label="Типы документов">
-                {documentTypes.map(dt => <option key={dt.id} value={dt.id}>{dt.name}</option>)}
-              </optgroup>
+              <SelectGroup label="Типы документов">
+                {documentTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>)}
+              </SelectGroup>
             )}
-          </select>
+          </Select>
         )}
       </div>
 

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -281,11 +282,10 @@ function SetDetail() {
           <form id="add-doc-form" onSubmit={handleAddDoc} className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-fg2 mb-1">Тип документа</label>
-              <select value={addTypeId} onChange={e => setAddTypeId(e.target.value)} required
-                className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-                <option value="">Выберите тип...</option>
-                {documentKindTypes.map(dt => <option key={dt.id} value={dt.id}>{dt.name}</option>)}
-              </select>
+              <Select value={addTypeId || undefined} onValueChange={setAddTypeId} required
+                placeholder="Выберите тип…" aria-label="Тип документа">
+                {documentKindTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>)}
+              </Select>
             </div>
             {addError && <p className="text-sm text-danger">{addError}</p>}
           </form>

--- a/src/client/src/shared/ui/Select.tsx
+++ b/src/client/src/shared/ui/Select.tsx
@@ -1,0 +1,82 @@
+import * as RS from '@radix-ui/react-select';
+import { Check, ChevronDown } from 'lucide-react';
+import { forwardRef, type ReactNode } from 'react';
+
+/**
+ * MD3-Select (issue #110, фаза 2) поверх Radix Select — замена нативному `<select>`
+ * (дефект «смесь нативных и кастомных контролов» из хендоффа). Radix даёт полный
+ * APG-listbox с клавиатуры (стрелки/Home/End/typeahead/Esc) — закрывает #107 F5.
+ * Outlined-поле в стиле MD3, кольцо фокуса, тема light/dark через токены.
+ *
+ * ВНИМАНИЕ: Radix запрещает пустую строку как value у Item. Для «пусто/все» используйте
+ * placeholder (не передавайте value) либо отдельный Item с непустым sentinel-значением.
+ */
+export interface SelectProps {
+  value: string | undefined;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  /** Для участия в форме (валидация required через скрытый нативный select у Radix). */
+  required?: boolean;
+  name?: string;
+  /** Класс триггера (например ширина). */
+  className?: string;
+  /** Доступная подпись, если рядом нет <label>. */
+  'aria-label'?: string;
+  children: ReactNode;
+}
+
+const TRIGGER =
+  'inline-flex items-center justify-between gap-2 w-full h-9 px-3 rounded-md border border-stroke-strong ' +
+  'bg-surface text-sm text-fg1 transition-colors data-[placeholder]:text-fg4 ' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand data-[state=open]:ring-2 ' +
+  'data-[state=open]:ring-brand disabled:opacity-50 disabled:pointer-events-none';
+
+export function Select({
+  value, onValueChange, placeholder, disabled, required, name, className = '', children, ...aria
+}: SelectProps) {
+  return (
+    <RS.Root value={value} onValueChange={onValueChange} disabled={disabled} required={required} name={name}>
+      <RS.Trigger className={`${TRIGGER} ${className}`} aria-label={aria['aria-label']}>
+        <RS.Value placeholder={placeholder} />
+        <RS.Icon className="text-fg4 shrink-0"><ChevronDown size={15} /></RS.Icon>
+      </RS.Trigger>
+      <RS.Portal>
+        <RS.Content position="popper" sideOffset={4}
+          className="z-50 min-w-[var(--radix-select-trigger-width)] max-h-[var(--radix-select-content-available-height)] overflow-hidden rounded-md border border-stroke bg-surface shadow-[var(--f-shadow16)]">
+          <RS.Viewport className="p-1">
+            {children}
+          </RS.Viewport>
+        </RS.Content>
+      </RS.Portal>
+    </RS.Root>
+  );
+}
+
+const ITEM =
+  'relative flex items-center gap-2 pl-3 pr-8 py-1.5 rounded text-sm text-fg1 select-none cursor-pointer ' +
+  'outline-none data-[highlighted]:bg-brand-subtle data-[highlighted]:text-brand-hover ' +
+  'data-[state=checked]:font-medium data-[disabled]:opacity-40 data-[disabled]:pointer-events-none';
+
+export const SelectItem = forwardRef<HTMLDivElement, { value: string; disabled?: boolean; children: ReactNode; className?: string }>(
+  function SelectItem({ value, disabled, children, className = '' }, ref) {
+    return (
+      <RS.Item ref={ref} value={value} disabled={disabled} className={`${ITEM} ${className}`}>
+        <RS.ItemText>{children}</RS.ItemText>
+        <RS.ItemIndicator className="absolute right-2 inline-flex text-brand">
+          <Check size={14} />
+        </RS.ItemIndicator>
+      </RS.Item>
+    );
+  },
+);
+
+/** Группа опций (аналог <optgroup>). */
+export function SelectGroup({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <RS.Group>
+      <RS.Label className="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-fg4">{label}</RS.Label>
+      {children}
+    </RS.Group>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.11</Version>
+    <Version>0.23.12</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2 рестайла MD3 (#110) — **контролы форм**. Часть 2a: новый `Select` + первые адопции.

## Новый `shared/ui/Select` (поверх Radix Select)
Замена нативному `<select>` — устраняет дефект хендоффа «смесь нативных и кастомных контролов».
- **Полный APG-listbox с клавиатуры** (стрелки / Home / End / typeahead / Esc) → закрывает **#107 F5**.
- Outlined-поле MD3, кольцо фокуса, тема light/dark через токены.
- `required` / `name` — участие в форме (Radix рендерит скрытый нативный select для валидации).
- `SelectItem` + `SelectGroup` (аналог `<optgroup>`).
- ⚠️ Radix запрещает пустую строку как value → для «Все/пусто» использовать placeholder или sentinel.

## Адопция (первые)
- `DocumentSetsPage` — выбор типа документа (`required`, placeholder).
- `SystemCommonDataPage` — фильтр по типу (sentinel `__all__` для «Все типы», с группами).

## Вне охвата
Остальные нативные `<select>` (~18 файлов) — следующими PR по областям.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- Живой фронт (Vite) на ветке — Select работает с клавиатуры

## Дальше
Адопция Select по областям; затем при желании MD3-TextField (outlined + плавающая подпись) как под-фаза 2b.