### PR TITLE
fix(md3): настоящий notch у TextField — прозрачный контейнер, вырез рамки (#178)

### DIFF
--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -37,24 +37,24 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
       <div className="relative">
         <input
           ref={ref} id={inputId} placeholder=" " required={required}
-          className={`peer w-full h-12 rounded-md bg-transparent text-sm text-fg1 px-3 ` +
-            `outline-none disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${className}`}
+          className={`peer w-full h-14 rounded-md bg-transparent text-sm text-fg1 px-4 ` +
+            `outline-none disabled:opacity-50 ${trailing ? 'pr-11' : ''} ${className}`}
           {...rest}
         />
         {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
         {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
             вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2 ` +
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
             `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
-          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
+          <legend className="h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
           </legend>
         </fieldset>
         <label
           htmlFor={inputId}
-          className={`absolute left-2 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
-            `block max-w-[calc(100%-1rem)] truncate ` +
+          className={`absolute left-3 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
+            `block max-w-[calc(100%-1.5rem)] truncate ` +
             `peer-focus:top-[-8px] peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-[-8px] peer-[:not(:placeholder-shown)]:text-xs`}
         >
           {label}{required && <span className="ml-0.5 text-danger">*</span>}

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -42,9 +42,12 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
           {...rest}
         />
         {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
+        {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
+            вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2`}>
-          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100 peer-focus:max-w-full peer-[:not(:placeholder-shown)]:max-w-full">
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2 ` +
+            `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
+          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
           </legend>
         </fieldset>

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -45,7 +45,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
             вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
+          className={`pointer-events-none absolute inset-x-0 bottom-0 top-[-5px] m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
             `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
           <legend className="h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
@@ -55,7 +55,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
           htmlFor={inputId}
           className={`absolute left-3 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
             `block max-w-[calc(100%-1.5rem)] truncate ` +
-            `peer-focus:top-[-8px] peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-[-8px] peer-[:not(:placeholder-shown)]:text-xs`}
+            `peer-focus:top-0 peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:text-xs`}
         >
           {label}{required && <span className="ml-0.5 text-danger">*</span>}
         </label>

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -1,12 +1,12 @@
 import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
 
 /**
- * MD3 outlined-текстовое поле (issue #110, фаза 2e) с плавающей подписью: подпись сидит
- * внутри поля, когда оно пустое и без фокуса, и всплывает в вырез рамки при фокусе/заполнении.
- * Фокус — рамка primary + inset-кольцо (без сдвига раскладки). Тема light/dark через токены.
+ * MD3 outlined-текстовое поле (issue #110/#178) с плавающей подписью. Реализован НАСТОЯЩИЙ
+ * вырез рамки (MD3 notch) через fieldset+legend: контейнер прозрачный, верхняя рамка реально
+ * прерывается под меткой. Благодаря этому поле корректно выглядит на ЛЮБОМ фоне (surface/base/
+ * карточка), а не только на surface. Тема light/dark — через токены.
  *
  * Требует placeholder=" " (пробел) — по нему :placeholder-shown отличает пустое поле.
- * Фон подписи (bg-surface) «прорезает» рамку — поле должно лежать на surface (карточка/модалка).
  */
 export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
   label: string;
@@ -27,29 +27,36 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
   const autoId = useId();
   const inputId = id ?? autoId;
   const bad = !!error || invalid;
-  const border = bad
-    ? 'border-danger focus:border-danger focus:ring-1 focus:ring-inset focus:ring-danger'
-    : 'border-stroke-strong focus:border-brand focus:ring-1 focus:ring-inset focus:ring-brand';
-  const labelFocus = bad ? 'peer-focus:text-danger' : 'peer-focus:text-brand';
+  const borderColor = bad
+    ? 'border-danger peer-focus:border-danger'
+    : 'border-stroke-strong peer-focus:border-brand';
+  const labelColor = bad ? 'text-danger peer-focus:text-danger' : 'text-fg4 peer-focus:text-brand';
+
   return (
     <div className={containerClassName}>
       <div className="relative">
         <input
           ref={ref} id={inputId} placeholder=" " required={required}
-          className={`peer w-full h-12 rounded-md border bg-surface text-sm text-fg1 px-3 pt-4 pb-1 ` +
-            `outline-none transition-colors disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${border} ${className}`}
+          className={`peer w-full h-12 rounded-md bg-transparent text-sm text-fg1 px-3 ` +
+            `outline-none disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${className}`}
           {...rest}
         />
+        {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
+        <fieldset aria-hidden
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2`}>
+          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100 peer-focus:max-w-full peer-[:not(:placeholder-shown)]:max-w-full">
+            <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
+          </legend>
+        </fieldset>
         <label
           htmlFor={inputId}
-          className={`absolute left-2.5 top-3.5 px-1 text-sm bg-surface text-fg4 pointer-events-none transition-all ` +
-            `block max-w-[calc(100%-1.25rem)] truncate ` +
-            `peer-focus:top-[-7px] peer-focus:text-xs ${labelFocus} ` +
-            `peer-[:not(:placeholder-shown)]:top-[-7px] peer-[:not(:placeholder-shown)]:text-xs`}
+          className={`absolute left-2 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
+            `block max-w-[calc(100%-1rem)] truncate ` +
+            `peer-focus:top-[-8px] peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-[-8px] peer-[:not(:placeholder-shown)]:text-xs`}
         >
           {label}{required && <span className="ml-0.5 text-danger">*</span>}
         </label>
-        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2">{trailing}</div>}
+        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">{trailing}</div>}
       </div>
       {error
         ? <p className="mt-1 px-1 text-xs text-danger">{error}</p>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.58</Version>
+    <Version>0.23.59</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Проблема (#178)
В Профиле поля ввода текста выглядели не по MD3. Причина: `TextField` имитировал «вырез»
рамки фоном метки (`bg-surface`), что верно только на `surface` (модалки), а Профиль — на
`bg-base`, отсюда рассинхрон (метка на несовпадающем фоне).

## Фикс (централизованный)
Переделал `TextField` на **настоящий MD3 outlined notch** через `fieldset`+`legend`:
контейнер **прозрачный**, верхняя рамка **реально прерывается** под плавающей меткой —
корректно на **любом фоне**. Один компонент → чинит Профиль и «другие места» (как отмечено в issue).

- Focus: рамка 2px `brand` + метка `brand`; error: `danger`; плавающая метка обрезается в одну строку.
- `trailing`/`hint`/`error`/`className`-passthrough сохранены.

## Проверка
Скриншоты: **Профиль** (`bg-base`) и **Логин** (surface, focus) — вырез настоящий, фон прозрачный,
совпадает с макетом «Контейнер прозрачный, рамка прерывается под меткой».
`tsc -b` / `build` / `vitest` **115**, **keyboard smoke 11/11**.

Версия → 0.23.59. Дальше — #176 (даты) переиспользует этот шелл.