### PR TITLE
fix(documents): значения по умолчанию при создании документа

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -17,7 +17,8 @@ import type { DocumentInstance, DocumentType, Template, PrimitiveTypeDef, EnumTy
 import { SCOPE_LABELS } from '@/shared/api/types';
 import { useCommonDataForSet } from '@/shared/api/commonData';
 import {
-  groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, parseSchemaFields, type SchemaField,
+  groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, parseSchemaFields,
+  getDefaultValues, type SchemaField,
 } from '@/shared/api/schema';
 import {
   STATUS_LABELS, STATUS_COLORS,
@@ -91,7 +92,13 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const { data: enumTypes = [] } = useListEnumTypes();
-  const [values, setValues] = useState<Record<string, unknown>>(() => ({ ...instance.requisites }));
+  // Свежий документ (пустые реквизиты) — засеваем значения по умолчанию из эффективных полей
+  // (включая переопределённые в дочернем типе); существующий грузим как сохранён. См. каталог,
+  // где дефолты применялись, а у документов — нет.
+  const [values, setValues] = useState<Record<string, unknown>>(() =>
+    Object.keys(instance.requisites ?? {}).length === 0
+      ? getDefaultValues(schemaFields)
+      : { ...instance.requisites });
   const [constraintErrors, setConstraintErrors] = useState<Record<string, string>>({});
   const [error, setError] = useState('');
   const [showValidation, setShowValidation] = useState(false);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.56</Version>
+    <Version>0.23.57</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Баг
При создании документа (напр. «Реестр работ») поля не заполнялись значениями по умолчанию —
хотя дефолты переопределены в дочернем типе.

## Корень
- Редактор реквизитов инициализировал `values` только из `instance.requisites` (у нового
  документа — `{}`); `getDefaultValues` в редакторе документов **не вызывался вообще**.
- У общих данных (каталог) дефолты применялись (`getDefaultValues(resolveEffectiveFields(...))`),
  у документов — нет. Асимметрия.
- Само наследование/переопределение (`fieldOverrides.defaultValue`) работает корректно —
  цепочку просто никто не дёргал для документов.

## Фикс (лёгкий вариант — согласован)
Для свежего инстанса (пустые `requisites`) засеваем `getDefaultValues(schemaFields)`, где
`schemaFields` уже = `resolveEffectiveFields(docType, …)` (с дочерними override). Существующий
документ грузится как сохранён.

Дефолты **видны сразу**; персистятся по «Сохранить» (как в каталоге).

## Проверка
`tsc -b` / `build` / `vitest` **115**. Версия → 0.23.57.