### PR TITLE
feat(md3): фаза 5 — ширина страницы настроек ≈760 (#110)

### DIFF
--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -338,7 +338,7 @@ export function SettingsPage() {
   }
 
   return (
-    <div className="px-6 py-4 max-w-2xl space-y-5">
+    <div className="px-6 py-4 max-w-3xl space-y-5">
       <h1 className="text-xl font-semibold text-fg1">Настройки</h1>
 
       {/* ── Template versioning ────────────────────────────────────────────── */}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.33</Version>
+    <Version>0.23.34</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 5 (#110) — финальный пункт по-экранной доводки.

## Что сделано
`SettingsPage`: `max-w-2xl` → `max-w-3xl` (≈768px) — по хендоффу «контейнер 760px устраняет пустую ширину».

## Фаза 5 в целом
Остальные пункты уже внедрены в предыдущих PR:
- сетка карточек строек 3-в-ряд (grid-cols-3);
- метки «ОБЛАСТЬ: комплект/раздел/стройка» (#138);
- таблицы вместо пустых полей (записи каталога/документы/качество);
- пустые состояния (`EmptyState`, #134/#135).

## Проверка
- `npx tsc -b` — чисто · `npm test` — 115 passed

Завершает MD3-рестайл (#110) — все фазы 0–5 внедрены.