### PR TITLE
feat(md3): фаза 2c — MD3 Select в типах и PDF-диалогах (#110)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
+
+/** Sentinel для «— не материализовать —» — Radix Select запрещает пустую строку. */
+const NO_TYPE = '__none__';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useSetMaterialization, useMaterializePreview } from '@/shared/api/datasets';
 import { MappingEditor } from '@/features/document-sets/editor/DataSetsTab';
@@ -53,13 +57,13 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
 
         <div>
           <label className="block text-sm font-medium text-fg1 mb-1">Тип для материализации</label>
-          <select value={typeId} onChange={e => { setTypeId(e.target.value); setMapping({}); setShowPreview(false); }}
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm">
-            <option value="">— не материализовать —</option>
+          <Select value={typeId || NO_TYPE} aria-label="Тип для материализации"
+            onValueChange={v => { setTypeId(v === NO_TYPE ? '' : v); setMapping({}); setShowPreview(false); }}>
+            <SelectItem value={NO_TYPE}>— не материализовать —</SelectItem>
             {allDocTypes.filter(t => !t.isAbstract).map(t => (
-              <option key={t.id} value={t.id}>{t.name} ({t.kind === 'Composite' ? 'составной' : 'документ'})</option>
+              <SelectItem key={t.id} value={t.id}>{t.name} ({t.kind === 'Composite' ? 'составной' : 'документ'})</SelectItem>
             ))}
-          </select>
+          </Select>
         </div>
 
         {selectedType && (

--- a/src/client/src/features/datasets/PdfSourceDialog.tsx
+++ b/src/client/src/features/datasets/PdfSourceDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { useCreatePdfSource, useRecognizeFile } from '@/shared/api/datasets';
 import { useTagRegistry, datasetTags } from '@/shared/api/tags';
 
@@ -61,11 +62,11 @@ export function PdfSourceDialog({ fileId, onClose }: { fileId: string; onClose: 
 
         <div>
           <label className="block text-sm font-medium text-fg1 mb-1">Профиль распознавания</label>
-          <select value={profile} onChange={e => setProfile(e.target.value as 'gost-titleblock' | 'invoice')}
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm">
-            <option value="gost-titleblock">Основная надпись (ГОСТ Р 21.101-2020) — реестр по страницам</option>
-            <option value="invoice">Счёт на оплату — шапка + таблица товаров</option>
-          </select>
+          <Select value={profile} onValueChange={v => setProfile(v as 'gost-titleblock' | 'invoice')}
+            aria-label="Профиль распознавания">
+            <SelectItem value="gost-titleblock">Основная надпись (ГОСТ Р 21.101-2020) — реестр по страницам</SelectItem>
+            <SelectItem value="invoice">Счёт на оплату — шапка + таблица товаров</SelectItem>
+          </Select>
         </div>
 
         {profile === 'gost-titleblock' && datasetTags(allTags).length > 0 && (

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -6,6 +6,7 @@ import {
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { apiError } from '@/shared/utils/apiError';
 import {
@@ -35,6 +36,9 @@ import { schemaToJson, validateFields, TYPE_LABELS, toCamelKey } from './schemaC
 import { useTagRegistry, typeTags as typeTagDefs } from '@/shared/api/tags';
 import { GroupEditor } from './GroupEditor';
 import { JsonPreview, FieldBuilder, DefaultValueCell } from './FieldBuilder';
+
+/** Sentinel для «— без родителя —» — Radix Select запрещает пустую строку как value. */
+const NO_PARENT = '__none__';
 
 function InheritedFieldsPanel({
   parentEffectiveFields, excludedFields, fieldOverrides, compositeTypes, enumTypes,
@@ -210,13 +214,13 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
       </div>
       <div>
         <label className="block text-xs font-medium text-fg2 mb-1">Родительский тип</label>
-        <select value={parentId} onChange={e => { setParentId(e.target.value); setSaved(false); }}
-          className="w-full border border-stroke-strong rounded-md px-3 py-1.5 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface">
-          <option value="">— без родителя —</option>
+        <Select value={parentId || NO_PARENT} aria-label="Родительский тип"
+          onValueChange={v => { setParentId(v === NO_PARENT ? '' : v); setSaved(false); }}>
+          <SelectItem value={NO_PARENT}>— без родителя —</SelectItem>
           {eligibleParents.map(dt => (
-            <option key={dt.id} value={dt.id}>{dt.name} ({dt.code})</option>
+            <SelectItem key={dt.id} value={dt.id}>{dt.name} ({dt.code})</SelectItem>
           ))}
-        </select>
+        </Select>
       </div>
       {error && <p className="text-xs text-danger">{error}</p>}
       <div className="flex items-center gap-3">
@@ -312,13 +316,13 @@ function CreateForm({
           <label className="block text-sm font-medium text-fg2 mb-1">
             Родительский тип (наследование)
           </label>
-          <select value={parentId} onChange={e => setParentId(e.target.value)}
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface">
-            <option value="">— без родителя —</option>
+          <Select value={parentId || NO_PARENT} aria-label="Родительский тип"
+            onValueChange={v => setParentId(v === NO_PARENT ? '' : v)}>
+            <SelectItem value={NO_PARENT}>— без родителя —</SelectItem>
             {sameKindTypes.map(dt => (
-              <option key={dt.id} value={dt.id}>{dt.name} ({dt.code})</option>
+              <SelectItem key={dt.id} value={dt.id}>{dt.name} ({dt.code})</SelectItem>
             ))}
-          </select>
+          </Select>
         </div>
       )}
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.13</Version>
+    <Version>0.23.14</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2c (#110) — продолжение адопции `Select`.

## Что сделано
- **`DocumentTypesPage`** — родительский тип (×2, sentinel `__none__` для «— без родителя —»).
- **`MaterializationDialog`** — тип материализации (sentinel «— не материализовать —»).
- **`PdfSourceDialog`** — профиль распознавания.

## Осталось (финальный батч)
- `SourceEditorDialog` — 3 динамических select (лист/XML-файл/кандидат), placeholder-based.
- Плотные cell/builder-select: `PrimitiveInput` (enum — поле и ячейка таблицы, самый важный), `ComplexFields`-ячейки, `FieldBuilder`, `XPathBuilder`, `PasteMappingModal`, `PdfGroupingEditor`, `TemplateParamsPanel` — требуют аккуратности с плотностью/выравниванием в ячейках.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed