### PR TITLE
feat(md3): фаза 3a — компонент EmptyState + адопция (#110)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Plus, Search, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Search, ChevronDown, ChevronUp, Database } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { EmptyState } from '@/shared/ui/EmptyState';
 import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
 
 /** Sentinel для «Все типы» — Radix Select запрещает пустую строку как value. */
@@ -90,10 +91,9 @@ export function SystemCommonDataPage() {
       {isLoading ? (
         <div className="text-center py-12 text-fg4 text-sm">Загрузка...</div>
       ) : entries.length === 0 ? (
-        <div className="text-center py-16">
-          <p className="text-fg4 text-sm mb-2">Системный каталог пуст</p>
-          <p className="text-xs text-stroke-strong">Добавьте справочные данные, которые будут доступны во всех проектах</p>
-        </div>
+        <EmptyState icon={<Database size={30} />} title="Системный каталог пуст"
+          description="Добавьте справочные данные (организации, лица, объекты) — они будут доступны во всех проектах."
+          action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setAddOpen(true)}>Добавить запись</Button>} />
       ) : filtered.length === 0 ? (
         <div className="text-center py-10 text-fg4 text-sm">Ничего не найдено</div>
       ) : (

--- a/src/client/src/features/datasets/DataSetsPage.tsx
+++ b/src/client/src/features/datasets/DataSetsPage.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { Button, IconButton } from '@/shared/ui/Button';
+import { EmptyState } from '@/shared/ui/EmptyState';
 import { Upload, Trash2, Database, RefreshCw, Download, Layers } from 'lucide-react';
 import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
 import type { DataSetFile } from '@/shared/api/types';
@@ -110,9 +111,10 @@ export function DataSetsPage() {
         {isLoading ? (
           <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>
         ) : files.length === 0 ? (
-          <div className="p-8 text-center text-sm text-fg4">
-            Нет загруженных наборов данных
-          </div>
+          <EmptyState className="m-4 border-0" icon={<Database size={30} />} title="Пока нет наборов данных"
+            description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) — из него можно собирать источники для колонок и таблиц документов."
+            action={<Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
+              loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>} />
         ) : (
           files.map(f => <FileRow key={f.id} file={f} />)
         )}

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -2,12 +2,13 @@ import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
 import {
   Plus, Trash2, ChevronRight, Download, Pencil, ChevronDown, ChevronUp, FolderOpen, Eye,
-  ArrowUp, ArrowDown, Layers, Search, X, Mail,
+  ArrowUp, ArrowDown, Layers, Building2, Search, X, Mail,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import { TextField } from '@/shared/ui/TextField';
+import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -557,7 +558,9 @@ function ConstructionDetail() {
       </div>
 
       {construction.sections.length === 0 ? (
-        <div className="text-center py-12 text-fg4 text-sm">Нет разделов. Добавьте первый раздел (дисциплину).</div>
+        <EmptyState icon={<Layers size={30} />} title="Пока нет разделов"
+          description="Добавьте первый раздел (дисциплину) — например «Электроснабжение» — чтобы собирать в нём комплекты документов."
+          action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setAddSectionOpen(true)}>Добавить раздел</Button>} />
       ) : (
         <div className="space-y-3">
           {construction.sections.map(s => (
@@ -702,7 +705,9 @@ function ConstructionsList() {
       {isLoading ? (
         <div className="text-center py-10 text-fg4 text-sm">Загрузка...</div>
       ) : constructions.length === 0 ? (
-        <div className="text-center py-16 text-fg4 text-sm">Нет строек. Создайте первую.</div>
+        <EmptyState icon={<Building2 size={30} />} title="Пока нет строек"
+          description="Создайте первую стройку, чтобы начать вести исполнительную документацию по её разделам и комплектам."
+          action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>Новая стройка</Button>} />
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {constructions.map(c => {

--- a/src/client/src/shared/ui/EmptyState.tsx
+++ b/src/client/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+/**
+ * MD3 пустое состояние (issue #110, фаза 3): dashed-контейнер, круглая плашка-иконка
+ * (secondary-container), заголовок + поясняющий текст, одна filled-кнопка действия.
+ * Для списков без данных (стройки, наборы, документы комплекта и т.п.).
+ */
+export function EmptyState({
+  icon, title, description, action, className = '',
+}: {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`flex flex-col items-center gap-4 rounded-2xl border border-dashed border-stroke px-6 py-12 text-center ${className}`}>
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-tonal text-on-tonal">
+        {icon}
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-base font-medium text-fg1">{title}</h3>
+        {description && <p className="mx-auto max-w-sm text-sm text-fg3">{description}</p>}
+      </div>
+      {action && <div className="pt-1">{action}</div>}
+    </div>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.21</Version>
+    <Version>0.23.22</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 3 рестайла MD3 (#110) — **карточки / диалоги / пустые состояния**. Часть 3a: `EmptyState`.

## Новый `shared/ui/EmptyState`
MD3-паттерн: dashed-контейнер (radius 16), круглая плашка-иконка (secondary-container/`bg-tonal`), заголовок + описание (max ~400px), одна filled-кнопка действия.

## Адопция (устраняет «слабые пустые состояния» из ревью)
- **Стройки**, **Разделы** (`DocumentSetsPage`) — иконка + описание + filled «Новая стройка»/«Добавить раздел».
- **Наборы данных** (`DataSetsPage`) — filled «Загрузить файл».
- **Системный каталог** (`SystemCommonDataPage`) — filled «Добавить запись».

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed · `npm run build` — ок

## Дальше в Фазе 3
Ещё пустые состояния (документы комплекта, пользователи, качество, шаблоны), диалоги под MD3-форму (Modal radius/scrim, «одна filled в футере»), карточки (outlined + hover-elevation).