### PR TITLE
feat(md3): фаза 2h — TextField в каталоге, качестве, примитивах (#110)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -6,6 +6,7 @@ import {
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import {
   useListCommonData, useCommonDataForSet, useCreateCommonDataEntry,
@@ -595,11 +596,7 @@ export function CatalogEntryForm({
         <span className="text-xs text-fg3">приоритет {SCOPE_PRIORITY[scope]}</span>
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-fg2 mb-1">Наименование</label>
-        <input value={displayName} onChange={e => setDisplayName(e.target.value)} required autoFocus
-          className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-      </div>
+      <TextField label="Наименование" value={displayName} onChange={e => setDisplayName(e.target.value)} required autoFocus />
 
       {/* Алиасы (issue #74) — доп. имена для поиска записи при связывании с источниками */}
       <div>

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { Loader2, ShieldCheck, Upload, Eye } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import {
   useCreateQualityDoc, useUpdateQualityDoc, useSetQualityDocScan, recognizeDocument,
   type QualityDocument, type RecognitionFieldReq,
@@ -165,11 +166,8 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
             {qualityTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>)}
           </Select>
         </div>
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Название в библиотеке</label>
-          <input value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder="авто из номера"
-            className="w-full border border-stroke-strong rounded-md px-2 py-1.5 text-sm bg-surface text-fg1" />
-        </div>
+        <TextField label="Название в библиотеке" value={displayName}
+          onChange={e => setDisplayName(e.target.value)} hint="авто из номера" />
       </div>
 
       <div className="flex items-center gap-2 flex-wrap">

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
 import { DateInput } from '@/shared/ui/DateInput';
 import {
   useListPrimitiveTypes,
@@ -237,27 +238,9 @@ function TypeForm({ initial, onSaved, onCancel }: TypeFormProps) {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
-          <input
-            type="text"
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
-            placeholder="Email"
-            value={name}
-            onChange={e => setName(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Код</label>
-          <input
-            type="text"
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm font-mono"
-            placeholder="email"
-            value={code}
-            onChange={e => setCode(e.target.value)}
-            disabled={!!initial}
-          />
-        </div>
+        <TextField label="Название" value={name} onChange={e => setName(e.target.value)} hint="Email" />
+        <TextField label="Код" value={code} onChange={e => setCode(e.target.value)}
+          disabled={!!initial} className="font-mono" hint="email" />
       </div>
 
       <div>
@@ -281,16 +264,8 @@ function TypeForm({ initial, onSaved, onCancel }: TypeFormProps) {
         </div>
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-fg1 mb-1">Описание</label>
-        <input
-          type="text"
-          className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm"
-          placeholder="Необязательное описание типа"
-          value={description}
-          onChange={e => setDescription(e.target.value)}
-        />
-      </div>
+      <TextField label="Описание" value={description} onChange={e => setDescription(e.target.value)}
+        hint="Необязательное описание типа" />
 
       <div className="border-t border-stroke pt-3">
         <p className="text-sm font-medium text-fg1 mb-3">Ограничения</p>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.18</Version>
+    <Version>0.23.19</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2h (#110) — адопция `TextField`, батч «каталог/качество/примитивы».

## Что сделано
- **`catalog/index.tsx`** — наименование записи (chips-инпут псевдонимов оставлен native).
- **`QualityDocForm`** — название в библиотеке.
- **`PrimitiveTypesPage`** — название / код / описание (поля `ConstraintEditor` — следующим батчем).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

## Осталось по TextField
`SettingsPage` (число/бэкап), интеграции (LLM/поиск), почта SMTP, датасет-диалоги (имена источников), `ConstraintEditor` (regex/min/max/даты). Затем — Фаза 3.