### PR TITLE
fix(auth): не слать письмо без ссылки при пустом App:PublicUrl (#148)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -72,7 +72,8 @@ public static class AccountEndpoints
 
             var token = await users.GenerateEmailConfirmationTokenAsync(user);
             try { await emails.SendEmailConfirmationAsync(user.Email!, token, ct); }
-            catch (EmailNotConfiguredException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (Exception ex) when (ex is EmailNotConfiguredException or AppUrlNotConfiguredException)
+            { return Results.BadRequest(new { error = ex.Message }); }
             return Results.Ok();
         });
 
@@ -94,7 +95,8 @@ public static class AccountEndpoints
 
             var token = await users.GenerateChangeEmailTokenAsync(user, newEmail);
             try { await emails.SendEmailChangeAsync(user.Id, newEmail, token, ct); }
-            catch (EmailNotConfiguredException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (Exception ex) when (ex is EmailNotConfiguredException or AppUrlNotConfiguredException)
+            { return Results.BadRequest(new { error = ex.Message }); }
             return Results.Ok();
         });
     }

--- a/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Users/UserEndpoints.cs
@@ -54,7 +54,8 @@ public static class UserEndpoints
                     var token = await users.GenerateEmailConfirmationTokenAsync(user);
                     await emails.SendEmailConfirmationAsync(user.Email!, token, ct);
                 }
-                catch (EmailNotConfiguredException) { /* SMTP не настроен — пользователь создан, письмо позже */ }
+                // SMTP/App:PublicUrl не настроены — пользователь создан, письмо отправят позже.
+                catch (Exception ex) when (ex is EmailNotConfiguredException or AppUrlNotConfiguredException) { }
             }
             return Results.Ok(new UserDto(user.Id, user.Email!, user.DisplayName, role));
         });

--- a/src/server/BHS.CRG.Api/appsettings.Development.json
+++ b/src/server/BHS.CRG.Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "App": {
+    "PublicUrl": "http://localhost:5173"
   }
 }

--- a/src/server/BHS.CRG.Application/Email/IEmailSender.cs
+++ b/src/server/BHS.CRG.Application/Email/IEmailSender.cs
@@ -12,6 +12,12 @@ public record EmailMessage(
 /// <summary>SMTP не сконфигурирован (нет host/from или выключен) — отдаём как понятную ошибку, не 500.</summary>
 public class EmailNotConfiguredException(string message) : Exception(message);
 
+/// <summary>Не задан публичный адрес приложения (App:PublicUrl) — ссылку в письме собрать нельзя.
+/// Отдаём как понятную ошибку инициатору действия, а НЕ шлём пользователю письмо без ссылки.</summary>
+public class AppUrlNotConfiguredException()
+    : Exception("Не задан адрес приложения (App:PublicUrl) — ссылки в письмах недоступны. " +
+                "Задайте его в конфигурации (переменная APP_PUBLIC_URL) и повторите.");
+
 /// <summary>Транспорт исходящей почты. Реализация — MailKit поверх SMTP-настроек (Настройки → Почта).</summary>
 public interface IEmailSender
 {

--- a/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Email/AccountEmailService.cs
@@ -4,57 +4,49 @@ using Microsoft.Extensions.Configuration;
 namespace BHS.CRG.Infrastructure.Email;
 
 /// <summary>
-/// Письма учётной записи (issue #148): сброс пароля, подтверждение почты. Собирает ссылку из
+/// Письма учётной записи (issue #148): сброс пароля, подтверждение/смена почты. Собирает ссылку из
 /// <c>App:PublicUrl</c> + url-encoded токен Identity и отправляет через <see cref="IEmailSender"/>.
-/// Оркестрация (генерация токена) — в endpoint'ах, здесь только сборка письма и отправка.
+/// Если <c>App:PublicUrl</c> не задан — бросает <see cref="AppUrlNotConfiguredException"/> и НИЧЕГО
+/// не отправляет (иначе пользователь получил бы письмо без ссылки).
 /// </summary>
 public class AccountEmailService(IEmailSender email, IConfiguration config)
 {
     /// <summary>Письмо со ссылкой сброса пароля (токен действует ~1 час).</summary>
     public async Task SendPasswordResetAsync(string toEmail, string token, CancellationToken ct = default)
     {
-        var link = BuildLink("reset-password", toEmail, token);
-        var body = link is null
-            ? "Вы запросили сброс пароля в BHS.CRG, но адрес приложения не настроен (App:PublicUrl). " +
-              "Обратитесь к администратору системы."
-            : "Вы запросили сброс пароля в BHS.CRG.\n\n" +
-              $"Ссылка для сброса (действует 1 час):\n{link}\n\n" +
-              "Если вы не запрашивали сброс — просто проигнорируйте это письмо, пароль останется прежним.";
+        var link = BuildLink("reset-password", $"email={Uri.EscapeDataString(toEmail)}&token={Uri.EscapeDataString(token)}");
+        var body = "Вы запросили сброс пароля в BHS.CRG.\n\n" +
+                   $"Ссылка для сброса (действует 1 час):\n{link}\n\n" +
+                   "Если вы не запрашивали сброс — просто проигнорируйте это письмо, пароль останется прежним.";
         await email.SendAsync(new EmailMessage([toEmail], "Сброс пароля — BHS.CRG", body), ct);
     }
 
     /// <summary>Письмо с подтверждением адреса (токен действует ~24 часа).</summary>
     public async Task SendEmailConfirmationAsync(string toEmail, string token, CancellationToken ct = default)
     {
-        var link = BuildLink("confirm-email", toEmail, token);
-        var body = link is null
-            ? "Для подтверждения адреса в BHS.CRG нужен адрес приложения (App:PublicUrl) — обратитесь к администратору."
-            : "Подтвердите адрес электронной почты для BHS.CRG.\n\n" +
-              $"Ссылка для подтверждения (действует 24 часа):\n{link}\n\n" +
-              "Если вы не заводили учётную запись — просто проигнорируйте это письмо.";
+        var link = BuildLink("confirm-email", $"email={Uri.EscapeDataString(toEmail)}&token={Uri.EscapeDataString(token)}");
+        var body = "Подтвердите адрес электронной почты для BHS.CRG.\n\n" +
+                   $"Ссылка для подтверждения (действует 24 часа):\n{link}\n\n" +
+                   "Если вы не заводили учётную запись — просто проигнорируйте это письмо.";
         await email.SendAsync(new EmailMessage([toEmail], "Подтверждение адреса — BHS.CRG", body), ct);
     }
 
     /// <summary>Письмо на НОВЫЙ адрес для подтверждения смены email (токен действует ~24 часа).</summary>
     public async Task SendEmailChangeAsync(Guid userId, string newEmail, string token, CancellationToken ct = default)
     {
-        var publicUrl = config["App:PublicUrl"]?.TrimEnd('/');
-        var link = string.IsNullOrEmpty(publicUrl) ? null
-            : $"{publicUrl}/confirm-email-change?uid={Uri.EscapeDataString(userId.ToString())}" +
-              $"&email={Uri.EscapeDataString(newEmail)}&token={Uri.EscapeDataString(token)}";
-        var body = link is null
-            ? "Для смены адреса в BHS.CRG нужен адрес приложения (App:PublicUrl) — обратитесь к администратору."
-            : "Запрошена смена адреса входа в BHS.CRG на этот email.\n\n" +
-              $"Ссылка для подтверждения (действует 24 часа):\n{link}\n\n" +
-              "Если вы не запрашивали смену — проигнорируйте это письмо, адрес останется прежним.";
+        var link = BuildLink("confirm-email-change",
+            $"uid={Uri.EscapeDataString(userId.ToString())}&email={Uri.EscapeDataString(newEmail)}&token={Uri.EscapeDataString(token)}");
+        var body = "Запрошена смена адреса входа в BHS.CRG на этот email.\n\n" +
+                   $"Ссылка для подтверждения (действует 24 часа):\n{link}\n\n" +
+                   "Если вы не запрашивали смену — проигнорируйте это письмо, адрес останется прежним.";
         await email.SendAsync(new EmailMessage([newEmail], "Смена адреса входа — BHS.CRG", body), ct);
     }
 
-    /// <summary>Собирает ссылку на фронт-роут с url-encoded email и токеном, либо null если PublicUrl пуст.</summary>
-    private string? BuildLink(string route, string email, string token)
+    /// <summary>Ссылка на фронт-роут с уже url-encoded query. Бросает, если App:PublicUrl не задан.</summary>
+    private string BuildLink(string route, string query)
     {
         var publicUrl = config["App:PublicUrl"]?.TrimEnd('/');
-        if (string.IsNullOrEmpty(publicUrl)) return null;
-        return $"{publicUrl}/{route}?email={Uri.EscapeDataString(email)}&token={Uri.EscapeDataString(token)}";
+        if (string.IsNullOrEmpty(publicUrl)) throw new AppUrlNotConfiguredException();
+        return $"{publicUrl}/{route}?{query}";
     }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.49</Version>
+    <Version>0.23.50</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Баг (со скриншота)
При неустановленном `App:PublicUrl` письмо подтверждения адреса всё равно уходило пользователю —
с текстом «Для подтверждения адреса… обратитесь к администратору» **вместо ссылки**. Конечный
пользователь получал бесполезное письмо, адресованное админу, и не мог ничего сделать.

## Фикс
- **`AccountEmailService`**: если `App:PublicUrl` пуст — бросаем `AppUrlNotConfiguredException`
  и **ничего не отправляем** (никаких писем-заглушек). Письмо уходит только с рабочей ссылкой.
- **Инициатор действия получает понятную ошибку**, а не пользователь — бесполезное письмо:
  - `resend-confirmation` / `change-email` → **400** с текстом про `App:PublicUrl`;
  - заведение юзера админом с «отправить подтверждение» → тихо пропускает (юзер создан, письмо позже);
  - `forgot-password` → по-прежнему **200** (enumeration-safe), просто без письма.
- **Dev**: `App:PublicUrl=http://localhost:5173` в `appsettings.Development.json` — ссылки в письмах
  работают локально из коробки. Prod задаёт `APP_PUBLIC_URL` (уже проброшен в deploy compose).

## Проверка
- С `PublicUrl` (dev): `resend-confirmation` → **200**, письмо с реальной ссылкой.
- С пустым `PublicUrl` (env override): `resend-confirmation` → **400** «Не задан адрес приложения
  (App:PublicUrl)…», письмо **НЕ** уходит.
- `dotnet test` **380**.

Версия → 0.23.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)