### PR TITLE
feat(a11y): командная палитра Ctrl+K (#107)

### DIFF
--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useAppVersion } from '@/shared/api/version';
@@ -6,26 +6,9 @@ import { useTheme, type Theme } from '@/shared/ui/ThemeProvider';
 import { NotificationsCenter } from '@/features/notifications/NotificationsCenter';
 import { ActiveJobsIndicator } from '@/features/jobs/ActiveJobsIndicator';
 import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
-import {
-  FolderOpen, BookOpen, FileText, Settings, LogOut,
-  Sun, Moon, Monitor, Layers, Database, Tag, ShieldCheck, Users, KeyRound,
-} from 'lucide-react';
-
-const workNav = [
-  { to: '/document-sets', label: 'Стройки',        icon: FolderOpen },
-  { to: '/common-data',   label: 'Общие данные',    icon: Database   },
-  { to: '/datasets',      label: 'Наборы данных',   icon: Layers     },
-  { to: '/quality-docs',  label: 'Документы качества', icon: ShieldCheck },
-];
-
-const settingsNav = [
-  { to: '/document-types',  label: 'Типы документов', icon: BookOpen  },
-  { to: '/composite-types', label: 'Составные типы',  icon: Layers    },
-  { to: '/field-types',     label: 'Типы полей',      icon: Tag       },
-  { to: '/templates',       label: 'Шаблоны',         icon: FileText  },
-  { to: '/users',           label: 'Пользователи',    icon: Users     },
-  { to: '/settings',        label: 'Настройки',       icon: Settings  },
-];
+import { CommandPalette } from '@/shared/ui/CommandPalette';
+import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
+import { LogOut, Sun, Moon, Monitor, KeyRound } from 'lucide-react';
 
 const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'light',  icon: Sun,     label: 'Светлая'   },
@@ -61,7 +44,7 @@ function NavSection({
   items,
 }: {
   label: string;
-  items: { to: string; label: string; icon: typeof FolderOpen }[];
+  items: NavItem[];
 }) {
   return (
     <div>
@@ -102,6 +85,19 @@ export function AppShell() {
   const { user, logout } = useAuth();
   const isAdmin = user?.role === 'Admin';
   const [pwOpen, setPwOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // Глобальный Ctrl/⌘+K — командная палитра (issue #107).
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setPaletteOpen(o => !o);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
 
   return (
     <div className="flex h-screen bg-base">
@@ -148,6 +144,7 @@ export function AppShell() {
         </div>
       </aside>
       <ChangePasswordModal open={pwOpen} onClose={() => setPwOpen(false)} />
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
 
       {/* Content */}
       <main className="flex-1 flex flex-col overflow-hidden">

--- a/src/client/src/shared/ui/CommandPalette.tsx
+++ b/src/client/src/shared/ui/CommandPalette.tsx
@@ -1,0 +1,81 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { Search } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/shared/hooks/useAuth';
+import { workNav, settingsNav } from './navConfig';
+
+/**
+ * Командная палитра (issue #107, Ctrl+K) — быстрый переход к любому разделу с клавиатуры.
+ * v1: навигация. Стрелки ↑↓ двигают выделение, Enter — переход, Esc — закрыть, ввод фильтрует.
+ * Открывается глобальным Ctrl/⌘+K (слушатель в AppShell). Только после закрытия per-widget
+ * контрактов (F1–F3) — палитра ведёт в клавиатурно-проходимые экраны.
+ */
+export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'Admin';
+
+  const items = useMemo(() => [
+    ...workNav.map(n => ({ ...n, section: 'Документы и данные' })),
+    ...(isAdmin ? settingsNav.map(n => ({ ...n, section: 'Настройка системы' })) : []),
+  ], [isAdmin]);
+
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const filtered = useMemo(
+    () => items.filter(i => i.label.toLowerCase().includes(query.trim().toLowerCase())),
+    [items, query],
+  );
+
+  useEffect(() => { setActive(0); }, [query]);
+  useEffect(() => { if (!open) setQuery(''); }, [open]);
+
+  function go(to: string) { navigate(to); onOpenChange(false); }
+
+  function onKey(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, filtered.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); const it = filtered[active]; if (it) go(it.to); }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" style={{ backdropFilter: 'blur(2px)' }} />
+        <Dialog.Content
+          className="fixed left-1/2 top-24 z-50 w-full max-w-lg -translate-x-1/2 overflow-hidden rounded-2xl border border-stroke bg-surface focus:outline-none"
+          style={{ boxShadow: 'var(--f-shadow28)' }}
+        >
+          <Dialog.Title className="sr-only">Командная палитра</Dialog.Title>
+          <div className="flex items-center gap-2 border-b border-stroke px-4">
+            <Search size={16} className="shrink-0 text-fg4" />
+            <input
+              autoFocus value={query} onChange={e => setQuery(e.target.value)} onKeyDown={onKey}
+              placeholder="Перейти к разделу…"
+              className="h-12 flex-1 bg-transparent text-sm text-fg1 outline-none placeholder:text-fg4"
+            />
+            <kbd className="rounded border border-stroke px-1 text-[10px] text-fg4">Esc</kbd>
+          </div>
+          <ul className="max-h-80 overflow-y-auto p-2">
+            {filtered.length === 0 ? (
+              <li className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</li>
+            ) : filtered.map((it, i) => (
+              <li key={it.to}>
+                <button
+                  type="button" onMouseEnter={() => setActive(i)} onClick={() => go(it.to)}
+                  className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                    i === active ? 'bg-tonal text-on-tonal' : 'text-fg1'}`}
+                >
+                  <it.icon size={16} className={i === active ? 'text-on-tonal' : 'text-fg3'} />
+                  <span className="flex-1">{it.label}</span>
+                  <span className="text-[10px] text-fg4">{it.section}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/client/src/shared/ui/navConfig.ts
+++ b/src/client/src/shared/ui/navConfig.ts
@@ -1,0 +1,20 @@
+import { FolderOpen, BookOpen, FileText, Settings, Layers, Database, Tag, ShieldCheck, Users } from 'lucide-react';
+
+/** Пункты навигации — общий источник для сайдбара (AppShell) и командной палитры (Ctrl+K). */
+export interface NavItem { to: string; label: string; icon: typeof FolderOpen }
+
+export const workNav: NavItem[] = [
+  { to: '/document-sets', label: 'Стройки',           icon: FolderOpen },
+  { to: '/common-data',   label: 'Общие данные',       icon: Database   },
+  { to: '/datasets',      label: 'Наборы данных',      icon: Layers     },
+  { to: '/quality-docs',  label: 'Документы качества', icon: ShieldCheck },
+];
+
+export const settingsNav: NavItem[] = [
+  { to: '/document-types',  label: 'Типы документов', icon: BookOpen  },
+  { to: '/composite-types', label: 'Составные типы',  icon: Layers    },
+  { to: '/field-types',     label: 'Типы полей',      icon: Tag       },
+  { to: '/templates',       label: 'Шаблоны',         icon: FileText  },
+  { to: '/users',           label: 'Пользователи',    icon: Users     },
+  { to: '/settings',        label: 'Настройки',       icon: Settings  },
+];

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.26</Version>
+    <Version>0.23.27</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Командная палитра Ctrl+K (#107) — keyboard-first быстрый переход к разделам. Разблокировано после закрытия per-widget контрактов (F1–F3).

## Что сделано
- **`shared/ui/CommandPalette`** + глобальный **Ctrl/⌘+K** слушатель в `AppShell`.
- v1: навигация по всем разделам (`workNav` + `settingsNav` для админа), с секцией-подписью.
- Клавиатура: ввод фильтрует, **↑↓** выделение, **Enter** — переход, **Esc** — закрыть; focus-trap Radix Dialog, MD3-вид (radius 16, scrim, активный пункт — secondary-container).
- Конфиг навигации вынесен в **`shared/ui/navConfig`** (общий для сайдбара и палитры — без циклического импорта).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed · `npm run build` — ок

## Дальше (опц.)
v2 палитры: топ-действия («Новая стройка», смена темы) помимо навигации; `?`-шпаргалка шорткатов.