### PR TITLE
feat(auth): refresh-токены + короткий access-JWT (#148 follow-up)

### DIFF
--- a/src/client/src/shared/api/account.ts
+++ b/src/client/src/shared/api/account.ts
@@ -31,7 +31,7 @@ export function useUpdateAccount() {
 export function useChangeMyPassword() {
   return useMutation({
     mutationFn: (dto: { currentPassword: string; newPassword: string }) =>
-      apiClient.post<{ accessToken?: string }>('/account/change-password', dto).then(r => r.data),
+      apiClient.post<{ accessToken?: string; refreshToken?: string }>('/account/change-password', dto).then(r => r.data),
   });
 }
 

--- a/src/client/src/shared/api/account.ts
+++ b/src/client/src/shared/api/account.ts
@@ -31,7 +31,7 @@ export function useUpdateAccount() {
 export function useChangeMyPassword() {
   return useMutation({
     mutationFn: (dto: { currentPassword: string; newPassword: string }) =>
-      apiClient.post('/account/change-password', dto),
+      apiClient.post<{ accessToken?: string }>('/account/change-password', dto).then(r => r.data),
   });
 }
 

--- a/src/client/src/shared/api/client.ts
+++ b/src/client/src/shared/api/client.ts
@@ -1,9 +1,9 @@
-import axios from 'axios';
-import { getToken, clearToken } from './token';
+import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import { getToken, getRefreshToken, replaceTokens, clearToken } from './token';
 
-export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? '/api',
-});
+const baseURL = import.meta.env.VITE_API_URL ?? '/api';
+
+export const apiClient = axios.create({ baseURL });
 
 apiClient.interceptors.request.use((config) => {
   const token = getToken();
@@ -11,17 +11,51 @@ apiClient.interceptors.request.use((config) => {
   return config;
 });
 
+// Тихое обновление access по refresh-токену (issue #148 follow-up). Один общий запрос
+// на все параллельные 401 (single-flight); голый axios — чтобы не зациклить интерсептор.
+let refreshPromise: Promise<string | null> | null = null;
+
+async function refreshAccess(): Promise<string | null> {
+  const refresh = getRefreshToken();
+  if (!refresh) return null;
+  try {
+    const { data } = await axios.post<{ accessToken: string; refreshToken: string }>(
+      `${baseURL}/auth/refresh`, { refreshToken: refresh });
+    replaceTokens(data.accessToken, data.refreshToken);
+    return data.accessToken;
+  } catch {
+    return null;
+  }
+}
+
+function toLogin() {
+  clearToken();
+  if (window.location.pathname !== '/login') window.location.href = '/login';
+}
+
 apiClient.interceptors.response.use(
   (r) => r,
-  (err) => {
-    if (err.response?.status === 401) {
-      clearToken();
-      window.location.href = '/login';
+  async (err: AxiosError) => {
+    const original = err.config as (InternalAxiosRequestConfig & { _retried?: boolean }) | undefined;
+    const url = original?.url ?? '';
+    const isAuthCall = url.includes('/auth/refresh') || url.includes('/auth/login');
+
+    if (err.response?.status === 401 && original && !isAuthCall) {
+      if (!original._retried && getRefreshToken()) {
+        original._retried = true;
+        refreshPromise ??= refreshAccess().finally(() => { refreshPromise = null; });
+        const newAccess = await refreshPromise;
+        if (newAccess) {
+          original.headers.Authorization = `Bearer ${newAccess}`;
+          return apiClient(original);
+        }
+      }
+      toLogin();
     }
-    const serverMessage = err.response?.data?.error ?? err.response?.data?.detail;
-    if (serverMessage) {
-      err.message = serverMessage;
-    }
+
+    const serverMessage = (err.response?.data as { error?: string; detail?: string } | undefined)?.error
+      ?? (err.response?.data as { detail?: string } | undefined)?.detail;
+    if (serverMessage) err.message = serverMessage;
     return Promise.reject(err);
-  }
+  },
 );

--- a/src/client/src/shared/api/token.ts
+++ b/src/client/src/shared/api/token.ts
@@ -27,3 +27,9 @@ export function clearToken(): void {
   localStorage.removeItem(KEY);
   sessionStorage.removeItem(KEY);
 }
+
+/** Заменяет токен, сохраняя выбранное хранилище (напр. после re-issue при смене пароля). */
+export function replaceToken(token: string): void {
+  if (sessionStorage.getItem(KEY) !== null) sessionStorage.setItem(KEY, token);
+  else localStorage.setItem(KEY, token);
+}

--- a/src/client/src/shared/api/token.ts
+++ b/src/client/src/shared/api/token.ts
@@ -1,35 +1,40 @@
 /**
- * Хранилище access-токена с поддержкой «Запомнить меня».
- *
- * remember = true  → localStorage (переживает закрытие вкладки/браузера);
- * remember = false → sessionStorage (живёт только до закрытия вкладки).
- *
- * Чтение всегда смотрит в оба хранилища, очистка — тоже, чтобы не оставить
- * «висящий» токен при смене режима или логауте.
+ * Хранилище токенов сессии (issue #148 follow-up): короткий access-JWT + долгоживущий
+ * refresh-токен. «Запомнить меня» выбирает хранилище: localStorage (переживает вкладку)
+ * либо sessionStorage (до закрытия вкладки). Чтение/очистка смотрят оба.
  */
-const KEY = 'access_token';
+const ACCESS = 'access_token';
+const REFRESH = 'refresh_token';
 
 export function getToken(): string | null {
-  return localStorage.getItem(KEY) ?? sessionStorage.getItem(KEY);
+  return localStorage.getItem(ACCESS) ?? sessionStorage.getItem(ACCESS);
 }
 
-export function setToken(token: string, remember: boolean): void {
-  if (remember) {
-    localStorage.setItem(KEY, token);
-    sessionStorage.removeItem(KEY);
-  } else {
-    sessionStorage.setItem(KEY, token);
-    localStorage.removeItem(KEY);
-  }
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH) ?? sessionStorage.getItem(REFRESH);
+}
+
+/** Сохранить пару токенов в выбранное хранилище (при логине). */
+export function setTokens(access: string, refresh: string, remember: boolean): void {
+  const store = remember ? localStorage : sessionStorage;
+  const other = remember ? sessionStorage : localStorage;
+  store.setItem(ACCESS, access);
+  store.setItem(REFRESH, refresh);
+  other.removeItem(ACCESS);
+  other.removeItem(REFRESH);
+}
+
+/** Обновить пару, сохранив текущее хранилище (после refresh-ротации или смены пароля). */
+export function replaceTokens(access: string, refresh: string): void {
+  const inSession = sessionStorage.getItem(ACCESS) !== null;
+  const store = inSession ? sessionStorage : localStorage;
+  store.setItem(ACCESS, access);
+  store.setItem(REFRESH, refresh);
 }
 
 export function clearToken(): void {
-  localStorage.removeItem(KEY);
-  sessionStorage.removeItem(KEY);
-}
-
-/** Заменяет токен, сохраняя выбранное хранилище (напр. после re-issue при смене пароля). */
-export function replaceToken(token: string): void {
-  if (sessionStorage.getItem(KEY) !== null) sessionStorage.setItem(KEY, token);
-  else localStorage.setItem(KEY, token);
+  localStorage.removeItem(ACCESS);
+  sessionStorage.removeItem(ACCESS);
+  localStorage.removeItem(REFRESH);
+  sessionStorage.removeItem(REFRESH);
 }

--- a/src/client/src/shared/hooks/useAuth.ts
+++ b/src/client/src/shared/hooks/useAuth.ts
@@ -12,6 +12,8 @@ export interface AuthUser {
 export interface AuthContextValue {
   user: AuthUser | null;
   login: (email: string, password: string, remember?: boolean) => Promise<void>;
+  /** Обновить сессию по свежему токену (напр. re-issue при смене пароля). */
+  updateSession: (accessToken: string) => void;
   logout: () => void;
 }
 

--- a/src/client/src/shared/hooks/useAuth.ts
+++ b/src/client/src/shared/hooks/useAuth.ts
@@ -12,8 +12,8 @@ export interface AuthUser {
 export interface AuthContextValue {
   user: AuthUser | null;
   login: (email: string, password: string, remember?: boolean) => Promise<void>;
-  /** Обновить сессию по свежему токену (напр. re-issue при смене пароля). */
-  updateSession: (accessToken: string) => void;
+  /** Обновить сессию по свежей паре токенов (напр. re-issue при смене пароля). */
+  updateSession: (accessToken: string, refreshToken: string) => void;
   logout: () => void;
 }
 

--- a/src/client/src/shared/ui/AuthProvider.tsx
+++ b/src/client/src/shared/ui/AuthProvider.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, type ReactNode } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { apiClient } from '@/shared/api/client';
-import { getToken, setToken, clearToken, replaceToken } from '@/shared/api/token';
+import { getToken, getRefreshToken, setTokens, clearToken, replaceTokens } from '@/shared/api/token';
 import { AuthContext, type AuthUser, type UserRole } from '@/shared/hooks/useAuth';
 
 function decodeUser(token: string): AuthUser {
@@ -18,17 +18,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const login = useCallback(async (email: string, password: string, remember = true) => {
-    const { data } = await apiClient.post<{ accessToken: string }>('/auth/login', { email, password });
-    setToken(data.accessToken, remember);
+    const { data } = await apiClient.post<{ accessToken: string; refreshToken: string }>(
+      '/auth/login', { email, password });
+    setTokens(data.accessToken, data.refreshToken, remember);
     setUser(decodeUser(data.accessToken));
   }, []);
 
-  const updateSession = useCallback((accessToken: string) => {
-    replaceToken(accessToken);
+  const updateSession = useCallback((accessToken: string, refreshToken: string) => {
+    replaceTokens(accessToken, refreshToken);
     setUser(decodeUser(accessToken));
   }, []);
 
   const logout = useCallback(() => {
+    // Отзываем refresh-токен на сервере (best-effort), затем чистим локально.
+    const refresh = getRefreshToken();
+    if (refresh) void apiClient.post('/auth/logout', { refreshToken: refresh }).catch(() => {});
     clearToken();
     setUser(null);
   }, []);

--- a/src/client/src/shared/ui/AuthProvider.tsx
+++ b/src/client/src/shared/ui/AuthProvider.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, type ReactNode } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { apiClient } from '@/shared/api/client';
-import { getToken, setToken, clearToken } from '@/shared/api/token';
+import { getToken, setToken, clearToken, replaceToken } from '@/shared/api/token';
 import { AuthContext, type AuthUser, type UserRole } from '@/shared/hooks/useAuth';
 
 function decodeUser(token: string): AuthUser {
@@ -23,13 +23,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(decodeUser(data.accessToken));
   }, []);
 
+  const updateSession = useCallback((accessToken: string) => {
+    replaceToken(accessToken);
+    setUser(decodeUser(accessToken));
+  }, []);
+
   const logout = useCallback(() => {
     clearToken();
     setUser(null);
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, updateSession, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/client/src/shared/ui/ChangePasswordModal.tsx
+++ b/src/client/src/shared/ui/ChangePasswordModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { useChangeMyPassword } from '@/shared/api/account';
+import { useAuth } from '@/shared/hooks/useAuth';
 
 function apiError(e: unknown): string {
   const err = e as { response?: { data?: { error?: string; errors?: { description: string }[] } }; message?: string };
@@ -12,6 +13,7 @@ function apiError(e: unknown): string {
 
 export function ChangePasswordModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const change = useChangeMyPassword();
+  const { updateSession } = useAuth();
   const [current, setCurrent] = useState('');
   const [next, setNext] = useState('');
   const [confirm, setConfirm] = useState('');
@@ -25,7 +27,9 @@ export function ChangePasswordModal({ open, onClose }: { open: boolean; onClose:
     setError('');
     if (next !== confirm) { setError('Новый пароль и подтверждение не совпадают'); return; }
     try {
-      await change.mutateAsync({ currentPassword: current, newPassword: next });
+      const res = await change.mutateAsync({ currentPassword: current, newPassword: next });
+      // Смена пароля обновляет SecurityStamp → используем свежий токен, чтобы не разлогиниться.
+      if (res?.accessToken) updateSession(res.accessToken);
       setDone(true);
       setTimeout(() => { reset(); onClose(); }, 1200);
     } catch (err) { setError(apiError(err)); }

--- a/src/client/src/shared/ui/ChangePasswordModal.tsx
+++ b/src/client/src/shared/ui/ChangePasswordModal.tsx
@@ -28,8 +28,8 @@ export function ChangePasswordModal({ open, onClose }: { open: boolean; onClose:
     if (next !== confirm) { setError('Новый пароль и подтверждение не совпадают'); return; }
     try {
       const res = await change.mutateAsync({ currentPassword: current, newPassword: next });
-      // Смена пароля обновляет SecurityStamp → используем свежий токен, чтобы не разлогиниться.
-      if (res?.accessToken) updateSession(res.accessToken);
+      // Смена пароля отзывает старые токены → применяем свежую пару, чтобы не разлогиниться.
+      if (res?.accessToken && res?.refreshToken) updateSession(res.accessToken, res.refreshToken);
       setDone(true);
       setTimeout(() => { reset(); onClose(); }, 1200);
     } catch (err) { setError(apiError(err)); }

--- a/src/server/BHS.CRG.Api/Auth/JwtTokens.cs
+++ b/src/server/BHS.CRG.Api/Auth/JwtTokens.cs
@@ -30,11 +30,13 @@ public static class JwtTokens
         foreach (var role in roles)
             claims.Add(new Claim("role", role));
 
+        // Короткий срок жизни access-токена (issue #148 follow-up): продление — через refresh.
+        var minutes = int.TryParse(jwtCfg["AccessTokenMinutes"], out var m) ? m : 60;
         var token = new JwtSecurityToken(
             issuer: jwtCfg["Issuer"],
             audience: jwtCfg["Audience"],
             claims: claims,
-            expires: DateTime.UtcNow.AddDays(7),
+            expires: DateTime.UtcNow.AddMinutes(minutes),
             signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
         return new JwtSecurityTokenHandler().WriteToken(token);
     }

--- a/src/server/BHS.CRG.Api/Auth/JwtTokens.cs
+++ b/src/server/BHS.CRG.Api/Auth/JwtTokens.cs
@@ -1,0 +1,41 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BHS.CRG.Api.Auth;
+
+/// <summary>
+/// Выпуск access-JWT. Кроме sub/email/displayName/role кладём <c>sstamp</c> — текущий
+/// SecurityStamp пользователя (issue #148 follow-up). Он проверяется на каждом запросе
+/// (см. JwtBearer OnTokenValidated в Program.cs): сброс/смена пароля меняют стамп → ранее
+/// выданные токены становятся недействительными.
+/// </summary>
+public static class JwtTokens
+{
+    public const string SecurityStampClaim = "sstamp";
+
+    public static string Create(ApplicationUser user, IList<string> roles, string securityStamp, IConfiguration cfg)
+    {
+        var jwtCfg = cfg.GetSection("Jwt");
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtCfg["Key"]!));
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email!),
+            new("displayName", user.DisplayName),
+            new(SecurityStampClaim, securityStamp),
+        };
+        foreach (var role in roles)
+            claims.Add(new Claim("role", role));
+
+        var token = new JwtSecurityToken(
+            issuer: jwtCfg["Issuer"],
+            audience: jwtCfg["Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddDays(7),
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -43,7 +43,8 @@ public static class AccountEndpoints
 
         // Смена пароля текущим пользователем (перенесено из /api/auth в #148).
         g.MapPost("/change-password", async (ChangePasswordRequest req,
-            UserManager<ApplicationUser> users, ClaimsPrincipal principal, IConfiguration cfg) =>
+            UserManager<ApplicationUser> users, RefreshTokenService refreshTokens,
+            ClaimsPrincipal principal, IConfiguration cfg, CancellationToken ct) =>
         {
             var user = await FindCurrent(users, principal);
             if (user is null) return Results.Unauthorized();
@@ -51,11 +52,14 @@ public static class AccountEndpoints
             var result = await users.ChangePasswordAsync(user, req.CurrentPassword, req.NewPassword);
             if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
 
-            // Смена пароля обновляет SecurityStamp → текущий токен становится недействительным.
-            // Выдаём свежий, чтобы не разлогинивать активную сессию (issue #148 follow-up).
+            // Смена пароля обновляет SecurityStamp и отзывает все refresh-сессии. Чтобы не разлогинить
+            // текущую — выдаём свежую пару access+refresh (issue #148 follow-up).
+            await refreshTokens.RevokeAllForUserAsync(user.Id, ct);
             var roles = await users.GetRolesAsync(user);
             var stamp = await users.GetSecurityStampAsync(user);
-            return Results.Ok(new { accessToken = JwtTokens.Create(user, roles, stamp, cfg) });
+            var access = JwtTokens.Create(user, roles, stamp, cfg);
+            var refresh = await refreshTokens.IssueAsync(user.Id, ct);
+            return Results.Ok(new { accessToken = access, refreshToken = refresh });
         });
 
         // Повторно отправить письмо подтверждения себе (issue #148).

--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using BHS.CRG.Api.Auth;
 using BHS.CRG.Application.Email;
 using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
@@ -42,13 +43,19 @@ public static class AccountEndpoints
 
         // Смена пароля текущим пользователем (перенесено из /api/auth в #148).
         g.MapPost("/change-password", async (ChangePasswordRequest req,
-            UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
+            UserManager<ApplicationUser> users, ClaimsPrincipal principal, IConfiguration cfg) =>
         {
             var user = await FindCurrent(users, principal);
             if (user is null) return Results.Unauthorized();
 
             var result = await users.ChangePasswordAsync(user, req.CurrentPassword, req.NewPassword);
-            return result.Succeeded ? Results.Ok() : Results.BadRequest(new { error = DescribeErrors(result) });
+            if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            // Смена пароля обновляет SecurityStamp → текущий токен становится недействительным.
+            // Выдаём свежий, чтобы не разлогинивать активную сессию (issue #148 follow-up).
+            var roles = await users.GetRolesAsync(user);
+            var stamp = await users.GetSecurityStampAsync(user);
+            return Results.Ok(new { accessToken = JwtTokens.Create(user, roles, stamp, cfg) });
         });
 
         // Повторно отправить письмо подтверждения себе (issue #148).

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -1,10 +1,7 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
+using BHS.CRG.Api.Auth;
 using BHS.CRG.Infrastructure.Email;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.IdentityModel.Tokens;
 
 namespace BHS.CRG.Api.Endpoints.Auth;
 
@@ -58,7 +55,8 @@ public static class AuthEndpoints
 
             await users.ResetAccessFailedCountAsync(user);
             var roles = await users.GetRolesAsync(user);
-            var token = CreateToken(user, roles, cfg);
+            var stamp = await users.GetSecurityStampAsync(user);
+            var token = JwtTokens.Create(user, roles, stamp, cfg);
             return Results.Ok(new { accessToken = token });
         });
         // Смена пароля переехала в /api/account/change-password (issue #148).
@@ -135,28 +133,6 @@ public static class AuthEndpoints
 
     private static string DescribeErrors(IdentityResult r) =>
         string.Join("; ", r.Errors.Select(e => e.Description));
-
-    private static string CreateToken(ApplicationUser user, IList<string> roles, IConfiguration cfg)
-    {
-        var jwtCfg = cfg.GetSection("Jwt");
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtCfg["Key"]!));
-        var claims = new List<Claim>
-        {
-            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
-            new(JwtRegisteredClaimNames.Email, user.Email!),
-            new("displayName", user.DisplayName),
-        };
-        foreach (var role in roles)
-            claims.Add(new Claim("role", role));
-
-        var token = new JwtSecurityToken(
-            issuer: jwtCfg["Issuer"],
-            audience: jwtCfg["Audience"],
-            claims: claims,
-            expires: DateTime.UtcNow.AddDays(7),
-            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
 
     record RegisterRequest(string Email, string Password, string DisplayName);
     record LoginRequest(string Email, string Password);

--- a/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Auth/AuthEndpoints.cs
@@ -32,8 +32,8 @@ public static class AuthEndpoints
             Results.Ok(new { open = !users.Users.Any() }));
 
         g.MapPost("/login", async (LoginRequest req,
-            UserManager<ApplicationUser> users,
-            IConfiguration cfg) =>
+            UserManager<ApplicationUser> users, RefreshTokenService refreshTokens,
+            IConfiguration cfg, CancellationToken ct) =>
         {
             var user = await users.FindByEmailAsync(req.Email);
             if (user is null)
@@ -56,10 +56,35 @@ public static class AuthEndpoints
             await users.ResetAccessFailedCountAsync(user);
             var roles = await users.GetRolesAsync(user);
             var stamp = await users.GetSecurityStampAsync(user);
-            var token = JwtTokens.Create(user, roles, stamp, cfg);
-            return Results.Ok(new { accessToken = token });
+            var access = JwtTokens.Create(user, roles, stamp, cfg);
+            var refresh = await refreshTokens.IssueAsync(user.Id, ct);
+            return Results.Ok(new { accessToken = access, refreshToken = refresh });
         });
         // Смена пароля переехала в /api/account/change-password (issue #148).
+
+        // Обмен refresh-токена на новую пару (issue #148 follow-up). Ротация: старый ревокается.
+        g.MapPost("/refresh", async (RefreshRequest req,
+            UserManager<ApplicationUser> users, RefreshTokenService refreshTokens,
+            IConfiguration cfg, CancellationToken ct) =>
+        {
+            var rotated = await refreshTokens.RotateAsync(req.RefreshToken, ct);
+            if (rotated is null) return Results.Unauthorized();
+
+            var user = await users.FindByIdAsync(rotated.Value.UserId.ToString());
+            if (user is null) return Results.Unauthorized();
+
+            var roles = await users.GetRolesAsync(user);
+            var stamp = await users.GetSecurityStampAsync(user);
+            var access = JwtTokens.Create(user, roles, stamp, cfg);
+            return Results.Ok(new { accessToken = access, refreshToken = rotated.Value.NewToken });
+        }).RequireRateLimiting("auth");
+
+        // Логаут: отзыв refresh-токена текущей сессии.
+        g.MapPost("/logout", async (RefreshRequest req, RefreshTokenService refreshTokens, CancellationToken ct) =>
+        {
+            await refreshTokens.RevokeAsync(req.RefreshToken, ct);
+            return Results.Ok();
+        });
 
         // Сброс пароля (issue #148). Анонимные, под rate-limit «auth».
         // Enumeration-safe: forgot всегда 200, существование адреса не раскрываем.
@@ -85,7 +110,7 @@ public static class AuthEndpoints
         }).RequireRateLimiting("auth");
 
         g.MapPost("/reset-password", async (ResetPasswordRequest req,
-            UserManager<ApplicationUser> users) =>
+            UserManager<ApplicationUser> users, RefreshTokenService refreshTokens, CancellationToken ct) =>
         {
             var user = await users.FindByEmailAsync(req.Email);
             if (user is null)
@@ -95,9 +120,10 @@ public static class AuthEndpoints
             if (!result.Succeeded)
                 return Results.BadRequest(new { error = DescribeErrors(result) });
 
-            // Успешный сброс снимает блокировку по неудачным попыткам (issue #148 follow-up).
+            // Успешный сброс снимает блокировку и отзывает все refresh-сессии (issue #148 follow-up).
             await users.SetLockoutEndDateAsync(user, null);
             await users.ResetAccessFailedCountAsync(user);
+            await refreshTokens.RevokeAllForUserAsync(user.Id, ct);
             return Results.Ok();
         }).RequireRateLimiting("auth");
 
@@ -140,4 +166,5 @@ public static class AuthEndpoints
     record ResetPasswordRequest(string Email, string Token, string NewPassword);
     record ConfirmEmailRequest(string Email, string Token);
     record ConfirmEmailChangeRequest(Guid UserId, string NewEmail, string Token);
+    record RefreshRequest(string RefreshToken);
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
@@ -80,7 +80,7 @@ public static class UserEndpoints
         });
 
         g.MapPost("/{id:guid}/reset-password", async (Guid id, ResetPasswordRequest req,
-            UserManager<ApplicationUser> users) =>
+            UserManager<ApplicationUser> users, RefreshTokenService refreshTokens, CancellationToken ct) =>
         {
             var user = await users.FindByIdAsync(id.ToString());
             if (user is null) return Results.NotFound();
@@ -88,9 +88,10 @@ public static class UserEndpoints
             var result = await users.ResetPasswordAsync(user, token, req.NewPassword);
             if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
 
-            // Сброс пароля админом снимает и блокировку по неудачным попыткам (issue #148 follow-up).
+            // Сброс пароля админом снимает блокировку и отзывает refresh-сессии (issue #148 follow-up).
             await users.SetLockoutEndDateAsync(user, null);
             await users.ResetAccessFailedCountAsync(user);
+            await refreshTokens.RevokeAllForUserAsync(user.Id, ct);
             return Results.Ok();
         });
 

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -138,6 +138,23 @@ builder.Services.AddAuthentication(opt =>
                     ctx.HttpContext.Request.Path.StartsWithSegments("/hubs"))
                     ctx.Token = token;
                 return Task.CompletedTask;
+            },
+            // Проверка SecurityStamp (issue #148 follow-up): токен со «старым» стампом
+            // (после сброса/смены пароля или logout-all) отклоняется, даже не истёкший.
+            OnTokenValidated = async ctx =>
+            {
+                var principal = ctx.Principal;
+                var userId = principal?.FindFirst("sub")?.Value;
+                var tokenStamp = principal?.FindFirst(JwtTokens.SecurityStampClaim)?.Value;
+                if (userId is null || tokenStamp is null) { ctx.Fail("Недействительный токен."); return; }
+
+                var userManager = ctx.HttpContext.RequestServices.GetRequiredService<UserManager<ApplicationUser>>();
+                var user = await userManager.FindByIdAsync(userId);
+                if (user is null) { ctx.Fail("Пользователь не найден."); return; }
+
+                var currentStamp = await userManager.GetSecurityStampAsync(user);
+                if (!string.Equals(tokenStamp, currentStamp, StringComparison.Ordinal))
+                    ctx.Fail("Сессия недействительна — войдите заново.");
             }
         };
     });

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -206,6 +206,7 @@ builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IIntegrationSettings, IntegrationSettingsService>();
 builder.Services.AddScoped<BHS.CRG.Application.Email.IEmailSender, BHS.CRG.Infrastructure.Email.MailKitEmailSender>();
 builder.Services.AddScoped<BHS.CRG.Infrastructure.Email.AccountEmailService>();
+builder.Services.AddScoped<RefreshTokenService>();
 
 // ── Фоновые задачи (долгие операции: распознавание набора/таблицы) ──────────────
 builder.Services.AddSingleton<JobQueue>();

--- a/src/server/BHS.CRG.Api/appsettings.json
+++ b/src/server/BHS.CRG.Api/appsettings.json
@@ -48,7 +48,8 @@
   "Jwt": {
     "Key": "CHANGE_ME_TO_A_LONG_RANDOM_SECRET_KEY_32CHARS",
     "Issuer": "BHS.CRG",
-    "Audience": "BHS.CRG.Client"
+    "Audience": "BHS.CRG.Client",
+    "AccessTokenMinutes": 60
   },
   "BlobStorage": {
     "Endpoint": "localhost:9000",

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260715013936_AddRefreshTokens.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260715013936_AddRefreshTokens.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715013936_AddRefreshTokens")]
+    partial class AddRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1161,7 +1164,7 @@ namespace BHS.CRG.Infrastructure.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("RefreshTokens", (string)null);
+                    b.ToTable("RefreshTokens");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", b =>

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260715013936_AddRefreshTokens.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260715013936_AddRefreshTokens.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TokenHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RevokedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_TokenHash",
+                table: "RefreshTokens",
+                column: "TokenHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
@@ -41,6 +41,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options)
     public DbSet<BHS.CRG.Domain.Settings.IntegrationSettingsEntity> IntegrationSettings => Set<BHS.CRG.Domain.Settings.IntegrationSettingsEntity>();
     public DbSet<BHS.CRG.Domain.Notifications.Notification> Notifications => Set<BHS.CRG.Domain.Notifications.Notification>();
     public DbSet<BHS.CRG.Domain.Jobs.Job> Jobs => Set<BHS.CRG.Domain.Jobs.Job>();
+    public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/server/BHS.CRG.Infrastructure/Persistence/RefreshToken.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/RefreshToken.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BHS.CRG.Infrastructure.Persistence;
+
+/// <summary>
+/// Refresh-токен (issue #148 follow-up): долгоживущий, серверный, с ротацией. Хранится ТОЛЬКО
+/// хэш (SHA-256 сырого токена) — как пароль. Access-JWT короткий; клиент меняет истёкший access
+/// на новый через /api/auth/refresh, при этом refresh ротируется (старый ревокается).
+/// </summary>
+public class RefreshToken
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string TokenHash { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public DateTime? RevokedAt { get; set; }
+
+    public bool IsActive => RevokedAt is null && DateTime.UtcNow < ExpiresAt;
+}
+
+public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+{
+    public void Configure(EntityTypeBuilder<RefreshToken> b)
+    {
+        b.HasKey(t => t.Id);
+        b.Property(t => t.TokenHash).HasMaxLength(128);
+        b.HasIndex(t => t.TokenHash).IsUnique();
+        b.HasIndex(t => t.UserId);
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/RefreshTokenService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/RefreshTokenService.cs
@@ -1,0 +1,81 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.Persistence;
+
+/// <summary>
+/// Выпуск/ротация/ревокация refresh-токенов (issue #148 follow-up). Сырой токен возвращается
+/// клиенту один раз; в БД лежит только SHA-256 хэш. Ротация: при обмене старый ревокается,
+/// выдаётся новый. Срок жизни — <see cref="Lifetime"/>.
+/// </summary>
+public class RefreshTokenService(AppDbContext db)
+{
+    public static readonly TimeSpan Lifetime = TimeSpan.FromDays(14);
+
+    public async Task<string> IssueAsync(Guid userId, CancellationToken ct = default)
+    {
+        var raw = GenerateRaw();
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            TokenHash = Hash(raw),
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.Add(Lifetime),
+        });
+        await db.SaveChangesAsync(ct);
+        return raw;
+    }
+
+    /// <summary>Проверяет и ротирует токен. Возвращает (userId, новый сырой токен) или null, если
+    /// токен неизвестен / отозван / истёк.</summary>
+    public async Task<(Guid UserId, string NewToken)?> RotateAsync(string rawToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawToken)) return null;
+        var hash = Hash(rawToken);
+        var token = await db.RefreshTokens.FirstOrDefaultAsync(t => t.TokenHash == hash, ct);
+        if (token is null || !token.IsActive) return null;
+
+        token.RevokedAt = DateTime.UtcNow;
+        var raw = GenerateRaw();
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = token.UserId,
+            TokenHash = Hash(raw),
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.Add(Lifetime),
+        });
+        await db.SaveChangesAsync(ct);
+        return (token.UserId, raw);
+    }
+
+    /// <summary>Отзывает конкретный токен (logout). Молча игнорирует неизвестный.</summary>
+    public async Task RevokeAsync(string rawToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawToken)) return;
+        var hash = Hash(rawToken);
+        var token = await db.RefreshTokens.FirstOrDefaultAsync(t => t.TokenHash == hash && t.RevokedAt == null, ct);
+        if (token is null) return;
+        token.RevokedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Отзывает все активные токены пользователя (смена/сброс пароля, «выйти со всех устройств»).</summary>
+    public async Task RevokeAllForUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        await db.RefreshTokens
+            .Where(t => t.UserId == userId && t.RevokedAt == null)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.RevokedAt, now), ct);
+    }
+
+    private static string GenerateRaw()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    private static string Hash(string raw) =>
+        Convert.ToHexString(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(raw)));
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.46</Version>
+    <Version>0.23.47</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.47</Version>
+    <Version>0.23.48</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Полноценная **refresh-модель** поверх stamp-инвалидации (#162): access-JWT короткий,
продление — по refresh-токену с ротацией. Закрывает исходный компромисс (7-дневный access).

> ⚠️ **Стек на #162.** Мёржить после #162 (GitHub переставит базу на master).

## Backend
- **`RefreshToken`** (entity + config + миграция `AddRefreshTokens`): в БД только **SHA-256 хэш**;
  `RefreshTokenService` — Issue / Rotate (старый → ревок) / Revoke / RevokeAllForUser.
- `login` → `{accessToken, refreshToken}`; **`POST /api/auth/refresh`** (ротация, rate-limit `auth`);
  **`POST /api/auth/logout`** (отзыв refresh).
- **Access-JWT срок 7д → 60 мин** (`Jwt:AccessTokenMinutes`, конфиг).
- Сброс пароля (email/админ) и смена пароля **отзывают все refresh-сессии**; self-смена пароля
  выдаёт свежую пару (текущая сессия не рвётся).

## Frontend
- `token.ts`: пара access+refresh, хранилище по remember-me (local/session).
- `client.ts`: **тихий refresh на 401** — single-flight (один общий запрос на параллельные 401),
  retry-once, голый axios без рекурсии; провал refresh → чистка + редирект `/login`.
- `AuthProvider`: login хранит пару, **logout ревокает refresh на сервере**, `updateSession(пара)`.

## Проверка
- Backend (curl): rotation (старый refresh → **401**), logout → **401**, новая пара работает.
- Frontend (Playwright): **тихий refresh** — порча access-токена → `/profile` грузится через refresh,
  токен обновляется, редиректа на login **нет**.
- `dotnet test` **380**, `vitest` **115**, **keyboard smoke 11/11**.

Версия → 0.23.48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)