### PR TITLE
feat(auth): инвалидация JWT при сбросе/смене пароля (SecurityStamp) (#148 follow-up)

### DIFF
--- a/src/client/src/shared/api/account.ts
+++ b/src/client/src/shared/api/account.ts
@@ -31,7 +31,7 @@ export function useUpdateAccount() {
 export function useChangeMyPassword() {
   return useMutation({
     mutationFn: (dto: { currentPassword: string; newPassword: string }) =>
-      apiClient.post('/account/change-password', dto),
+      apiClient.post<{ accessToken?: string }>('/account/change-password', dto).then(r => r.data),
   });
 }
 

--- a/src/client/src/shared/api/token.ts
+++ b/src/client/src/shared/api/token.ts
@@ -27,3 +27,9 @@ export function clearToken(): void {
   localStorage.removeItem(KEY);
   sessionStorage.removeItem(KEY);
 }
+
+/** Заменяет токен, сохраняя выбранное хранилище (напр. после re-issue при смене пароля). */
+export function replaceToken(token: string): void {
+  if (sessionStorage.getItem(KEY) !== null) sessionStorage.setItem(KEY, token);
+  else localStorage.setItem(KEY, token);
+}

--- a/src/client/src/shared/hooks/useAuth.ts
+++ b/src/client/src/shared/hooks/useAuth.ts
@@ -12,6 +12,8 @@ export interface AuthUser {
 export interface AuthContextValue {
   user: AuthUser | null;
   login: (email: string, password: string, remember?: boolean) => Promise<void>;
+  /** Обновить сессию по свежему токену (напр. re-issue при смене пароля). */
+  updateSession: (accessToken: string) => void;
   logout: () => void;
 }
 

--- a/src/client/src/shared/ui/AuthProvider.tsx
+++ b/src/client/src/shared/ui/AuthProvider.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, type ReactNode } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { apiClient } from '@/shared/api/client';
-import { getToken, setToken, clearToken } from '@/shared/api/token';
+import { getToken, setToken, clearToken, replaceToken } from '@/shared/api/token';
 import { AuthContext, type AuthUser, type UserRole } from '@/shared/hooks/useAuth';
 
 function decodeUser(token: string): AuthUser {
@@ -23,13 +23,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(decodeUser(data.accessToken));
   }, []);
 
+  const updateSession = useCallback((accessToken: string) => {
+    replaceToken(accessToken);
+    setUser(decodeUser(accessToken));
+  }, []);
+
   const logout = useCallback(() => {
     clearToken();
     setUser(null);
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, updateSession, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/client/src/shared/ui/ChangePasswordModal.tsx
+++ b/src/client/src/shared/ui/ChangePasswordModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { useChangeMyPassword } from '@/shared/api/account';
+import { useAuth } from '@/shared/hooks/useAuth';
 
 function apiError(e: unknown): string {
   const err = e as { response?: { data?: { error?: string; errors?: { description: string }[] } }; message?: string };
@@ -12,6 +13,7 @@ function apiError(e: unknown): string {
 
 export function ChangePasswordModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const change = useChangeMyPassword();
+  const { updateSession } = useAuth();
   const [current, setCurrent] = useState('');
   const [next, setNext] = useState('');
   const [confirm, setConfirm] = useState('');
@@ -25,7 +27,9 @@ export function ChangePasswordModal({ open, onClose }: { open: boolean; onClose:
     setError('');
     if (next !== confirm) { setError('Новый пароль и подтверждение не совпадают'); return; }
     try {
-      await change.mutateAsync({ currentPassword: current, newPassword: next });
+      const res = await change.mutateAsync({ currentPassword: current, newPassword: next });
+      // Смена пароля обновляет SecurityStamp → используем свежий токен, чтобы не разлогиниться.
+      if (res?.accessToken) updateSession(res.accessToken);
       setDone(true);
       setTimeout(() => { reset(); onClose(); }, 1200);
     } catch (err) { setError(apiError(err)); }

--- a/src/server/BHS.CRG.Api/Auth/JwtTokens.cs
+++ b/src/server/BHS.CRG.Api/Auth/JwtTokens.cs
@@ -1,0 +1,41 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BHS.CRG.Api.Auth;
+
+/// <summary>
+/// Выпуск access-JWT. Кроме sub/email/displayName/role кладём <c>sstamp</c> — текущий
+/// SecurityStamp пользователя (issue #148 follow-up). Он проверяется на каждом запросе
+/// (см. JwtBearer OnTokenValidated в Program.cs): сброс/смена пароля меняют стамп → ранее
+/// выданные токены становятся недействительными.
+/// </summary>
+public static class JwtTokens
+{
+    public const string SecurityStampClaim = "sstamp";
+
+    public static string Create(ApplicationUser user, IList<string> roles, string securityStamp, IConfiguration cfg)
+    {
+        var jwtCfg = cfg.GetSection("Jwt");
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtCfg["Key"]!));
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email!),
+            new("displayName", user.DisplayName),
+            new(SecurityStampClaim, securityStamp),
+        };
+        foreach (var role in roles)
+            claims.Add(new Claim("role", role));
+
+        var token = new JwtSecurityToken(
+            issuer: jwtCfg["Issuer"],
+            audience: jwtCfg["Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddDays(7),
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using BHS.CRG.Api.Auth;
 using BHS.CRG.Application.Email;
 using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
@@ -42,13 +43,19 @@ public static class AccountEndpoints
 
         // Смена пароля текущим пользователем (перенесено из /api/auth в #148).
         g.MapPost("/change-password", async (ChangePasswordRequest req,
-            UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
+            UserManager<ApplicationUser> users, ClaimsPrincipal principal, IConfiguration cfg) =>
         {
             var user = await FindCurrent(users, principal);
             if (user is null) return Results.Unauthorized();
 
             var result = await users.ChangePasswordAsync(user, req.CurrentPassword, req.NewPassword);
-            return result.Succeeded ? Results.Ok() : Results.BadRequest(new { error = DescribeErrors(result) });
+            if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            // Смена пароля обновляет SecurityStamp → текущий токен становится недействительным.
+            // Выдаём свежий, чтобы не разлогинивать активную сессию (issue #148 follow-up).
+            var roles = await users.GetRolesAsync(user);
+            var stamp = await users.GetSecurityStampAsync(user);
+            return Results.Ok(new { accessToken = JwtTokens.Create(user, roles, stamp, cfg) });
         });
 
         // Повторно отправить письмо подтверждения себе (issue #148).

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -1,10 +1,7 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
+using BHS.CRG.Api.Auth;
 using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.IdentityModel.Tokens;
 
 namespace BHS.CRG.Api.Endpoints.Auth;
 
@@ -58,7 +55,8 @@ public static class AuthEndpoints
 
             await users.ResetAccessFailedCountAsync(user);
             var roles = await users.GetRolesAsync(user);
-            var token = CreateToken(user, roles, cfg);
+            var stamp = await users.GetSecurityStampAsync(user);
+            var token = JwtTokens.Create(user, roles, stamp, cfg);
             return Results.Ok(new { accessToken = token });
         });
         // Смена пароля переехала в /api/account/change-password (issue #148).
@@ -135,28 +133,6 @@ public static class AuthEndpoints
 
     private static string DescribeErrors(IdentityResult r) =>
         string.Join("; ", r.Errors.Select(e => e.Description));
-
-    private static string CreateToken(ApplicationUser user, IList<string> roles, IConfiguration cfg)
-    {
-        var jwtCfg = cfg.GetSection("Jwt");
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtCfg["Key"]!));
-        var claims = new List<Claim>
-        {
-            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
-            new(JwtRegisteredClaimNames.Email, user.Email!),
-            new("displayName", user.DisplayName),
-        };
-        foreach (var role in roles)
-            claims.Add(new Claim("role", role));
-
-        var token = new JwtSecurityToken(
-            issuer: jwtCfg["Issuer"],
-            audience: jwtCfg["Audience"],
-            claims: claims,
-            expires: DateTime.UtcNow.AddDays(7),
-            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
 
     record RegisterRequest(string Email, string Password, string DisplayName);
     record LoginRequest(string Email, string Password);

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -138,6 +138,23 @@ builder.Services.AddAuthentication(opt =>
                     ctx.HttpContext.Request.Path.StartsWithSegments("/hubs"))
                     ctx.Token = token;
                 return Task.CompletedTask;
+            },
+            // Проверка SecurityStamp (issue #148 follow-up): токен со «старым» стампом
+            // (после сброса/смены пароля или logout-all) отклоняется, даже не истёкший.
+            OnTokenValidated = async ctx =>
+            {
+                var principal = ctx.Principal;
+                var userId = principal?.FindFirst("sub")?.Value;
+                var tokenStamp = principal?.FindFirst(JwtTokens.SecurityStampClaim)?.Value;
+                if (userId is null || tokenStamp is null) { ctx.Fail("Недействительный токен."); return; }
+
+                var userManager = ctx.HttpContext.RequestServices.GetRequiredService<UserManager<ApplicationUser>>();
+                var user = await userManager.FindByIdAsync(userId);
+                if (user is null) { ctx.Fail("Пользователь не найден."); return; }
+
+                var currentStamp = await userManager.GetSecurityStampAsync(user);
+                if (!string.Equals(tokenStamp, currentStamp, StringComparison.Ordinal))
+                    ctx.Fail("Сессия недействительна — войдите заново.");
             }
         };
     });

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.46</Version>
+    <Version>0.23.47</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Реализует отложенный пункт Архитектора — **«сброс инвалидирует активные JWT»** — лёгким
способом через SecurityStamp, **без refresh-токенов и без миграций**.

## Что
- В access-JWT добавлен claim `sstamp` = `SecurityStamp` пользователя (общая фабрика `JwtTokens.Create`
  для login и re-issue).
- `JwtBearer.OnTokenValidated`: сверяем `sstamp` из токена с текущим `SecurityStamp` в БД →
  расхождение = **401** (токен со «старым» стампом отклоняется, даже если не истёк).
- Сброс пароля (email/админ) и смена пароля меняют `SecurityStamp` → ранее выданные токены
  становятся недействительными сразу.
- **Self change-password** возвращает свежий `accessToken`; фронт применяет его
  (`updateSession`/`replaceToken`, хранилище remember-me сохраняется) — активная сессия не рвётся.

## Компромиссы (осознанно)
- Срок токена остаётся 7 дней — полноценный **short-access + refresh с ротацией** это отдельный,
  бóльший follow-up. Здесь — целевая инвалидация при смене учётных данных.
- Добавляется per-request чтение пользователя из БД (проверка стампа) — для масштаба системы приемлемо.
- После деплоя ранее выданные токены (без `sstamp`) разлогинятся один раз.

## Проверка
- Вручную: смена пароля → старый токен **401** / новый **200**; админ-сброс → токен юзера **401**,
  чужой аккаунт не затронут (**200**); re-login **200**.
- `dotnet test` **380**, `vitest` **115**, **keyboard smoke 11/11** (авторизованная навигация с
  per-request проверкой стампа работает).

Версия → 0.23.47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)