### PR TITLE
feat(md3): фаза 2f — адопция TextField в диалогах создания (#110)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -7,6 +7,7 @@ import {
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -415,12 +416,8 @@ function SectionCard({ section, construction, expanded, onToggle, allDocTypes }:
         }>
         {addSetOpen && (
           <form id="add-set-form" onSubmit={handleAddSet} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-fg2 mb-1">Наименование</label>
-              <input value={newSetName} onChange={e => setNewSetName(e.target.value)} required autoFocus
-                placeholder="например: Кабельный журнал, секция 2"
-                className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-            </div>
+            <TextField label="Наименование" value={newSetName} onChange={e => setNewSetName(e.target.value)}
+              required autoFocus hint="например: Кабельный журнал, секция 2" />
             {addError && <p className="text-sm text-danger">{addError}</p>}
           </form>
         )}
@@ -590,12 +587,9 @@ function ConstructionDetail() {
         }>
         {addSectionOpen && (
           <form id="add-section-form" onSubmit={handleAddSection} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-fg2 mb-1">Название раздела (дисциплина)</label>
-              <input value={newSectionName} onChange={e => setNewSectionName(e.target.value)} required autoFocus
-                placeholder="например: Электроснабжение, Слаботочные системы"
-                className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-            </div>
+            <TextField label="Название раздела (дисциплина)" value={newSectionName}
+              onChange={e => setNewSectionName(e.target.value)} required autoFocus
+              hint="например: Электроснабжение, Слаботочные системы" />
             {sectionError && <p className="text-sm text-danger">{sectionError}</p>}
           </form>
         )}
@@ -768,12 +762,8 @@ function ConstructionsList() {
         }>
         {createOpen && (
           <form id="create-construction-form" onSubmit={handleCreate} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-fg2 mb-1">Название стройки</label>
-              <input value={newName} onChange={e => setNewName(e.target.value)} required autoFocus
-                placeholder="например: ЖК Северный, корпус 1"
-                className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-            </div>
+            <TextField label="Название стройки" value={newName} onChange={e => setNewName(e.target.value)}
+              required autoFocus hint="например: ЖК Северный, корпус 1" />
             {createError && <p className="text-sm text-danger">{createError}</p>}
           </form>
         )}

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -3,6 +3,7 @@ import { Plus, KeyRound, Trash2, ShieldCheck, User as UserIcon, Mail } from 'luc
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { SendMessageDialog } from '@/shared/ui/SendMessageDialog';
 import { useAuth, type UserRole } from '@/shared/hooks/useAuth';
@@ -151,22 +152,11 @@ function CreateUserModal({ open, onClose }: { open: boolean; onClose: () => void
   return (
     <Modal open={open} onOpenChange={o => { if (!o) { reset(); onClose(); } }} title="Новый пользователь">
       <form onSubmit={submit} className="space-y-3">
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Email</label>
-          <input type="email" value={email} onChange={e => setEmail(e.target.value)} required autoFocus
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Отображаемое имя</label>
-          <input value={displayName} onChange={e => setDisplayName(e.target.value)}
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Начальный пароль</label>
-          <input type="text" value={password} onChange={e => setPassword(e.target.value)} required minLength={6}
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm font-mono bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-          <p className="text-xs text-fg4 mt-1">Минимум 6 символов. Пользователь сможет сменить его сам.</p>
-        </div>
+        <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required autoFocus />
+        <TextField label="Отображаемое имя" value={displayName} onChange={e => setDisplayName(e.target.value)} />
+        <TextField label="Начальный пароль" type="text" value={password} onChange={e => setPassword(e.target.value)}
+          required minLength={6} className="font-mono"
+          hint="Минимум 6 символов. Пользователь сможет сменить его сам." />
         <div>
           <label className="block text-sm font-medium text-fg2 mb-1">Роль</label>
           <Select value={role} onValueChange={v => setRole(v as UserRole)} aria-label="Роль">
@@ -204,12 +194,8 @@ function ResetPasswordModal({ user, onClose }: { user: AppUser | null; onClose: 
     <Modal open={!!user} onOpenChange={o => { if (!o) { setPassword(''); setError(''); setDone(false); onClose(); } }}
       title={`Сброс пароля — ${user?.email ?? ''}`}>
       <form onSubmit={submit} className="space-y-3">
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Новый пароль</label>
-          <input type="text" value={password} onChange={e => setPassword(e.target.value)} required minLength={6} autoFocus
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm font-mono bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand" />
-          <p className="text-xs text-fg4 mt-1">Сообщите новый пароль пользователю.</p>
-        </div>
+        <TextField label="Новый пароль" type="text" value={password} onChange={e => setPassword(e.target.value)}
+          required minLength={6} autoFocus className="font-mono" hint="Сообщите новый пароль пользователю." />
         {error && <p className="text-sm text-danger">{error}</p>}
         {done && <p className="text-sm text-success">Пароль изменён</p>}
         <div className="flex justify-end gap-2 pt-1">

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -11,13 +11,15 @@ import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'rea
 export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
   label: string;
   error?: string;
+  /** Вспомогательный текст под полем (напр. пример ввода) — скрывается при наличии error. */
+  hint?: string;
   /** Правый адорнмент (например «глаз» пароля). */
   trailing?: ReactNode;
   containerClassName?: string;
 }
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function TextField(
-  { label, error, trailing, className = '', containerClassName = '', id, required, ...rest },
+  { label, error, hint, trailing, className = '', containerClassName = '', id, required, ...rest },
   ref,
 ) {
   const autoId = useId();
@@ -45,7 +47,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         </label>
         {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2">{trailing}</div>}
       </div>
-      {error && <p className="mt-1 px-1 text-xs text-danger">{error}</p>}
+      {error
+        ? <p className="mt-1 px-1 text-xs text-danger">{error}</p>
+        : hint ? <p className="mt-1 px-1 text-xs text-fg4">{hint}</p> : null}
     </div>
   );
 });

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.16</Version>
+    <Version>0.23.17</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2f (#110) — адопция `TextField` (плавающая подпись), первый батч: диалоги создания.

## Что сделано
- **`DocumentSetsPage`** — имена стройки / раздела / комплекта (example-placeholder → `hint`).
- **`UsersPage`** — email / имя / начальный пароль (создание) + новый пароль (сброс).
- В `TextField` добавлен **`hint`** (supporting text под полем) — бывшие «например: …» сохранены.

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed

## Дальше
Адопция TextField продолжается по областям (каталог/запись, типы, шаблоны, качество, датасет-диалоги, настройки). Инлайн-редактирование (rename по месту), поиск-инпуты с иконкой и Select-поля (label-above) — по своим паттернам. Затем — Фаза 3.