### PR TITLE
feat(a11y): клавиатура в RefPickerModal — завершение F5 (#107)

### DIFF
--- a/src/client/src/features/document-sets/fields/RefPickerModal.tsx
+++ b/src/client/src/features/document-sets/fields/RefPickerModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FileText, ChevronDown, ChevronRight } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { useCommonDataForScope } from '@/shared/api/commonData';
@@ -67,6 +67,29 @@ export function RefPickerModal({
       })
     : [];
 
+  // Плоский список навигируемых опций (issue #107 F5): видимые (в раскрытых группах) записи
+  // каталога + источники-документы — в порядке отображения. Стрелки/Enter ходят по ним.
+  type RpOption =
+    | { type: 'catalog'; entry: CommonDataEntry }
+    | { type: 'doc'; inst: DocumentInstance; dt: DocumentType; field: SchemaField };
+  const options: RpOption[] = [
+    ...groups.flatMap(g => isExpanded(g.scope) ? g.entries.map(entry => ({ type: 'catalog' as const, entry })) : []),
+    ...docSources.map(d => ({ type: 'doc' as const, ...d })),
+  ];
+  const [active, setActive] = useState(0);
+  useEffect(() => { setActive(0); }, [search, collapseOverride]);
+  const optKey = (o: RpOption) => o.type === 'catalog' ? `c:${o.entry.id}` : `d:${o.inst.id}-${o.field.key}`;
+  const indexByKey = new Map(options.map((o, i) => [optKey(o), i]));
+  function activate(o: RpOption) {
+    if (o.type === 'catalog') selectCatalog(o.entry);
+    else selectDocument(o.inst, o.dt, o.field);
+  }
+  function onKey(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, options.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); const o = options[active]; if (o) activate(o); }
+  }
+
   function selectCatalog(entry: CommonDataEntry) {
     onSelect({
       $ref: 'catalog',
@@ -91,10 +114,10 @@ export function RefPickerModal({
     <Modal open={open} onOpenChange={onOpenChange} title="Выбрать объект">
       <div className="space-y-4">
         <input
-          value={search} onChange={e => setSearch(e.target.value)}
-          placeholder="Поиск..."
+          value={search} onChange={e => setSearch(e.target.value)} onKeyDown={onKey}
+          placeholder="Поиск…" autoFocus role="combobox" aria-expanded
+          aria-activedescendant={options.length ? `rp-opt-${active}` : undefined}
           className="w-full border border-stroke-strong rounded-md px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface"
-          autoFocus
         />
 
         {groups.length > 0 && (
@@ -118,12 +141,18 @@ export function RefPickerModal({
                     </button>
                     {expanded && (
                       <div className="space-y-0.5 pl-1.5">
-                        {g.entries.map(entry => (
-                          <button key={entry.id} onClick={() => selectCatalog(entry)}
-                            className="w-full flex items-center px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                            <span className="flex-1 font-medium text-fg1 truncate">{entry.displayName}</span>
-                          </button>
-                        ))}
+                        {g.entries.map(entry => {
+                          const gi = indexByKey.get(`c:${entry.id}`) ?? -1;
+                          const on = gi === active;
+                          return (
+                            <button key={entry.id} type="button" role="option" aria-selected={on} id={`rp-opt-${gi}`}
+                              onMouseEnter={() => setActive(gi)} onClick={() => selectCatalog(entry)}
+                              className={`w-full flex items-center px-3 py-2 text-sm text-left rounded-md transition-colors ${
+                                on ? 'bg-tonal text-on-tonal' : 'hover:bg-brand-subtle'}`}>
+                              <span className={`flex-1 font-medium truncate ${on ? 'text-on-tonal' : 'text-fg1'}`}>{entry.displayName}</span>
+                            </button>
+                          );
+                        })}
                       </div>
                     )}
                   </div>
@@ -139,16 +168,21 @@ export function RefPickerModal({
               Из других документов комплекта
             </p>
             <div className="space-y-1">
-              {docSources.map(({ inst, dt, field }) => (
-                <button key={`${inst.id}-${field.key}`}
-                  onClick={() => selectDocument(inst, dt, field)}
-                  className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md hover:bg-brand-subtle transition-colors">
-                  <FileText size={14} className="text-fg4 shrink-0" />
-                  <span className="flex-1 font-medium text-fg1 truncate">
-                    {dt.name} → {field.title}
-                  </span>
-                </button>
-              ))}
+              {docSources.map(({ inst, dt, field }) => {
+                const gi = indexByKey.get(`d:${inst.id}-${field.key}`) ?? -1;
+                const on = gi === active;
+                return (
+                  <button key={`${inst.id}-${field.key}`} type="button" role="option" aria-selected={on} id={`rp-opt-${gi}`}
+                    onMouseEnter={() => setActive(gi)} onClick={() => selectDocument(inst, dt, field)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left rounded-md transition-colors ${
+                      on ? 'bg-tonal text-on-tonal' : 'hover:bg-brand-subtle'}`}>
+                    <FileText size={14} className={`shrink-0 ${on ? 'text-on-tonal' : 'text-fg4'}`} />
+                    <span className={`flex-1 font-medium truncate ${on ? 'text-on-tonal' : 'text-fg1'}`}>
+                      {dt.name} → {field.title}
+                    </span>
+                  </button>
+                );
+              })}
             </div>
           </div>
         )}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.28</Version>
+    <Version>0.23.29</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Завершение #107 **F5** — второй (grouped) пикер.

## `RefPickerModal` (композитный $ref-пикер)
- Видимые записи каталога (в раскрытых скоуп-группах) + источники-документы объединены в единый плоский список опций.
- Стрелки **↑↓** двигают выделение, **Enter** выбирает, ввод фильтрует; `role="option"` + `aria-selected` + combobox-инпут с `aria-activedescendant`; активная опция — secondary-container; hover синхронизирован.
- Заголовки скоуп-групп остаются отдельными сворачивающими кнопками (`aria-expanded`).

## Итог F5
Оба кастомных пикера — плоский `BaseCandidatePicker` (#140) и grouped `RefPickerModal` (этот PR) — на клавиатурной навигации. **F5 закрыт.**

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed