### PR TITLE
feat(md3): фаза 2d — MD3 Select для enum-полей и остальных форм (#110)

### DIFF
--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { useCreateDataSetSource, useUpdateDataSetSource, useListZipXmlEntries, useSourceCandidates } from '@/shared/api/datasets';
 import { XPathBuilder } from './xpath/XPathBuilder';
 import { JsonPathBuilder } from './jsonpath/JsonPathBuilder';
@@ -159,13 +160,12 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
         {isPdf ? (
           <div>
             <label className="block text-sm font-medium text-fg1 mb-1">Данные набора</label>
-            <select value={sheetOrPath} onChange={e => { setSheetOrPath(e.target.value); const c = candidates.find(x => x.sheetOrPath === e.target.value); if (c) setName(prev => prev || c.name); }}
-              className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm">
-              <option value="">— выберите —</option>
+            <Select value={sheetOrPath || undefined} placeholder="— выберите —" aria-label="Данные набора"
+              onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
               {candidates.map(c => (
-                <option key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</option>
+                <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
               ))}
-            </select>
+            </Select>
             {candidates.length === 0 && (
               <p className="text-xs text-fg4 mt-1">Набор ещё не распознан — сначала запустите «Распознать».</p>
             )}
@@ -177,13 +177,12 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
           needsSheet ? (
             <div>
               <label className="block text-sm font-medium text-fg1 mb-1">Лист</label>
-              <select value={sheetOrPath} onChange={e => setSheetOrPath(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm">
-                <option value="">— выберите лист —</option>
+              <Select value={sheetOrPath || undefined} placeholder="— выберите лист —" aria-label="Лист"
+                onValueChange={setSheetOrPath}>
                 {candidates.map(c => (
-                  <option key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</option>
+                  <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
                 ))}
-              </select>
+              </Select>
               {candidates.length === 0 && (
                 <p className="text-xs text-fg4 mt-1">Листы не обнаружены.</p>
               )}
@@ -202,11 +201,10 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
             {isZip && (
               <div>
                 <label className="block text-sm font-medium text-fg1 mb-1">Файл в архиве</label>
-                <select value={entryPath} onChange={e => setEntryPath(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm font-mono">
-                  <option value="">— выберите XML-файл в архиве —</option>
-                  {entryOptions.map(p => <option key={p} value={p}>{p}</option>)}
-                </select>
+                <Select value={entryPath || undefined} placeholder="— выберите XML-файл в архиве —"
+                  aria-label="Файл в архиве" onValueChange={setEntryPath} className="font-mono">
+                  {entryOptions.map(p => <SelectItem key={p} value={p}>{p}</SelectItem>)}
+                </Select>
                 {entryOptions.length === 0 && (
                   <p className="text-xs text-fg4 mt-1">В архиве не найдено XML-файлов.</p>
                 )}

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import {
   useListCommonData, useCommonDataForSet, useCreateCommonDataEntry,
@@ -628,25 +629,23 @@ export function CatalogEntryForm({
       {!entry ? (
         <div>
           <label className="block text-sm font-medium text-fg2 mb-1">Тип</label>
-          <select value={typeId} onChange={e => {
-              const newId = e.target.value;
+          <Select value={typeId || undefined} required placeholder="Выберите тип…" aria-label="Тип"
+            onValueChange={newId => {
               setTypeId(newId);
               const t = allSelectableTypes.find(c => c.id === newId);
               setValues(t ? getDefaultValues(resolveEffectiveFields(t, allDocTypes)) : {});
-            }} required
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface">
-            <option value="">Выберите тип...</option>
+            }}>
             {compositeTypes.length > 0 && (
-              <optgroup label="Составные типы">
-                {compositeTypes.map(ct => <option key={ct.id} value={ct.id}>{ct.name} ({ct.code})</option>)}
-              </optgroup>
+              <SelectGroup label="Составные типы">
+                {compositeTypes.map(ct => <SelectItem key={ct.id} value={ct.id}>{ct.name} ({ct.code})</SelectItem>)}
+              </SelectGroup>
             )}
             {documentTypes.length > 0 && (
-              <optgroup label="Типы документов (внешние)">
-                {documentTypes.map(dt => <option key={dt.id} value={dt.id}>{dt.name} ({dt.code})</option>)}
-              </optgroup>
+              <SelectGroup label="Типы документов (внешние)">
+                {documentTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name} ({dt.code})</SelectItem>)}
+              </SelectGroup>
             )}
-          </select>
+          </Select>
         </div>
       ) : (
         <p className="text-sm text-fg3">

--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { Loader2, Link2, Unlink, ShieldCheck, Search, Globe, ExternalLink, Download, Eye, Check } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import { usePreviewDataSetBindings } from '@/shared/api/datasets';
 import {
   useListQualityDocs, useListMaterialLinks, useSetMaterialLinks, useRemoveMaterialLink,
@@ -233,10 +234,10 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
       {tab === 'search' && (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <select value={searchType} onChange={e => setSearchType(e.target.value)}
-              className="border border-stroke-strong rounded-md px-2 py-2 text-sm bg-surface text-fg1">
-              {qualityTypes.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
-            </select>
+            <Select value={searchType || undefined} onValueChange={setSearchType}
+              placeholder="Тип" aria-label="Тип документа качества" className="w-52">
+              {qualityTypes.map(t => <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>)}
+            </Select>
             <div className="flex-1 flex items-center gap-2 border border-stroke-strong rounded-md px-2">
               <Search size={14} className="text-fg4" />
               <input value={query} onChange={e => setQuery(e.target.value)}
@@ -453,11 +454,11 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
         <span className="text-xs text-fg4">{materials.length} материалов · привязано {linkedCount}</span>
         <div className="ml-auto flex items-center gap-2">
           <label className="text-xs text-fg3">Область связи:</label>
-          <select value={scope} onChange={e => setScope(e.target.value as CatalogScope)}
-            className="border border-stroke rounded-md px-2 py-1 text-xs bg-surface text-fg1">
-            <option value="System">Общая (System)</option>
-            <option value="Set">Только этот комплект</option>
-          </select>
+          <Select value={scope} onValueChange={v => setScope(v as CatalogScope)}
+            aria-label="Область связи" className="w-52">
+            <SelectItem value="System">Общая (System)</SelectItem>
+            <SelectItem value="Set">Только этот комплект</SelectItem>
+          </Select>
         </div>
       </div>
 

--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -1,5 +1,6 @@
 import { formatDateRu, ruToISO } from '@/shared/utils/date';
 import { DateInput } from '@/shared/ui/DateInput';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import type { SchemaField } from '@/shared/api/schema';
 import type { PrimitiveTypeDef, FieldConstraints, EnumTypeDef } from '@/shared/api/types';
 import { isFieldRef } from '@/shared/api/types';
@@ -57,22 +58,23 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
       </label>
     );
   if (field.type === 'enum') {
+    const selCls = invalid ? 'border-danger' : '';
     if (enumTypeDef) {
       return (
-        <select value={strVal} onChange={e => onChange(e.target.value)} disabled={readOnly} className={cls}>
-          <option value="">— выберите —</option>
-          {enumTypeDef.values.map(v => <option key={v.code} value={v.code}>{v.label}</option>)}
-        </select>
+        <Select value={strVal || undefined} onValueChange={onChange} disabled={readOnly}
+          placeholder="— выберите —" aria-label={field.title} className={selCls}>
+          {enumTypeDef.values.map(v => <SelectItem key={v.code} value={v.code}>{v.label}</SelectItem>)}
+        </Select>
       );
     }
     const opts = (field.options ?? []).filter(o => o !== '');
     if (opts.length === 0)
       return <p className="text-xs text-fg4 italic py-1">Нет вариантов — добавьте их в схеме типа документа</p>;
     return (
-      <select value={strVal} onChange={e => onChange(e.target.value)} disabled={readOnly} className={cls}>
-        <option value="">— выберите —</option>
-        {opts.map(opt => <option key={opt} value={opt}>{opt}</option>)}
-      </select>
+      <Select value={strVal || undefined} onValueChange={onChange} disabled={readOnly}
+        placeholder="— выберите —" aria-label={field.title} className={selCls}>
+        {opts.map(opt => <SelectItem key={opt} value={opt}>{opt}</SelectItem>)}
+      </Select>
     );
   }
   if (field.type === 'primitive' && primitiveTypeDef) {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.14</Version>
+    <Version>0.23.15</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2d (#110) — финальный батч форменных `<select>` → MD3 `Select`.

## Что сделано
- **`PrimitiveInput`** — enum-поле (ключевой enum-контрол во всех формах документов/данных/качества).
- **`SourceEditorDialog`** — 3 динамических select (набор / лист / XML-файл в архиве).
- **`catalog/index.tsx`** — тип записи (с группами составные/документы).
- **`QualityLinksTab`** — тип поиска, область связи.

## Осознанно оставлены нативными
Плотные **cell/builder-select**: `ComplexFields` TableCell (ячейки таблицы), `FieldBuilder`, `XPathBuilder`, `PasteMappingModal`, `PdfGroupingEditor`, `TemplateParamsPanel`. Это компактные ячейки/грид-строки, где полноразмерный MD3-dropdown (h-9) ломает плотность, а нативный `<select>` уже клавиатурно-доступен. Визуальный дефект хендоффа был про standalone form-контролы — они все на MD3 Select.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed

## Итог Фазы 2 (Select)
Все standalone форм-селекты — на MD3 Select (APG-клавиатура, #107 F5). Дальше — опционально **TextField** (outlined + плавающая подпись, под-фаза 2e) либо переход к Фазе 3 (карточки/диалоги/пустые состояния).