### PR TITLE
fix(a11y): видимый фокус для полей без собственного кольца (#107 A)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -185,7 +185,7 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
 
       {tab === 'pick' && (
         <div className="space-y-2">
-          <div className="flex items-center gap-2 border border-stroke-strong rounded-md px-2">
+          <div className="flex items-center gap-2 border border-stroke-strong rounded-md px-2 transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
             <Search size={14} className="text-fg4" />
             <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Поиск по материалу / названию..."
               className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />
@@ -238,7 +238,7 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
               placeholder="Тип" aria-label="Тип документа качества" className="w-52">
               {qualityTypes.map(t => <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>)}
             </Select>
-            <div className="flex-1 flex items-center gap-2 border border-stroke-strong rounded-md px-2">
+            <div className="flex-1 flex items-center gap-2 border border-stroke-strong rounded-md px-2 transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
               <Search size={14} className="text-fg4" />
               <input value={query} onChange={e => setQuery(e.target.value)}
                 onKeyDown={e => { if (e.key === 'Enter') void runSearch(); }}

--- a/src/client/src/features/document-sets/fields/constants.ts
+++ b/src/client/src/features/document-sets/fields/constants.ts
@@ -38,7 +38,7 @@ export function defaultColWidth(f: SchemaField) {
 }
 
 export const CELL_INPUT =
-  'w-full h-full px-1.5 bg-transparent border-none outline-none text-xs text-fg1 tabular-nums';
+  'w-full h-full px-1.5 bg-transparent border-none outline-none text-xs text-fg1 tabular-nums focus:bg-brand-subtle';
 
 export function tryPrettyJson(val: unknown): string {
   try { return JSON.stringify(val, null, 2); } catch { return '{}'; }

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -165,7 +165,7 @@ export function QualityDocsPage() {
       </div>
 
       <div className="flex items-center gap-3 mb-4 flex-wrap">
-        <div className="flex items-center gap-2 border border-stroke-strong rounded-md px-2 flex-1 min-w-[220px] max-w-md">
+        <div className="flex items-center gap-2 border border-stroke-strong rounded-md px-2 flex-1 min-w-[220px] max-w-md transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
           <Search size={14} className="text-fg4" />
           <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск по названию..."
             className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.38</Version>
+    <Version>0.23.39</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Структурный проход keyboard-first (#107, раздел A — «запрет голого `outline:none`
без замены»). Аудитом найдены поля, у которых `outline-none` не сопровождался
никаким видимым индикатором фокуса.

## Исправлено
- **Поисковые input-group** (в редакторе документов: библиотека качества + веб-поиск;
  страница «Документы качества») — на обёртке добавлен
  `focus-within:border-brand focus-within:ring-1 focus-within:ring-brand`.
  Раньше таб в поле поиска не давал никакой визуальной реакции.
- **`CELL_INPUT`** (текст/число в табличном редакторе массивов) — добавлен
  `focus:bg-brand-subtle`, как у соседних веток ячеек (enum/date). Теперь фокус
  ячейки виден при навигации по таблице с клавиатуры.

Прочие `outline-none` проверены и признаны корректными: контейнеры Radix
(диалоги/поповеры), поля со сменой рамки/фона на фокусе, подсветка
`data-[highlighted]` в Select/меню, инлайновые rename-инпуты (видимы только в режиме
правки, brand-подчёркивание = аффорданс).

## Проверка
- `npx tsc -b` — чисто
- `npm test` — 115 passed
- `npm run build` — ок

Версия → 0.23.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)