### PR TITLE
feat(a11y): палитра v2 (действия) + шпаргалка «?» (#107)

### DIFF
--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -7,6 +7,7 @@ import { NotificationsCenter } from '@/features/notifications/NotificationsCente
 import { ActiveJobsIndicator } from '@/features/jobs/ActiveJobsIndicator';
 import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
+import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
 import { LogOut, Sun, Moon, Monitor, KeyRound } from 'lucide-react';
 
@@ -86,13 +87,20 @@ export function AppShell() {
   const isAdmin = user?.role === 'Admin';
   const [pwOpen, setPwOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
 
-  // Глобальный Ctrl/⌘+K — командная палитра (issue #107).
+  // Глобальные шорткаты (issue #107): Ctrl/⌘+K — палитра, «?» — справка (не в полях ввода).
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setPaletteOpen(o => !o);
+        return;
+      }
+      if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const el = document.activeElement as HTMLElement | null;
+        const editable = !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable);
+        if (!editable) { e.preventDefault(); setHelpOpen(o => !o); }
       }
     }
     window.addEventListener('keydown', onKey);
@@ -145,6 +153,7 @@ export function AppShell() {
       </aside>
       <ChangePasswordModal open={pwOpen} onClose={() => setPwOpen(false)} />
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      <ShortcutsHelp open={helpOpen} onOpenChange={setHelpOpen} />
 
       {/* Content */}
       <main className="flex-1 flex flex-col overflow-hidden">

--- a/src/client/src/shared/ui/CommandPalette.tsx
+++ b/src/client/src/shared/ui/CommandPalette.tsx
@@ -1,9 +1,12 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Search } from 'lucide-react';
+import { Search, Sun, Moon, Monitor, LogOut, type LucideIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
+import { useTheme } from '@/shared/ui/ThemeProvider';
 import { workNav, settingsNav } from './navConfig';
+
+interface Cmd { id: string; label: string; section: string; icon: LucideIcon; run: () => void }
 
 /**
  * Командная палитра (issue #107, Ctrl+K) — быстрый переход к любому разделу с клавиатуры.
@@ -13,13 +16,23 @@ import { workNav, settingsNav } from './navConfig';
  */
 export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
+  const { setTheme } = useTheme();
   const isAdmin = user?.role === 'Admin';
 
-  const items = useMemo(() => [
-    ...workNav.map(n => ({ ...n, section: 'Документы и данные' })),
-    ...(isAdmin ? settingsNav.map(n => ({ ...n, section: 'Настройка системы' })) : []),
-  ], [isAdmin]);
+  const items = useMemo<Cmd[]>(() => {
+    const nav = [
+      ...workNav.map(n => ({ ...n, section: 'Документы и данные' })),
+      ...(isAdmin ? settingsNav.map(n => ({ ...n, section: 'Настройка системы' })) : []),
+    ].map(n => ({ id: n.to, label: n.label, section: n.section, icon: n.icon, run: () => navigate(n.to) }));
+    const actions: Cmd[] = [
+      { id: 'theme-light',  label: 'Тема: светлая',   section: 'Действия', icon: Sun,     run: () => setTheme('light') },
+      { id: 'theme-dark',   label: 'Тема: тёмная',    section: 'Действия', icon: Moon,    run: () => setTheme('dark') },
+      { id: 'theme-system', label: 'Тема: системная', section: 'Действия', icon: Monitor, run: () => setTheme('system') },
+      { id: 'logout',       label: 'Выйти',           section: 'Действия', icon: LogOut,  run: logout },
+    ];
+    return [...nav, ...actions];
+  }, [isAdmin, navigate, setTheme, logout]);
 
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
@@ -31,12 +44,12 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
   useEffect(() => { setActive(0); }, [query]);
   useEffect(() => { if (!open) setQuery(''); }, [open]);
 
-  function go(to: string) { navigate(to); onOpenChange(false); }
+  function exec(it: Cmd) { it.run(); onOpenChange(false); }
 
   function onKey(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, filtered.length - 1)); }
     else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, 0)); }
-    else if (e.key === 'Enter') { e.preventDefault(); const it = filtered[active]; if (it) go(it.to); }
+    else if (e.key === 'Enter') { e.preventDefault(); const it = filtered[active]; if (it) exec(it); }
   }
 
   return (
@@ -61,15 +74,15 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
             {filtered.length === 0 ? (
               <li className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</li>
             ) : filtered.map((it, i) => (
-              <li key={it.to}>
+              <li key={it.id}>
                 <button
-                  type="button" onMouseEnter={() => setActive(i)} onClick={() => go(it.to)}
+                  type="button" onMouseEnter={() => setActive(i)} onClick={() => exec(it)}
                   className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
                     i === active ? 'bg-tonal text-on-tonal' : 'text-fg1'}`}
                 >
                   <it.icon size={16} className={i === active ? 'text-on-tonal' : 'text-fg3'} />
                   <span className="flex-1">{it.label}</span>
-                  <span className="text-[10px] text-fg4">{it.section}</span>
+                  <span className={`text-[10px] ${i === active ? 'text-on-tonal/80' : 'text-fg4'}`}>{it.section}</span>
                 </button>
               </li>
             ))}

--- a/src/client/src/shared/ui/ShortcutsHelp.tsx
+++ b/src/client/src/shared/ui/ShortcutsHelp.tsx
@@ -1,0 +1,28 @@
+import { Modal } from './Modal';
+
+/** Шпаргалка по горячим клавишам (issue #107) — открывается клавишей «?». */
+const SHORTCUTS: [string, string][] = [
+  ['Ctrl / ⌘ + K', 'Командная палитра — переход к разделам и действия'],
+  ['?', 'Эта справка по горячим клавишам'],
+  ['↑ ↓ + Enter', 'Навигация по спискам и пикерам (палитра, выбор объекта)'],
+  ['← →', 'Переключение вкладок в редакторе документа'],
+  ['Esc', 'Закрыть диалог или палитру'],
+  ['Tab', 'Переход между полями формы'],
+];
+
+export function ShortcutsHelp({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title="Горячие клавиши">
+      <div className="divide-y divide-muted">
+        {SHORTCUTS.map(([keys, desc]) => (
+          <div key={keys} className="flex items-center gap-4 py-2">
+            <kbd className="min-w-[120px] shrink-0 rounded bg-muted px-2 py-1 text-center text-xs font-medium text-fg2">
+              {keys}
+            </kbd>
+            <span className="text-sm text-fg2">{desc}</span>
+          </div>
+        ))}
+      </div>
+    </Modal>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.29</Version>
+    <Version>0.23.30</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Округление keyboard-first набора (#107).

## Командная палитра v2 (Ctrl+K)
Помимо навигации по разделам — **действия**:
- «Тема: светлая / тёмная / системная»;
- «Выйти».
Унифицированная модель `Cmd { label, section, icon, run }`; те же стрелки ↑↓/Enter/фильтр.

## Шпаргалка шорткатов «?»
Новый `shared/ui/ShortcutsHelp` — справка по горячим клавишам (Ctrl+K, ?, ↑↓+Enter, ←→, Esc, Tab). Открывается клавишей **?** (глобальный слушатель в `AppShell`, **не срабатывает** в полях ввода/`contenteditable`).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed · `npm run build` — ок
- Живой фронт: Ctrl+K → есть раздел «Действия»; «?» вне поля → справка.