### PR TITLE
feat(md3): фаза 2e — MD3 TextField (плавающая подпись) + экран входа (#110)

### DIFF
--- a/src/client/src/features/catalog/LoginPage.tsx
+++ b/src/client/src/features/catalog/LoginPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FileCheck2 } from 'lucide-react';
+import { FileCheck2, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useAppVersion } from '@/shared/api/version';
-import { Button } from '@/shared/ui/Button';
+import { Button, IconButton } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
 
 export function LoginPage() {
   const { login } = useAuth();
@@ -11,6 +12,7 @@ export function LoginPage() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -47,30 +49,16 @@ export function LoginPage() {
           Исполнительная документация
         </p>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1 text-fg2">
-              Email
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1 text-fg2">
-              Пароль
-            </label>
-            <input
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface"
-              required
-            />
-          </div>
+          <TextField label="Email" type="email" autoComplete="email" required autoFocus
+            value={email} onChange={e => setEmail(e.target.value)} />
+          <TextField label="Пароль" type={showPassword ? 'text' : 'password'} autoComplete="current-password" required
+            value={password} onChange={e => setPassword(e.target.value)}
+            trailing={
+              <IconButton label={showPassword ? 'Скрыть пароль' : 'Показать пароль'} size="sm"
+                onClick={() => setShowPassword(v => !v)}>
+                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              </IconButton>
+            } />
           {error && <p className="text-sm text-danger">{error}</p>}
           <Button type="submit" variant="filled" size="lg" fullWidth loading={loading} className="mt-2">
             {loading ? 'Вход…' : 'Войти'}

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -1,0 +1,51 @@
+import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
+
+/**
+ * MD3 outlined-текстовое поле (issue #110, фаза 2e) с плавающей подписью: подпись сидит
+ * внутри поля, когда оно пустое и без фокуса, и всплывает в вырез рамки при фокусе/заполнении.
+ * Фокус — рамка primary + inset-кольцо (без сдвига раскладки). Тема light/dark через токены.
+ *
+ * Требует placeholder=" " (пробел) — по нему :placeholder-shown отличает пустое поле.
+ * Фон подписи (bg-surface) «прорезает» рамку — поле должно лежать на surface (карточка/модалка).
+ */
+export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
+  label: string;
+  error?: string;
+  /** Правый адорнмент (например «глаз» пароля). */
+  trailing?: ReactNode;
+  containerClassName?: string;
+}
+
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function TextField(
+  { label, error, trailing, className = '', containerClassName = '', id, required, ...rest },
+  ref,
+) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+  const border = error
+    ? 'border-danger focus:border-danger focus:ring-1 focus:ring-inset focus:ring-danger'
+    : 'border-stroke-strong focus:border-brand focus:ring-1 focus:ring-inset focus:ring-brand';
+  const labelFocus = error ? 'peer-focus:text-danger' : 'peer-focus:text-brand';
+  return (
+    <div className={containerClassName}>
+      <div className="relative">
+        <input
+          ref={ref} id={inputId} placeholder=" " required={required}
+          className={`peer w-full h-12 rounded-md border bg-surface text-sm text-fg1 px-3 pt-4 pb-1 ` +
+            `outline-none transition-colors disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${border} ${className}`}
+          {...rest}
+        />
+        <label
+          htmlFor={inputId}
+          className={`absolute left-2.5 top-3.5 px-1 text-sm bg-surface text-fg4 pointer-events-none transition-all ` +
+            `peer-focus:top-[-7px] peer-focus:text-xs ${labelFocus} ` +
+            `peer-[:not(:placeholder-shown)]:top-[-7px] peer-[:not(:placeholder-shown)]:text-xs`}
+        >
+          {label}{required && <span className="ml-0.5 text-danger">*</span>}
+        </label>
+        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2">{trailing}</div>}
+      </div>
+      {error && <p className="mt-1 px-1 text-xs text-danger">{error}</p>}
+    </div>
+  );
+});

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.15</Version>
+    <Version>0.23.16</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Под-фаза 2e (#110) — **TextField** (outlined + плавающая подпись MD3).

## Новый `shared/ui/TextField`
- Outlined-поле MD3 с **плавающей подписью**: подпись внутри пустого поля, всплывает в вырез рамки при фокусе/заполнении.
- Фокус — рамка `primary` + inset-кольцо (без сдвига раскладки).
- Тема light/dark, слот `trailing` (адорнмент, напр. «глаз» пароля), `error`.
- Механика: `peer` + `:placeholder-shown` (`placeholder=" "`). Фон подписи (`bg-surface`) прорезает рамку → поле должно лежать на surface.

## Адопция (проф)
- **Экран входа** (хендофф 1): Email + Пароль на TextField, trailing-«глаз» показа пароля (`IconButton`).

## ⚠️ Прошу оценить перед массовой адопцией
Плавающая подпись меняет вертикальный ритм относительно текущего **компактного label-above** (ваше устоявшееся предпочтение по плотности). Прежде чем катить TextField на все формы — гляньте вид на `localhost:5173/login` (dev-сервер на этой ветке). Если ок — адоптирую по областям; если хотите label-above сохранить в плотных формах, можно применять floating-label только к «крупным» экранам (вход/крупные диалоги), а компактные оставить.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- `npm run build` — ок (floating-label утилиты в CSS)