### PR TITLE
feat(auth): сброс пароля по email + Data Protection (#148 PR-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Thumbs.db
 
 # ── Local tooling config ──────────────────────────────
 .claude/
+
+# Data Protection keys (issue #148) — секрет, не коммитить
+src/server/BHS.CRG.Api/dp-keys/
+dp-keys/

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -93,8 +93,14 @@ services:
       Gemini__ApiKey: ${GEMINI_API_KEY:-}
       WebSearch__ApiKey: ${SERPER_API_KEY:-}
       AllowedOrigins: ${ALLOWED_ORIGINS:-http://localhost:${WEB_PORT:-8080}}
-      # Публичный адрес системы — для ссылки в письме, когда документ/комплект слишком велик для вложения.
+      # Публичный адрес системы — для ссылок в письмах (сброс пароля, подтверждение почты,
+      # ссылка на большой комплект). Без него ссылки в письмах собрать нельзя.
       App__PublicUrl: ${APP_PUBLIC_URL:-}
+      # Ключи Data Protection (шифруют токены сброса/подтверждения) — на томе, иначе токены
+      # инвалидируются при пересоздании контейнера.
+      DataProtection__KeysPath: "/app/dp-keys"
+    volumes:
+      - dp_keys:/app/dp-keys
     restart: unless-stopped
 
   web:
@@ -111,3 +117,4 @@ volumes:
   postgres_data:
   minio_data:
   ollama_data:
+  dp_keys:

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -16,6 +16,8 @@ import { DataSetsPage } from '@/features/datasets/DataSetsPage';
 import { PdfGroupingEditor } from '@/features/datasets/PdfGroupingEditor';
 import { QualityDocsPage } from '@/features/quality-docs/QualityDocsPage';
 import { ProfilePage } from '@/features/account/ProfilePage';
+import { ForgotPasswordPage } from '@/features/auth/ForgotPasswordPage';
+import { ResetPasswordPage } from '@/features/auth/ResetPasswordPage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
@@ -29,6 +31,8 @@ export default function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+            <Route path="/reset-password" element={<ResetPasswordPage />} />
             <Route element={<ProtectedRoute />}>
               <Route element={<AppShell />}>
                 <Route index element={<Navigate to="/document-sets" replace />} />

--- a/src/client/src/features/auth/AuthCard.tsx
+++ b/src/client/src/features/auth/AuthCard.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { FileCheck2 } from 'lucide-react';
+
+/** Общая центрированная карточка для вспомогательных экранов авторизации
+ *  (сброс пароля, подтверждение почты) — в едином стиле со страницей входа. */
+export function AuthCard({ title, subtitle, children }: {
+  title: string; subtitle?: string; children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-base p-4">
+      <div className="w-full max-w-sm rounded-[28px] bg-surface border border-stroke p-8"
+        style={{ boxShadow: 'var(--f-shadow16)' }}>
+        <div className="flex items-center gap-3 mb-6">
+          <span className="flex items-center justify-center w-11 h-11 rounded-lg bg-brand text-white shrink-0"
+            style={{ boxShadow: 'var(--f-shadow4)' }}>
+            <FileCheck2 size={22} />
+          </span>
+          <span className="text-2xl font-semibold text-brand leading-none">BHS.CRG</span>
+        </div>
+        <h1 className="text-xl font-normal text-fg1">{title}</h1>
+        {subtitle && <p className="mt-1.5 mb-6 text-sm text-fg3">{subtitle}</p>}
+        <div className={subtitle ? '' : 'mt-6'}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/features/auth/ForgotPasswordPage.tsx
+++ b/src/client/src/features/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthCard } from './AuthCard';
+import { TextField } from '@/shared/ui/TextField';
+import { Button } from '@/shared/ui/Button';
+import { useForgotPassword } from '@/shared/api/auth';
+import { MailCheck } from 'lucide-react';
+
+/** Запрос ссылки для сброса пароля (issue #148). Ответ всегда «письмо отправлено»,
+ *  существование адреса не раскрываем. */
+export function ForgotPasswordPage() {
+  const forgot = useForgotPassword();
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    try { await forgot.mutateAsync({ email: email.trim() }); } catch { /* enumeration-safe: игнорируем */ }
+    setSent(true);
+  }
+
+  if (sent) {
+    return (
+      <AuthCard title="Проверьте почту">
+        <div className="space-y-4">
+          <p className="flex items-start gap-2 text-sm text-fg2">
+            <MailCheck size={18} className="shrink-0 mt-0.5 text-success" />
+            Если аккаунт с адресом <span className="font-medium">{email.trim()}</span> существует,
+            мы отправили письмо со ссылкой для сброса пароля. Ссылка действует 1 час.
+          </p>
+          <Link to="/login" className="inline-block text-sm font-medium text-brand hover:underline">
+            Вернуться ко входу
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Восстановление пароля" subtitle="Укажите email — пришлём ссылку для сброса.">
+      <form onSubmit={submit} className="space-y-5">
+        <TextField label="Email" type="email" autoComplete="email" required autoFocus
+          value={email} onChange={e => setEmail(e.target.value)} />
+        <Button type="submit" variant="filled" size="lg" fullWidth loading={forgot.isPending}>
+          Отправить ссылку
+        </Button>
+        <Link to="/login" className="block text-center text-sm font-medium text-brand hover:underline">
+          Вернуться ко входу
+        </Link>
+      </form>
+    </AuthCard>
+  );
+}

--- a/src/client/src/features/auth/ResetPasswordPage.tsx
+++ b/src/client/src/features/auth/ResetPasswordPage.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { AuthCard } from './AuthCard';
+import { TextField } from '@/shared/ui/TextField';
+import { Button } from '@/shared/ui/Button';
+import { useResetPassword } from '@/shared/api/auth';
+import { apiError } from '@/shared/utils/apiError';
+
+/** Установка нового пароля по ссылке из письма (issue #148). email и token — из query. */
+export function ResetPasswordPage() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const reset = useResetPassword();
+  const email = params.get('email') ?? '';
+  const token = params.get('token') ?? '';
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+
+  const linkValid = !!email && !!token;
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    if (password !== confirm) { setError('Пароль и подтверждение не совпадают'); return; }
+    try {
+      await reset.mutateAsync({ email, token, newPassword: password });
+      setDone(true);
+      setTimeout(() => navigate('/login', { replace: true }), 1500);
+    } catch (err) {
+      setError(apiError(err, 'Не удалось сбросить пароль. Возможно, ссылка устарела.'));
+    }
+  }
+
+  if (!linkValid) {
+    return (
+      <AuthCard title="Ссылка недействительна">
+        <div className="space-y-4">
+          <p className="text-sm text-fg2">Ссылка для сброса пароля неполная или устарела. Запросите новую.</p>
+          <Link to="/forgot-password" className="inline-block text-sm font-medium text-brand hover:underline">
+            Запросить сброс заново
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  if (done) {
+    return (
+      <AuthCard title="Пароль изменён">
+        <p className="text-sm text-success">Готово. Перенаправляем ко входу…</p>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Новый пароль" subtitle={`Аккаунт: ${email}`}>
+      <form onSubmit={submit} className="space-y-5">
+        <TextField label="Новый пароль" type="password" autoComplete="new-password" required autoFocus minLength={6}
+          value={password} onChange={e => setPassword(e.target.value)} />
+        <TextField label="Подтверждение" type="password" autoComplete="new-password" required minLength={6}
+          value={confirm} onChange={e => setConfirm(e.target.value)} />
+        {error && <p className="text-sm text-danger">{error}</p>}
+        <Button type="submit" variant="filled" size="lg" fullWidth loading={reset.isPending}>
+          Сохранить пароль
+        </Button>
+        <Link to="/login" className="block text-center text-sm font-medium text-brand hover:underline">
+          Вернуться ко входу
+        </Link>
+      </form>
+    </AuthCard>
+  );
+}

--- a/src/client/src/features/catalog/LoginPage.tsx
+++ b/src/client/src/features/catalog/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { FileCheck2, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useAppVersion } from '@/shared/api/version';
@@ -22,7 +22,6 @@ export function LoginPage() {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [remember, setRemember] = useState(true);
-  const [forgotOpen, setForgotOpen] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -100,16 +99,11 @@ export function LoginPage() {
               } />
 
             <div className="flex justify-end -mt-2">
-              <button type="button" onClick={() => setForgotOpen(o => !o)} aria-expanded={forgotOpen}
+              <Link to="/forgot-password"
                 className="text-sm font-medium text-brand px-3 py-2 rounded-full hover:bg-brand/10 transition-colors">
                 Забыли пароль?
-              </button>
+              </Link>
             </div>
-            {forgotOpen && (
-              <p className="-mt-3 px-1 text-xs text-fg3">
-                Самостоятельный сброс пока недоступен — пароль сбрасывает администратор системы.
-              </p>
-            )}
 
             <label className="flex items-center gap-3 text-sm text-fg1 cursor-pointer select-none">
               <input type="checkbox" checked={remember} onChange={e => setRemember(e.target.checked)}

--- a/src/client/src/shared/api/auth.ts
+++ b/src/client/src/shared/api/auth.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from './client';
+
+/** Запрос письма для сброса пароля (issue #148). Ответ всегда 200 — существование
+ *  адреса не раскрывается (enumeration-safe). */
+export function useForgotPassword() {
+  return useMutation({
+    mutationFn: (dto: { email: string }) =>
+      apiClient.post('/auth/forgot-password', dto),
+  });
+}
+
+/** Установка нового пароля по токену из письма. */
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: (dto: { email: string; token: string; newPassword: string }) =>
+      apiClient.post('/auth/reset-password', dto),
+  });
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
@@ -45,7 +46,46 @@ public static class AuthEndpoints
             return Results.Ok(new { accessToken = token });
         });
         // Смена пароля переехала в /api/account/change-password (issue #148).
+
+        // Сброс пароля (issue #148). Анонимные, под rate-limit «auth».
+        // Enumeration-safe: forgot всегда 200, существование адреса не раскрываем.
+        g.MapPost("/forgot-password", async (ForgotPasswordRequest req,
+            UserManager<ApplicationUser> users, AccountEmailService emails,
+            ILoggerFactory loggers, CancellationToken ct) =>
+        {
+            var user = await users.FindByEmailAsync(req.Email);
+            if (user is not null)
+            {
+                try
+                {
+                    var token = await users.GeneratePasswordResetTokenAsync(user);
+                    await emails.SendPasswordResetAsync(user.Email!, token, ct);
+                }
+                catch (Exception ex)
+                {
+                    // Не роняем ответ (и не раскрываем существование адреса) — только лог без секретов.
+                    loggers.CreateLogger("Auth").LogWarning(ex, "Не удалось отправить письмо сброса пароля");
+                }
+            }
+            return Results.Ok();
+        }).RequireRateLimiting("auth");
+
+        g.MapPost("/reset-password", async (ResetPasswordRequest req,
+            UserManager<ApplicationUser> users) =>
+        {
+            var user = await users.FindByEmailAsync(req.Email);
+            if (user is null)
+                return Results.BadRequest(new { error = "Ссылка недействительна или устарела." });
+
+            var result = await users.ResetPasswordAsync(user, req.Token, req.NewPassword);
+            return result.Succeeded
+                ? Results.Ok()
+                : Results.BadRequest(new { error = DescribeErrors(result) });
+        }).RequireRateLimiting("auth");
     }
+
+    private static string DescribeErrors(IdentityResult r) =>
+        string.Join("; ", r.Errors.Select(e => e.Description));
 
     private static string CreateToken(ApplicationUser user, IList<string> roles, IConfiguration cfg)
     {
@@ -71,4 +111,6 @@ public static class AuthEndpoints
 
     record RegisterRequest(string Email, string Password, string DisplayName);
     record LoginRequest(string Email, string Password);
+    record ForgotPasswordRequest(string Email);
+    record ResetPasswordRequest(string Email, string Token, string NewPassword);
 }

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 using BHS.CRG.Api.Endpoints.Account;
 using BHS.CRG.Api.Endpoints.Attachments;
 using BHS.CRG.Api.Endpoints.Auth;
@@ -45,7 +46,9 @@ using BHS.CRG.Infrastructure.Persistence;
 using BHS.CRG.Infrastructure.Plugins;
 using BHS.CRG.Infrastructure.Storage;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Minio;
@@ -69,6 +72,29 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(opt =>
     })
     .AddEntityFrameworkStores<AppDbContext>()
     .AddDefaultTokenProviders();
+
+// Токены сброса/подтверждения (issue #148) шифруются ключами Data Protection. БЕЗ персистентных
+// ключей они инвалидируются при каждом рестарте API (и ломаются при >1 инстанса). Персистим на диск
+// (в контейнере — том); путь настраивается, дефолт — рядом с приложением.
+var dpKeysPath = cfg["DataProtection:KeysPath"];
+if (string.IsNullOrWhiteSpace(dpKeysPath))
+    dpKeysPath = Path.Combine(builder.Environment.ContentRootPath, "dp-keys");
+Directory.CreateDirectory(dpKeysPath);
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(dpKeysPath))
+    .SetApplicationName("BHS.CRG");
+
+// Время жизни токенов сброса пароля / подтверждения (дефолтный token-провайдер) — 1 час.
+builder.Services.Configure<DataProtectionTokenProviderOptions>(o => o.TokenLifespan = TimeSpan.FromHours(1));
+
+// Rate limiting для чувствительных анонимных эндпоинтов сброса пароля (по IP).
+builder.Services.AddRateLimiter(o =>
+{
+    o.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    o.AddPolicy("auth", ctx => RateLimitPartition.GetFixedWindowLimiter(
+        ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+        _ => new FixedWindowRateLimiterOptions { PermitLimit = 10, Window = TimeSpan.FromMinutes(15), QueueLimit = 0 }));
+});
 
 // ── JWT ───────────────────────────────────────────────────────────────────────
 var jwtSection = cfg.GetSection("Jwt");
@@ -152,6 +178,7 @@ builder.Services.AddScoped<IDocumentRecognizer, ChainDocumentRecognizer>();
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IIntegrationSettings, IntegrationSettingsService>();
 builder.Services.AddScoped<BHS.CRG.Application.Email.IEmailSender, BHS.CRG.Infrastructure.Email.MailKitEmailSender>();
+builder.Services.AddScoped<BHS.CRG.Infrastructure.Email.AccountEmailService>();
 
 // ── Фоновые задачи (долгие операции: распознавание набора/таблицы) ──────────────
 builder.Services.AddSingleton<JobQueue>();
@@ -274,6 +301,7 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 app.MapAttachmentEndpoints();
 app.MapAuthEndpoints();

--- a/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
@@ -1,0 +1,33 @@
+using BHS.CRG.Application.Email;
+using Microsoft.Extensions.Configuration;
+
+namespace BHS.CRG.Infrastructure.Email;
+
+/// <summary>
+/// Письма учётной записи (issue #148): сброс пароля, подтверждение почты. Собирает ссылку из
+/// <c>App:PublicUrl</c> + url-encoded токен Identity и отправляет через <see cref="IEmailSender"/>.
+/// Оркестрация (генерация токена) — в endpoint'ах, здесь только сборка письма и отправка.
+/// </summary>
+public class AccountEmailService(IEmailSender email, IConfiguration config)
+{
+    /// <summary>Письмо со ссылкой сброса пароля (токен действует ~1 час).</summary>
+    public async Task SendPasswordResetAsync(string toEmail, string token, CancellationToken ct = default)
+    {
+        var link = BuildLink("reset-password", toEmail, token);
+        var body = link is null
+            ? "Вы запросили сброс пароля в BHS.CRG, но адрес приложения не настроен (App:PublicUrl). " +
+              "Обратитесь к администратору системы."
+            : "Вы запросили сброс пароля в BHS.CRG.\n\n" +
+              $"Ссылка для сброса (действует 1 час):\n{link}\n\n" +
+              "Если вы не запрашивали сброс — просто проигнорируйте это письмо, пароль останется прежним.";
+        await email.SendAsync(new EmailMessage([toEmail], "Сброс пароля — BHS.CRG", body), ct);
+    }
+
+    /// <summary>Собирает ссылку на фронт-роут с url-encoded email и токеном, либо null если PublicUrl пуст.</summary>
+    private string? BuildLink(string route, string email, string token)
+    {
+        var publicUrl = config["App:PublicUrl"]?.TrimEnd('/');
+        if (string.IsNullOrEmpty(publicUrl)) return null;
+        return $"{publicUrl}/{route}?email={Uri.EscapeDataString(email)}&token={Uri.EscapeDataString(token)}";
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.43</Version>
+    <Version>0.23.44</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Срез #148 — **сброс пароля** («Забыл пароль») + фундамент для email-потоков (свёрнутый PR-A).

> ⚠️ **Стек на #156 (PR-B)** — базовая ветка `issue-148-b-profile`. Мёржить после PR-B
> (GitHub переставит базу на master автоматически).

## Backend
- **Персистентность Data Protection** на диск (`PersistKeysToFileSystem`, путь
  `DataProtection:KeysPath`, дефолт `dp-keys` рядом с приложением). Без этого токены
  сброса/подтверждения инвалидируются при рестарте API — ключевой улов Архитектора.
- **TTL** token-провайдеров = **1 час**.
- **Rate limiter** (fixed window 10 / 15 мин по IP), политика `auth` на forgot/reset.
- **AccountEmailService** — письмо сброса со ссылкой из `App:PublicUrl` (url-encoded токен).
- `POST /api/auth/forgot-password` — всегда **200** (enumeration-safe; SMTP-ошибки глушим, лог без секрета).
- `POST /api/auth/reset-password` — Identity `ResetPasswordAsync`, **400** при плохом токене.

## Frontend
- `shared/api/auth.ts` (`useForgotPassword` / `useResetPassword`).
- Страницы **`/forgot-password`** и **`/reset-password`** (общий `AuthCard` в стиле входа);
  reset читает `email`/`token` из query, редирект на `/login` после успеха.
- Кнопка **«Забыли пароль?»** на входе ведёт на `/forgot-password` (заглушка убрана).

## Deploy / безопасность
- Том `dp_keys` + `DataProtection__KeysPath` в `docker-compose`; `dp-keys/` в `.gitignore` (секрет).
- Миграций нет.

## Проверка
- `dotnet test` **380**; `tsc -b` / `build` / `vitest` **115** — зелёные.
- Вручную: forgot **200** (в т.ч. неизвестный email), reset bad-token **400**, rate-limit **429**,
  ключ Data Protection записан на диск; скриншоты форм forgot/reset.

Версия → 0.23.44. Дальше — **PR-D: подтверждение email + смена email** (стек на этой ветке).

🤖 Generated with [Claude Code](https://claude.com/claude-code)