### PR TITLE
feat(md3): общий MD3-стиль таблиц данных (#154)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { dtCard, dtTable, dtTh, dtTd, dtRow } from '@/shared/ui/dataTable';
 import { Select, SelectItem } from '@/shared/ui/Select';
 
 /** Sentinel для «— не материализовать —» — Radix Select запрещает пустую строку. */
@@ -92,23 +93,23 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
               {showPreview ? 'Скрыть предпросмотр' : 'Предпросмотр материализации'}
             </button>
             {showPreview && (
-              <div className="mt-2 rounded-lg border border-stroke overflow-auto max-h-72">
+              <div className={`mt-2 ${dtCard} max-h-72`}>
                 {preview.isLoading ? (
                   <p className="text-xs text-fg4 p-3">Загрузка…</p>
                 ) : preview.data?.error ? (
                   <p className="text-xs text-danger p-3">{preview.data.error}</p>
                 ) : preview.data && preview.data.rows.length > 0 ? (
-                  <table className="text-xs w-full">
+                  <table className={dtTable}>
                     <thead>
-                      <tr className="bg-base">
-                        {previewCols.map(c => <th key={c} className="text-left px-2 py-1 font-medium text-fg3">{c}</th>)}
+                      <tr>
+                        {previewCols.map(c => <th key={c} className={dtTh}>{c}</th>)}
                       </tr>
                     </thead>
                     <tbody>
                       {preview.data.rows.map((row, i) => (
-                        <tr key={i} className="border-t border-stroke">
+                        <tr key={i} className={dtRow}>
                           {previewCols.map(c => (
-                            <td key={c} className="px-2 py-1 text-fg2 align-top">{renderCell(row[c])}</td>
+                            <td key={c} className={`${dtTd} text-fg2 align-top`}>{renderCell(row[c])}</td>
                           ))}
                         </tr>
                       ))}

--- a/src/client/src/features/datasets/SourcePreviewDialog.tsx
+++ b/src/client/src/features/datasets/SourcePreviewDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Loader2, FileText, ExternalLink } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { dtCard, dtTable, dtTh, dtTd, dtRow } from '@/shared/ui/dataTable';
 import { usePreviewDataSetSource } from '@/shared/api/datasets';
 import { openAttachmentInNewTab, formatBytes } from '@/shared/api/attachments';
 import type { DataSetPreview, DataSetSource } from '@/shared/api/types';
@@ -95,20 +96,20 @@ export function SourcePreviewDialog({ source, onClose }: { source: DataSetSource
       ) : isGostDocuments ? (
         <GostDocumentsPreview data={data} />
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-stroke">
-          <table className="text-xs w-full">
+        <div className={dtCard}>
+          <table className={dtTable}>
             <thead>
-              <tr className="bg-base">
+              <tr>
                 {data.columns.map(c => (
-                  <th key={c} className="px-3 py-1.5 text-left font-medium whitespace-nowrap text-fg3">{c}</th>
+                  <th key={c} className={dtTh}>{c}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {data.rows.map((row, i) => (
-                <tr key={i} className="border-t border-stroke">
+                <tr key={i} className={dtRow}>
                   {row.map((v, j) => (
-                    <td key={j} className={`px-3 py-1.5 whitespace-nowrap ${v == null ? 'text-fg4' : 'text-fg1'}`}>
+                    <td key={j} className={`${dtTd} whitespace-nowrap ${v == null ? 'text-fg4' : 'text-fg1'}`}>
                       {v ?? <em>null</em>}
                     </td>
                   ))}

--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Database, Pencil, Trash2, Plus, LayoutTemplate, PlayCircle, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { dtTable, dtTh, dtTd, dtRow } from '@/shared/ui/dataTable';
 import { ApplyTemplateDialog } from './ApplyTemplateDialog';
 import {
   useAvailableDataSetFiles, useListDataSetBindings,
@@ -555,19 +556,19 @@ function PreviewPanel({ results }: { results: DataSetBindingPreviewResult[] }) {
                   <p className="px-3 py-2 text-xs text-fg4">Нет данных</p>
                 );
                 return (
-                  <table className="text-xs w-full">
+                  <table className={dtTable}>
                     <thead>
-                      <tr className="bg-base">
+                      <tr>
                         {keys.map(k => (
-                          <th key={k} className="px-3 py-1.5 text-left font-medium whitespace-nowrap text-fg3">{k}</th>
+                          <th key={k} className={dtTh}>{k}</th>
                         ))}
                       </tr>
                     </thead>
                     <tbody>
                       {preview.map((row, i) => (
-                        <tr key={i} className="border-t border-stroke">
+                        <tr key={i} className={dtRow}>
                           {keys.map(k => (
-                            <td key={k} className={`px-3 py-1.5 whitespace-nowrap ${row[k] == null ? 'text-fg4' : 'text-fg1'}`}>
+                            <td key={k} className={`${dtTd} whitespace-nowrap ${row[k] == null ? 'text-fg4' : 'text-fg1'}`}>
                               {renderCellValue(row[k])}
                             </td>
                           ))}

--- a/src/client/src/features/notifications/NotificationsCenter.tsx
+++ b/src/client/src/features/notifications/NotificationsCenter.tsx
@@ -1,7 +1,8 @@
 import * as Popover from '@radix-ui/react-popover';
 import {
-  Bell, Info, AlertTriangle, AlertCircle, X, Check, CheckCheck, Trash2, Activity, Download,
+  Bell, BellOff, Info, AlertTriangle, AlertCircle, X, Check, CheckCheck, Trash2, HeartPulse, Download,
 } from 'lucide-react';
+import { IconButton } from '@/shared/ui/Button';
 import {
   useNotifications, useHealth,
   useMarkNotificationRead, useMarkAllNotificationsRead,
@@ -27,10 +28,11 @@ async function openResult(linkUrl: string) {
   URL.revokeObjectURL(url);
 }
 
-const SEVERITY: Record<NotificationSeverity, { icon: typeof Info; color: string; bg: string; label: string }> = {
-  Info:    { icon: Info,          color: 'text-brand',   bg: 'bg-brand-subtle',   label: 'Информация' },
-  Warning: { icon: AlertTriangle, color: 'text-warning', bg: 'bg-warning-subtle', label: 'Предупреждение' },
-  Error:   { icon: AlertCircle,   color: 'text-danger',  bg: 'bg-danger-subtle',  label: 'Ошибка' },
+// Аватар-иконка уведомления: для ошибок — error-container, иначе — соответствующий контейнер.
+const SEVERITY: Record<NotificationSeverity, { icon: typeof Info; color: string; bg: string }> = {
+  Info:    { icon: Info,          color: 'text-brand',   bg: 'bg-brand-subtle' },
+  Warning: { icon: AlertTriangle, color: 'text-warning', bg: 'bg-warning-subtle' },
+  Error:   { icon: AlertCircle,   color: 'text-danger',  bg: 'bg-danger-subtle' },
 };
 
 function relTime(iso: string): string {
@@ -48,51 +50,42 @@ function NotificationRow({ n }: { n: NotificationDto }) {
   const meta = SEVERITY[n.severity];
   const Icon = meta.icon;
   return (
-    <div
-      className={`group flex gap-3 px-4 py-3 border-b border-stroke last:border-b-0 ${n.isRead ? 'opacity-65' : ''}`}
-    >
-      <div className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${meta.bg}`}>
-        <Icon size={15} className={meta.color} />
+    <div className={`group flex gap-3.5 pl-5 pr-3 py-4 transition-colors ${n.isRead ? '' : 'bg-tonal'}`}>
+      <div className={`shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${meta.bg}`}>
+        <Icon size={20} className={meta.color} />
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <p className="text-sm font-medium text-fg1 truncate">{n.title}</p>
-          {!n.isRead && <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-brand" />}
+          {!n.isRead && <span className="shrink-0 w-2 h-2 rounded-full bg-brand" />}
         </div>
-        <p className="text-xs text-fg2 mt-0.5 break-words whitespace-pre-wrap">{n.message}</p>
+        <p className="text-[13px] leading-[1.45] text-fg3 mt-1 break-words whitespace-pre-wrap">{n.message}</p>
         {n.linkUrl && (
           <button
             type="button"
             onClick={() => { void openResult(n.linkUrl!); }}
-            className="mt-1.5 inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium bg-brand-subtle text-brand hover:bg-brand/15 transition-colors"
+            className="mt-2 inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-xs font-medium bg-tonal text-on-tonal hover:brightness-95 transition"
           >
             <Download size={13} /> {n.linkLabel ?? 'Открыть результат'}
           </button>
         )}
-        <div className="flex items-center gap-2 mt-1 text-[11px] text-fg4">
-          {n.source && <span className="px-1.5 py-0.5 rounded bg-base">{n.source}</span>}
+        <div className="flex items-center gap-2 mt-2 text-xs text-fg3">
+          {n.source && (
+            <span className="inline-flex items-center h-6 px-3 rounded-lg border border-stroke font-medium">{n.source}</span>
+          )}
           <span>{relTime(n.createdAt)}</span>
         </div>
       </div>
-      <div className="shrink-0 self-start flex flex-col items-center gap-1.5">
+      <div className="shrink-0 self-start flex flex-col items-center">
         {!n.isRead && (
-          <button
-            type="button"
-            onClick={() => markRead.mutate(n.id)}
-            title="Отметить прочитанным"
-            className="text-fg4 hover:text-brand transition-colors"
-          >
-            <Check size={14} />
-          </button>
+          <IconButton label="Отметить прочитанным" size="sm" onClick={() => markRead.mutate(n.id)}>
+            <Check size={16} />
+          </IconButton>
         )}
-        <button
-          type="button"
-          onClick={() => dismiss.mutate(n.id)}
-          title="Удалить"
-          className="text-fg4 hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
-        >
-          <X size={14} />
-        </button>
+        <IconButton label="Удалить" size="sm" danger onClick={() => dismiss.mutate(n.id)}
+          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity">
+          <X size={16} />
+        </IconButton>
       </div>
     </div>
   );
@@ -102,16 +95,16 @@ function HealthSection() {
   const { data: health } = useHealth();
   if (!health || health.length === 0) return null;
   return (
-    <div className="px-4 py-3 border-b border-stroke bg-base/50">
-      <div className="flex items-center gap-1.5 mb-2 text-[11px] font-semibold uppercase tracking-wide text-fg3">
-        <Activity size={12} /> Состояние системы
+    <div className="px-5 pt-1 pb-2">
+      <div className="flex items-center gap-1.5 mb-1 text-xs font-medium uppercase tracking-wide text-fg3">
+        <HeartPulse size={16} /> Состояние системы
       </div>
-      <div className="space-y-1.5">
+      <div>
         {health.map(c => (
-          <div key={c.name} className="flex items-center gap-2 text-xs">
+          <div key={c.name} className="flex items-center gap-2.5 h-9 text-sm">
             <span className={`w-2 h-2 rounded-full shrink-0 ${c.healthy ? 'bg-success' : 'bg-danger'}`} />
-            <span className="text-fg2 flex-1">{c.name}</span>
-            <span className={c.healthy ? 'text-fg4' : 'text-danger'}>
+            <span className="text-fg1 flex-1">{c.name}</span>
+            <span className={`text-xs font-medium ${c.healthy ? 'text-fg3' : 'text-danger'}`}>
               {c.healthy ? 'в норме' : (c.detail ? 'сбой' : 'недоступен')}
             </span>
           </div>
@@ -128,7 +121,6 @@ export function NotificationsCenter() {
 
   const items = data?.items ?? [];
   const unread = data?.unreadCount ?? 0;
-  const hasError = items.some(n => !n.isRead && n.severity === 'Error');
 
   return (
     <Popover.Root>
@@ -136,14 +128,12 @@ export function NotificationsCenter() {
         <button
           type="button"
           title="Уведомления"
-          className="relative flex items-center justify-center w-9 h-9 rounded-md transition-colors text-fg3 hover:text-fg1 hover:bg-base data-[state=open]:bg-base data-[state=open]:text-fg1"
+          aria-label="Уведомления"
+          className="relative flex items-center justify-center w-11 h-11 rounded-full transition-colors text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 data-[state=open]:bg-tonal data-[state=open]:text-on-tonal"
         >
-          <Bell size={18} />
+          <Bell size={22} />
           {unread > 0 && (
-            <span
-              className={`absolute -top-0.5 -right-0.5 min-w-[16px] h-4 px-1 rounded-full text-[10px] font-semibold
-                flex items-center justify-center text-white ${hasError ? 'bg-danger' : 'bg-brand'}`}
-            >
+            <span className="absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full text-[11px] font-medium flex items-center justify-center text-white bg-danger">
               {unread > 99 ? '99+' : unread}
             </span>
           )}
@@ -153,43 +143,33 @@ export function NotificationsCenter() {
         <Popover.Content
           align="end"
           sideOffset={8}
-          className="w-96 max-h-[75vh] flex flex-col rounded-xl border border-stroke bg-surface shadow-lg z-50 overflow-hidden focus:outline-none"
+          className="w-[400px] max-w-[calc(100vw-40px)] max-h-[calc(100vh-90px)] flex flex-col rounded-2xl border border-stroke bg-surface z-50 overflow-hidden focus:outline-none"
+          style={{ boxShadow: 'var(--f-shadow16)' }}
         >
-          {/* Header */}
-          <div className="flex items-center justify-between px-4 py-2.5 border-b border-stroke shrink-0">
-            <span className="text-sm font-semibold text-fg1">Уведомления</span>
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() => markAll.mutate()}
-                disabled={unread === 0}
-                title="Отметить все прочитанными"
-                className="p-1.5 rounded text-fg3 hover:text-fg1 hover:bg-base disabled:opacity-40 disabled:hover:bg-transparent"
-              >
-                <CheckCheck size={15} />
-              </button>
-              <button
-                type="button"
-                onClick={() => clearAll.mutate()}
-                disabled={items.length === 0}
-                title="Очистить все"
-                className="p-1.5 rounded text-fg3 hover:text-danger hover:bg-base disabled:opacity-40 disabled:hover:bg-transparent"
-              >
-                <Trash2 size={15} />
-              </button>
-            </div>
+          {/* Header (фиксированная шапка) */}
+          <div className="flex items-center gap-2 pl-5 pr-2 py-3 shrink-0">
+            <span className="flex-1 text-base font-medium text-fg1">Уведомления</span>
+            <IconButton label="Отметить все прочитанными" onClick={() => markAll.mutate()} disabled={unread === 0}>
+              <CheckCheck size={18} />
+            </IconButton>
+            <IconButton label="Очистить все" onClick={() => clearAll.mutate()} disabled={items.length === 0}>
+              <Trash2 size={18} />
+            </IconButton>
           </div>
 
           {/* Scrollable body */}
           <div className="flex-1 overflow-y-auto min-h-0">
             <HealthSection />
+            <div className="border-t border-stroke" />
             {items.length === 0 ? (
-              <div className="px-4 py-10 text-center text-sm text-fg4">
-                <Bell size={24} className="mx-auto mb-2 opacity-40" />
-                Нет уведомлений
+              <div className="px-6 py-9 text-center text-sm text-fg3">
+                <BellOff size={36} className="mx-auto mb-2 opacity-50" />
+                Нет новых уведомлений
               </div>
             ) : (
-              items.map(n => <NotificationRow key={n.id} n={n} />)
+              <div className="divide-y divide-stroke">
+                {items.map(n => <NotificationRow key={n.id} n={n} />)}
+              </div>
             )}
           </div>
         </Popover.Content>

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -10,7 +10,7 @@ import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
-import { LogOut, Sun, Moon, Monitor, KeyRound, UserRound, MailWarning, X } from 'lucide-react';
+import { LogOut, Sun, Moon, Monitor, KeyRound, Check, ChevronsUpDown, MailWarning, X } from 'lucide-react';
 
 const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'light',  icon: Sun,     label: 'Светлая'   },
@@ -18,27 +18,36 @@ const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
   { value: 'system', icon: Monitor, label: 'Системная' },
 ];
 
+// MD3 segmented button (issue #157): выбранный сегмент — tonal + галочка.
 function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   return (
-    <div
-      className="flex items-center gap-0.5 rounded-md p-0.5 bg-muted"
-      title="Тема оформления"
-    >
-      {themeOptions.map(({ value, icon: Icon, label }) => (
-        <button
-          key={value}
-          onClick={() => setTheme(value)}
-          title={label}
-          className={`flex items-center justify-center w-7 h-7 rounded transition-colors ${
-            theme === value ? 'text-fg1 shadow-sm bg-surface' : 'text-fg3 hover:text-fg2'
-          }`}
-        >
-          <Icon size={14} />
-        </button>
-      ))}
+    <div role="group" aria-label="Тема оформления"
+      className="flex h-10 rounded-full border border-stroke-strong overflow-hidden">
+      {themeOptions.map(({ value, icon: Icon, label }, i) => {
+        const active = theme === value;
+        return (
+          <button key={value} type="button" onClick={() => setTheme(value)}
+            title={label} aria-label={label} aria-pressed={active}
+            className={`flex-1 flex items-center justify-center gap-1 text-xs transition-colors ` +
+              `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand ` +
+              `${i > 0 ? 'border-l border-stroke-strong' : ''} ` +
+              (active ? 'bg-tonal text-on-tonal' : 'text-fg3 hover:bg-black/5 dark:hover:bg-white/10')}>
+            {active && <Check size={14} className="shrink-0" />}
+            <Icon size={16} />
+          </button>
+        );
+      })}
     </div>
   );
+}
+
+/** Инициалы для аватара: 2 буквы из имени (или email). */
+function initialsOf(name?: string, email?: string): string {
+  const src = (name || email || '').trim();
+  const parts = src.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return src.slice(0, 2).toUpperCase();
 }
 
 function NavSection({
@@ -130,30 +139,38 @@ export function AppShell() {
           )}
         </nav>
 
-        {/* Bottom: theme + user */}
-        <div className="px-3 py-3 border-t border-stroke space-y-3 shrink-0">
-          <ThemeToggle />
-          <NavLink to="/profile"
-            className={({ isActive }) => `flex items-center gap-2 text-xs truncate transition-colors ` +
-              (isActive ? 'text-brand' : 'text-fg3 hover:text-brand')}>
-            <UserRound size={14} className="shrink-0" />
-            <span className="truncate">
-              {user?.displayName || user?.email}
-              <span className="ml-1 text-fg4">· {isAdmin ? 'Администратор' : 'Пользователь'}</span>
-            </span>
-          </NavLink>
-          <button
-            onClick={() => setPwOpen(true)}
-            className="flex items-center gap-2 text-sm transition-colors w-full text-fg2 hover:text-brand"
-          >
-            <KeyRound size={14} /> Сменить пароль
-          </button>
-          <button
-            onClick={logout}
-            className="flex items-center gap-2 text-sm transition-colors w-full text-fg2 hover:text-danger"
-          >
-            <LogOut size={14} /> Выйти
-          </button>
+        {/* Bottom: theme + user (MD3 drawer footer, issue #157) */}
+        <div className="px-3 pt-3 pb-1 border-t border-stroke shrink-0">
+          <div className="mb-3"><ThemeToggle /></div>
+
+          <div className="space-y-0.5">
+            {/* Блок пользователя — пилюля с аватаром */}
+            <NavLink to="/profile"
+              className={({ isActive }) => `flex items-center gap-3 h-14 px-4 rounded-[28px] transition-colors ` +
+                `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
+                (isActive ? 'bg-tonal' : 'hover:bg-black/5 dark:hover:bg-white/10')}>
+              <span className="flex items-center justify-center w-10 h-10 rounded-full shrink-0 bg-brand-subtle text-on-brand-subtle text-[15px] font-medium">
+                {initialsOf(user?.displayName, user?.email)}
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm font-medium text-fg1 truncate">{user?.displayName || user?.email}</span>
+                <span className="block text-xs text-fg3">{isAdmin ? 'Администратор' : 'Пользователь'}</span>
+              </span>
+              <ChevronsUpDown size={18} className="text-fg3 shrink-0" />
+            </NavLink>
+
+            <button type="button" onClick={() => setPwOpen(true)}
+              className="w-full flex items-center gap-3 h-14 px-4 rounded-[28px] text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">
+              <KeyRound size={22} className="text-fg3 shrink-0" />
+              <span className="text-sm font-medium text-fg1">Сменить пароль</span>
+            </button>
+            <button type="button" onClick={logout}
+              className="w-full flex items-center gap-3 h-14 px-4 rounded-[28px] text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">
+              <LogOut size={22} className="text-fg3 shrink-0" />
+              <span className="text-sm font-medium text-fg1">Выйти</span>
+            </button>
+          </div>
+
           <VersionLabel />
         </div>
       </aside>
@@ -218,7 +235,7 @@ function VersionLabel() {
     data.buildDate && new Date(data.buildDate).toLocaleString('ru-RU'),
   ].filter(Boolean).join(' · ');
   return (
-    <div className="text-[10px] text-fg4 truncate pt-1" title={title}>
+    <div className="text-[11px] text-fg3 truncate px-4 pt-2.5 pb-1.5" title={title}>
       v{data.version}{data.commit ? ` · ${data.commit}` : ''}
     </div>
   );

--- a/src/client/src/shared/ui/dataTable.ts
+++ b/src/client/src/shared/ui/dataTable.ts
@@ -1,0 +1,28 @@
+/**
+ * Общий MD3-стиль таблиц данных (issue #154): карточка со скруглением, sticky-шапка на
+ * surface-container, тонкие бордеры (outline-variant), hover-строки, числовые колонки
+ * с tabular-nums. Применяется подстановкой классов в существующую разметку `<table>`.
+ *
+ * Важно: sticky-шапка требует `border-separate border-spacing-0` на таблице (иначе граница
+ * шапки уезжает при скролле) — это уже в `dtTable`.
+ */
+
+/** Обёртка-карточка со скроллом. */
+export const dtCard = 'overflow-auto rounded-xl border border-stroke bg-surface';
+
+/** Сама таблица (border-separate — для корректной sticky-шапки). */
+export const dtTable = 'w-full border-separate border-spacing-0 text-sm';
+
+/** Ячейка шапки: липкая, на surface-container, вторичный текст. */
+export const dtTh =
+  'sticky top-0 z-10 bg-muted text-left text-xs font-medium text-fg3 ' +
+  'px-3 h-[42px] align-middle border-b border-stroke whitespace-nowrap';
+
+/** Ячейка тела: тонкая нижняя граница, средняя плотность. */
+export const dtTd = 'px-3 py-2 border-b border-stroke align-middle';
+
+/** Класс строки: hover-подсветка. */
+export const dtRow = 'transition-colors hover:bg-black/[.03] dark:hover:bg-white/[.05]';
+
+/** Числовая колонка: выравнивание вправо + tabular-nums. */
+export const dtNum = 'text-right tabular-nums';

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.52</Version>
+    <Version>0.23.53</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.51</Version>
+    <Version>0.23.52</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.50</Version>
+    <Version>0.23.51</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Третья из MD3-тройки. По вашему решению — **общий MD3-стиль таблиц** (единый визуальный
проход), **без** тяжёлой machinery выбора/контекст-панели/пагинации из макета.

> ⚠️ **Стек на #169 (#155) → #168 (#157).** Мёржить последним в цепочке #157 → #155 → #154.

## Что сделано
- **Общий набор классов `shared/ui/dataTable`** (`dtCard` / `dtTable` / `dtTh` / `dtTd` /
  `dtRow` / `dtNum`): карточка со скруглением 16, **sticky-шапка** на `surface-container`,
  тонкие бордеры (`outline-variant`), **hover-строки**, `tabular-nums` для чисел.
  `border-separate` — чтобы sticky-шапка держала границу при скролле (нюанс из макета).
- Применено к **каноническим data-таблицам**: превью источника датасета
  (`SourcePreviewDialog`), предпросмотр материализации (`MaterializationDialog`),
  предпросмотр привязки в редакторе (`DataSetsTab`).
- Набор **переиспользуемый** — остальные таблицы приложения можно перевести на него
  инкрементально (отдельным проходом, если нужно полное покрытие).

Токен-first, корректно в light/dark.

## Проверка
`tsc -b` / `build` / `vitest` **115**. Изменение — подстановка общих классов в существующую
разметку (низкий риск); таблицы-превью датасетов лежат глубоко в навигации, скриншот не
делал — положился на сборку.

Версия → 0.23.53. **Это закрывает MD3-тройку** (#157 / #155 / #154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)