### PR TITLE
feat(md3): фаза 2i — TextField в настройках почты и интеграций (#110)

### DIFF
--- a/src/client/src/features/settings/EmailSettingsSection.tsx
+++ b/src/client/src/features/settings/EmailSettingsSection.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Mail, Send, CheckCircle, XCircle, AlertTriangle, PlugZap } from 'lucide-react';
+import { TextField } from '@/shared/ui/TextField';
 import {
   useIntegrationSettings, useSaveSmtp, useTestEmail, useTestSmtpConnection, useEmailUserStatus,
   type SmtpUpdate,
@@ -76,31 +77,17 @@ export function EmailSettingsSection() {
       </label>
 
       <div className="grid grid-cols-2 gap-3">
-        <div className="col-span-2 sm:col-span-1">
-          <label className="block text-xs font-medium text-fg2 mb-1">SMTP-сервер (host)</label>
-          <input className={fieldCls} value={form.host ?? ''} onChange={e => set('host', e.target.value)} placeholder="smtp.example.com" />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Порт</label>
-          <input type="number" className={fieldCls} value={form.port} onChange={e => set('port', Number(e.target.value))} />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Пользователь</label>
-          <input className={fieldCls} value={form.user ?? ''} onChange={e => set('user', e.target.value)} placeholder="user@example.com" />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Пароль</label>
-          <input type="password" className={fieldCls} value={form.password ?? ''} onChange={e => set('password', e.target.value)}
-            placeholder={hasPassword ? '•••••• (не менять)' : ''} />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Адрес отправителя (From)</label>
-          <input className={fieldCls} value={form.from ?? ''} onChange={e => set('from', e.target.value)} placeholder="docs@example.com" />
-        </div>
-        <div className="col-span-2 sm:col-span-1">
-          <label className="block text-xs font-medium text-fg2 mb-1">Имя отправителя</label>
-          <input className={fieldCls} value={form.fromName ?? ''} onChange={e => set('fromName', e.target.value)} placeholder="BHS.CRG" />
-        </div>
+        <TextField containerClassName="col-span-2 sm:col-span-1" label="SMTP-сервер (host)"
+          value={form.host ?? ''} onChange={e => set('host', e.target.value)} hint="smtp.example.com" />
+        <TextField label="Порт" type="number" value={form.port} onChange={e => set('port', Number(e.target.value))} />
+        <TextField label="Пользователь" value={form.user ?? ''} onChange={e => set('user', e.target.value)}
+          hint="user@example.com" />
+        <TextField label="Пароль" type="password" value={form.password ?? ''} onChange={e => set('password', e.target.value)}
+          hint={hasPassword ? '•••••• (не менять)' : undefined} />
+        <TextField label="Адрес отправителя (From)" value={form.from ?? ''} onChange={e => set('from', e.target.value)}
+          hint="docs@example.com" />
+        <TextField containerClassName="col-span-2 sm:col-span-1" label="Имя отправителя"
+          value={form.fromName ?? ''} onChange={e => set('fromName', e.target.value)} hint="BHS.CRG" />
       </div>
 
       <label className="flex items-center gap-2 text-sm text-fg2">

--- a/src/client/src/features/settings/IntegrationSettingsSection.tsx
+++ b/src/client/src/features/settings/IntegrationSettingsSection.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { TextField } from '@/shared/ui/TextField';
+import { Select, SelectItem } from '@/shared/ui/Select';
 import {
   useIntegrationSettings,
   useSaveIntegrationSettings,
@@ -114,16 +116,9 @@ function EngineCard({
       <p className="text-xs text-fg4">{meta.hint}</p>
 
       {!meta.keyless && (
-        <Field label="API-ключ">
-          <input
-            type="password"
-            autoComplete="off"
-            value={form.apiKey}
-            onChange={e => onChange({ ...form, apiKey: e.target.value })}
-            placeholder={form.hasKey ? '•••••••• (ключ задан — оставьте пустым, чтобы не менять)' : 'ключ не задан'}
-            className={inputCls}
-          />
-        </Field>
+        <TextField label="API-ключ" type="password" autoComplete="off" value={form.apiKey}
+          onChange={e => onChange({ ...form, apiKey: e.target.value })}
+          hint={form.hasKey ? '•••••••• (ключ задан — оставьте пустым, чтобы не менять)' : 'ключ не задан'} />
       )}
 
       {meta.modelLabel && (() => {
@@ -138,41 +133,28 @@ function EngineCard({
                   : 'Список моделей недоступен'}
               </div>
             ) : (
-              <select
-                value={form.model}
-                onChange={e => onChange({ ...form, model: e.target.value })}
-                className={inputCls}
-              >
-                {!form.model && <option value="">— выберите —</option>}
-                {opts.map(o => <option key={o} value={o}>{o}</option>)}
-              </select>
+              <Select value={form.model || undefined} placeholder="— выберите —" aria-label={meta.modelLabel}
+                onValueChange={m => onChange({ ...form, model: m })}>
+                {opts.map(o => <SelectItem key={o} value={o}>{o}</SelectItem>)}
+              </Select>
             )}
           </Field>
         );
       })()}
 
       {meta.showBaseUrl && (
-        <Field label="Базовый URL">
-          <input type="text" value={form.baseUrl} placeholder="http://localhost:11434"
-            onChange={e => onChange({ ...form, baseUrl: e.target.value })}
-            className={inputCls} />
-        </Field>
+        <TextField label="Базовый URL" value={form.baseUrl} hint="http://localhost:11434"
+          onChange={e => onChange({ ...form, baseUrl: e.target.value })} />
       )}
 
       {meta.showFolderId && (
-        <Field label="Folder ID">
-          <input type="text" value={form.folderId}
-            onChange={e => onChange({ ...form, folderId: e.target.value })}
-            className={inputCls} />
-        </Field>
+        <TextField label="Folder ID" value={form.folderId}
+          onChange={e => onChange({ ...form, folderId: e.target.value })} />
       )}
 
       {meta.showHost && (
-        <Field label="Host (необязательно)">
-          <input type="text" value={form.host} placeholder="https://yandex.ru/search/xml"
-            onChange={e => onChange({ ...form, host: e.target.value })}
-            className={inputCls} />
-        </Field>
+        <TextField label="Host (необязательно)" value={form.host} hint="https://yandex.ru/search/xml"
+          onChange={e => onChange({ ...form, host: e.target.value })} />
       )}
     </div>
   );

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.19</Version>
+    <Version>0.23.20</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2i (#110) — адопция `TextField`, батч «настройки: почта + интеграции».

## Что сделано
- **`EmailSettingsSection`** — host / порт / пользователь / пароль / from / имя отправителя.
- **`IntegrationSettingsSection`** — API-ключ / базовый URL / Folder ID / Host (в engine-картах); модель-`<select>` → MD3 `Select`. Textarea промпта оставлена native (TextField — для однострочных).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

## Осталось (финальный батч TextField)
`SettingsPage` (число/бэкап-инпуты), датасет-диалоги (имена источников: PdfSource/SourceEditor/SaveAsTemplate/rename), `ConstraintEditor` (regex/сообщение/min-max), `TypstRendersEditor`, `BindingTemplatesDialog`. Затем — Фаза 3.