### PR TITLE
feat(md3): фаза 2g — TextField в формах типов и шаблонов (#110)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -7,6 +7,7 @@ import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { apiError } from '@/shared/utils/apiError';
 import {
@@ -201,16 +202,9 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
     <form onSubmit={handleSave} className="space-y-3 pb-4 border-b border-stroke mb-4">
       <p className="text-xs font-medium text-fg3 uppercase tracking-wide">Параметры типа</p>
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Наименование</label>
-          <input value={name} onChange={e => handleNameChange(e.target.value)} required
-            className="w-full border border-stroke-strong rounded-md px-3 py-1.5 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Код</label>
-          <input value={code} onChange={e => { setCode(e.target.value); setSaved(false); }} required spellCheck={false}
-            className="w-full border border-stroke-strong rounded-md px-3 py-1.5 text-sm font-mono focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        </div>
+        <TextField label="Наименование" value={name} onChange={e => handleNameChange(e.target.value)} required />
+        <TextField label="Код" value={code} onChange={e => { setCode(e.target.value); setSaved(false); }}
+          required spellCheck={false} className="font-mono" />
       </div>
       <div>
         <label className="block text-xs font-medium text-fg2 mb-1">Родительский тип</label>
@@ -290,16 +284,9 @@ function CreateForm({
     <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-5">
       <div className="grid grid-cols-2 gap-4">
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Наименование</label>
-          <input value={name} onChange={e => handleNameChange(e.target.value)} required
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Код</label>
-          <input value={code} onChange={e => setCode(e.target.value)} required spellCheck={false}
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm font-mono focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        </div>
+        <TextField label="Наименование" value={name} onChange={e => handleNameChange(e.target.value)} required />
+        <TextField label="Код" value={code} onChange={e => setCode(e.target.value)}
+          required spellCheck={false} className="font-mono" />
       </div>
 
       {kind === 'Document' && (

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
 import {
   useListEnumTypes,
   useCreateEnumType,
@@ -108,39 +109,14 @@ function EnumForm({ initial, onSaved, onCancel }: {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
-          <input
-            type="text"
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
-            placeholder="Статус документа"
-            value={name}
-            onChange={e => handleNameChange(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Код</label>
-          <input
-            type="text"
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm font-mono"
-            placeholder="status"
-            value={code}
-            onChange={e => setCode(e.target.value)}
-            disabled={!!initial}
-          />
-        </div>
+        <TextField label="Название" value={name} onChange={e => handleNameChange(e.target.value)}
+          hint="Статус документа" />
+        <TextField label="Код" value={code} onChange={e => setCode(e.target.value)}
+          disabled={!!initial} className="font-mono" hint="status" />
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-fg1 mb-1">Описание</label>
-        <input
-          type="text"
-          className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
-          placeholder="Необязательное описание типа"
-          value={description}
-          onChange={e => setDescription(e.target.value)}
-        />
-      </div>
+      <TextField label="Описание" value={description} onChange={e => setDescription(e.target.value)}
+        hint="Необязательное описание типа" />
 
       <div className="border-t border-stroke pt-3">
         <p className="text-sm font-medium text-fg1 mb-3">Варианты</p>

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Library } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -43,11 +44,7 @@ function NewTemplateForm({ documentTypeId, docType, allDocTypes, onClose, onCrea
   return (
     <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Название шаблона</label>
-          <input value={name} onChange={(e) => setName(e.target.value)} required autoFocus
-            className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        </div>
+        <TextField label="Название шаблона" value={name} onChange={(e) => setName(e.target.value)} required autoFocus />
         <p className="text-xs text-fg4">
           Будет создан Typst-шаблон с колонтитулами, нумерацией страниц и списком всех реквизитов типа документа.
         </p>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.17</Version>
+    <Version>0.23.18</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2g (#110) — адопция `TextField`, батч «типы/шаблоны».

## Что сделано
- **`EnumTypesSection`** — название / код / описание.
- **`DocumentTypesPage`** — наименование / код (редактор свойств + модалка создания).
- **`TemplatesPage`** — название шаблона.

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

## Осталось по TextField
Каталог (запись/псевдонимы), PrimitiveTypes (name/code/desc + ConstraintEditor), QualityDocForm, настройки (SettingsPage/интеграции/почта/бэкап), датасет-диалоги (имена источников), SubscribersPanel-и т.п. Затем — Фаза 3.