### PR TITLE
feat(a11y): клавиатурный ресайз колонок в редакторе таблицы (#107 F8b-часть)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -252,8 +252,14 @@ export function ArrayTableModal({
                   <span className="flex items-center px-2 text-left text-xs font-semibold text-fg2 truncate" style={{ height: 28 }}>
                     {f.title}{f.required && <span className="text-danger ml-0.5">*</span>}
                   </span>
-                  <div onMouseDown={e => startResize(e, f.key, getW(f))}
-                    className="hover:bg-brand-subtle/40 transition-colors"
+                  <div role="separator" aria-orientation="vertical" tabIndex={0}
+                    aria-label={`Ширина колонки «${f.title}» — стрелки ←→`}
+                    onMouseDown={e => startResize(e, f.key, getW(f))}
+                    onKeyDown={e => {
+                      if (e.key === 'ArrowLeft') { e.preventDefault(); setColWidths(p => ({ ...p, [f.key]: Math.max(44, getW(f) - 16) })); }
+                      else if (e.key === 'ArrowRight') { e.preventDefault(); setColWidths(p => ({ ...p, [f.key]: getW(f) + 16 })); }
+                    }}
+                    className="hover:bg-brand-subtle/40 focus-visible:bg-brand focus-visible:outline-none transition-colors"
                     style={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 5, cursor: 'col-resize', zIndex: 1 }} />
                 </th>
               ))}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.30</Version>
+    <Version>0.23.31</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Ограниченный, но реальный кусок #107 **F8b** — клавиатурный ресайз колонок.

## Что сделано
`ArrayTableModal`: ручка ресайза колонки → фокусируемый **separator**:
- `role="separator"`, `aria-orientation="vertical"`, `tabIndex=0`, `aria-label`;
- стрелки **←→** меняют ширину шагом 16px (мин 44); видимый фокус.
- Мышиный ресайз сохранён.

Закрывает пункт аудита «ресайз колонок — мышь-only».

## Вне охвата (осознанно)
Полный APG grid (навигация по всем ячейкам с модальностью edit/navigate, роли `grid`/`gridcell`, выделение строк) остаётся в «фазе таблиц» — крупная переработка управления фокусом; ↑↓ между ячейками колонки уже есть (F8a).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed