### PR TITLE
feat(auth): профиль пользователя + смена пароля (#148 PR-B)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -15,6 +15,7 @@ import { UsersPage } from '@/features/settings/UsersPage';
 import { DataSetsPage } from '@/features/datasets/DataSetsPage';
 import { PdfGroupingEditor } from '@/features/datasets/PdfGroupingEditor';
 import { QualityDocsPage } from '@/features/quality-docs/QualityDocsPage';
+import { ProfilePage } from '@/features/account/ProfilePage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
@@ -36,6 +37,7 @@ export default function App() {
                 <Route path="datasets" element={<DataSetsPage />} />
                 <Route path="datasets/files/:fileId/grouping" element={<PdfGroupingEditor />} />
                 <Route path="quality-docs" element={<QualityDocsPage />} />
+                <Route path="profile" element={<ProfilePage />} />
                 <Route element={<AdminRoute />}>
                   <Route path="document-types/*" element={<DocumentTypesPage kind="Document" />} />
                   <Route path="composite-types/*" element={<DocumentTypesPage kind="Composite" />} />

--- a/src/client/src/features/account/ProfilePage.tsx
+++ b/src/client/src/features/account/ProfilePage.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react';
+import { useAccount, useUpdateAccount } from '@/shared/api/account';
+import { TextField } from '@/shared/ui/TextField';
+import { Button } from '@/shared/ui/Button';
+import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
+import { apiError } from '@/shared/utils/apiError';
+import { KeyRound, CheckCircle2, AlertCircle } from 'lucide-react';
+
+/** Профиль текущего пользователя (issue #148): просмотр учётных данных,
+ *  редактирование отображаемого имени, смена пароля. Доступно любой роли. */
+export function ProfilePage() {
+  const { data: account, isLoading } = useAccount();
+  const update = useUpdateAccount();
+  const [displayName, setDisplayName] = useState('');
+  const [pwOpen, setPwOpen] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => { if (account) setDisplayName(account.displayName); }, [account]);
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setError(''); setSaved(false);
+    try {
+      await update.mutateAsync({ displayName: displayName.trim() });
+      setSaved(true);
+    } catch (err) {
+      setError(apiError(err, 'Не удалось сохранить профиль'));
+    }
+  }
+
+  if (isLoading || !account) {
+    return <div className="px-6 py-4 text-sm text-fg4">Загрузка…</div>;
+  }
+
+  const dirty = displayName.trim() !== account.displayName;
+
+  return (
+    <div className="px-6 py-4 max-w-lg">
+      <h1 className="text-xl font-semibold text-fg1 mb-1">Профиль</h1>
+      <p className="text-xs text-fg4 mb-5">Ваши учётные данные.</p>
+
+      <form onSubmit={save} className="space-y-5">
+        <div>
+          <div className="text-xs text-fg4 mb-1">Email</div>
+          <div className="flex items-center gap-2 text-sm text-fg1">
+            {account.email}
+            {account.emailConfirmed
+              ? <span className="inline-flex items-center gap-1 text-xs text-success"><CheckCircle2 size={13} /> подтверждён</span>
+              : <span className="inline-flex items-center gap-1 text-xs text-fg4"><AlertCircle size={13} /> не подтверждён</span>}
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs text-fg4 mb-1">Роль</div>
+          <div className="text-sm text-fg1">{account.role === 'Admin' ? 'Администратор' : 'Пользователь'}</div>
+        </div>
+
+        <TextField label="Отображаемое имя" value={displayName}
+          onChange={e => { setDisplayName(e.target.value); setSaved(false); }} />
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+        {saved && <p className="text-sm text-success">Сохранено</p>}
+
+        <div className="flex items-center gap-2">
+          <Button type="submit" variant="filled" loading={update.isPending} disabled={!dirty}>
+            Сохранить
+          </Button>
+          <Button type="button" variant="text" icon={<KeyRound size={14} />} onClick={() => setPwOpen(true)}>
+            Сменить пароль
+          </Button>
+        </div>
+      </form>
+
+      <ChangePasswordModal open={pwOpen} onClose={() => setPwOpen(false)} />
+    </div>
+  );
+}

--- a/src/client/src/shared/api/account.ts
+++ b/src/client/src/shared/api/account.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from './client';
+import type { UserRole } from '@/shared/hooks/useAuth';
+
+const QK = 'account';
+
+export interface Account {
+  email: string;
+  displayName: string;
+  role: UserRole;
+  emailConfirmed: boolean;
+}
+
+/** Профиль текущего пользователя (issue #148). */
+export function useAccount() {
+  return useQuery<Account>({
+    queryKey: [QK],
+    queryFn: () => apiClient.get('/account').then(r => r.data),
+  });
+}
+
+export function useUpdateAccount() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: { displayName: string }) =>
+      apiClient.put<Account>('/account', dto).then(r => r.data),
+    onSuccess: (data) => qc.setQueryData([QK], data),
+  });
+}
+
+export function useChangeMyPassword() {
+  return useMutation({
+    mutationFn: (dto: { currentPassword: string; newPassword: string }) =>
+      apiClient.post('/account/change-password', dto),
+  });
+}

--- a/src/client/src/shared/api/users.ts
+++ b/src/client/src/shared/api/users.ts
@@ -61,9 +61,3 @@ export function useSendEmail() {
   });
 }
 
-export function useChangeMyPassword() {
-  return useMutation({
-    mutationFn: (dto: { currentPassword: string; newPassword: string }) =>
-      apiClient.post('/auth/change-password', dto),
-  });
-}

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -9,7 +9,7 @@ import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
-import { LogOut, Sun, Moon, Monitor, KeyRound } from 'lucide-react';
+import { LogOut, Sun, Moon, Monitor, KeyRound, UserRound } from 'lucide-react';
 
 const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'light',  icon: Sun,     label: 'Светлая'   },
@@ -132,10 +132,15 @@ export function AppShell() {
         {/* Bottom: theme + user */}
         <div className="px-3 py-3 border-t border-stroke space-y-3 shrink-0">
           <ThemeToggle />
-          <div className="text-xs truncate text-fg3">
-            {user?.displayName || user?.email}
-            <span className="ml-1 text-fg4">· {isAdmin ? 'Администратор' : 'Пользователь'}</span>
-          </div>
+          <NavLink to="/profile"
+            className={({ isActive }) => `flex items-center gap-2 text-xs truncate transition-colors ` +
+              (isActive ? 'text-brand' : 'text-fg3 hover:text-brand')}>
+            <UserRound size={14} className="shrink-0" />
+            <span className="truncate">
+              {user?.displayName || user?.email}
+              <span className="ml-1 text-fg4">· {isAdmin ? 'Администратор' : 'Пользователь'}</span>
+            </span>
+          </NavLink>
           <button
             onClick={() => setPwOpen(true)}
             className="flex items-center gap-2 text-sm transition-colors w-full text-fg2 hover:text-brand"

--- a/src/client/src/shared/ui/ChangePasswordModal.tsx
+++ b/src/client/src/shared/ui/ChangePasswordModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
-import { useChangeMyPassword } from '@/shared/api/users';
+import { useChangeMyPassword } from '@/shared/api/account';
 
 function apiError(e: unknown): string {
   const err = e as { response?: { data?: { error?: string; errors?: { description: string }[] } }; message?: string };

--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -1,0 +1,69 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Identity;
+
+namespace BHS.CRG.Api.Endpoints.Account;
+
+/// <summary>
+/// Профиль текущего пользователя (issue #148): просмотр/редактирование собственных
+/// данных и смена пароля. Работает для любой роли — только со своей учётной записью
+/// (пользователь берётся из JWT, не из параметра).
+/// </summary>
+public static class AccountEndpoints
+{
+    public static void MapAccountEndpoints(this IEndpointRouteBuilder app)
+    {
+        var g = app.MapGroup("/api/account").RequireAuthorization();
+
+        g.MapGet("/", async (UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
+        {
+            var user = await FindCurrent(users, principal);
+            if (user is null) return Results.Unauthorized();
+            var roles = await users.GetRolesAsync(user);
+            return Results.Ok(ToDto(user, roles));
+        });
+
+        g.MapPut("/", async (UpdateAccountRequest req,
+            UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
+        {
+            var user = await FindCurrent(users, principal);
+            if (user is null) return Results.Unauthorized();
+
+            user.DisplayName = (req.DisplayName ?? "").Trim();
+            var result = await users.UpdateAsync(user);
+            if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            var roles = await users.GetRolesAsync(user);
+            return Results.Ok(ToDto(user, roles));
+        });
+
+        // Смена пароля текущим пользователем (перенесено из /api/auth в #148).
+        g.MapPost("/change-password", async (ChangePasswordRequest req,
+            UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
+        {
+            var user = await FindCurrent(users, principal);
+            if (user is null) return Results.Unauthorized();
+
+            var result = await users.ChangePasswordAsync(user, req.CurrentPassword, req.NewPassword);
+            return result.Succeeded ? Results.Ok() : Results.BadRequest(new { error = DescribeErrors(result) });
+        });
+    }
+
+    private static async Task<ApplicationUser?> FindCurrent(UserManager<ApplicationUser> users, ClaimsPrincipal p)
+    {
+        var id = p.FindFirstValue(JwtRegisteredClaimNames.Sub)
+              ?? p.FindFirstValue(ClaimTypes.NameIdentifier);
+        return id is null ? null : await users.FindByIdAsync(id);
+    }
+
+    private static AccountDto ToDto(ApplicationUser u, IList<string> roles) =>
+        new(u.Email ?? "", u.DisplayName, roles.FirstOrDefault() ?? "User", u.EmailConfirmed);
+
+    private static string DescribeErrors(IdentityResult r) =>
+        string.Join("; ", r.Errors.Select(e => e.Description));
+
+    record AccountDto(string Email, string DisplayName, string Role, bool EmailConfirmed);
+    record UpdateAccountRequest(string? DisplayName);
+    record ChangePasswordRequest(string CurrentPassword, string NewPassword);
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -44,20 +44,7 @@ public static class AuthEndpoints
             var token = CreateToken(user, roles, cfg);
             return Results.Ok(new { accessToken = token });
         });
-
-        // Самостоятельная смена пароля текущим пользователем.
-        g.MapPost("/change-password", async (ChangePasswordRequest req,
-            UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
-        {
-            var id = principal.FindFirstValue(JwtRegisteredClaimNames.Sub)
-                  ?? principal.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (id is null) return Results.Unauthorized();
-            var user = await users.FindByIdAsync(id);
-            if (user is null) return Results.Unauthorized();
-
-            var result = await users.ChangePasswordAsync(user, req.CurrentPassword, req.NewPassword);
-            return result.Succeeded ? Results.Ok() : Results.BadRequest(result.Errors);
-        }).RequireAuthorization();
+        // Смена пароля переехала в /api/account/change-password (issue #148).
     }
 
     private static string CreateToken(ApplicationUser user, IList<string> roles, IConfiguration cfg)
@@ -84,5 +71,4 @@ public static class AuthEndpoints
 
     record RegisterRequest(string Email, string Password, string DisplayName);
     record LoginRequest(string Email, string Password);
-    record ChangePasswordRequest(string CurrentPassword, string NewPassword);
 }

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json.Serialization;
+using BHS.CRG.Api.Endpoints.Account;
 using BHS.CRG.Api.Endpoints.Attachments;
 using BHS.CRG.Api.Endpoints.Auth;
 using BHS.CRG.Api.Endpoints.Backup;
@@ -276,6 +277,7 @@ app.UseAuthorization();
 
 app.MapAttachmentEndpoints();
 app.MapAuthEndpoints();
+app.MapAccountEndpoints();
 app.MapUserEndpoints();
 app.MapBackupEndpoints();
 app.MapCatalogEndpoints();

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.42</Version>
+    <Version>0.23.43</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Первый срез #148 (усиление авторизации) — **профиль + смена пароля**. Самодостаточен,
без email-потоков. Часть плана: B → (A+C) → D.

## Backend
- Новая группа **`/api/account`** (`RequireAuthorization`, работает только со своей
  учёткой — пользователь из JWT, не из параметра):
  - `GET /api/account` → `{email, displayName, role, emailConfirmed}`
  - `PUT /api/account` → `{displayName}`
  - `POST /api/account/change-password` → `{currentPassword, newPassword}` (перенесён из `/api/auth`)
- Из `AuthEndpoints` удалён `change-password` (переехал в account).

## Frontend
- `shared/api/account.ts`: `useAccount` / `useUpdateAccount` / `useChangeMyPassword`
  (последний переведён на `/account/change-password`; `ChangePasswordModal` обновлён).
- Страница **`/profile`** (`features/account/ProfilePage`): email + статус подтверждения,
  роль, редактирование отображаемого имени, смена пароля. Доступна любой роли.
- Блок пользователя в `AppShell` стал ссылкой на `/profile`.

## Проверка
- `dotnet test` — **380 passed**; `tsc -b` / `npm run build` / `vitest` — зелёные.
- Эндпоинты вручную: login → GET/PUT/change-password; старый `/api/auth/change-password` → **404**; неверный текущий пароль → **400**.
- Скриншот `/profile` — рендерится корректно (см. сессию).

Версия → 0.23.43. Дальше по плану — **PR-C: сброс пароля** (+ фундамент Data Protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)