### PR TITLE
feat(md3): плавающая подпись в одну строку + сворачиваемый rail разделов (#110)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -33,6 +33,7 @@ import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
   PrimitiveInput, FileField, ImageField, AutoFieldsSection,
   BaseInstancePanel, SCOPE_TIER, type BaseCandidate,
+  SectionRail,
 } from '../fields';
 
 // Отчёт «Проверить связки» (issue #99): статус каждого @@ref-поля.
@@ -573,21 +574,15 @@ export function CatalogEntryForm({
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
       <div className={showRail ? 'flex gap-5 items-start' : ''}>
       {showRail && (
-        <nav aria-label="Разделы" className="hidden lg:block sticky top-0 w-52 shrink-0 self-start space-y-0.5">
-          <div className="text-[10px] font-semibold uppercase tracking-wide text-fg4 px-2 pb-1">Разделы</div>
-          {titledSections.map(section => {
-            const expanded = expandedGroups.has(section.key);
-            return (
-              <button key={section.key} type="button" onClick={() => goToSection(section.key)}
-                aria-current={expanded ? 'true' : undefined}
-                className={`w-full flex items-center gap-1.5 text-left text-xs px-2 py-1 rounded transition-colors
-                  ${expanded ? 'bg-base text-fg1 font-medium' : 'text-fg3 hover:bg-base hover:text-fg1'}`}>
-                <span className="flex-1 truncate">{section.title}</span>
-                <span className="text-[10px] text-fg4 shrink-0">{section.fields.length}</span>
-              </button>
-            );
-          })}
-        </nav>
+        <SectionRail
+          sections={titledSections.map(section => ({
+            key: section.key,
+            title: section.title!,
+            count: section.fields.length,
+          }))}
+          isActive={key => expandedGroups.has(key)}
+          onSelect={goToSection}
+        />
       )}
       <div className="flex-1 min-w-0 space-y-4">
       <div className="flex items-center gap-2">

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -24,6 +24,7 @@ import {
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
   DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup, AutoFieldsSection,
   BaseInstancePanel, SCOPE_TIER, ancestorTypeIds, parseBaseRef, type BaseCandidate,
+  SectionRail,
 } from '../fields';
 import { DataSetsTab } from './DataSetsTab';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
@@ -392,26 +393,16 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
       <div className={showRail ? 'flex gap-5 items-start' : ''}>
       {showRail && (
-        <nav aria-label="Разделы" className="hidden lg:block sticky top-0 w-52 shrink-0 self-start space-y-0.5">
-          <div className="text-[10px] font-semibold uppercase tracking-wide text-fg4 px-2 pb-1">Разделы</div>
-          {titledSections.map(section => {
-            const expanded = expandedGroups.has(section.key);
-            const missing = showValidation && section.fields.some(f => isFieldMissing(f, values[f.key]));
-            return (
-              <button key={section.key} type="button" onClick={() => goToSection(section.key)}
-                aria-current={expanded ? 'true' : undefined}
-                className={`w-full flex items-center gap-1.5 text-left text-xs px-2 py-1 rounded transition-colors
-                  ${expanded ? 'bg-base text-fg1 font-medium' : 'text-fg3 hover:bg-base hover:text-fg1'}`}>
-                <span className="flex-1 truncate">{section.title}</span>
-                {missing && <>
-                  <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" aria-hidden="true" />
-                  <span className="sr-only">не заполнено</span>
-                </>}
-                <span className="text-[10px] text-fg4 shrink-0">{section.fields.length}</span>
-              </button>
-            );
-          })}
-        </nav>
+        <SectionRail
+          sections={titledSections.map(section => ({
+            key: section.key,
+            title: section.title!,
+            count: section.fields.length,
+            missing: showValidation && section.fields.some(f => isFieldMissing(f, values[f.key])),
+          }))}
+          isActive={key => expandedGroups.has(key)}
+          onSelect={goToSection}
+        />
       )}
       <div className="flex-1 min-w-0 space-y-4">
       {hasBase && (

--- a/src/client/src/features/document-sets/fields/SectionRail.tsx
+++ b/src/client/src/features/document-sets/fields/SectionRail.tsx
@@ -1,0 +1,59 @@
+import { List } from 'lucide-react';
+
+export interface RailSection {
+  key: string;
+  title: string;
+  count: number;
+  /** Есть незаполненные обязательные поля (красная точка). */
+  missing?: boolean;
+}
+
+/**
+ * Rail разделов формы (issue #102 P3, #110 итерация): в диалогах свёрнут до узкой
+ * полоски-аффорданса (иконка + точки по числу разделов) и раскрывается оверлеем по
+ * наведению/фокусу — не отъедает ширину формы и не сдвигает раскладку.
+ * Клавиатурой доступен: кнопки в tab-порядке, focus-within раскрывает панель.
+ */
+export function SectionRail({ sections, isActive, onSelect }: {
+  sections: RailSection[];
+  isActive: (key: string) => boolean;
+  onSelect: (key: string) => void;
+}) {
+  return (
+    <div className="group/rail relative hidden lg:block w-8 shrink-0 self-start sticky top-0">
+      {/* Свёрнутый аффорданс — исчезает при раскрытии */}
+      <div aria-hidden="true"
+        className="flex flex-col items-center gap-1 py-1.5 rounded-lg bg-muted/60 transition-opacity
+                   group-hover/rail:opacity-0 group-focus-within/rail:opacity-0">
+        <List size={14} className="text-fg4" />
+        {sections.map(s => (
+          <span key={s.key}
+            className={`w-1.5 h-1.5 rounded-full ${
+              s.missing ? 'bg-danger' : isActive(s.key) ? 'bg-fg2' : 'bg-fg4/40'}`} />
+        ))}
+      </div>
+
+      {/* Раскрываемая панель — оверлей, без сдвига раскладки */}
+      <nav aria-label="Разделы"
+        className="absolute left-0 top-0 z-20 w-52 space-y-0.5 rounded-lg border border-stroke bg-surface p-1.5
+                   shadow-[var(--f-shadow4)] transition -translate-x-1 opacity-0 pointer-events-none
+                   group-hover/rail:opacity-100 group-hover/rail:pointer-events-auto group-hover/rail:translate-x-0
+                   group-focus-within/rail:opacity-100 group-focus-within/rail:pointer-events-auto group-focus-within/rail:translate-x-0">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-fg4 px-2 pb-1">Разделы</div>
+        {sections.map(section => (
+          <button key={section.key} type="button" onClick={() => onSelect(section.key)}
+            aria-current={isActive(section.key) ? 'true' : undefined}
+            className={`w-full flex items-center gap-1.5 text-left text-xs px-2 py-1 rounded transition-colors
+              ${isActive(section.key) ? 'bg-base text-fg1 font-medium' : 'text-fg3 hover:bg-base hover:text-fg1'}`}>
+            <span className="flex-1 truncate">{section.title}</span>
+            {section.missing && <>
+              <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" aria-hidden="true" />
+              <span className="sr-only">не заполнено</span>
+            </>}
+            <span className="text-[10px] text-fg4 shrink-0">{section.count}</span>
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/client/src/features/document-sets/fields/index.ts
+++ b/src/client/src/features/document-sets/fields/index.ts
@@ -9,3 +9,4 @@ export * from './DocRefField';
 export * from './PasteMappingModal';
 export * from './ComplexFields';
 export * from './BaseCandidatePicker';
+export * from './SectionRail';

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -43,6 +43,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         <label
           htmlFor={inputId}
           className={`absolute left-2.5 top-3.5 px-1 text-sm bg-surface text-fg4 pointer-events-none transition-all ` +
+            `block max-w-[calc(100%-1.25rem)] truncate ` +
             `peer-focus:top-[-7px] peer-focus:text-xs ${labelFocus} ` +
             `peer-[:not(:placeholder-shown)]:top-[-7px] peer-[:not(:placeholder-shown)]:text-xs`}
         >

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.37</Version>
+    <Version>0.23.38</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Две отложенные итерации из аудита MD3 (вы отметили их после G1).

## 1. Плавающая подпись — одна строка
В `TextField` подпись в покоящемся состоянии (поле пустое и без фокуса) больше не
переносится на несколько строк: `block + max-w + truncate` → одна строка с многоточием.
На всплывшей подписи поведение то же (одна строка).

## 2. Rail разделов в диалогах — сворачиваемый, раскрытие по hover
Панель «Разделы» в крупных формах свёрнута до узкой полоски-аффорданса (иконка +
вертикальные точки по числу разделов; красная точка — есть незаполненные обязательные)
и раскрывается **оверлеем** по наведению или фокусу. Ключевое:
- **не отъедает ширину формы** (резерв 2rem вместо ~13rem) и **не сдвигает раскладку**
  при раскрытии (панель — `absolute`, `z-20`, тень);
- **доступность с клавиатуры**: кнопки разделов остаются в tab-порядке, `focus-within`
  раскрывает панель — навигация работает без мыши.

Логика вынесена в общий компонент `SectionRail` и переиспользована в редакторе
документов и каталоге общих данных (убрано дублирование разметки rail).

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- `npm run build` — ок

Версия → 0.23.38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)