### PR TITLE
feat(md3): фаза 2j — TextField в датасет-диалогах и настройках (финал форм) (#110)

### DIFF
--- a/src/client/src/features/datasets/PdfSourceDialog.tsx
+++ b/src/client/src/features/datasets/PdfSourceDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import { useCreatePdfSource, useRecognizeFile } from '@/shared/api/datasets';
 import { useTagRegistry, datasetTags } from '@/shared/api/tags';
 
@@ -53,12 +54,8 @@ export function PdfSourceDialog({ fileId, onClose }: { fileId: string; onClose: 
         </div>
       }>
       <div className="space-y-4 min-w-[420px]">
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
-          <input value={name} onChange={e => setName(e.target.value)} autoFocus
-            placeholder={profile === 'invoice' ? 'Счёт на оплату' : 'Реестр листов'}
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm" />
-        </div>
+        <TextField label="Название" value={name} onChange={e => setName(e.target.value)} autoFocus
+          hint={profile === 'invoice' ? 'Счёт на оплату' : 'Реестр листов'} />
 
         <div>
           <label className="block text-sm font-medium text-fg1 mb-1">Профиль распознавания</label>

--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TextField } from '@/shared/ui/TextField';
 import { useCreateDataSetSource, useUpdateDataSetSource, useListZipXmlEntries, useSourceCandidates } from '@/shared/api/datasets';
 import { XPathBuilder } from './xpath/XPathBuilder';
 import { JsonPathBuilder } from './jsonpath/JsonPathBuilder';
@@ -150,12 +151,8 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
         </div>
       }>
       <div className="space-y-4 min-w-[520px]">
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
-          <input value={name} onChange={e => setName(e.target.value)}
-            placeholder={tabular ? 'Позиции спецификации' : 'Позиции спецификации'}
-            className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm" />
-        </div>
+        <TextField label="Название" value={name} onChange={e => setName(e.target.value)}
+          hint="Позиции спецификации" />
 
         {isPdf ? (
           <div>

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -14,6 +14,7 @@ import {
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
 import { RowActionsMenu, type RowAction } from '@/shared/ui/RowActionsMenu';
 import { SourceEditorDialog } from './SourceEditorDialog';
 import { MaterializationDialog } from './MaterializationDialog';
@@ -52,10 +53,8 @@ function SaveAsTemplateDialog({ defaultName, isPending, onSave, onClose }: {
         Row-selector/колонки (Extraction) и текущие Filter/Transformation/Sort источника
         станут переиспользуемым шаблоном — копия, не живая ссылка.
       </p>
-      <input value={name} onChange={e => setName(e.target.value)} autoFocus
-        onKeyDown={e => { if (e.key === 'Enter' && canSave) onSave(name.trim()); }}
-        placeholder="Название шаблона"
-        className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-base text-sm" />
+      <TextField label="Название шаблона" value={name} onChange={e => setName(e.target.value)} autoFocus
+        onKeyDown={e => { if (e.key === 'Enter' && canSave) onSave(name.trim()); }} />
     </Modal>
   );
 }
@@ -221,10 +220,8 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
             </div>
           }>
           <div className="min-w-[380px]">
-            <label className="block text-sm font-medium text-fg1 mb-1">Название</label>
-            <input value={renameVal} onChange={e => setRenameVal(e.target.value)} autoFocus
-              onKeyDown={e => { if (e.key === 'Enter' && renameVal.trim()) renameMutation.mutateAsync({ id: src.id, name: renameVal.trim() }).then(() => setRenaming(false)); }}
-              className="w-full px-3 py-2 rounded-lg border border-stroke-strong bg-surface text-sm" />
+            <TextField label="Название" value={renameVal} onChange={e => setRenameVal(e.target.value)} autoFocus
+              onKeyDown={e => { if (e.key === 'Enter' && renameVal.trim()) renameMutation.mutateAsync({ id: src.id, name: renameVal.trim() }).then(() => setRenaming(false)); }} />
           </div>
         </Modal>
       )}

--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { Download, Upload, CheckCircle, XCircle, AlertTriangle, Info } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
 import { downloadBackup, restoreBackup } from '@/shared/api/backup';
 import type { RestoreReport } from '@/shared/api/types';
 import {
@@ -344,17 +345,12 @@ export function SettingsPage() {
       <form onSubmit={handleSave}>
         <CollapsibleSection title="Шаблоны" storageKey="templates">
           <div>
-            <label className="block text-sm font-medium text-fg2 mb-1">
-              Максимум версий шаблона
-            </label>
             <p className="text-xs text-fg3 mb-2">
               При превышении система предложит удалить старые версии. Минимум — 2.
             </p>
-            <input
+            <TextField containerClassName="w-40" label="Максимум версий шаблона"
               type="number" min={2} max={100} value={input}
-              onChange={e => { setInput(e.target.value); setSaved(false); }}
-              className="w-28 border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface"
-            />
+              onChange={e => { setInput(e.target.value); setSaved(false); }} />
           </div>
           <div className="flex items-center gap-3">
             <Button type="submit" variant="filled">Сохранить</Button>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.20</Version>
+    <Version>0.23.21</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2j (#110) — **финальный батч** адопции `TextField` для standalone форм-полей.

## Что сделано
- `PdfSourceDialog`, `SourceEditorDialog` — имя источника.
- `SourcesExpander` — имя шаблона (SaveAsTemplate) + переименование источника.
- `SettingsPage` — «Максимум версий шаблона» (number).

## Осознанно оставлены нативными
Плотные **builder/cell/search/chips**-инпуты: `ConstraintEditor`, `FieldBuilder`, `XPathBuilder`, `PasteMappingModal`, `ProcessingTemplatesDialog`, `ComplexFields`-ячейки, поиск-с-иконкой, chips-инпут псевдонимов — где floating-label h-12 ломает плотность (та же логика, что для native-селектов в ячейках).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

## Итог Фазы 2
Контролы форм на MD3: **Select** (все standalone-селекты, APG-клавиатура) + **TextField** (все standalone форм-поля, floating-label). Фаза 2 закрыта. Дальше — **Фаза 3** (карточки / диалоги / пустые состояния).