### PR TITLE
feat(auth): блокировка входа после серии неудач (#148 follow-up)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -39,9 +39,24 @@ public static class AuthEndpoints
             IConfiguration cfg) =>
         {
             var user = await users.FindByEmailAsync(req.Email);
-            if (user is null || !await users.CheckPasswordAsync(user, req.Password))
+            if (user is null)
                 return Results.Unauthorized();
 
+            // Защита от перебора пароля: временная блокировка после N неудач (issue #148 follow-up).
+            if (await users.IsLockedOutAsync(user))
+                return Results.Json(new { error = "Слишком много попыток. Аккаунт временно заблокирован, попробуйте позже." },
+                    statusCode: StatusCodes.Status423Locked);
+
+            if (!await users.CheckPasswordAsync(user, req.Password))
+            {
+                await users.AccessFailedAsync(user);
+                if (await users.IsLockedOutAsync(user))
+                    return Results.Json(new { error = "Слишком много попыток. Аккаунт временно заблокирован, попробуйте позже." },
+                        statusCode: StatusCodes.Status423Locked);
+                return Results.Unauthorized();
+            }
+
+            await users.ResetAccessFailedCountAsync(user);
             var roles = await users.GetRolesAsync(user);
             var token = CreateToken(user, roles, cfg);
             return Results.Ok(new { accessToken = token });
@@ -79,9 +94,13 @@ public static class AuthEndpoints
                 return Results.BadRequest(new { error = "Ссылка недействительна или устарела." });
 
             var result = await users.ResetPasswordAsync(user, req.Token, req.NewPassword);
-            return result.Succeeded
-                ? Results.Ok()
-                : Results.BadRequest(new { error = DescribeErrors(result) });
+            if (!result.Succeeded)
+                return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            // Успешный сброс снимает блокировку по неудачным попыткам (issue #148 follow-up).
+            await users.SetLockoutEndDateAsync(user, null);
+            await users.ResetAccessFailedCountAsync(user);
+            return Results.Ok();
         }).RequireRateLimiting("auth");
 
         // Подтверждение адреса по ссылке из письма (issue #148). Анонимные.

--- a/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
@@ -86,7 +86,12 @@ public static class UserEndpoints
             if (user is null) return Results.NotFound();
             var token = await users.GeneratePasswordResetTokenAsync(user);
             var result = await users.ResetPasswordAsync(user, token, req.NewPassword);
-            return result.Succeeded ? Results.Ok() : Results.BadRequest(new { error = DescribeErrors(result) });
+            if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            // Сброс пароля админом снимает и блокировку по неудачным попыткам (issue #148 follow-up).
+            await users.SetLockoutEndDateAsync(user, null);
+            await users.ResetAccessFailedCountAsync(user);
+            return Results.Ok();
         });
 
         g.MapDelete("/{id:guid}", async (Guid id,

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -70,6 +70,10 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(opt =>
         opt.Password.RequireDigit = false;
         opt.Password.RequireNonAlphanumeric = false;
         opt.Password.RequiredLength = 6;
+        // Защита от перебора пароля (issue #148 follow-up): блокировка на 15 минут после 5 неудач.
+        opt.Lockout.AllowedForNewUsers = true;
+        opt.Lockout.MaxFailedAccessAttempts = 5;
+        opt.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
         // Подтверждение/смена email — на отдельном 24-часовом провайдере (issue #148),
         // сброс пароля остаётся на дефолтном (1 час).
         opt.Tokens.EmailConfirmationTokenProvider = "EmailConfirmDP";

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.45</Version>
+    <Version>0.23.46</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Первый из follow-up'ов после #148 — **защита входа от перебора пароля** через встроенный
Identity-lockout. Без миграции (колонки `LockoutEnd`/`AccessFailedCount` уже в схеме).

## Что
- Identity: `MaxFailedAccessAttempts=5`, `DefaultLockoutTimeSpan=15 мин`, `AllowedForNewUsers`.
- `POST /api/auth/login`: `IsLockedOut` → **423 Locked**; неудачная попытка → `AccessFailedAsync`
  (при достижении лимита сразу 423); успех → `ResetAccessFailedCount`.
- **Разблокировка**, чтобы не застревать на 15 мин: снимается при успешном сбросе пароля
  (email-flow) и при сбросе пароля админом (`/api/users/{id}/reset-password`).

## Проверка (вручную + тесты)
- 4×**401** → 5-я неудача **423**; верный пароль при блокировке → **423**; другой аккаунт не затронут (**200**);
  админ-сброс снимает блокировку → вход **200**.
- `dotnet test` — **380 passed**. Фронтенд не затронут.

Компромисс (известный): lockout по аккаунту допускает DoS-блокировку чужого входа спамом
неверных паролей; для внутренней системы с окном 15 мин это стандартный приемлемый вариант
(альтернатива — IP-rate-limit — ложно блокирует общий офисный IP).

Версия → 0.23.46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)