### PR TITLE
feat(md3): выбор строк + удаление + drag-reorder в редакторе таблицы (#171)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
-  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, Link2, Pencil, Plus, Trash2, Unlink, X,
+  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Link2, Pencil, Plus, Trash2, Unlink, X,
 } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
@@ -130,12 +130,21 @@ export function ArrayTableModal({
   setId?: string; scope?: CatalogScope; scopeId?: string | null;
 }) {
   const [rows, setRows] = useState<Record<string, unknown>[]>([]);
+  // Стабильные id строк (issue #171): переживают reorder/удаление, служат ключом выбора.
+  const [rowIds, setRowIds] = useState<string[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [dropIdx, setDropIdx] = useState<number | null>(null);
   const [colWidths, setColWidths] = useState<Record<string, number>>({});
   const [pasteOpen, setPasteOpen] = useState(false);
   const [pasteText, setPasteText] = useState('');
 
   useEffect(() => {
-    if (open) setRows(items.map(r => ({ ...r })));
+    if (open) {
+      setRows(items.map(r => ({ ...r })));
+      setRowIds(items.map(() => crypto.randomUUID()));
+      setSelected(new Set());
+    }
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Единая цепочка скопов (issue #82): комплект → (Set, setId), иначе (scope, scopeId) — с подъёмом по родителям.
@@ -168,9 +177,37 @@ export function ArrayTableModal({
   function updateCell(ri: number, key: string, val: unknown) {
     setRows(prev => prev.map((r, i) => i === ri ? { ...r, [key]: val } : r));
   }
-  function addRow() { setRows(prev => [...prev, getDefaultValues(subFields)]); }
-  function removeRow(idx: number) { setRows(prev => prev.filter((_, i) => i !== idx)); }
+  function addRow() {
+    setRows(prev => [...prev, getDefaultValues(subFields)]);
+    setRowIds(prev => [...prev, crypto.randomUUID()]);
+  }
+  function removeRow(idx: number) {
+    const id = rowIds[idx];
+    setRows(prev => prev.filter((_, i) => i !== idx));
+    setRowIds(prev => prev.filter((_, i) => i !== idx));
+    if (id) setSelected(prev => { const n = new Set(prev); n.delete(id); return n; });
+  }
   function handleSave() { onSave(rows); onOpenChange(false); }
+
+  // ── Выбор строк (issue #171) ────────────────────────────────────────────
+  function toggleSelect(id: string) {
+    setSelected(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  }
+  function toggleAll() {
+    setSelected(prev => prev.size === rowIds.length ? new Set() : new Set(rowIds));
+  }
+  function deleteSelected() {
+    setRows(prev => prev.filter((_, i) => !selected.has(rowIds[i])));
+    setRowIds(prev => prev.filter(id => !selected.has(id)));
+    setSelected(new Set());
+  }
+
+  // ── Изменение порядка строк: drag-and-drop + клавиатура (issue #171) ─────
+  function moveRow(from: number, to: number) {
+    if (to < 0 || to >= rows.length || from === to) return;
+    setRows(prev => { const a = [...prev]; const [m] = a.splice(from, 1); a.splice(to, 0, m); return a; });
+    setRowIds(prev => { const a = [...prev]; const [m] = a.splice(from, 1); a.splice(to, 0, m); return a; });
+  }
 
   async function handlePasteClick() {
     let text = '';
@@ -221,7 +258,6 @@ export function ArrayTableModal({
 
   const BORDER = '1px solid #d1d5db';
   const TH_BG = '#f3f4f6';
-  const IDX_BG = '#f9fafb';
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}
@@ -230,9 +266,19 @@ export function ArrayTableModal({
       footer={
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <Button variant="text" size="sm" icon={<Plus size={13} />} onClick={addRow}>Добавить строку</Button>
-            <span className="text-stroke-strong">·</span>
-            <Button variant="text" size="sm" icon={<Clipboard size={13} />} onClick={handlePasteClick}>Вставить из Excel</Button>
+            {selected.size > 0 ? (
+              <>
+                <span className="text-sm font-medium text-fg2 px-2">Выбрано: {selected.size}</span>
+                <Button variant="text" size="sm" danger icon={<Trash2 size={13} />} onClick={deleteSelected}>Удалить выбранные</Button>
+                <Button variant="text" size="sm" onClick={() => setSelected(new Set())}>Сбросить</Button>
+              </>
+            ) : (
+              <>
+                <Button variant="text" size="sm" icon={<Plus size={13} />} onClick={addRow}>Добавить строку</Button>
+                <span className="text-stroke-strong">·</span>
+                <Button variant="text" size="sm" icon={<Clipboard size={13} />} onClick={handlePasteClick}>Вставить из Excel</Button>
+              </>
+            )}
           </div>
           <div className="flex gap-2">
             <Button variant="text" onClick={() => onOpenChange(false)}>Отмена</Button>
@@ -244,13 +290,22 @@ export function ArrayTableModal({
         <table ref={tableRef} onKeyDown={onGridKey} role="grid" aria-label={`Строки: ${compositeType?.name ?? field.title}`}
           style={{ tableLayout: 'fixed', borderCollapse: 'collapse', width: 'max-content', minWidth: '100%' }}>
           <colgroup>
-            <col style={{ width: 32 }} />
+            <col style={{ width: 34 }} />
+            <col style={{ width: 44 }} />
             {tableFields.map(f => <col key={f.key} style={{ width: getW(f) }} />)}
             <col style={{ width: 26 }} />
           </colgroup>
           <thead>
             <tr role="row">
-              <th role="columnheader" style={{ border: BORDER, background: TH_BG, padding: 0, width: 32 }}>
+              <th style={{ border: BORDER, background: TH_BG, padding: 0, width: 34 }}>
+                <span className="flex items-center justify-center" style={{ height: 28 }}>
+                  <input type="checkbox" aria-label="Выбрать все строки"
+                    checked={rowIds.length > 0 && selected.size === rowIds.length}
+                    ref={el => { if (el) el.indeterminate = selected.size > 0 && selected.size < rowIds.length; }}
+                    onChange={toggleAll} className="w-4 h-4 accent-brand cursor-pointer" />
+                </span>
+              </th>
+              <th role="columnheader" style={{ border: BORDER, background: TH_BG, padding: 0, width: 44 }}>
                 <span className="flex items-center justify-center text-xs text-fg4 font-normal" style={{ height: 28 }}>#</span>
               </th>
               {tableFields.map(f => (
@@ -274,17 +329,43 @@ export function ArrayTableModal({
             </tr>
           </thead>
           <tbody>
-            {rows.map((row, i) => (
-              <tr key={i} role="row">
-                <td role="rowheader" style={{ border: BORDER, background: IDX_BG, padding: 0, textAlign: 'center' }}>
-                  <span className="flex items-center justify-center text-xs text-fg4 font-mono" style={{ height: 26 }}>{i + 1}</span>
+            {rows.map((row, i) => {
+              const sel = selected.has(rowIds[i]);
+              return (
+              <tr key={rowIds[i]} role="row"
+                onDragOver={e => { if (dragIdx !== null) { e.preventDefault(); if (dropIdx !== i) setDropIdx(i); } }}
+                onDrop={e => { e.preventDefault(); if (dragIdx !== null) moveRow(dragIdx, i); setDragIdx(null); setDropIdx(null); }}
+                style={dragIdx !== null && dropIdx === i && dragIdx !== i
+                  ? { outline: '2px solid var(--color-brand)', outlineOffset: '-2px' } : undefined}>
+                <td style={{ border: BORDER, padding: 0, textAlign: 'center' }} className={sel ? 'bg-brand-subtle' : ''}>
+                  <span className="flex items-center justify-center" style={{ height: 26 }}>
+                    <input type="checkbox" checked={sel} onChange={() => toggleSelect(rowIds[i])}
+                      aria-label={`Выбрать строку ${i + 1}`} className="w-4 h-4 accent-brand cursor-pointer" />
+                  </span>
+                </td>
+                <td role="rowheader" style={{ border: BORDER, padding: 0 }} className={sel ? 'bg-brand-subtle' : 'bg-base'}>
+                  <div className="flex items-center justify-center gap-0.5" style={{ height: 26 }}>
+                    <button type="button" draggable
+                      onDragStart={e => { setDragIdx(i); e.dataTransfer.effectAllowed = 'move'; }}
+                      onDragEnd={() => { setDragIdx(null); setDropIdx(null); }}
+                      onKeyDown={e => {
+                        if (e.key === 'ArrowUp') { e.preventDefault(); e.stopPropagation(); moveRow(i, i - 1); }
+                        else if (e.key === 'ArrowDown') { e.preventDefault(); e.stopPropagation(); moveRow(i, i + 1); }
+                      }}
+                      title="Перетащить для изменения порядка (или стрелки ↑↓)"
+                      aria-label={`Переместить строку ${i + 1}: стрелки вверх/вниз`}
+                      className="cursor-grab active:cursor-grabbing text-fg4 hover:text-fg2 focus-visible:outline-none focus-visible:text-brand">
+                      <GripVertical size={12} />
+                    </button>
+                    <span className="text-xs text-fg4 font-mono">{i + 1}</span>
+                  </div>
                 </td>
                 {tableFields.map((f, ci) => {
                   const compositeForField = f.type === 'complex'
                     ? allDocTypes.find(dt => dt.id === f.typeId) ?? null : null;
                   return (
                     <td key={f.key} data-r={i} data-c={ci} role="gridcell"
-                      className="focus-within:bg-brand-subtle transition-colors"
+                      className={`focus-within:bg-brand-subtle transition-colors ${sel ? 'bg-brand-subtle' : ''}`}
                       style={{ border: BORDER, padding: 0, height: 26 }}>
                       <TableCell field={f} value={row[f.key]} onChange={v => updateCell(i, f.key, v)}
                         compositeType={compositeForField} setId={setId} allDocTypes={allDocTypes}
@@ -292,7 +373,7 @@ export function ArrayTableModal({
                     </td>
                   );
                 })}
-                <td style={{ border: BORDER, padding: 0, width: 26 }}>
+                <td style={{ border: BORDER, padding: 0, width: 26 }} className={sel ? 'bg-brand-subtle' : ''}>
                   <button type="button" onClick={() => removeRow(i)}
                     className="w-full h-full flex items-center justify-center text-stroke-strong hover:text-danger transition-colors"
                     style={{ height: 26 }}>
@@ -300,7 +381,8 @@ export function ArrayTableModal({
                   </button>
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
         {rows.length === 0 && (

--- a/src/server/BHS.CRG.Api/Auth/RuIdentityErrorDescriber.cs
+++ b/src/server/BHS.CRG.Api/Auth/RuIdentityErrorDescriber.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace BHS.CRG.Api.Auth;
+
+/// <summary>
+/// Русские сообщения об ошибках ASP.NET Identity (issue #165). Подключается через
+/// <c>.AddErrorDescriber&lt;RuIdentityErrorDescriber&gt;()</c>. Тексты доезжают до фронта,
+/// т.к. endpoint'ы отдают <c>{ error: DescribeErrors(...) }</c>.
+/// </summary>
+public class RuIdentityErrorDescriber : IdentityErrorDescriber
+{
+    public override IdentityError DefaultError() =>
+        E(nameof(DefaultError), "Произошла неизвестная ошибка.");
+
+    public override IdentityError ConcurrencyFailure() =>
+        E(nameof(ConcurrencyFailure), "Данные были изменены другим процессом. Обновите и повторите.");
+
+    // ── Пароль ──────────────────────────────────────────────────────────────
+    public override IdentityError PasswordMismatch() =>
+        E(nameof(PasswordMismatch), "Неверный пароль.");
+
+    public override IdentityError PasswordTooShort(int length) =>
+        E(nameof(PasswordTooShort), $"Пароль должен быть не короче {length} символов.");
+
+    public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) =>
+        E(nameof(PasswordRequiresUniqueChars), $"Пароль должен содержать не менее {uniqueChars} различных символов.");
+
+    public override IdentityError PasswordRequiresNonAlphanumeric() =>
+        E(nameof(PasswordRequiresNonAlphanumeric), "Пароль должен содержать хотя бы один спецсимвол.");
+
+    public override IdentityError PasswordRequiresDigit() =>
+        E(nameof(PasswordRequiresDigit), "Пароль должен содержать хотя бы одну цифру.");
+
+    public override IdentityError PasswordRequiresLower() =>
+        E(nameof(PasswordRequiresLower), "Пароль должен содержать хотя бы одну строчную букву.");
+
+    public override IdentityError PasswordRequiresUpper() =>
+        E(nameof(PasswordRequiresUpper), "Пароль должен содержать хотя бы одну заглавную букву.");
+
+    // ── Email / имя пользователя ───────────────────────────────────────────
+    public override IdentityError InvalidEmail(string? email) =>
+        E(nameof(InvalidEmail), $"Некорректный адрес «{email}».");
+
+    public override IdentityError DuplicateEmail(string email) =>
+        E(nameof(DuplicateEmail), $"Адрес «{email}» уже используется.");
+
+    public override IdentityError InvalidUserName(string? userName) =>
+        E(nameof(InvalidUserName), $"Недопустимое имя пользователя «{userName}».");
+
+    public override IdentityError DuplicateUserName(string userName) =>
+        E(nameof(DuplicateUserName), $"Пользователь «{userName}» уже существует.");
+
+    // ── Токены / прочее ────────────────────────────────────────────────────
+    public override IdentityError InvalidToken() =>
+        E(nameof(InvalidToken), "Ссылка недействительна или устарела.");
+
+    public override IdentityError UserAlreadyHasPassword() =>
+        E(nameof(UserAlreadyHasPassword), "У пользователя уже задан пароль.");
+
+    public override IdentityError UserAlreadyInRole(string role) =>
+        E(nameof(UserAlreadyInRole), $"Роль «{role}» уже назначена.");
+
+    public override IdentityError UserNotInRole(string role) =>
+        E(nameof(UserNotInRole), $"Роль «{role}» не назначена.");
+
+    public override IdentityError RecoveryCodeRedemptionFailed() =>
+        E(nameof(RecoveryCodeRedemptionFailed), "Код восстановления недействителен.");
+
+    private static IdentityError E(string code, string description) => new() { Code = code, Description = description };
+}

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -84,6 +84,7 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(opt =>
         opt.Tokens.ChangeEmailTokenProvider = "EmailConfirmDP";
     })
     .AddEntityFrameworkStores<AppDbContext>()
+    .AddErrorDescriber<RuIdentityErrorDescriber>()
     .AddDefaultTokenProviders()
     .AddTokenProvider<EmailConfirmTokenProvider>("EmailConfirmDP");
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.54</Version>
+    <Version>0.23.55</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.53</Version>
+    <Version>0.23.54</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Редактируемая таблица (`ArrayTableModal` — редактор массива составных типов): множественное
удаление строк + изменение порядка. Reorder — **drag-and-drop** (ваш выбор) + клавиатурная
альтернатива.

> ⚠️ **Стек на #172 (#165).** Мёржить после #165.

## Что сделано
- **Выбор строк**: колонка чекбоксов + **tri-state** «выбрать все» в шапке; выбранные строки
  подсвечены (`brand-subtle`). Контекстные действия в футере при выборе ≥1: «Выбрано: N»,
  «Удалить выбранные», «Сбросить» (паттерн из макета #154).
- **Reorder — drag-and-drop** за grip-иконку (нативный HTML5 DnD, индикатор строки-цели) +
  **клавиатура**: стрелки ↑↓ на grip перемещают строку (важно для #107 keyboard-first).
- **Стабильные id строк** (`crypto.randomUUID`) параллельно `rows` — выбор **и фокус** переживают
  reorder/удаление; `key` строки = id → корректная реконсиляция при перестановке (без багов
  ввода в ячейках).

MD3: чекбоксы `accent-brand`, выбранная строка/контекст на токенах `brand-subtle`. Существующие
grid-навигация (↑↓←→), ресайз колонок, «Вставить из Excel», сохранение — не тронуты.

## Проверка
- `tsc -b` / `build` / `vitest` **115**, **keyboard smoke 11/11** (регресс — приложение и ключевые
  экраны работают).
- ⚠️ **Живьё drag-and-drop и выбор** рекомендую проверить в документе с полем-массивом составного
  типа (модалка редактора таблицы лежит глубоко в навигации, скриптом надёжно не дотянулся).
  Логика самодостаточна и стандартна (Set по стабильным id, splice-reorder, нативный DnD).

Версия → 0.23.55. Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)