### PR TITLE
feat(md3): панель уведомлений по макету (#155)

### DIFF
--- a/src/client/src/features/notifications/NotificationsCenter.tsx
+++ b/src/client/src/features/notifications/NotificationsCenter.tsx
@@ -1,7 +1,8 @@
 import * as Popover from '@radix-ui/react-popover';
 import {
-  Bell, Info, AlertTriangle, AlertCircle, X, Check, CheckCheck, Trash2, Activity, Download,
+  Bell, BellOff, Info, AlertTriangle, AlertCircle, X, Check, CheckCheck, Trash2, HeartPulse, Download,
 } from 'lucide-react';
+import { IconButton } from '@/shared/ui/Button';
 import {
   useNotifications, useHealth,
   useMarkNotificationRead, useMarkAllNotificationsRead,
@@ -27,10 +28,11 @@ async function openResult(linkUrl: string) {
   URL.revokeObjectURL(url);
 }
 
-const SEVERITY: Record<NotificationSeverity, { icon: typeof Info; color: string; bg: string; label: string }> = {
-  Info:    { icon: Info,          color: 'text-brand',   bg: 'bg-brand-subtle',   label: 'Информация' },
-  Warning: { icon: AlertTriangle, color: 'text-warning', bg: 'bg-warning-subtle', label: 'Предупреждение' },
-  Error:   { icon: AlertCircle,   color: 'text-danger',  bg: 'bg-danger-subtle',  label: 'Ошибка' },
+// Аватар-иконка уведомления: для ошибок — error-container, иначе — соответствующий контейнер.
+const SEVERITY: Record<NotificationSeverity, { icon: typeof Info; color: string; bg: string }> = {
+  Info:    { icon: Info,          color: 'text-brand',   bg: 'bg-brand-subtle' },
+  Warning: { icon: AlertTriangle, color: 'text-warning', bg: 'bg-warning-subtle' },
+  Error:   { icon: AlertCircle,   color: 'text-danger',  bg: 'bg-danger-subtle' },
 };
 
 function relTime(iso: string): string {
@@ -48,51 +50,42 @@ function NotificationRow({ n }: { n: NotificationDto }) {
   const meta = SEVERITY[n.severity];
   const Icon = meta.icon;
   return (
-    <div
-      className={`group flex gap-3 px-4 py-3 border-b border-stroke last:border-b-0 ${n.isRead ? 'opacity-65' : ''}`}
-    >
-      <div className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${meta.bg}`}>
-        <Icon size={15} className={meta.color} />
+    <div className={`group flex gap-3.5 pl-5 pr-3 py-4 transition-colors ${n.isRead ? '' : 'bg-tonal'}`}>
+      <div className={`shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${meta.bg}`}>
+        <Icon size={20} className={meta.color} />
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <p className="text-sm font-medium text-fg1 truncate">{n.title}</p>
-          {!n.isRead && <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-brand" />}
+          {!n.isRead && <span className="shrink-0 w-2 h-2 rounded-full bg-brand" />}
         </div>
-        <p className="text-xs text-fg2 mt-0.5 break-words whitespace-pre-wrap">{n.message}</p>
+        <p className="text-[13px] leading-[1.45] text-fg3 mt-1 break-words whitespace-pre-wrap">{n.message}</p>
         {n.linkUrl && (
           <button
             type="button"
             onClick={() => { void openResult(n.linkUrl!); }}
-            className="mt-1.5 inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium bg-brand-subtle text-brand hover:bg-brand/15 transition-colors"
+            className="mt-2 inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-xs font-medium bg-tonal text-on-tonal hover:brightness-95 transition"
           >
             <Download size={13} /> {n.linkLabel ?? 'Открыть результат'}
           </button>
         )}
-        <div className="flex items-center gap-2 mt-1 text-[11px] text-fg4">
-          {n.source && <span className="px-1.5 py-0.5 rounded bg-base">{n.source}</span>}
+        <div className="flex items-center gap-2 mt-2 text-xs text-fg3">
+          {n.source && (
+            <span className="inline-flex items-center h-6 px-3 rounded-lg border border-stroke font-medium">{n.source}</span>
+          )}
           <span>{relTime(n.createdAt)}</span>
         </div>
       </div>
-      <div className="shrink-0 self-start flex flex-col items-center gap-1.5">
+      <div className="shrink-0 self-start flex flex-col items-center">
         {!n.isRead && (
-          <button
-            type="button"
-            onClick={() => markRead.mutate(n.id)}
-            title="Отметить прочитанным"
-            className="text-fg4 hover:text-brand transition-colors"
-          >
-            <Check size={14} />
-          </button>
+          <IconButton label="Отметить прочитанным" size="sm" onClick={() => markRead.mutate(n.id)}>
+            <Check size={16} />
+          </IconButton>
         )}
-        <button
-          type="button"
-          onClick={() => dismiss.mutate(n.id)}
-          title="Удалить"
-          className="text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
-        >
-          <X size={14} />
-        </button>
+        <IconButton label="Удалить" size="sm" danger onClick={() => dismiss.mutate(n.id)}
+          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity">
+          <X size={16} />
+        </IconButton>
       </div>
     </div>
   );
@@ -102,16 +95,16 @@ function HealthSection() {
   const { data: health } = useHealth();
   if (!health || health.length === 0) return null;
   return (
-    <div className="px-4 py-3 border-b border-stroke bg-base/50">
-      <div className="flex items-center gap-1.5 mb-2 text-[11px] font-semibold uppercase tracking-wide text-fg3">
-        <Activity size={12} /> Состояние системы
+    <div className="px-5 pt-1 pb-2">
+      <div className="flex items-center gap-1.5 mb-1 text-xs font-medium uppercase tracking-wide text-fg3">
+        <HeartPulse size={16} /> Состояние системы
       </div>
-      <div className="space-y-1.5">
+      <div>
         {health.map(c => (
-          <div key={c.name} className="flex items-center gap-2 text-xs">
+          <div key={c.name} className="flex items-center gap-2.5 h-9 text-sm">
             <span className={`w-2 h-2 rounded-full shrink-0 ${c.healthy ? 'bg-success' : 'bg-danger'}`} />
-            <span className="text-fg2 flex-1">{c.name}</span>
-            <span className={c.healthy ? 'text-fg4' : 'text-danger'}>
+            <span className="text-fg1 flex-1">{c.name}</span>
+            <span className={`text-xs font-medium ${c.healthy ? 'text-fg3' : 'text-danger'}`}>
               {c.healthy ? 'в норме' : (c.detail ? 'сбой' : 'недоступен')}
             </span>
           </div>
@@ -128,7 +121,6 @@ export function NotificationsCenter() {
 
   const items = data?.items ?? [];
   const unread = data?.unreadCount ?? 0;
-  const hasError = items.some(n => !n.isRead && n.severity === 'Error');
 
   return (
     <Popover.Root>
@@ -136,14 +128,12 @@ export function NotificationsCenter() {
         <button
           type="button"
           title="Уведомления"
-          className="relative flex items-center justify-center w-9 h-9 rounded-md transition-colors text-fg3 hover:text-fg1 hover:bg-base data-[state=open]:bg-base data-[state=open]:text-fg1"
+          aria-label="Уведомления"
+          className="relative flex items-center justify-center w-11 h-11 rounded-full transition-colors text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 data-[state=open]:bg-tonal data-[state=open]:text-on-tonal"
         >
-          <Bell size={18} />
+          <Bell size={22} />
           {unread > 0 && (
-            <span
-              className={`absolute -top-0.5 -right-0.5 min-w-[16px] h-4 px-1 rounded-full text-[10px] font-semibold
-                flex items-center justify-center text-white ${hasError ? 'bg-danger' : 'bg-brand'}`}
-            >
+            <span className="absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full text-[11px] font-medium flex items-center justify-center text-white bg-danger">
               {unread > 99 ? '99+' : unread}
             </span>
           )}
@@ -153,43 +143,33 @@ export function NotificationsCenter() {
         <Popover.Content
           align="end"
           sideOffset={8}
-          className="w-96 max-h-[75vh] flex flex-col rounded-xl border border-stroke bg-surface shadow-lg z-50 overflow-hidden focus:outline-none"
+          className="w-[400px] max-w-[calc(100vw-40px)] max-h-[calc(100vh-90px)] flex flex-col rounded-2xl border border-stroke bg-surface z-50 overflow-hidden focus:outline-none"
+          style={{ boxShadow: 'var(--f-shadow16)' }}
         >
-          {/* Header */}
-          <div className="flex items-center justify-between px-4 py-2.5 border-b border-stroke shrink-0">
-            <span className="text-sm font-semibold text-fg1">Уведомления</span>
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() => markAll.mutate()}
-                disabled={unread === 0}
-                title="Отметить все прочитанными"
-                className="p-1.5 rounded text-fg3 hover:text-fg1 hover:bg-base disabled:opacity-40 disabled:hover:bg-transparent"
-              >
-                <CheckCheck size={15} />
-              </button>
-              <button
-                type="button"
-                onClick={() => clearAll.mutate()}
-                disabled={items.length === 0}
-                title="Очистить все"
-                className="p-1.5 rounded text-fg3 hover:text-danger hover:bg-base disabled:opacity-40 disabled:hover:bg-transparent"
-              >
-                <Trash2 size={15} />
-              </button>
-            </div>
+          {/* Header (фиксированная шапка) */}
+          <div className="flex items-center gap-2 pl-5 pr-2 py-3 shrink-0">
+            <span className="flex-1 text-base font-medium text-fg1">Уведомления</span>
+            <IconButton label="Отметить все прочитанными" onClick={() => markAll.mutate()} disabled={unread === 0}>
+              <CheckCheck size={18} />
+            </IconButton>
+            <IconButton label="Очистить все" onClick={() => clearAll.mutate()} disabled={items.length === 0}>
+              <Trash2 size={18} />
+            </IconButton>
           </div>
 
           {/* Scrollable body */}
           <div className="flex-1 overflow-y-auto min-h-0">
             <HealthSection />
+            <div className="border-t border-stroke" />
             {items.length === 0 ? (
-              <div className="px-4 py-10 text-center text-sm text-fg4">
-                <Bell size={24} className="mx-auto mb-2 opacity-40" />
-                Нет уведомлений
+              <div className="px-6 py-9 text-center text-sm text-fg3">
+                <BellOff size={36} className="mx-auto mb-2 opacity-50" />
+                Нет новых уведомлений
               </div>
             ) : (
-              items.map(n => <NotificationRow key={n.id} n={n} />)
+              <div className="divide-y divide-stroke">
+                {items.map(n => <NotificationRow key={n.id} n={n} />)}
+              </div>
             )}
           </div>
         </Popover.Content>

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -10,7 +10,7 @@ import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
-import { LogOut, Sun, Moon, Monitor, KeyRound, UserRound, MailWarning, X } from 'lucide-react';
+import { LogOut, Sun, Moon, Monitor, KeyRound, Check, ChevronsUpDown, MailWarning, X } from 'lucide-react';
 
 const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'light',  icon: Sun,     label: 'Светлая'   },
@@ -18,27 +18,36 @@ const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'system', icon: Monitor, label: 'Системная' },
 ];
 
+// MD3 segmented button (issue #157): выбранный сегмент — tonal + галочка.
 function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   return (
-    <div
-      className="flex items-center gap-0.5 rounded-md p-0.5 bg-muted"
-      title="Тема оформления"
-    >
-      {themeOptions.map(({ value, icon: Icon, label }) => (
-        <button
-          key={value}
-          onClick={() => setTheme(value)}
-          title={label}
-          className={`flex items-center justify-center w-7 h-7 rounded transition-colors ${
-            theme === value ? 'text-fg1 shadow-sm bg-surface' : 'text-fg3 hover:text-fg2'
-          }`}
-        >
-          <Icon size={14} />
-        </button>
-      ))}
+    <div role="group" aria-label="Тема оформления"
+      className="flex h-10 rounded-full border border-stroke-strong overflow-hidden">
+      {themeOptions.map(({ value, icon: Icon, label }, i) => {
+        const active = theme === value;
+        return (
+          <button key={value} type="button" onClick={() => setTheme(value)}
+            title={label} aria-label={label} aria-pressed={active}
+            className={`flex-1 flex items-center justify-center gap-1 text-xs transition-colors ` +
+              `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand ` +
+              `${i > 0 ? 'border-l border-stroke-strong' : ''} ` +
+              (active ? 'bg-tonal text-on-tonal' : 'text-fg3 hover:bg-black/5 dark:hover:bg-white/10')}>
+            {active && <Check size={14} className="shrink-0" />}
+            <Icon size={16} />
+          </button>
+        );
+      })}
     </div>
   );
+}
+
+/** Инициалы для аватара: 2 буквы из имени (или email). */
+function initialsOf(name?: string, email?: string): string {
+  const src = (name || email || '').trim();
+  const parts = src.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return src.slice(0, 2).toUpperCase();
 }
 
 function NavSection({
@@ -130,30 +139,38 @@ export function AppShell() {
           )}
         </nav>
 
-        {/* Bottom: theme + user */}
-        <div className="px-3 py-3 border-t border-stroke space-y-3 shrink-0">
-          <ThemeToggle />
-          <NavLink to="/profile"
-            className={({ isActive }) => `flex items-center gap-2 text-xs truncate transition-colors ` +
-              (isActive ? 'text-brand' : 'text-fg3 hover:text-brand')}>
-            <UserRound size={14} className="shrink-0" />
-            <span className="truncate">
-              {user?.displayName || user?.email}
-              <span className="ml-1 text-fg4">· {isAdmin ? 'Администратор' : 'Пользователь'}</span>
-            </span>
-          </NavLink>
-          <button
-            onClick={() => setPwOpen(true)}
-            className="flex items-center gap-2 text-sm transition-colors w-full text-fg2 hover:text-brand"
-          >
-            <KeyRound size={14} /> Сменить пароль
-          </button>
-          <button
-            onClick={logout}
-            className="flex items-center gap-2 text-sm transition-colors w-full text-fg2 hover:text-danger"
-          >
-            <LogOut size={14} /> Выйти
-          </button>
+        {/* Bottom: theme + user (MD3 drawer footer, issue #157) */}
+        <div className="px-3 pt-3 pb-1 border-t border-stroke shrink-0">
+          <div className="mb-3"><ThemeToggle /></div>
+
+          <div className="space-y-0.5">
+            {/* Блок пользователя — пилюля с аватаром */}
+            <NavLink to="/profile"
+              className={({ isActive }) => `flex items-center gap-3 h-14 px-4 rounded-[28px] transition-colors ` +
+                `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
+                (isActive ? 'bg-tonal' : 'hover:bg-black/5 dark:hover:bg-white/10')}>
+              <span className="flex items-center justify-center w-10 h-10 rounded-full shrink-0 bg-brand-subtle text-on-brand-subtle text-[15px] font-medium">
+                {initialsOf(user?.displayName, user?.email)}
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm font-medium text-fg1 truncate">{user?.displayName || user?.email}</span>
+                <span className="block text-xs text-fg3">{isAdmin ? 'Администратор' : 'Пользователь'}</span>
+              </span>
+              <ChevronsUpDown size={18} className="text-fg3 shrink-0" />
+            </NavLink>
+
+            <button type="button" onClick={() => setPwOpen(true)}
+              className="w-full flex items-center gap-3 h-14 px-4 rounded-[28px] text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">
+              <KeyRound size={22} className="text-fg3 shrink-0" />
+              <span className="text-sm font-medium text-fg1">Сменить пароль</span>
+            </button>
+            <button type="button" onClick={logout}
+              className="w-full flex items-center gap-3 h-14 px-4 rounded-[28px] text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">
+              <LogOut size={22} className="text-fg3 shrink-0" />
+              <span className="text-sm font-medium text-fg1">Выйти</span>
+            </button>
+          </div>
+
           <VersionLabel />
         </div>
       </aside>
@@ -218,7 +235,7 @@ function VersionLabel() {
     data.buildDate && new Date(data.buildDate).toLocaleString('ru-RU'),
   ].filter(Boolean).join(' · ');
   return (
-    <div className="text-[10px] text-fg4 truncate pt-1" title={title}>
+    <div className="text-[11px] text-fg3 truncate px-4 pt-2.5 pb-1.5" title={title}>
       v{data.version}{data.commit ? ` · ${data.commit}` : ''}
     </div>
   );

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.51</Version>
+    <Version>0.23.52</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.50</Version>
+    <Version>0.23.51</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Вторая из MD3-тройки. Панель уведомлений приведена к Material Design 3 по макету
(`Панель уведомлений MD3.dc.html`). Логика/данные (health-мониторинг, пометка
прочитанным, очистка, скачивание результата) без изменений — только вид.

> ⚠️ **Стек на #168 (#157).** Мёржить после #157.

## Что сделано
- **Колокольчик** — круглая кнопка 44px; при открытии панели фон `tonal`; **бейдж
  непрочитанных** на `error` (danger) в углу.
- **Панель** — 400px, radius 16, elevation (`f-shadow16`); фиксированная шапка (заголовок
  16/500 + icon-кнопки «прочитать все» / «очистить» через общий `IconButton`).
- **«Состояние системы»** — иконка `HeartPulse` + caps-заголовок; строки сервисов 36px
  (точка ok/error + имя + статус); разделитель после секции.
- **Уведомление** — непрочитанное на `tonal` + primary-точка; аватар-иконка 40px в контейнере
  по severity (ошибка → `danger-subtle`); текст `on-surface-variant`; источник — **outlined-chip**;
  время; `IconButton` «прочитать». Доп. фичи приложения сохранены: «Скачать результат»
  (tonal-chip) и удаление (по hover).
- **Пустое состояние** — `BellOff` + «Нет новых уведомлений».

Токен-first (`tonal` / `brand-subtle` / `danger-subtle` / `stroke`) — корректно в light/dark.

Примечание: в макете есть опциональный mono-блок стектрейса (`code?`), но в модели
`NotificationDto` отдельного поля кода нет — блок не добавлял (нет данных); текст
уведомления рендерится как есть.

## Проверка
`tsc -b` / `build` / `vitest` **115**; скриншоты light + dark (панель, health-секция, строки).

Версия → 0.23.52. Дальше — **#154 таблицы данных**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)