### PR TITLE
feat(md3): фаза 2b — адопция MD3 Select в формах (#110)

### DIFF
--- a/src/client/src/features/document-sets/SubscribersPanel.tsx
+++ b/src/client/src/features/document-sets/SubscribersPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Users, ChevronDown, ChevronRight, Trash2, Mail, Plus, AlertTriangle } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { useListUsers } from '@/shared/api/users';
 import {
   useSubscribers, useRecipients, useAddSubscriber, useRemoveSubscriber, type SubscriptionScope,
@@ -87,11 +88,10 @@ export function SubscribersPanel({ scope, scopeId }: { scope: SubscriptionScope;
 
           {isAdmin && (
             <div className="flex items-center gap-2">
-              <select value={addUserId} onChange={e => setAddUserId(e.target.value)}
-                className="flex-1 border border-stroke-strong rounded-md px-2 py-1.5 text-sm bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-                <option value="">Добавить подписчика…</option>
-                {available.map(u => <option key={u.id} value={u.id}>{u.displayName || u.email}</option>)}
-              </select>
+              <Select value={addUserId || undefined} onValueChange={setAddUserId}
+                placeholder="Добавить подписчика…" aria-label="Подписчик" className="flex-1">
+                {available.map(u => <SelectItem key={u.id} value={u.id}>{u.displayName || u.email}</SelectItem>)}
+              </Select>
               <button onClick={handleAdd} disabled={!addUserId || add.isPending}
                 className="flex items-center gap-1 text-sm px-3 py-1.5 border border-stroke-strong rounded-md hover:bg-base transition-colors disabled:opacity-50">
                 <Plus size={13} /> Добавить

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { Loader2, ShieldCheck, Upload, Eye } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import {
   useCreateQualityDoc, useUpdateQualityDoc, useSetQualityDocScan, recognizeDocument,
   type QualityDocument, type RecognitionFieldReq,
@@ -159,10 +160,10 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className="block text-xs font-medium text-fg2 mb-1">Тип документа</label>
-          <select value={typeId} onChange={e => setTypeId(e.target.value)}
-            className="w-full border border-stroke-strong rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
-            {qualityTypes.map(dt => <option key={dt.id} value={dt.id}>{dt.name}</option>)}
-          </select>
+          <Select value={typeId || undefined} onValueChange={setTypeId}
+            placeholder="Выберите тип…" aria-label="Тип документа">
+            {qualityTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>)}
+          </Select>
         </div>
         <div>
           <label className="block text-xs font-medium text-fg2 mb-1">Название в библиотеке</label>

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Plus, Pencil, Trash2, ShieldCheck, FileText, Search, Globe, ExternalLink, Download, Loader2, ChevronRight, ChevronDown } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -168,11 +169,11 @@ export function QualityDocsPage() {
           <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск по названию..."
             className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />
         </div>
-        <select value={scopeFilter} onChange={e => setScopeFilter(e.target.value as 'all' | 'System')}
-          className="border border-stroke-strong rounded-md px-2 py-2 text-sm bg-surface text-fg1">
-          <option value="all">Все области</option>
-          <option value="System">Только общие (System)</option>
-        </select>
+        <Select value={scopeFilter} onValueChange={v => setScopeFilter(v as 'all' | 'System')}
+          aria-label="Область" className="w-48">
+          <SelectItem value="all">Все области</SelectItem>
+          <SelectItem value="System">Только общие (System)</SelectItem>
+        </Select>
       </div>
 
       <div className="border border-stroke rounded-lg overflow-hidden bg-surface">

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Plus, KeyRound, Trash2, ShieldCheck, User as UserIcon, Mail } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { SendMessageDialog } from '@/shared/ui/SendMessageDialog';
 import { useAuth, type UserRole } from '@/shared/hooks/useAuth';
@@ -84,12 +85,11 @@ export function UsersPage() {
                       {rowError?.id === u.id && <div className="text-xs text-danger mt-1">{rowError.msg}</div>}
                     </td>
                     <td className="px-4 py-2.5">
-                      <select value={u.role} onChange={e => onRoleChange(u, e.target.value as UserRole)}
-                        disabled={changeRole.isPending}
-                        className="border border-stroke-strong rounded-md px-2 py-1.5 text-sm bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-                        <option value="Admin">Администратор</option>
-                        <option value="User">Пользователь</option>
-                      </select>
+                      <Select value={u.role} onValueChange={v => onRoleChange(u, v as UserRole)}
+                        disabled={changeRole.isPending} aria-label="Роль" className="w-44">
+                        <SelectItem value="Admin">Администратор</SelectItem>
+                        <SelectItem value="User">Пользователь</SelectItem>
+                      </Select>
                     </td>
                     <td className="px-4 py-2.5">
                       <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
@@ -169,11 +169,10 @@ function CreateUserModal({ open, onClose }: { open: boolean; onClose: () => void
         </div>
         <div>
           <label className="block text-sm font-medium text-fg2 mb-1">Роль</label>
-          <select value={role} onChange={e => setRole(e.target.value as UserRole)}
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-            <option value="User">Пользователь — только документы и данные</option>
-            <option value="Admin">Администратор — полный доступ</option>
-          </select>
+          <Select value={role} onValueChange={v => setRole(v as UserRole)} aria-label="Роль">
+            <SelectItem value="User">Пользователь — только документы и данные</SelectItem>
+            <SelectItem value="Admin">Администратор — полный доступ</SelectItem>
+          </Select>
         </div>
         {error && <p className="text-sm text-danger">{error}</p>}
         <div className="flex justify-end gap-2 pt-1">

--- a/src/client/src/features/templates/TemplateSidebar.tsx
+++ b/src/client/src/features/templates/TemplateSidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Plus, Trash2, Star, ChevronDown, ChevronUp, AlertTriangle, Copy } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import type { Template, DocumentType } from '@/shared/api/types';
 import { useDeleteTemplate } from '@/shared/api/templates';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
@@ -137,13 +138,12 @@ export function DocTypeSelector({ docTypes, selected, onSelect }: {
 }) {
   const nonAbstractDocs = docTypes.filter(dt => dt.kind === 'Document' && !dt.isAbstract);
   return (
-    <select value={selected} onChange={(e) => onSelect(e.target.value)}
-      className="border border-stroke-strong rounded-md px-3 py-2 text-sm text-fg1 bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
-      <option value="">Выберите тип документа</option>
+    <Select value={selected || undefined} onValueChange={onSelect}
+      placeholder="Выберите тип документа" aria-label="Тип документа" className="w-56">
       {nonAbstractDocs.map((dt) => (
-        <option key={dt.id} value={dt.id}>{dt.name}</option>
+        <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>
       ))}
-    </select>
+    </Select>
   );
 }
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.12</Version>
+    <Version>0.23.13</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2b (#110) — адопция `Select` в форменных `<select>`.

## Что сделано
Нативные `<select>` → MD3 `Select` (APG-клавиатура):
- **`UsersPage`** — роль (строка таблицы + форма создания);
- **`QualityDocForm`** — тип документа; **`QualityDocsPage`** — фильтр области;
- **`SubscribersPanel`** — добавление подписчика (placeholder);
- **`TemplateSidebar`** — выбор типа документа (placeholder).

## Вне охвата (следующими PR)
- Parent-type селекты (`DocumentTypesPage`) — с пустым sentinel «— без родителя —».
- Плотные cell/builder-селекты: `PrimitiveInput` (enum-поле/ячейка), `ComplexFields`-ячейки, `FieldBuilder`, `XPathBuilder`, `PasteMappingModal`, `PdfGroupingEditor`, dataset-диалоги (`Materialization`/`PdfSource`/`SourceEditor`) — требуют аккуратности (плотность/ячейки таблиц).

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed