### PR TITLE
feat(md3): фаза 3c — MD3-форма карточек (радиусы + hover-elevation) (#110)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -715,7 +715,7 @@ function ConstructionsList() {
           {constructions.map(c => {
             const setsCount = c.sections.reduce((acc, s) => acc + s.documentSets.length, 0);
             return (
-              <div key={c.id} className="bg-surface border border-stroke rounded-xl p-5 flex flex-col gap-3 hover:border-brand-subtle hover:shadow-sm transition-all group cursor-pointer"
+              <div key={c.id} className="bg-surface border border-stroke rounded-xl p-5 flex flex-col gap-3 hover:border-brand hover:shadow-[var(--f-shadow16)] transition-all group cursor-pointer"
                 onClick={() => editId !== c.id && navigate(`/document-sets/${c.id}`)}>
                 <div className="flex items-start justify-between gap-2">
                   {editId === c.id ? (

--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -52,11 +52,12 @@
   --f-shadow16: 0 2px 8px rgba(16,35,63,.12), 0 1px 2px rgba(16,35,63,.10);
   --f-shadow28: 0 8px 24px rgba(0,0,0,.28), 0 2px 6px rgba(0,0,0,.14);
 
-  /* Border radii */
-  --f-r-sm: 2px;
-  --f-r-md: 4px;
-  --f-r-lg: 6px;
-  --f-r-xl: 8px;
+  /* Border radii — MD3 (issue #110 фаза 3): карточки/панели крупнее (xl → 16),
+     диалоги задают radius 28 напрямую. sm/md/lg — контролы/чипы. */
+  --f-r-sm: 4px;
+  --f-r-md: 6px;
+  --f-r-lg: 10px;
+  --f-r-xl: 16px;
 }
 
 /* ── Dark theme ──────────────────────────────────────────────────────────────── */

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.23</Version>
+    <Version>0.23.24</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 3c (#110) — **карточки** под MD3-форму.

## Token-first сдвиг формы
`--f-r-*` радиусы укрупнены под MD3: `sm 4 / md 6 / lg 10 / xl 16`. Карточки и панели (`rounded-xl` → **16**) получают MD3-скругление **одним изменением токена**, без правок компонентов. Диалоги задают radius 28 напрямую (Фаза 3b), не через токен.

## Кликабельные карточки
Карточки строек: hover → **border primary + elevation level2** (было border-subtle + shadow-sm) — MD3-паттерн clickable card.

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed · `npm run build` — ок

## Дальше
Фаза 3 по сути закрыта (пустые состояния, диалоги, карточки). Далее — **Фаза 4** (навигация: MD3 drawer-пункты пилюлями, top app bar, табы = APG-tablist/#107 F3).