### PR TITLE
feat(a11y): Ctrl+Enter — сохранить-и-закрыть в редакторе документа (#107 F7)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -31,6 +31,7 @@ import { mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
 import { QualityLinksTab } from './QualityLinksTab';
 import { DocumentTemplateParams } from './DocumentTemplateParams';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 
 type SaveRef = { current: (() => Promise<boolean>) | null };
 
@@ -823,7 +824,14 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
   }
 
   return (
-    <div className="flex flex-col min-h-0 flex-1">
+    <div className="flex flex-col min-h-0 flex-1"
+      onKeyDown={e => {
+        // Ctrl/⌘+Enter — сохранить и закрыть (issue #107 F7); работает из любого поля вкладки реквизитов.
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && editable && !saving) {
+          e.preventDefault();
+          void doSaveAndClose();
+        }
+      }}>
       <div className="shrink-0 px-6 pt-1 bg-surface">
         <div className="flex items-center gap-2 mb-1 min-w-0">
           <div className="flex-1 min-w-0">
@@ -874,18 +882,14 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
       <div className="shrink-0 px-6 py-3 bg-surface border-t border-stroke flex items-center gap-2 flex-wrap">
         {editable ? (
           <>
-            <button onClick={() => void doSave()} disabled={saving}
-              className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors disabled:opacity-50">
-              {saving ? 'Сохранение...' : 'Сохранить'}
-            </button>
-            <button onClick={() => void doSaveAndClose()} disabled={saving}
-              className="px-4 py-2 text-sm border border-brand text-brand-hover hover:bg-brand-subtle rounded-md transition-colors disabled:opacity-50">
+            <Button variant="filled" onClick={() => void doSaveAndClose()} loading={saving}
+              title="Ctrl+Enter">
               Сохранить и закрыть
-            </button>
-            <button onClick={onClose} disabled={saving}
-              className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md transition-colors disabled:opacity-50">
-              Отмена
-            </button>
+            </Button>
+            <Button variant="text" onClick={() => void doSave()} disabled={saving}>
+              {saving ? 'Сохранение…' : 'Сохранить'}
+            </Button>
+            <Button variant="text" onClick={onClose} disabled={saving}>Отмена</Button>
             {savedFlash && <span className="text-sm text-success">Сохранено</span>}
           </>
         ) : (

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.32</Version>
+    <Version>0.23.33</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #107 **F7** — быстрое сохранение с клавиатуры.

## Что сделано
- **Ctrl/⌘+Enter** из любого поля вкладки «Реквизиты» → «Сохранить и закрыть».
- Заодно **футер редактора документа приведён к MD3-иерархии** хендоффа: filled «Сохранить и закрыть» (primary, tooltip Ctrl+Enter) + text «Сохранить» + text «Отмена». Было: filled «Сохранить» + outlined «Сохранить и закрыть» (обратный порядок, pre-MD3) — конвертированы на `Button`.

Простые формы (native `<form>`) уже сабмитятся по Enter, поэтому доп. правок там не нужно.

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed