### PR TITLE
refactor(md3): завершение G2 — pill-свип raw-кнопок диалогов (#110)

### DIFF
--- a/src/client/src/features/document-sets/EmailSendDialog.tsx
+++ b/src/client/src/features/document-sets/EmailSendDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
-import { Loader2, AlertTriangle, CheckCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { useRecipients } from '@/shared/api/subscriptions';
 import { apiError } from '@/shared/utils/apiError';
 
@@ -64,12 +65,11 @@ export function EmailSendDialog({ open, onClose, setId, itemName, defaultSubject
     <Modal open={open} onOpenChange={o => { if (!o) { onClose(); setQueued(false); setError(''); } }} title={`Отправить: ${itemName}`}
       footer={
         <div className="flex justify-end gap-3">
-          <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Закрыть</button>
-          <button type="button" onClick={handleSend} disabled={sending || queued || !ready || to.length === 0}
-            className="flex items-center gap-2 px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-            {sending ? <Loader2 size={14} className="animate-spin" /> : null}
+          <Button variant="text" onClick={onClose}>Закрыть</Button>
+          <Button variant="filled" onClick={handleSend} loading={sending}
+            disabled={queued || !ready || to.length === 0}>
             Отправить ({to.length})
-          </button>
+          </Button>
         </div>
       }>
       <div className="space-y-4">

--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { Loader2, Link2, Unlink, ShieldCheck, Search, Globe, ExternalLink, Download, Eye, Check } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import { usePreviewDataSetBindings } from '@/shared/api/datasets';
 import {
@@ -202,10 +203,9 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
                     : queryTokens.length > 0 ? 'По материалу в библиотеке ничего не найдено.'
                     : 'Нет подходящих (непросроченных) документов.'}
                 </p>
-                <button onClick={enterSearch}
-                  className="inline-flex items-center gap-2 px-3 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md">
-                  <Globe size={14} /> Искать в интернете
-                </button>
+                <Button variant="filled" size="sm" onClick={enterSearch} icon={<Globe size={14} />}>
+                  Искать в интернете
+                </Button>
               </div>
             ) : (
               <div className="max-h-80 overflow-y-auto divide-y divide-muted border border-stroke rounded-md">
@@ -244,10 +244,10 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
                 onKeyDown={e => { if (e.key === 'Enter') void runSearch(); }}
                 placeholder="строка поиска" className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />
             </div>
-            <button onClick={() => runSearch()} disabled={searching || !query.trim()}
-              className="flex items-center gap-1.5 px-3 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-              {searching ? <Loader2 size={14} className="animate-spin" /> : <Search size={14} />} Найти
-            </button>
+            <Button variant="filled" size="sm" onClick={() => runSearch()} loading={searching}
+              disabled={!query.trim()} icon={<Search size={14} />}>
+              Найти
+            </Button>
           </div>
           {searchError && <p className="text-sm text-danger">{searchError}</p>}
           {results && results.length === 0 && <p className="text-sm text-fg4 py-3 text-center">Ничего не найдено.</p>}
@@ -263,11 +263,11 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
                     </a>
                     {c.snippet && <p className="text-xs text-fg4 line-clamp-2">{c.snippet}</p>}
                   </div>
-                  <button onClick={() => importAndLink(c)} disabled={importingUrl !== null}
-                    className="flex items-center gap-1 px-2 py-1 text-xs bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50 shrink-0">
-                    {importingUrl === c.url ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
+                  <Button variant="filled" size="sm" onClick={() => importAndLink(c)}
+                    loading={importingUrl === c.url} disabled={importingUrl !== null}
+                    icon={<Download size={12} />} className="shrink-0">
                     В библиотеку
-                  </button>
+                  </Button>
                 </div>
               ))}
             </div>
@@ -510,7 +510,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
                               {suggestion.doc.displayName}
                             </button>
                             <button onClick={() => void acceptSuggestion(m, suggestion.doc.id)} title="Привязать предложенный документ"
-                              className="flex items-center gap-1 px-1.5 py-0.5 text-xs bg-brand hover:bg-brand-hover text-white rounded">
+                              className="flex items-center gap-1 px-1.5 py-0.5 text-xs bg-brand hover:bg-brand-hover text-on-brand rounded-full">
                               <Check size={12} /> привязать
                             </button>
                           </span>
@@ -526,10 +526,10 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
       )}
 
       <div className="flex items-center gap-3">
-        <button onClick={() => setPickerOpen(true)} disabled={selected.size === 0}
-          className="flex items-center gap-2 px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
-          <Link2 size={14} /> Связать выбранные ({selected.size})
-        </button>
+        <Button variant="filled" onClick={() => setPickerOpen(true)} disabled={selected.size === 0}
+          icon={<Link2 size={14} />}>
+          Связать выбранные ({selected.size})
+        </Button>
         <button onClick={() => void acceptAllSuggestions()} disabled={suggestCount === 0 || setLinks.isPending}
           title="Привязать все предложенные из библиотеки документы"
           className="flex items-center gap-2 px-4 py-2 text-sm bg-brand-subtle text-brand rounded-md hover:bg-brand/15 disabled:opacity-50">
@@ -567,11 +567,11 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
         title="Предложенные связи" wide
         footer={
           <div className="flex items-center gap-2">
-            <button onClick={applySuggestions} disabled={suggestSel.size === 0 || setLinks.isPending}
-              className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md disabled:opacity-50">
+            <Button variant="filled" onClick={applySuggestions} loading={setLinks.isPending}
+              disabled={suggestSel.size === 0}>
               {setLinks.isPending ? 'Применение...' : `Применить выбранные (${suggestSel.size})`}
-            </button>
-            <button onClick={() => setSuggestions(null)} className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
+            </Button>
+            <Button variant="text" onClick={() => setSuggestions(null)}>Отмена</Button>
           </div>
         }>
         {suggestions && suggestions.length === 0 ? (

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -632,23 +632,21 @@ function GenerationTab({ instance, setId }: { instance: DocumentInstance; setId:
       )}
 
       <div className="flex gap-3">
-        <button onClick={() => handleGenerate()} disabled={mutation.isPending || noTemplates}
-          className="flex items-center gap-2 px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors disabled:opacity-50">
-          {mutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <FileText size={14} />}
+        <Button variant="filled" onClick={() => handleGenerate()} disabled={noTemplates}
+          loading={mutation.isPending} icon={<FileText size={14} />}>
           Сгенерировать PDF
-        </button>
-        <button onClick={handleValidate} disabled={validating}
+        </Button>
+        <Button variant="outlined" onClick={handleValidate} loading={validating}
           title="Проверить разрешение ссылок (каталог, наборы данных) без генерации"
-          className="flex items-center gap-2 px-4 py-2 text-sm border border-stroke rounded-md hover:bg-base transition-colors disabled:opacity-50">
-          {validating ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} className="text-fg3" />}
+          icon={<ShieldCheck size={14} />}>
           Проверить ссылки
-        </button>
-        <button onClick={handleDebugBundle} disabled={debugBusy || noTemplates}
+        </Button>
+        <Button variant="outlined" onClick={handleDebugBundle} disabled={debugBusy || noTemplates}
+          loading={debugBusy}
           title="Скачать ZIP с template.typ, data.json, typeblocks.typ и userlib.typ для отладки во внешнем инструменте (typst compile template.typ)"
-          className="flex items-center gap-2 px-4 py-2 text-sm border border-stroke rounded-md hover:bg-base transition-colors disabled:opacity-50">
-          {debugBusy ? <Loader2 size={14} className="animate-spin" /> : <Bug size={14} className="text-fg3" />}
+          icon={<Bug size={14} />}>
           Отладочный пакет
-        </button>
+        </Button>
       </div>
       {(mutation.isPending || instance.status === 'Generating') && (
         <p className="flex items-center gap-2 text-xs text-fg4">
@@ -912,18 +910,15 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           title="Документ не сохранён"
           footer={
             <div className="flex gap-2 justify-end flex-wrap">
-              <button onClick={() => setPendingTab(null)} disabled={switching}
-                className="px-3 py-1.5 text-sm rounded-md border border-stroke text-fg2 hover:bg-muted transition-colors disabled:opacity-50">
+              <Button variant="text" size="sm" onClick={() => setPendingTab(null)} disabled={switching}>
                 Отмена
-              </button>
-              <button onClick={() => switchTo(pendingTab)} disabled={switching}
-                className="px-3 py-1.5 text-sm rounded-md text-danger hover:bg-danger-subtle transition-colors disabled:opacity-50">
+              </Button>
+              <Button variant="text" size="sm" danger onClick={() => switchTo(pendingTab)} disabled={switching}>
                 Не сохранять
-              </button>
-              <button onClick={saveThenSwitch} disabled={switching}
-                className="px-3 py-1.5 text-sm rounded-md bg-brand hover:bg-brand-hover text-white transition-colors disabled:opacity-50">
+              </Button>
+              <Button variant="filled" size="sm" onClick={saveThenSwitch} loading={switching}>
                 {switching ? 'Сохранение...' : 'Сохранить'}
-              </button>
+              </Button>
             </div>
           }>
           <p className="text-xs text-fg3">

--- a/src/client/src/features/document-sets/fields/FileField.tsx
+++ b/src/client/src/features/document-sets/fields/FileField.tsx
@@ -68,7 +68,7 @@ export function FilePreviewModal({ open, onOpenChange, attachment }: {
           <FileSpreadsheet size={48} className="text-success" />
           <p className="text-sm text-fg3">Предпросмотр недоступен для этого формата.</p>
           <a href={objectUrl} download={attachment.fileName}
-            className="flex items-center gap-2 px-4 py-2 bg-brand hover:bg-brand-hover text-white text-sm rounded-md transition-colors">
+            className="inline-flex items-center gap-2 h-9 px-4 bg-brand hover:bg-brand-hover active:bg-brand-pressed text-on-brand text-sm font-medium rounded-full shadow-[var(--f-shadow4)] transition-colors">
             <Download size={14} /> Скачать
           </a>
         </div>

--- a/src/client/src/features/document-sets/fields/PasteMappingModal.tsx
+++ b/src/client/src/features/document-sets/fields/PasteMappingModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import type { CommonDataEntry, DocumentType, FieldRef } from '@/shared/api/types';
 import { resolveEffectiveFields, isSubtypeOf, type SchemaField } from '@/shared/api/schema';
 // ─── Paste mapping modal ──────────────────────────────────────────────────────
@@ -101,13 +102,11 @@ export function PasteMappingModal({
       <Modal open={open} onOpenChange={onOpenChange} title="Вставить из Excel" wide
         footer={
           <div className="flex justify-end gap-3">
-            <button type="button" onClick={() => onOpenChange(false)}
-              className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-            <button type="button" disabled={!rawText.trim()}
-              onClick={() => { initMapping(rawText); setStep('map'); }}
-              className="px-4 py-2 text-sm bg-brand text-white rounded-md disabled:opacity-50 hover:bg-brand-hover">
+            <Button variant="text" onClick={() => onOpenChange(false)}>Отмена</Button>
+            <Button variant="filled" disabled={!rawText.trim()}
+              onClick={() => { initMapping(rawText); setStep('map'); }}>
               Далее →
-            </button>
+            </Button>
           </div>
         }>
         <div className="space-y-4">
@@ -129,15 +128,12 @@ export function PasteMappingModal({
     <Modal open={open} onOpenChange={onOpenChange} title="Сопоставление столбцов" wide
       footer={
         <div className="flex justify-between">
-          <button type="button" onClick={() => setStep('input')}
-            className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">← Назад</button>
+          <Button variant="text" onClick={() => setStep('input')}>← Назад</Button>
           <div className="flex gap-3">
-            <button type="button" onClick={() => onOpenChange(false)}
-              className="px-4 py-2 text-sm text-fg2 hover:bg-muted rounded-md">Отмена</button>
-            <button type="button" onClick={apply} disabled={importCount === 0}
-              className="px-4 py-2 text-sm bg-brand text-white rounded-md disabled:opacity-50 hover:bg-brand-hover">
+            <Button variant="text" onClick={() => onOpenChange(false)}>Отмена</Button>
+            <Button variant="filled" onClick={apply} disabled={importCount === 0}>
               Импортировать {importCount > 0 ? `(${importCount} стр.)` : ''}
-            </button>
+            </Button>
           </div>
         </div>
       }>

--- a/src/client/src/features/settings/EmailSettingsSection.tsx
+++ b/src/client/src/features/settings/EmailSettingsSection.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Mail, Send, CheckCircle, XCircle, AlertTriangle, PlugZap } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import {
   useIntegrationSettings, useSaveSmtp, useTestEmail, useTestSmtpConnection, useEmailUserStatus,
@@ -96,16 +97,14 @@ export function EmailSettingsSection() {
       </label>
 
       <div className="flex items-center gap-3 flex-wrap">
-        <button type="button" onClick={handleSave} disabled={saveSmtp.isPending}
-          className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors disabled:opacity-50">
+        <Button variant="filled" onClick={handleSave} loading={saveSmtp.isPending}>
           {saveSmtp.isPending ? 'Сохранение...' : 'Сохранить'}
-        </button>
-        <button type="button" onClick={handleTestConnection} disabled={testConn.isPending || !form.host}
+        </Button>
+        <Button variant="outlined" onClick={handleTestConnection} disabled={testConn.isPending || !form.host}
           title="Проверить соединение и аутентификацию по введённым значениям (письмо не отправляется)"
-          className="flex items-center gap-2 px-3 py-2 text-sm border border-stroke-strong hover:bg-base rounded-md transition-colors disabled:opacity-50">
-          <PlugZap size={14} className="text-fg3" />
+          icon={<PlugZap size={14} />}>
           {testConn.isPending ? 'Проверка...' : 'Проверить подключение'}
-        </button>
+        </Button>
         {saved && <span className="text-sm text-success">Сохранено</span>}
         {saveError && <span className="text-sm text-danger flex items-center gap-1"><XCircle size={14} /> {saveError}</span>}
         {connResult && (connResult.ok

--- a/src/client/src/features/settings/IntegrationSettingsSection.tsx
+++ b/src/client/src/features/settings/IntegrationSettingsSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import {
@@ -317,14 +318,9 @@ export function IntegrationSettingsSection() {
           </div>
 
           <div className="flex items-center gap-3 pt-1">
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={save.isPending}
-              className="px-4 py-2 text-sm font-medium rounded-md bg-brand text-white hover:bg-brand-hover disabled:opacity-50"
-            >
+            <Button variant="filled" onClick={handleSave} loading={save.isPending}>
               {save.isPending ? 'Сохранение…' : 'Сохранить'}
-            </button>
+            </Button>
             {saved && <span className="text-sm text-success">Сохранено</span>}
             {save.isError && <span className="text-sm text-danger">Ошибка сохранения</span>}
           </div>

--- a/src/client/src/features/settings/TypstRendersEditor.tsx
+++ b/src/client/src/features/settings/TypstRendersEditor.tsx
@@ -4,6 +4,7 @@ import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { Plus, Trash2, Maximize2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
 import type { DocumentType } from '@/shared/api/types';
 import { resolveEffectiveFields, type SchemaField, type TypstRender } from '@/shared/api/schema';
 // ─── Typst it-field autocomplete ──────────────────────────────────────────────
@@ -111,14 +112,8 @@ function TypstBlockDialog({ render, onSave, onClose }: {
       isDirty={isDirty}
       footer={
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onClose}
-            className="px-4 py-2 text-sm text-fg2 hover:text-fg1 border border-stroke-strong rounded-md transition-colors">
-            Отмена
-          </button>
-          <button type="button" onClick={() => { onSave(draft); onClose(); }}
-            className="px-4 py-2 text-sm bg-brand hover:bg-brand-hover text-white rounded-md transition-colors">
-            Применить
-          </button>
+          <Button variant="text" onClick={onClose}>Отмена</Button>
+          <Button variant="filled" onClick={() => { onSave(draft); onClose(); }}>Применить</Button>
         </div>
       }
     >

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.36</Version>
+    <Version>0.23.37</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Завершение gap **G2** из аудита Дизайнера (MD3): сплошной перевод оставшихся сырых
`bg-brand text-white rounded-md` кнопок на компонент `Button` (MD3-пилюля, state-layer,
кольцо фокуса, иерархия filled/outlined/text).

## Что переведено
- **editor/index.tsx** — панель генерации: «Сгенерировать PDF» (filled) +
  «Проверить ссылки» / «Отладочный пакет» (outlined); footer-гард «Документ не сохранён»
  (text / text-danger / filled).
- **QualityLinksTab** — «Искать в интернете», «Найти», «В библиотеку», «Связать выбранные»,
  модалка предложенных связей; крошечный inline-чип «привязать» переведён на токен
  `text-on-brand` + `rounded-full` (форма-плотность сохранена).
- **EmailSendDialog**, **EmailSettingsSection**, **IntegrationSettingsSection**,
  **TypstRendersEditor**, **PasteMappingModal** → `Button`.
- **FileField** — ссылка «Скачать» приведена к виду filled-пилюли (остаётся `<a>`).

## Что НЕ трогалось (осознанно)
- Активные состояния **сегментных контролов** (`x === y ? bg-brand text-white`) в
  RowFilterDialog / SortSpecDialog / XPathBuilder / PrimitiveTypesPage — это не кнопки,
  а задел под будущий MD3 segmented-control.
- Лого-плашка на LoginPage (`<div>`).

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- `npm run build` — ок

Версия → 0.23.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)