### PR TITLE
feat(md3): фаза 5 — метки «ОБЛАСТЬ: …» над скоуп-панелями (#110)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -257,7 +257,8 @@ function SetDetail() {
       </div>
 
       {setId && (
-        <div className="mt-6 space-y-4">
+        <div className="mt-6 pt-5 border-t border-stroke space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-fg4">Область: комплект</h2>
           <ScopedCatalogPanel scope="Set" scopeId={setId} allDocTypes={docTypes} setId={setId} />
           <ScopedDataSetsPanel scope="Set" scopeId={setId} />
           <SubscribersPanel scope="Set" scopeId={setId} />
@@ -402,9 +403,12 @@ function SectionCard({ section, construction, expanded, onToggle, allDocTypes }:
           <Button variant="text" size="sm" icon={<Plus size={14} />} onClick={() => setAddSetOpen(true)} className="mt-1">
             Добавить комплект
           </Button>
-          <ScopedCatalogPanel scope="Section" scopeId={section.id} allDocTypes={allDocTypes} />
-          <ScopedDataSetsPanel scope="Section" scopeId={section.id} />
-          <SubscribersPanel scope="Section" scopeId={section.id} />
+          <div className="pt-3 mt-2 border-t border-muted space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-fg4">Область: раздел</h3>
+            <ScopedCatalogPanel scope="Section" scopeId={section.id} allDocTypes={allDocTypes} />
+            <ScopedDataSetsPanel scope="Section" scopeId={section.id} />
+            <SubscribersPanel scope="Section" scopeId={section.id} />
+          </div>
         </div>
       )}
 
@@ -575,7 +579,7 @@ function ConstructionDetail() {
 
       {/* Блок уровня «Стройка» — визуально обособлен от списка разделов (иначе читается как ещё один раздел). */}
       <div className="mt-6 pt-5 border-t border-stroke space-y-3">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-fg4">Общие для стройки</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-fg4">Область: стройка</h2>
         <ScopedCatalogPanel scope="Construction" scopeId={constructionId!} allDocTypes={docTypes} />
         <ScopedDataSetsPanel scope="Construction" scopeId={constructionId!} />
         <SubscribersPanel scope="Construction" scopeId={constructionId!} />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.25</Version>
+    <Version>0.23.26</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 5 (#110) — по-экранная доводка. Первый пункт: **явные метки уровня скоупа**.

## Проблема из ревью
«Повторяющийся блок скоупов без явной маркировки уровня» — панели «Каталог общих данных / Наборы данных / Подписчики» повторяются на страницах комплекта, раздела и стройки и визуально неотличимы.

## Решение
Над каждой группой панелей — явный uppercase-заголовок уровня (единый паттерн border-top + label):
- **«Область: комплект»** (SetDetail);
- **«Область: раздел»** (SectionCard);
- **«Область: стройка»** (ConstructionDetail — переименован с «Общие для стройки»).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed