### PR TITLE
feat(md3): searchable-пикер типа (поиск + недавние + иконки семейств)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
-import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
+import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
 import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import {
@@ -218,6 +218,7 @@ export function CatalogEntryForm({
     setAliasDraft('');
   }
   const [typeId, setTypeId] = useState(entry?.compositeTypeId ?? '');
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [values, setValues] = useState<Record<string, unknown>>(() => entry?.data ?? {});
   const [error, setError] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
@@ -622,23 +623,26 @@ export function CatalogEntryForm({
       {!entry ? (
         <div>
           <label className="block text-sm font-medium text-fg2 mb-1">Тип</label>
-          <Select value={typeId || undefined} required placeholder="Выберите тип…" aria-label="Тип"
-            onValueChange={newId => {
+          <button type="button" onClick={() => setPickerOpen(true)} aria-label="Тип"
+            className="w-full h-10 flex items-center justify-between gap-2 rounded-md border border-stroke-strong bg-surface px-3 text-sm text-left transition-colors hover:border-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand">
+            <span className={typeId ? 'text-fg1 truncate' : 'text-fg4'}>
+              {typeId ? (allSelectableTypes.find(c => c.id === typeId)?.name ?? typeId) : 'Выберите тип…'}
+            </span>
+            <ChevronDown size={16} className="text-fg4 shrink-0" />
+          </button>
+          <TypePicker
+            open={pickerOpen} onOpenChange={setPickerOpen}
+            recentKey={`common-data-type:${scope}`}
+            types={[
+              ...compositeTypes.map<PickType>(ct => ({ id: ct.id, name: ct.name, code: ct.code, section: 'Составные типы' })),
+              ...(documentTypes ?? []).map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Типы документов (внешние)' })),
+            ]}
+            onSelect={newId => {
               setTypeId(newId);
               const t = allSelectableTypes.find(c => c.id === newId);
               setValues(t ? getDefaultValues(resolveEffectiveFields(t, allDocTypes)) : {});
-            }}>
-            {compositeTypes.length > 0 && (
-              <SelectGroup label="Составные типы">
-                {compositeTypes.map(ct => <SelectItem key={ct.id} value={ct.id}>{ct.name} ({ct.code})</SelectItem>)}
-              </SelectGroup>
-            )}
-            {documentTypes.length > 0 && (
-              <SelectGroup label="Типы документов (внешние)">
-                {documentTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name} ({dt.code})</SelectItem>)}
-              </SelectGroup>
-            )}
-          </Select>
+            }}
+          />
         </div>
       ) : (
         <p className="text-sm text-fg3">

--- a/src/client/src/shared/ui/TypePicker.tsx
+++ b/src/client/src/shared/ui/TypePicker.tsx
@@ -1,6 +1,24 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Search, Boxes, FileText } from 'lucide-react';
+import {
+  Search, Boxes, FileText, Building2, User, MapPin, Wrench, Package, Ruler, CalendarDays,
+  type LucideIcon,
+} from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+
+// Иконка семейства по эвристике (имя+код). Категории из данных не выводятся (нет тегов/единого
+// parentId-дерева), поэтому иконку подбираем по ключевым словам; неточное совпадение безвредно.
+function typeIcon(t: PickType): LucideIcon {
+  const s = `${t.name} ${t.code}`.toLowerCase();
+  if (/организ|сро|надзор|подрядчик|заказчик/.test(s)) return Building2;
+  if (/персон|фио|подписант/.test(s)) return User;
+  if (/адрес|координат|объект строит/.test(s)) return MapPin;
+  if (/работ/.test(s)) return Wrench;
+  if (/материал/.test(s)) return Package;
+  if (/единиц|измерен|угол|лаборатори/.test(s)) return Ruler;
+  if (/период|срок|дата/.test(s)) return CalendarDays;
+  if (t.section.toLowerCase().includes('документ')) return FileText;
+  return Boxes;
+}
 
 /**
  * Searchable-пикер типа (issue: длинный несортированный Select) — модалка в стиле командной
@@ -96,7 +114,7 @@ export function TypePicker({ open, onOpenChange, types, onSelect, recentKey, tit
                 <ul>
                   {g.items.map(t => {
                     const i = ++idx;
-                    const Icon = t.section.toLowerCase().includes('документ') ? FileText : Boxes;
+                    const Icon = typeIcon(t);
                     const code = t.code.trim();
                     const showCode = !!code && code.toLowerCase() !== t.name.trim().toLowerCase();
                     return (

--- a/src/client/src/shared/ui/TypePicker.tsx
+++ b/src/client/src/shared/ui/TypePicker.tsx
@@ -1,0 +1,122 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { Search, Boxes, FileText } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+/**
+ * Searchable-пикер типа (issue: длинный несортированный Select) — модалка в стиле командной
+ * палитры: поиск по имени+коду, блок «Недавние» (localStorage), сортировка по алфавиту,
+ * клавиатура ↑↓/Enter/Esc, MD3-строки с ведущей иконкой семейства. Код показывается только
+ * если отличается от имени (убираем шум «Название (Код)»).
+ */
+export interface PickType { id: string; name: string; code: string; section: string }
+
+const RECENTS_CAP = 6;
+
+export function TypePicker({ open, onOpenChange, types, onSelect, recentKey, title = 'Выберите тип' }: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  types: PickType[];
+  onSelect: (id: string) => void;
+  recentKey?: string;
+  title?: string;
+}) {
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+
+  const storeKey = recentKey ? `typepicker-recents:${recentKey}` : null;
+  function loadRecents(): string[] {
+    if (!storeKey) return [];
+    try { return JSON.parse(localStorage.getItem(storeKey) || '[]') as string[]; } catch { return []; }
+  }
+  function pushRecent(id: string) {
+    if (!storeKey) return;
+    const next = [id, ...loadRecents().filter(x => x !== id)].slice(0, RECENTS_CAP);
+    localStorage.setItem(storeKey, JSON.stringify(next));
+  }
+
+  const q = query.trim().toLowerCase();
+  const sections = useMemo(() => {
+    const byName = (a: PickType, b: PickType) => a.name.localeCompare(b.name, 'ru');
+    const matches = (t: PickType) => `${t.name} ${t.code}`.toLowerCase().includes(q);
+    const groups: { label: string; items: PickType[] }[] = [];
+
+    if (!q) {
+      const recents = loadRecents()
+        .map(id => types.find(t => t.id === id))
+        .filter((t): t is PickType => !!t);
+      if (recents.length) groups.push({ label: 'Недавние', items: recents });
+    }
+    const order: string[] = [];
+    const bySection = new Map<string, PickType[]>();
+    for (const t of types) {
+      if (q && !matches(t)) continue;
+      if (!bySection.has(t.section)) { bySection.set(t.section, []); order.push(t.section); }
+      bySection.get(t.section)!.push(t);
+    }
+    for (const s of order) groups.push({ label: s, items: bySection.get(s)!.slice().sort(byName) });
+    return groups;
+  }, [types, q]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const flat = useMemo(() => sections.flatMap(g => g.items), [sections]);
+
+  useEffect(() => { setActive(0); }, [query]);
+  useEffect(() => { if (!open) setQuery(''); }, [open]);
+
+  function choose(t: PickType) { pushRecent(t.id); onSelect(t.id); onOpenChange(false); }
+
+  function onKey(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, flat.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); const t = flat[active]; if (t) choose(t); }
+  }
+
+  let idx = -1; // сквозной индекс строки (совпадает с порядком flat), корректен при дублях «Недавние»
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" style={{ backdropFilter: 'blur(2px)' }} />
+        <Dialog.Content
+          className="fixed left-1/2 top-16 z-50 w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 flex flex-col max-h-[calc(100vh-8rem)] overflow-hidden rounded-2xl border border-stroke bg-surface focus:outline-none"
+          style={{ boxShadow: 'var(--f-shadow28)' }}
+        >
+          <Dialog.Title className="sr-only">{title}</Dialog.Title>
+          <div className="flex items-center gap-2 border-b border-stroke px-4 shrink-0">
+            <Search size={16} className="shrink-0 text-fg4" />
+            <input autoFocus value={query} onChange={e => setQuery(e.target.value)} onKeyDown={onKey}
+              placeholder="Поиск типа по имени или коду…" aria-label="Поиск типа"
+              className="h-12 flex-1 bg-transparent text-sm text-fg1 outline-none placeholder:text-fg4" />
+            <kbd className="rounded border border-stroke px-1 text-[10px] text-fg4">Esc</kbd>
+          </div>
+          <ul className="overflow-y-auto p-2" role="listbox" aria-label={title}>
+            {flat.length === 0 ? (
+              <li className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</li>
+            ) : sections.map(g => (
+              <li key={g.label}>
+                <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-fg4">{g.label}</div>
+                <ul>
+                  {g.items.map(t => {
+                    const i = ++idx;
+                    const Icon = t.section.toLowerCase().includes('документ') ? FileText : Boxes;
+                    const code = t.code.trim();
+                    const showCode = !!code && code.toLowerCase() !== t.name.trim().toLowerCase();
+                    return (
+                      <li key={`${g.label}:${t.id}`} role="option" aria-selected={i === active}>
+                        <button type="button" onMouseEnter={() => setActive(i)} onClick={() => choose(t)}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                            i === active ? 'bg-tonal text-on-tonal' : 'text-fg1 hover:bg-black/5 dark:hover:bg-white/10'}`}>
+                          <Icon size={16} className={i === active ? 'text-on-tonal' : 'text-fg3'} />
+                          <span className="flex-1 truncate">{t.name}</span>
+                          {showCode && <span className={`text-[11px] font-mono shrink-0 ${i === active ? 'text-on-tonal/80' : 'text-fg4'}`}>{code}</span>}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.57</Version>
+    <Version>0.23.58</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
По итогам UX-анализа с Дизайнером — длинный несортированный `Select` выбора типа в диалоге
создания записи «Общих данных» заменён на **searchable-пикер** (стиль командной палитры).

## Что вошло
- **`shared/ui/TypePicker`**: Radix Dialog + **поиск** по имени+коду, **сортировка по алфавиту**,
  блок **«Недавние»** (localStorage, ключ по scope), клавиатура **↑↓/Enter/Esc**, пустое состояние.
- **Иконки семейств** (эвристика имя/код): Организация/СРО/надзор→Building2, Персона/ФИО→User,
  Адрес/координаты/объект→MapPin, Работа→Wrench, Материал→Package, единицы/измерения/лаборатория→Ruler,
  период→CalendarDays, документы→FileText, иначе Boxes. Ускоряет сканирование.
- **Убран шум `Название (Код)`**: код показывается только если ≠ имени, приглушённым mono-текстом.
- **`CatalogEntryForm`**: `Select` → MD3-триггер-поле (имя типа + шеврон) → открывает `TypePicker`.
  Дефолты при выборе засеваются как раньше. Применяется во всех scope (форма общая).

## Категории — осознанно пропущены
Анализ данных показал: авто-категоризации нет (у типов пустые `tags`, документы висят на одном
общем `parentId`-корне, семейство даёт только кластер «Организация»). Осмысленные категории-чипы
потребовали бы явного поля `category` на типе (бэкенд + экран настройки, через Архитектора) — по
решению пользователя не делаем; поиск+иконки закрывают основную боль.

## Проверка
`tsc -b` / `build` / `vitest` **115**, **keyboard smoke 11/11**; скриншоты (список отсортирован,
дедуп кода, различимые иконки семейств; поиск «орг» фильтрует по имени/коду).

Версия → 0.23.58.