### PR TITLE
feat(md3): фаза 3b — диалоги MD3 + ещё пустые состояния (#110)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
 import {
   Plus, Trash2, ChevronRight, Download, Pencil, ChevronDown, ChevronUp, FolderOpen, Eye,
-  ArrowUp, ArrowDown, Layers, Building2, Search, X, Mail,
+  ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
@@ -169,7 +169,9 @@ function SetDetail() {
 
       <div className="bg-surface border border-stroke rounded-xl overflow-hidden">
         {set.instances.length === 0 ? (
-          <div className="p-10 text-center text-fg4 text-sm">Документов нет</div>
+          <EmptyState className="m-4 border-0" icon={<FileText size={30} />} title="В комплекте пока нет документов"
+            description="Добавьте документ нужного типа — заполните реквизиты и сгенерируйте PDF."
+            action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setAddDocOpen(true)}>Добавить документ</Button>} />
         ) : (
           <table className="w-full text-sm">
             <thead className="bg-base border-b border-stroke">

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -4,6 +4,7 @@ import { Plus, Pencil, Trash2, ShieldCheck, FileText, Search, Globe, ExternalLin
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -180,7 +181,9 @@ export function QualityDocsPage() {
         {isLoading ? (
           <p className="text-sm text-fg4 text-center py-8">Загрузка...</p>
         ) : docs.length === 0 ? (
-          <p className="text-sm text-fg4 text-center py-8">Документов нет. Добавьте первый — можно загрузить скан и распознать реквизиты.</p>
+          <EmptyState className="m-4 border-0" icon={<ShieldCheck size={30} />} title="Документов качества пока нет"
+            description="Добавьте первый документ — можно загрузить скан и распознать реквизиты, либо найти в интернете."
+            action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>Добавить документ</Button>} />
         ) : (
           <table className="w-full text-sm">
             <thead className="bg-base border-b border-stroke">

--- a/src/client/src/shared/ui/ConfirmDialog.tsx
+++ b/src/client/src/shared/ui/ConfirmDialog.tsx
@@ -40,11 +40,11 @@ export function ConfirmDialog({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay
-          className="fixed inset-0 z-40 bg-black/50"
+          className="fixed inset-0 z-40 bg-black/40"
           style={{ backdropFilter: 'blur(2px)' }}
         />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-xl p-5 w-full max-w-sm bg-surface border border-stroke focus:outline-none"
+          className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-[28px] p-6 w-full max-w-sm bg-surface border border-stroke focus:outline-none"
           style={{ boxShadow: 'var(--f-shadow28)' }}
         >
           <Dialog.Title className="text-sm font-semibold mb-2 text-fg1">

--- a/src/client/src/shared/ui/Modal.tsx
+++ b/src/client/src/shared/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { useState, useEffect, type ReactNode } from 'react';
+import { Button } from './Button';
 
 interface ModalProps {
   open: boolean;
@@ -34,11 +35,11 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay
-          className="fixed inset-0 z-40 bg-black/50"
+          className="fixed inset-0 z-40 bg-black/40"
           style={{ backdropFilter: 'blur(2px)' }}
         />
         <Dialog.Content
-          className={`fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-lg max-h-[90vh] flex flex-col overflow-hidden focus:outline-none bg-surface border border-stroke ${
+          className={`fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-[28px] max-h-[90vh] flex flex-col overflow-hidden focus:outline-none bg-surface border border-stroke ${
             extraWide ? 'w-full max-w-5xl' : wide ? 'w-full max-w-2xl' : 'w-full max-w-lg'
           }`}
           style={{ boxShadow: 'var(--f-shadow28)' }}
@@ -62,9 +63,10 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
             <button
               type="button"
               onClick={attemptClose}
-              className="flex items-center justify-center w-8 h-8 rounded-md transition-colors text-fg3 hover:text-fg1 hover:bg-muted"
+              aria-label="Закрыть"
+              className="flex items-center justify-center w-9 h-9 rounded-full transition-colors text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
             >
-              <X size={16} />
+              <X size={18} />
             </button>
           </div>
           {flushBody ? (
@@ -84,8 +86,8 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
           )}
 
           {confirmClose && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-black/50">
-              <div className="rounded-xl p-5 shadow-2xl w-80 bg-surface border border-stroke">
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-[28px] bg-black/40">
+              <div className="rounded-3xl p-5 w-80 bg-surface border border-stroke" style={{ boxShadow: 'var(--f-shadow28)' }}>
                 <p className="text-sm font-semibold mb-1 text-fg1">
                   Закрыть без сохранения?
                 </p>
@@ -93,20 +95,13 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
                   Несохранённые изменения будут потеряны.
                 </p>
                 <div className="flex gap-2 justify-end">
-                  <button
-                    type="button"
-                    onClick={() => setConfirmClose(false)}
-                    className="px-3 py-1.5 text-sm rounded-md transition-colors border border-stroke text-fg2 hover:bg-muted"
-                  >
+                  <Button variant="text" size="sm" onClick={() => setConfirmClose(false)}>
                     Продолжить редактирование
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => { setConfirmClose(false); onOpenChange(false); }}
-                    className="px-3 py-1.5 text-sm rounded-md bg-danger text-white transition-colors"
-                  >
+                  </Button>
+                  <Button variant="filled" danger size="sm"
+                    onClick={() => { setConfirmClose(false); onOpenChange(false); }}>
                     Закрыть
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.22</Version>
+    <Version>0.23.23</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 3b (#110) — диалоги под MD3-форму + ещё пустые состояния.

## Диалоги (Modal + ConfirmDialog)
- Радиус **28** (`rounded-[28px]`), scrim **rgba(0,0,0,.4)**.
- Круглая close-кнопка (state-layer, кольцо фокуса, `aria-label`).
- Кнопки confirmClose-оверлея → MD3 `Button` (text + filled danger).
- Затрагивает **все** модалки и подтверждения приложения.

## Ещё пустые состояния (`EmptyState`)
- Документы качества (`QualityDocsPage`).
- Документы комплекта (`DocumentSetsPage` / SetDetail).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

## Дальше в Фазе 3
Карточки (outlined + hover-elevation) — карточки строек уже близки; довести до MD3-радиуса/hover. Остальные пустые состояния (пользователи, шаблоны) по необходимости. Затем Фаза 4 (навигация).