### PR TITLE
feat(auth): подтверждение email + смена email (#148 PR-D)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Thumbs.db
 
 # ── Local tooling config ──────────────────────────────
 .claude/
+
+# Data Protection keys (issue #148) — секрет, не коммитить
+src/server/BHS.CRG.Api/dp-keys/
+dp-keys/

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -93,8 +93,14 @@ services:
       Gemini__ApiKey: ${GEMINI_API_KEY:-}
       WebSearch__ApiKey: ${SERPER_API_KEY:-}
       AllowedOrigins: ${ALLOWED_ORIGINS:-http://localhost:${WEB_PORT:-8080}}
-      # Публичный адрес системы — для ссылки в письме, когда документ/комплект слишком велик для вложения.
+      # Публичный адрес системы — для ссылок в письмах (сброс пароля, подтверждение почты,
+      # ссылка на большой комплект). Без него ссылки в письмах собрать нельзя.
       App__PublicUrl: ${APP_PUBLIC_URL:-}
+      # Ключи Data Protection (шифруют токены сброса/подтверждения) — на томе, иначе токены
+      # инвалидируются при пересоздании контейнера.
+      DataProtection__KeysPath: "/app/dp-keys"
+    volumes:
+      - dp_keys:/app/dp-keys
     restart: unless-stopped
 
   web:
@@ -111,3 +117,4 @@ volumes:
   postgres_data:
   minio_data:
   ollama_data:
+  dp_keys:

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -16,6 +16,8 @@ import { DataSetsPage } from '@/features/datasets/DataSetsPage';
 import { PdfGroupingEditor } from '@/features/datasets/PdfGroupingEditor';
 import { QualityDocsPage } from '@/features/quality-docs/QualityDocsPage';
 import { ProfilePage } from '@/features/account/ProfilePage';
+import { ForgotPasswordPage } from '@/features/auth/ForgotPasswordPage';
+import { ResetPasswordPage } from '@/features/auth/ResetPasswordPage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
@@ -29,6 +31,8 @@ export default function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+            <Route path="/reset-password" element={<ResetPasswordPage />} />
             <Route element={<ProtectedRoute />}>
               <Route element={<AppShell />}>
                 <Route index element={<Navigate to="/document-sets" replace />} />

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -18,6 +18,8 @@ import { QualityDocsPage } from '@/features/quality-docs/QualityDocsPage';
 import { ProfilePage } from '@/features/account/ProfilePage';
 import { ForgotPasswordPage } from '@/features/auth/ForgotPasswordPage';
 import { ResetPasswordPage } from '@/features/auth/ResetPasswordPage';
+import { ConfirmEmailPage } from '@/features/auth/ConfirmEmailPage';
+import { ConfirmEmailChangePage } from '@/features/auth/ConfirmEmailChangePage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
@@ -33,6 +35,8 @@ export default function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
             <Route path="/reset-password" element={<ResetPasswordPage />} />
+            <Route path="/confirm-email" element={<ConfirmEmailPage />} />
+            <Route path="/confirm-email-change" element={<ConfirmEmailChangePage />} />
             <Route element={<ProtectedRoute />}>
               <Route element={<AppShell />}>
                 <Route index element={<Navigate to="/document-sets" replace />} />

--- a/src/client/src/features/account/ProfilePage.tsx
+++ b/src/client/src/features/account/ProfilePage.tsx
@@ -1,22 +1,48 @@
 import { useState, useEffect } from 'react';
-import { useAccount, useUpdateAccount } from '@/shared/api/account';
+import { useAccount, useUpdateAccount, useResendConfirmation, useChangeEmail } from '@/shared/api/account';
 import { TextField } from '@/shared/ui/TextField';
 import { Button } from '@/shared/ui/Button';
 import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { apiError } from '@/shared/utils/apiError';
-import { KeyRound, CheckCircle2, AlertCircle } from 'lucide-react';
+import { KeyRound, CheckCircle2, AlertCircle, Mail } from 'lucide-react';
 
 /** Профиль текущего пользователя (issue #148): просмотр учётных данных,
  *  редактирование отображаемого имени, смена пароля. Доступно любой роли. */
 export function ProfilePage() {
   const { data: account, isLoading } = useAccount();
   const update = useUpdateAccount();
+  const resend = useResendConfirmation();
+  const changeEmail = useChangeEmail();
   const [displayName, setDisplayName] = useState('');
   const [pwOpen, setPwOpen] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
 
+  const [resendMsg, setResendMsg] = useState('');
+  const [newEmail, setNewEmail] = useState('');
+  const [emailPassword, setEmailPassword] = useState('');
+  const [emailMsg, setEmailMsg] = useState('');
+  const [emailError, setEmailError] = useState('');
+
   useEffect(() => { if (account) setDisplayName(account.displayName); }, [account]);
+
+  async function resendConfirmation() {
+    setResendMsg('');
+    try { await resend.mutateAsync(); setResendMsg('Письмо отправлено — проверьте почту.'); }
+    catch (err) { setResendMsg(apiError(err, 'Не удалось отправить письмо.')); }
+  }
+
+  async function submitEmail(e: React.FormEvent) {
+    e.preventDefault();
+    setEmailError(''); setEmailMsg('');
+    try {
+      await changeEmail.mutateAsync({ newEmail: newEmail.trim(), currentPassword: emailPassword });
+      setEmailMsg(`Письмо для подтверждения отправлено на ${newEmail.trim()}. Адрес сменится после перехода по ссылке.`);
+      setNewEmail(''); setEmailPassword('');
+    } catch (err) {
+      setEmailError(apiError(err, 'Не удалось запустить смену email'));
+    }
+  }
 
   async function save(e: React.FormEvent) {
     e.preventDefault();
@@ -43,12 +69,18 @@ export function ProfilePage() {
       <form onSubmit={save} className="space-y-5">
         <div>
           <div className="text-xs text-fg4 mb-1">Email</div>
-          <div className="flex items-center gap-2 text-sm text-fg1">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-fg1">
             {account.email}
             {account.emailConfirmed
               ? <span className="inline-flex items-center gap-1 text-xs text-success"><CheckCircle2 size={13} /> подтверждён</span>
-              : <span className="inline-flex items-center gap-1 text-xs text-fg4"><AlertCircle size={13} /> не подтверждён</span>}
+              : <>
+                  <span className="inline-flex items-center gap-1 text-xs text-warning"><AlertCircle size={13} /> не подтверждён</span>
+                  <Button type="button" variant="text" size="sm" loading={resend.isPending} onClick={resendConfirmation}>
+                    Отправить письмо
+                  </Button>
+                </>}
           </div>
+          {resendMsg && <p className="mt-1 text-xs text-fg3">{resendMsg}</p>}
         </div>
 
         <div>
@@ -71,6 +103,27 @@ export function ProfilePage() {
           </Button>
         </div>
       </form>
+
+      <div className="mt-8 pt-6 border-t border-stroke">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-fg1 mb-1">
+          <Mail size={15} className="text-fg3" /> Сменить email
+        </h2>
+        <p className="text-xs text-fg4 mb-4">
+          Отправим письмо на новый адрес — он станет адресом входа после перехода по ссылке.
+        </p>
+        <form onSubmit={submitEmail} className="space-y-4">
+          <TextField label="Новый email" type="email" autoComplete="email" required
+            value={newEmail} onChange={e => { setNewEmail(e.target.value); setEmailMsg(''); }} />
+          <TextField label="Текущий пароль" type="password" autoComplete="current-password" required
+            value={emailPassword} onChange={e => setEmailPassword(e.target.value)} />
+          {emailError && <p className="text-sm text-danger">{emailError}</p>}
+          {emailMsg && <p className="text-sm text-success">{emailMsg}</p>}
+          <Button type="submit" variant="outlined" loading={changeEmail.isPending}
+            disabled={!newEmail.trim() || !emailPassword}>
+            Отправить подтверждение
+          </Button>
+        </form>
+      </div>
 
       <ChangePasswordModal open={pwOpen} onClose={() => setPwOpen(false)} />
     </div>

--- a/src/client/src/features/auth/AuthCard.tsx
+++ b/src/client/src/features/auth/AuthCard.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { FileCheck2 } from 'lucide-react';
+
+/** Общая центрированная карточка для вспомогательных экранов авторизации
+ *  (сброс пароля, подтверждение почты) — в едином стиле со страницей входа. */
+export function AuthCard({ title, subtitle, children }: {
+  title: string; subtitle?: string; children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-base p-4">
+      <div className="w-full max-w-sm rounded-[28px] bg-surface border border-stroke p-8"
+        style={{ boxShadow: 'var(--f-shadow16)' }}>
+        <div className="flex items-center gap-3 mb-6">
+          <span className="flex items-center justify-center w-11 h-11 rounded-lg bg-brand text-white shrink-0"
+            style={{ boxShadow: 'var(--f-shadow4)' }}>
+            <FileCheck2 size={22} />
+          </span>
+          <span className="text-2xl font-semibold text-brand leading-none">BHS.CRG</span>
+        </div>
+        <h1 className="text-xl font-normal text-fg1">{title}</h1>
+        {subtitle && <p className="mt-1.5 mb-6 text-sm text-fg3">{subtitle}</p>}
+        <div className={subtitle ? '' : 'mt-6'}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/features/auth/ConfirmEmailChangePage.tsx
+++ b/src/client/src/features/auth/ConfirmEmailChangePage.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { AuthCard } from './AuthCard';
+import { useConfirmEmailChange } from '@/shared/api/auth';
+import { apiError } from '@/shared/utils/apiError';
+import { CheckCircle2, Loader2, AlertCircle } from 'lucide-react';
+
+/** Подтверждение смены адреса входа по ссылке из письма на новый адрес (issue #148).
+ *  uid/email(новый)/token — из query, POST один раз при монтировании. */
+export function ConfirmEmailChangePage() {
+  const [params] = useSearchParams();
+  const confirm = useConfirmEmailChange();
+  const userId = params.get('uid') ?? '';
+  const newEmail = params.get('email') ?? '';
+  const token = params.get('token') ?? '';
+  const [status, setStatus] = useState<'pending' | 'ok' | 'error'>('pending');
+  const [error, setError] = useState('');
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    if (!userId || !newEmail || !token) { setStatus('error'); setError('Ссылка недействительна или устарела.'); return; }
+    confirm.mutateAsync({ userId, newEmail, token })
+      .then(() => setStatus('ok'))
+      .catch(err => { setStatus('error'); setError(apiError(err, 'Не удалось сменить адрес. Возможно, ссылка устарела.')); });
+  }, [userId, newEmail, token, confirm]);
+
+  return (
+    <AuthCard title="Смена адреса входа">
+      {status === 'pending' && (
+        <p className="flex items-center gap-2 text-sm text-fg3"><Loader2 size={16} className="animate-spin" /> Подтверждаем…</p>
+      )}
+      {status === 'ok' && (
+        <div className="space-y-4">
+          <p className="flex items-start gap-2 text-sm text-fg2">
+            <CheckCircle2 size={18} className="shrink-0 mt-0.5 text-success" />
+            Адрес входа изменён на <span className="font-medium">{newEmail}</span>. Войдите с новым email.
+          </p>
+          <Link to="/login" className="inline-block text-sm font-medium text-brand hover:underline">Перейти ко входу</Link>
+        </div>
+      )}
+      {status === 'error' && (
+        <div className="space-y-4">
+          <p className="flex items-start gap-2 text-sm text-danger">
+            <AlertCircle size={18} className="shrink-0 mt-0.5" /> {error}
+          </p>
+          <Link to="/login" className="inline-block text-sm font-medium text-brand hover:underline">Вернуться ко входу</Link>
+        </div>
+      )}
+    </AuthCard>
+  );
+}

--- a/src/client/src/features/auth/ConfirmEmailPage.tsx
+++ b/src/client/src/features/auth/ConfirmEmailPage.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { AuthCard } from './AuthCard';
+import { useConfirmEmail } from '@/shared/api/auth';
+import { apiError } from '@/shared/utils/apiError';
+import { CheckCircle2, Loader2, AlertCircle } from 'lucide-react';
+
+/** Подтверждение адреса по ссылке из письма (issue #148). email/token — из query,
+ *  POST выполняется один раз при монтировании. */
+export function ConfirmEmailPage() {
+  const [params] = useSearchParams();
+  const confirm = useConfirmEmail();
+  const email = params.get('email') ?? '';
+  const token = params.get('token') ?? '';
+  const [status, setStatus] = useState<'pending' | 'ok' | 'error'>('pending');
+  const [error, setError] = useState('');
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    if (!email || !token) { setStatus('error'); setError('Ссылка недействительна или устарела.'); return; }
+    confirm.mutateAsync({ email, token })
+      .then(() => setStatus('ok'))
+      .catch(err => { setStatus('error'); setError(apiError(err, 'Не удалось подтвердить адрес. Возможно, ссылка устарела.')); });
+  }, [email, token, confirm]);
+
+  return (
+    <AuthCard title="Подтверждение адреса">
+      {status === 'pending' && (
+        <p className="flex items-center gap-2 text-sm text-fg3"><Loader2 size={16} className="animate-spin" /> Подтверждаем…</p>
+      )}
+      {status === 'ok' && (
+        <div className="space-y-4">
+          <p className="flex items-start gap-2 text-sm text-fg2">
+            <CheckCircle2 size={18} className="shrink-0 mt-0.5 text-success" /> Адрес подтверждён. Спасибо!
+          </p>
+          <Link to="/login" className="inline-block text-sm font-medium text-brand hover:underline">Перейти ко входу</Link>
+        </div>
+      )}
+      {status === 'error' && (
+        <div className="space-y-4">
+          <p className="flex items-start gap-2 text-sm text-danger">
+            <AlertCircle size={18} className="shrink-0 mt-0.5" /> {error}
+          </p>
+          <Link to="/login" className="inline-block text-sm font-medium text-brand hover:underline">Вернуться ко входу</Link>
+        </div>
+      )}
+    </AuthCard>
+  );
+}

--- a/src/client/src/features/auth/ForgotPasswordPage.tsx
+++ b/src/client/src/features/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthCard } from './AuthCard';
+import { TextField } from '@/shared/ui/TextField';
+import { Button } from '@/shared/ui/Button';
+import { useForgotPassword } from '@/shared/api/auth';
+import { MailCheck } from 'lucide-react';
+
+/** Запрос ссылки для сброса пароля (issue #148). Ответ всегда «письмо отправлено»,
+ *  существование адреса не раскрываем. */
+export function ForgotPasswordPage() {
+  const forgot = useForgotPassword();
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    try { await forgot.mutateAsync({ email: email.trim() }); } catch { /* enumeration-safe: игнорируем */ }
+    setSent(true);
+  }
+
+  if (sent) {
+    return (
+      <AuthCard title="Проверьте почту">
+        <div className="space-y-4">
+          <p className="flex items-start gap-2 text-sm text-fg2">
+            <MailCheck size={18} className="shrink-0 mt-0.5 text-success" />
+            Если аккаунт с адресом <span className="font-medium">{email.trim()}</span> существует,
+            мы отправили письмо со ссылкой для сброса пароля. Ссылка действует 1 час.
+          </p>
+          <Link to="/login" className="inline-block text-sm font-medium text-brand hover:underline">
+            Вернуться ко входу
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Восстановление пароля" subtitle="Укажите email — пришлём ссылку для сброса.">
+      <form onSubmit={submit} className="space-y-5">
+        <TextField label="Email" type="email" autoComplete="email" required autoFocus
+          value={email} onChange={e => setEmail(e.target.value)} />
+        <Button type="submit" variant="filled" size="lg" fullWidth loading={forgot.isPending}>
+          Отправить ссылку
+        </Button>
+        <Link to="/login" className="block text-center text-sm font-medium text-brand hover:underline">
+          Вернуться ко входу
+        </Link>
+      </form>
+    </AuthCard>
+  );
+}

--- a/src/client/src/features/auth/ResetPasswordPage.tsx
+++ b/src/client/src/features/auth/ResetPasswordPage.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { AuthCard } from './AuthCard';
+import { TextField } from '@/shared/ui/TextField';
+import { Button } from '@/shared/ui/Button';
+import { useResetPassword } from '@/shared/api/auth';
+import { apiError } from '@/shared/utils/apiError';
+
+/** Установка нового пароля по ссылке из письма (issue #148). email и token — из query. */
+export function ResetPasswordPage() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const reset = useResetPassword();
+  const email = params.get('email') ?? '';
+  const token = params.get('token') ?? '';
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+
+  const linkValid = !!email && !!token;
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    if (password !== confirm) { setError('Пароль и подтверждение не совпадают'); return; }
+    try {
+      await reset.mutateAsync({ email, token, newPassword: password });
+      setDone(true);
+      setTimeout(() => navigate('/login', { replace: true }), 1500);
+    } catch (err) {
+      setError(apiError(err, 'Не удалось сбросить пароль. Возможно, ссылка устарела.'));
+    }
+  }
+
+  if (!linkValid) {
+    return (
+      <AuthCard title="Ссылка недействительна">
+        <div className="space-y-4">
+          <p className="text-sm text-fg2">Ссылка для сброса пароля неполная или устарела. Запросите новую.</p>
+          <Link to="/forgot-password" className="inline-block text-sm font-medium text-brand hover:underline">
+            Запросить сброс заново
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  if (done) {
+    return (
+      <AuthCard title="Пароль изменён">
+        <p className="text-sm text-success">Готово. Перенаправляем ко входу…</p>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Новый пароль" subtitle={`Аккаунт: ${email}`}>
+      <form onSubmit={submit} className="space-y-5">
+        <TextField label="Новый пароль" type="password" autoComplete="new-password" required autoFocus minLength={6}
+          value={password} onChange={e => setPassword(e.target.value)} />
+        <TextField label="Подтверждение" type="password" autoComplete="new-password" required minLength={6}
+          value={confirm} onChange={e => setConfirm(e.target.value)} />
+        {error && <p className="text-sm text-danger">{error}</p>}
+        <Button type="submit" variant="filled" size="lg" fullWidth loading={reset.isPending}>
+          Сохранить пароль
+        </Button>
+        <Link to="/login" className="block text-center text-sm font-medium text-brand hover:underline">
+          Вернуться ко входу
+        </Link>
+      </form>
+    </AuthCard>
+  );
+}

--- a/src/client/src/features/catalog/LoginPage.tsx
+++ b/src/client/src/features/catalog/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { FileCheck2, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useAppVersion } from '@/shared/api/version';
@@ -22,7 +22,6 @@ export function LoginPage() {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [remember, setRemember] = useState(true);
-  const [forgotOpen, setForgotOpen] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -100,16 +99,11 @@ export function LoginPage() {
               } />
 
             <div className="flex justify-end -mt-2">
-              <button type="button" onClick={() => setForgotOpen(o => !o)} aria-expanded={forgotOpen}
+              <Link to="/forgot-password"
                 className="text-sm font-medium text-brand px-3 py-2 rounded-full hover:bg-brand/10 transition-colors">
                 Забыли пароль?
-              </button>
+              </Link>
             </div>
-            {forgotOpen && (
-              <p className="-mt-3 px-1 text-xs text-fg3">
-                Самостоятельный сброс пока недоступен — пароль сбрасывает администратор системы.
-              </p>
-            )}
 
             <label className="flex items-center gap-3 text-sm text-fg1 cursor-pointer select-none">
               <input type="checkbox" checked={remember} onChange={e => setRemember(e.target.checked)}

--- a/src/client/src/shared/api/account.ts
+++ b/src/client/src/shared/api/account.ts
@@ -34,3 +34,18 @@ export function useChangeMyPassword() {
       apiClient.post('/account/change-password', dto),
   });
 }
+
+/** Повторно отправить письмо подтверждения адреса себе (issue #148). */
+export function useResendConfirmation() {
+  return useMutation({
+    mutationFn: () => apiClient.post('/account/resend-confirmation'),
+  });
+}
+
+/** Запустить смену email: письмо-подтверждение уходит на новый адрес. */
+export function useChangeEmail() {
+  return useMutation({
+    mutationFn: (dto: { newEmail: string; currentPassword: string }) =>
+      apiClient.post('/account/change-email', dto),
+  });
+}

--- a/src/client/src/shared/api/auth.ts
+++ b/src/client/src/shared/api/auth.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from './client';
+
+/** Запрос письма для сброса пароля (issue #148). Ответ всегда 200 — существование
+ *  адреса не раскрывается (enumeration-safe). */
+export function useForgotPassword() {
+  return useMutation({
+    mutationFn: (dto: { email: string }) =>
+      apiClient.post('/auth/forgot-password', dto),
+  });
+}
+
+/** Установка нового пароля по токену из письма. */
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: (dto: { email: string; token: string; newPassword: string }) =>
+      apiClient.post('/auth/reset-password', dto),
+  });
+}

--- a/src/client/src/shared/api/auth.ts
+++ b/src/client/src/shared/api/auth.ts
@@ -17,3 +17,19 @@ export function useResetPassword() {
       apiClient.post('/auth/reset-password', dto),
   });
 }
+
+/** Подтверждение адреса по ссылке из письма (issue #148). */
+export function useConfirmEmail() {
+  return useMutation({
+    mutationFn: (dto: { email: string; token: string }) =>
+      apiClient.post('/auth/confirm-email', dto),
+  });
+}
+
+/** Подтверждение смены адреса (переход по ссылке на новый адрес). */
+export function useConfirmEmailChange() {
+  return useMutation({
+    mutationFn: (dto: { userId: string; newEmail: string; token: string }) =>
+      apiClient.post('/auth/confirm-email-change', dto),
+  });
+}

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Link, Outlet } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useAppVersion } from '@/shared/api/version';
+import { useAccount, useResendConfirmation } from '@/shared/api/account';
 import { useTheme, type Theme } from '@/shared/ui/ThemeProvider';
 import { NotificationsCenter } from '@/features/notifications/NotificationsCenter';
 import { ActiveJobsIndicator } from '@/features/jobs/ActiveJobsIndicator';
@@ -9,7 +10,7 @@ import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
-import { LogOut, Sun, Moon, Monitor, KeyRound, UserRound } from 'lucide-react';
+import { LogOut, Sun, Moon, Monitor, KeyRound, UserRound, MailWarning, X } from 'lucide-react';
 
 const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'light',  icon: Sun,     label: 'Светлая'   },
@@ -166,10 +167,43 @@ export function AppShell() {
           <ActiveJobsIndicator />
           <NotificationsCenter />
         </header>
+        <EmailConfirmBanner />
         <div className="flex-1 overflow-auto">
           <Outlet />
         </div>
       </main>
+    </div>
+  );
+}
+
+/** Мягкий баннер «подтвердите email» (issue #148) — не гейтит вход, закрывается на сессию. */
+function EmailConfirmBanner() {
+  const { data: account } = useAccount();
+  const resend = useResendConfirmation();
+  const [dismissed, setDismissed] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  if (dismissed || !account || account.emailConfirmed) return null;
+
+  return (
+    <div className="shrink-0 flex items-center gap-2 px-4 py-2 text-sm bg-warning-subtle text-warning border-b border-warning/30">
+      <MailWarning size={16} className="shrink-0" />
+      <span className="flex-1">
+        Email <span className="font-medium">{account.email}</span> не подтверждён.{' '}
+        {sent
+          ? <span className="text-fg2">Письмо отправлено — проверьте почту.</span>
+          : <button type="button" onClick={() => resend.mutate(undefined, { onSuccess: () => setSent(true) })}
+              disabled={resend.isPending}
+              className="font-medium underline hover:no-underline disabled:opacity-50">
+              Отправить письмо
+            </button>}
+        {' · '}
+        <Link to="/profile" className="font-medium underline hover:no-underline">Профиль</Link>
+      </span>
+      <button type="button" onClick={() => setDismissed(true)} aria-label="Скрыть"
+        className="shrink-0 p-1 rounded hover:bg-warning/10">
+        <X size={14} />
+      </button>
     </div>
   );
 }

--- a/src/server/BHS.CRG.Api/Auth/EmailConfirmTokenProvider.cs
+++ b/src/server/BHS.CRG.Api/Auth/EmailConfirmTokenProvider.cs
@@ -1,0 +1,27 @@
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BHS.CRG.Api.Auth;
+
+/// <summary>
+/// Отдельный token-провайдер для подтверждения / смены email (issue #148) со сроком жизни 24 часа —
+/// в отличие от дефолтного (1 час, используется сбросом пароля). Подключается как именованный
+/// провайдер «EmailConfirmDP» и назначается на EmailConfirmation/ChangeEmail токены в IdentityOptions.
+/// </summary>
+public sealed class EmailConfirmTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public EmailConfirmTokenProviderOptions()
+    {
+        Name = "EmailConfirmDP";
+        TokenLifespan = TimeSpan.FromHours(24);
+    }
+}
+
+public sealed class EmailConfirmTokenProvider(
+    IDataProtectionProvider dataProtectionProvider,
+    IOptions<EmailConfirmTokenProviderOptions> options,
+    ILogger<DataProtectorTokenProvider<ApplicationUser>> logger)
+    : DataProtectorTokenProvider<ApplicationUser>(dataProtectionProvider, options, logger);

--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -1,5 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using BHS.CRG.Application.Email;
+using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;
 
@@ -48,6 +50,42 @@ public static class AccountEndpoints
             var result = await users.ChangePasswordAsync(user, req.CurrentPassword, req.NewPassword);
             return result.Succeeded ? Results.Ok() : Results.BadRequest(new { error = DescribeErrors(result) });
         });
+
+        // Повторно отправить письмо подтверждения себе (issue #148).
+        g.MapPost("/resend-confirmation", async (
+            UserManager<ApplicationUser> users, AccountEmailService emails, ClaimsPrincipal principal, CancellationToken ct) =>
+        {
+            var user = await FindCurrent(users, principal);
+            if (user is null) return Results.Unauthorized();
+            if (user.EmailConfirmed) return Results.Ok();
+
+            var token = await users.GenerateEmailConfirmationTokenAsync(user);
+            try { await emails.SendEmailConfirmationAsync(user.Email!, token, ct); }
+            catch (EmailNotConfiguredException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            return Results.Ok();
+        });
+
+        // Смена email: письмо-подтверждение уходит на НОВЫЙ адрес; сам email меняется
+        // только после перехода по ссылке (/api/auth/confirm-email-change). Требует текущий пароль.
+        g.MapPost("/change-email", async (ChangeEmailRequest req,
+            UserManager<ApplicationUser> users, AccountEmailService emails, ClaimsPrincipal principal, CancellationToken ct) =>
+        {
+            var user = await FindCurrent(users, principal);
+            if (user is null) return Results.Unauthorized();
+
+            var newEmail = (req.NewEmail ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(newEmail))
+                return Results.BadRequest(new { error = "Укажите новый email" });
+            if (!await users.CheckPasswordAsync(user, req.CurrentPassword))
+                return Results.BadRequest(new { error = "Неверный текущий пароль" });
+            if (await users.FindByEmailAsync(newEmail) is not null)
+                return Results.BadRequest(new { error = "Этот email уже используется" });
+
+            var token = await users.GenerateChangeEmailTokenAsync(user, newEmail);
+            try { await emails.SendEmailChangeAsync(user.Id, newEmail, token, ct); }
+            catch (EmailNotConfiguredException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            return Results.Ok();
+        });
     }
 
     private static async Task<ApplicationUser?> FindCurrent(UserManager<ApplicationUser> users, ClaimsPrincipal p)
@@ -66,4 +104,5 @@ public static class AccountEndpoints
     record AccountDto(string Email, string DisplayName, string Role, bool EmailConfirmed);
     record UpdateAccountRequest(string? DisplayName);
     record ChangePasswordRequest(string CurrentPassword, string NewPassword);
+    record ChangeEmailRequest(string? NewEmail, string CurrentPassword);
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
@@ -45,7 +46,46 @@ public static class AuthEndpoints
             return Results.Ok(new { accessToken = token });
         });
         // Смена пароля переехала в /api/account/change-password (issue #148).
+
+        // Сброс пароля (issue #148). Анонимные, под rate-limit «auth».
+        // Enumeration-safe: forgot всегда 200, существование адреса не раскрываем.
+        g.MapPost("/forgot-password", async (ForgotPasswordRequest req,
+            UserManager<ApplicationUser> users, AccountEmailService emails,
+            ILoggerFactory loggers, CancellationToken ct) =>
+        {
+            var user = await users.FindByEmailAsync(req.Email);
+            if (user is not null)
+            {
+                try
+                {
+                    var token = await users.GeneratePasswordResetTokenAsync(user);
+                    await emails.SendPasswordResetAsync(user.Email!, token, ct);
+                }
+                catch (Exception ex)
+                {
+                    // Не роняем ответ (и не раскрываем существование адреса) — только лог без секретов.
+                    loggers.CreateLogger("Auth").LogWarning(ex, "Не удалось отправить письмо сброса пароля");
+                }
+            }
+            return Results.Ok();
+        }).RequireRateLimiting("auth");
+
+        g.MapPost("/reset-password", async (ResetPasswordRequest req,
+            UserManager<ApplicationUser> users) =>
+        {
+            var user = await users.FindByEmailAsync(req.Email);
+            if (user is null)
+                return Results.BadRequest(new { error = "Ссылка недействительна или устарела." });
+
+            var result = await users.ResetPasswordAsync(user, req.Token, req.NewPassword);
+            return result.Succeeded
+                ? Results.Ok()
+                : Results.BadRequest(new { error = DescribeErrors(result) });
+        }).RequireRateLimiting("auth");
     }
+
+    private static string DescribeErrors(IdentityResult r) =>
+        string.Join("; ", r.Errors.Select(e => e.Description));
 
     private static string CreateToken(ApplicationUser user, IList<string> roles, IConfiguration cfg)
     {
@@ -71,4 +111,6 @@ public static class AuthEndpoints
 
     record RegisterRequest(string Email, string Password, string DisplayName);
     record LoginRequest(string Email, string Password);
+    record ForgotPasswordRequest(string Email);
+    record ResetPasswordRequest(string Email, string Token, string NewPassword);
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -23,7 +23,8 @@ public static class AuthEndpoints
             if (users.Users.Any())
                 return Results.Problem("Регистрация закрыта. Обратитесь к администратору.", statusCode: 403);
 
-            var user = new ApplicationUser { UserName = req.Email, Email = req.Email, DisplayName = req.DisplayName };
+            // Первому админу подтверждать адрес некому — считаем подтверждённым (issue #148).
+            var user = new ApplicationUser { UserName = req.Email, Email = req.Email, DisplayName = req.DisplayName, EmailConfirmed = true };
             var result = await users.CreateAsync(user, req.Password);
             if (!result.Succeeded) return Results.BadRequest(result.Errors);
             await users.AddToRoleAsync(user, "Admin");
@@ -82,6 +83,35 @@ public static class AuthEndpoints
                 ? Results.Ok()
                 : Results.BadRequest(new { error = DescribeErrors(result) });
         }).RequireRateLimiting("auth");
+
+        // Подтверждение адреса по ссылке из письма (issue #148). Анонимные.
+        g.MapPost("/confirm-email", async (ConfirmEmailRequest req, UserManager<ApplicationUser> users) =>
+        {
+            var user = await users.FindByEmailAsync(req.Email);
+            if (user is null)
+                return Results.BadRequest(new { error = "Ссылка недействительна или устарела." });
+
+            var result = await users.ConfirmEmailAsync(user, req.Token);
+            return result.Succeeded
+                ? Results.Ok()
+                : Results.BadRequest(new { error = DescribeErrors(result) });
+        }).RequireRateLimiting("auth");
+
+        // Подтверждение смены адреса (переход по ссылке из письма на НОВЫЙ адрес).
+        g.MapPost("/confirm-email-change", async (ConfirmEmailChangeRequest req, UserManager<ApplicationUser> users) =>
+        {
+            var user = await users.FindByIdAsync(req.UserId.ToString());
+            if (user is null)
+                return Results.BadRequest(new { error = "Ссылка недействительна или устарела." });
+
+            var result = await users.ChangeEmailAsync(user, req.NewEmail, req.Token);
+            if (!result.Succeeded)
+                return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            // UserName == Email (вход по email) — синхронизируем, иначе логин отвалится.
+            await users.SetUserNameAsync(user, req.NewEmail);
+            return Results.Ok();
+        }).RequireRateLimiting("auth");
     }
 
     private static string DescribeErrors(IdentityResult r) =>
@@ -113,4 +143,6 @@ public static class AuthEndpoints
     record LoginRequest(string Email, string Password);
     record ForgotPasswordRequest(string Email);
     record ResetPasswordRequest(string Email, string Token, string NewPassword);
+    record ConfirmEmailRequest(string Email, string Token);
+    record ConfirmEmailChangeRequest(Guid UserId, string NewEmail, string Token);
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
@@ -1,5 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using BHS.CRG.Application.Email;
+using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -26,7 +28,8 @@ public static class UserEndpoints
             return Results.Ok(result);
         });
 
-        g.MapPost("/", async (CreateUserRequest req, UserManager<ApplicationUser> users) =>
+        g.MapPost("/", async (CreateUserRequest req,
+            UserManager<ApplicationUser> users, AccountEmailService emails, CancellationToken ct) =>
         {
             var role = NormalizeRole(req.Role);
             if (role is null) return Results.BadRequest(new { error = "Недопустимая роль" });
@@ -41,6 +44,18 @@ public static class UserEndpoints
             var created = await users.CreateAsync(user, req.Password);
             if (!created.Succeeded) return Results.BadRequest(new { error = DescribeErrors(created) });
             await users.AddToRoleAsync(user, role);
+
+            // По желанию админа — сразу отправить письмо для подтверждения адреса (issue #148).
+            // Ошибку отправки не роняем в ответ: пользователь уже создан, письмо можно переслать позже.
+            if (req.SendConfirmation == true)
+            {
+                try
+                {
+                    var token = await users.GenerateEmailConfirmationTokenAsync(user);
+                    await emails.SendEmailConfirmationAsync(user.Email!, token, ct);
+                }
+                catch (EmailNotConfiguredException) { /* SMTP не настроен — пользователь создан, письмо позже */ }
+            }
             return Results.Ok(new UserDto(user.Id, user.Email!, user.DisplayName, role));
         });
 
@@ -106,7 +121,7 @@ public static class UserEndpoints
         string.Join("; ", r.Errors.Select(e => e.Description));
 
     record UserDto(Guid Id, string Email, string DisplayName, string Role);
-    record CreateUserRequest(string Email, string? DisplayName, string Password, string Role);
+    record CreateUserRequest(string Email, string? DisplayName, string Password, string Role, bool? SendConfirmation);
     record ChangeRoleRequest(string Role);
     record ResetPasswordRequest(string NewPassword);
 }

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 using BHS.CRG.Api.Endpoints.Account;
 using BHS.CRG.Api.Endpoints.Attachments;
 using BHS.CRG.Api.Endpoints.Auth;
@@ -45,7 +46,9 @@ using BHS.CRG.Infrastructure.Persistence;
 using BHS.CRG.Infrastructure.Plugins;
 using BHS.CRG.Infrastructure.Storage;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Minio;
@@ -69,6 +72,29 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(opt =>
     })
     .AddEntityFrameworkStores<AppDbContext>()
     .AddDefaultTokenProviders();
+
+// Токены сброса/подтверждения (issue #148) шифруются ключами Data Protection. БЕЗ персистентных
+// ключей они инвалидируются при каждом рестарте API (и ломаются при >1 инстанса). Персистим на диск
+// (в контейнере — том); путь настраивается, дефолт — рядом с приложением.
+var dpKeysPath = cfg["DataProtection:KeysPath"];
+if (string.IsNullOrWhiteSpace(dpKeysPath))
+    dpKeysPath = Path.Combine(builder.Environment.ContentRootPath, "dp-keys");
+Directory.CreateDirectory(dpKeysPath);
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(dpKeysPath))
+    .SetApplicationName("BHS.CRG");
+
+// Время жизни токенов сброса пароля / подтверждения (дефолтный token-провайдер) — 1 час.
+builder.Services.Configure<DataProtectionTokenProviderOptions>(o => o.TokenLifespan = TimeSpan.FromHours(1));
+
+// Rate limiting для чувствительных анонимных эндпоинтов сброса пароля (по IP).
+builder.Services.AddRateLimiter(o =>
+{
+    o.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    o.AddPolicy("auth", ctx => RateLimitPartition.GetFixedWindowLimiter(
+        ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+        _ => new FixedWindowRateLimiterOptions { PermitLimit = 10, Window = TimeSpan.FromMinutes(15), QueueLimit = 0 }));
+});
 
 // ── JWT ───────────────────────────────────────────────────────────────────────
 var jwtSection = cfg.GetSection("Jwt");
@@ -152,6 +178,7 @@ builder.Services.AddScoped<IDocumentRecognizer, ChainDocumentRecognizer>();
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IIntegrationSettings, IntegrationSettingsService>();
 builder.Services.AddScoped<BHS.CRG.Application.Email.IEmailSender, BHS.CRG.Infrastructure.Email.MailKitEmailSender>();
+builder.Services.AddScoped<BHS.CRG.Infrastructure.Email.AccountEmailService>();
 
 // ── Фоновые задачи (долгие операции: распознавание набора/таблицы) ──────────────
 builder.Services.AddSingleton<JobQueue>();
@@ -274,6 +301,7 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 app.MapAttachmentEndpoints();
 app.MapAuthEndpoints();

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
+using BHS.CRG.Api.Auth;
 using BHS.CRG.Api.Endpoints.Account;
 using BHS.CRG.Api.Endpoints.Attachments;
 using BHS.CRG.Api.Endpoints.Auth;
@@ -69,9 +70,14 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(opt =>
         opt.Password.RequireDigit = false;
         opt.Password.RequireNonAlphanumeric = false;
         opt.Password.RequiredLength = 6;
+        // Подтверждение/смена email — на отдельном 24-часовом провайдере (issue #148),
+        // сброс пароля остаётся на дефолтном (1 час).
+        opt.Tokens.EmailConfirmationTokenProvider = "EmailConfirmDP";
+        opt.Tokens.ChangeEmailTokenProvider = "EmailConfirmDP";
     })
     .AddEntityFrameworkStores<AppDbContext>()
-    .AddDefaultTokenProviders();
+    .AddDefaultTokenProviders()
+    .AddTokenProvider<EmailConfirmTokenProvider>("EmailConfirmDP");
 
 // Токены сброса/подтверждения (issue #148) шифруются ключами Data Protection. БЕЗ персистентных
 // ключей они инвалидируются при каждом рестарте API (и ломаются при >1 инстанса). Персистим на диск

--- a/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
@@ -23,6 +23,33 @@ public class AccountEmailService(IEmailSender email, IConfiguration config)
         await email.SendAsync(new EmailMessage([toEmail], "Сброс пароля — BHS.CRG", body), ct);
     }
 
+    /// <summary>Письмо с подтверждением адреса (токен действует ~24 часа).</summary>
+    public async Task SendEmailConfirmationAsync(string toEmail, string token, CancellationToken ct = default)
+    {
+        var link = BuildLink("confirm-email", toEmail, token);
+        var body = link is null
+            ? "Для подтверждения адреса в BHS.CRG нужен адрес приложения (App:PublicUrl) — обратитесь к администратору."
+            : "Подтвердите адрес электронной почты для BHS.CRG.\n\n" +
+              $"Ссылка для подтверждения (действует 24 часа):\n{link}\n\n" +
+              "Если вы не заводили учётную запись — просто проигнорируйте это письмо.";
+        await email.SendAsync(new EmailMessage([toEmail], "Подтверждение адреса — BHS.CRG", body), ct);
+    }
+
+    /// <summary>Письмо на НОВЫЙ адрес для подтверждения смены email (токен действует ~24 часа).</summary>
+    public async Task SendEmailChangeAsync(Guid userId, string newEmail, string token, CancellationToken ct = default)
+    {
+        var publicUrl = config["App:PublicUrl"]?.TrimEnd('/');
+        var link = string.IsNullOrEmpty(publicUrl) ? null
+            : $"{publicUrl}/confirm-email-change?uid={Uri.EscapeDataString(userId.ToString())}" +
+              $"&email={Uri.EscapeDataString(newEmail)}&token={Uri.EscapeDataString(token)}";
+        var body = link is null
+            ? "Для смены адреса в BHS.CRG нужен адрес приложения (App:PublicUrl) — обратитесь к администратору."
+            : "Запрошена смена адреса входа в BHS.CRG на этот email.\n\n" +
+              $"Ссылка для подтверждения (действует 24 часа):\n{link}\n\n" +
+              "Если вы не запрашивали смену — проигнорируйте это письмо, адрес останется прежним.";
+        await email.SendAsync(new EmailMessage([newEmail], "Смена адреса входа — BHS.CRG", body), ct);
+    }
+
     /// <summary>Собирает ссылку на фронт-роут с url-encoded email и токеном, либо null если PublicUrl пуст.</summary>
     private string? BuildLink(string route, string email, string token)
     {

--- a/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
@@ -1,0 +1,33 @@
+using BHS.CRG.Application.Email;
+using Microsoft.Extensions.Configuration;
+
+namespace BHS.CRG.Infrastructure.Email;
+
+/// <summary>
+/// Письма учётной записи (issue #148): сброс пароля, подтверждение почты. Собирает ссылку из
+/// <c>App:PublicUrl</c> + url-encoded токен Identity и отправляет через <see cref="IEmailSender"/>.
+/// Оркестрация (генерация токена) — в endpoint'ах, здесь только сборка письма и отправка.
+/// </summary>
+public class AccountEmailService(IEmailSender email, IConfiguration config)
+{
+    /// <summary>Письмо со ссылкой сброса пароля (токен действует ~1 час).</summary>
+    public async Task SendPasswordResetAsync(string toEmail, string token, CancellationToken ct = default)
+    {
+        var link = BuildLink("reset-password", toEmail, token);
+        var body = link is null
+            ? "Вы запросили сброс пароля в BHS.CRG, но адрес приложения не настроен (App:PublicUrl). " +
+              "Обратитесь к администратору системы."
+            : "Вы запросили сброс пароля в BHS.CRG.\n\n" +
+              $"Ссылка для сброса (действует 1 час):\n{link}\n\n" +
+              "Если вы не запрашивали сброс — просто проигнорируйте это письмо, пароль останется прежним.";
+        await email.SendAsync(new EmailMessage([toEmail], "Сброс пароля — BHS.CRG", body), ct);
+    }
+
+    /// <summary>Собирает ссылку на фронт-роут с url-encoded email и токеном, либо null если PublicUrl пуст.</summary>
+    private string? BuildLink(string route, string email, string token)
+    {
+        var publicUrl = config["App:PublicUrl"]?.TrimEnd('/');
+        if (string.IsNullOrEmpty(publicUrl)) return null;
+        return $"{publicUrl}/{route}?email={Uri.EscapeDataString(email)}&token={Uri.EscapeDataString(token)}";
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.43</Version>
+    <Version>0.23.44</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.44</Version>
+    <Version>0.23.45</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Финальный срез #148 — **подтверждение email + смена email**.

> ⚠️ **Стек на #158 (PR-C) → #156 (PR-B)**. Мёржить последним, после B и C
> (GitHub переставит базы автоматически по мере мёржа).

## Backend
- Отдельный **24-часовой** token-провайдер `EmailConfirmDP` для подтверждения/смены email
  (сброс пароля остаётся на дефолтном 1-часовом).
- Анонимные `POST /api/auth/confirm-email`, `POST /api/auth/confirm-email-change`
  (при смене синхронизируем `UserName`, т.к. вход по email); под rate-limit `auth`.
- Авторизованные `POST /api/account/resend-confirmation`, `POST /api/account/change-email`
  (требует текущий пароль; письмо-подтверждение уходит на **новый** адрес; сам email
  меняется только после перехода по ссылке). `EmailNotConfiguredException` → чистая **400**.
- **Bootstrap-админ** создаётся `EmailConfirmed=true` (подтверждать некому).
- Заведение юзера админом: опциональный флажок `SendConfirmation` (ошибку SMTP не роняем —
  юзер уже создан).
- `AccountEmailService`: письма подтверждения и смены адреса (ссылки из `App:PublicUrl`).

## Frontend
- Публичные роуты `/confirm-email`, `/confirm-email-change` (POST при монтировании, `AuthCard`).
- **Профиль**: кнопка «Отправить письмо» при неподтверждённом email + секция **«Сменить email»**.
- **Мягкий баннер** «email не подтверждён» в `AppShell` — не гейтит вход, закрывается на сессию,
  «Отправить письмо» + ссылка на профиль.

## Решения (по плану)
Мягкий баннер (НЕ гейт), смена email с подтверждением нового адреса, JWT при этом не инвалидируется
(v1). **Миграций нет** (`EmailConfirmed`/`SecurityStamp` уже в схеме).

## Проверка
- `dotnet test` **380**; `tsc -b` / `build` / `vitest` **115** — зелёные.
- Вручную: confirm-email / confirm-email-change bad-token → **400**, resend → **200**,
  change-email неверный пароль → **400**; скриншот профиля с баннером и секцией смены email.

Версия → 0.23.45. **Это закрывает #148** (B/C/D). Мёрдж-порядок: #156 → #158 → #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)