### PR TITLE
feat(md3): фаза 4 — навигация (drawer-пилюли) + APG-табы редактора (#110, #107 F3)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -789,10 +789,23 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
     ['generation', 'Генерация'],
   ];
 
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   function requestTab(next: InstanceTab) {
     if (next === tab) return;
     if (dirty) setPendingTab(next);   // есть несохранённые изменения — спрашиваем
     else setTab(next);
+  }
+  // APG-tablist (issue #107 F3): стрелки/Home/End двигают ФОКУС между вкладками (manual
+  // activation — переключение по Enter/Space через onClick, чтобы dirty-guard не срабатывал на скролле).
+  function onTabKey(e: React.KeyboardEvent, i: number) {
+    let ni = -1;
+    if (e.key === 'ArrowRight') ni = (i + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft') ni = (i - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') ni = 0;
+    else if (e.key === 'End') ni = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    tabRefs.current[ni]?.focus();
   }
   function switchTo(next: InstanceTab) {
     setDirty(false);
@@ -823,10 +836,13 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
             {STATUS_LABELS[instance.status] ?? instance.status}
           </span>
         </div>
-        <div className="flex border-b border-stroke gap-0">
-          {tabs.map(([key, label]) => (
-            <button key={key} onClick={() => requestTab(key)}
-              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${tab === key ? 'border-brand text-brand-hover' : 'border-transparent text-fg3 hover:text-fg2'}`}>
+        <div role="tablist" aria-label="Разделы документа" className="flex border-b border-stroke gap-0">
+          {tabs.map(([key, label], i) => (
+            <button key={key} role="tab" aria-selected={tab === key} tabIndex={tab === key ? 0 : -1}
+              ref={el => { tabRefs.current[i] = el; }}
+              onClick={() => requestTab(key)} onKeyDown={e => onTabKey(e, i)}
+              className={`h-12 px-4 text-sm font-medium border-b-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand ${
+                tab === key ? 'border-brand text-brand' : 'border-transparent text-fg3 hover:text-fg1'}`}>
               {label}{key === tab && dirty && <span className="ml-1 text-warning" title="Есть несохранённые изменения">•</span>}
             </button>
           ))}

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -74,20 +74,21 @@ function NavSection({
             key={to}
             to={to}
             className={({ isActive }) =>
-              `group flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors select-none ${
-                isActive ? 'bg-brand-subtle' : ''
+              `group flex items-center gap-3 px-3 py-2.5 rounded-full text-sm font-medium select-none transition-colors ` +
+              `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand ${
+                isActive
+                  ? 'bg-tonal text-on-tonal'
+                  : 'text-fg1 hover:bg-black/5 dark:hover:bg-white/10'
               }`
             }
           >
             {({ isActive }) => (
               <>
                 <Icon
-                  size={16}
-                  className={`shrink-0 ${isActive ? 'text-brand' : 'text-fg3'}`}
+                  size={18}
+                  className={`shrink-0 ${isActive ? 'text-on-tonal' : 'text-fg3'}`}
                 />
-                <span className={isActive ? 'text-brand' : 'text-fg1'}>
-                  {itemLabel}
-                </span>
+                <span>{itemLabel}</span>
               </>
             )}
           </NavLink>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.24</Version>
+    <Version>0.23.25</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 4 рестайла MD3 (#110) — **навигация**.

## Navigation drawer (AppShell)
Пункты навигации → MD3 drawer-пилюли:
- `rounded-full`; активный — **secondary-container** (`bg-tonal`/`text-on-tonal`); hover — state-layer; видимое кольцо фокуса.
- иконка/текст активного — `on-tonal`.

## Табы редактора документа → APG tablist (закрывает #107 F3)
Табы «Реквизиты / Данные / Документы качества / Генерация»:
- `role="tablist"`/`role="tab"`, `aria-selected`, **roving tabindex**;
- навигация **стрелками ←→ / Home / End** (manual activation — переключение по Enter/Space, чтобы dirty-guard не срабатывал при простом перемещении фокуса);
- MD3-стиль (h-48, активный — нижняя граница `primary` + текст `primary`), кольцо фокуса.

Это закрывает последний «now»-пункт клавиатурного трека #107 — **F3 (табы→APG)**.

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

## Дальше
Остаётся **Фаза 5** (по-экранная доводка раскладок из хендоффа: сетки 3-в-ряд, метки «ОБЛАСТЬ: …» и т.п.) — по желанию/точечно. Основной MD3-язык (токены, кнопки, контролы, карточки, диалоги, пустые состояния, навигация) — внедрён.