### PR TITLE
feat(md3): поля даты в outlined-стиле (DateField) (#176)

### DIFF
--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { formatDateRu, ruToISO } from '@/shared/utils/date';
 import { DateInput } from '@/shared/ui/DateInput';
+import { DateField } from '@/shared/ui/DateField';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import { TextField } from '@/shared/ui/TextField';
 import type { SchemaField } from '@/shared/api/schema';
@@ -96,9 +97,11 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
   if (field.type === 'primitive' && primitiveTypeDef) {
     const bt = primitiveTypeDef.baseType;
     if (bt === 'date') {
-      return withLabel(<DateInput value={strVal} onChange={v => onChange(v)}
-        precision={primitiveTypeDef.constraints.datePrecision ?? 'day'}
-        className={cls} disabled={readOnly} />);
+      const prec = primitiveTypeDef.constraints.datePrecision ?? 'day';
+      return label != null
+        ? <DateField label={label} required={field.required} hint={hint ?? primitiveTypeDef.description}
+            invalid={invalid} value={strVal} onChange={v => onChange(v)} precision={prec} disabled={readOnly} />
+        : <DateInput value={strVal} onChange={v => onChange(v)} precision={prec} className={cls} disabled={readOnly} />;
     }
     const step = bt === 'number' && primitiveTypeDef.constraints.integer ? 1 : undefined;
     const onCh = (v: string) => onChange(bt === 'number' ? (v === '' ? '' : Number(v)) : v);
@@ -112,7 +115,10 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
     );
   }
   if (field.type === 'date') {
-    return withLabel(<DateInput value={strVal} onChange={v => onChange(v)} className={cls} disabled={readOnly} />);
+    return label != null
+      ? <DateField label={label} required={field.required} hint={hint} invalid={invalid}
+          value={strVal} onChange={v => onChange(v)} disabled={readOnly} />
+      : <DateInput value={strVal} onChange={v => onChange(v)} className={cls} disabled={readOnly} />;
   }
   const onCh = (v: string) => onChange(field.type === 'number' ? (v === '' ? '' : Number(v)) : v);
   if (label != null)

--- a/src/client/src/shared/ui/DateField.tsx
+++ b/src/client/src/shared/ui/DateField.tsx
@@ -32,12 +32,12 @@ export function DateField({
           <DateInput value={value} onChange={onChange} precision={precision} disabled={disabled} />
         </div>
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-3 transition-colors ${borderColor} ${focused ? 'border-2' : ''}`}>
+          className={`pointer-events-none absolute inset-x-0 bottom-0 top-[-5px] m-0 rounded-md border px-3 transition-colors ${borderColor} ${focused ? 'border-2' : ''}`}>
           <legend className="h-2.5 w-auto max-w-full whitespace-nowrap p-0 text-xs">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
           </legend>
         </fieldset>
-        <span className={`absolute left-3 top-[-8px] px-1 text-xs pointer-events-none transition-colors ${labelColor} block max-w-[calc(100%-1.5rem)] truncate`}>
+        <span className={`absolute left-3 top-0 -translate-y-1/2 px-1 text-xs pointer-events-none transition-colors ${labelColor} block max-w-[calc(100%-1.5rem)] truncate`}>
           {label}{required && <span className="ml-0.5 text-danger">*</span>}
         </span>
       </div>

--- a/src/client/src/shared/ui/DateField.tsx
+++ b/src/client/src/shared/ui/DateField.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { DateInput } from './DateInput';
+import type { DatePrecision } from '@/shared/api/types';
+
+/**
+ * MD3 outlined-поле даты (issue #176): сегментный ввод ДД.ММ.ГГГГ внутри той же outlined-рамки
+ * с вырезом, что и TextField (#178). Поскольку у даты всегда видны плейсхолдеры сегментов,
+ * метка держится ПОСТОЯННО во всплывшем положении (notch всегда открыт) — это штатный MD3-паттерн
+ * для полей с форматной подсказкой. Фон прозрачный → корректно на любом фоне.
+ */
+export function DateField({
+  label, value, onChange, precision, required, hint, invalid, disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (iso: string) => void;
+  precision?: DatePrecision;
+  required?: boolean;
+  hint?: string;
+  invalid?: boolean;
+  disabled?: boolean;
+}) {
+  const [focused, setFocused] = useState(false);
+  const borderColor = invalid ? 'border-danger' : focused ? 'border-brand' : 'border-stroke-strong';
+  const labelColor = invalid ? 'text-danger' : focused ? 'text-brand' : 'text-fg4';
+  return (
+    <div>
+      <div className="relative"
+        onFocus={() => setFocused(true)}
+        onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocused(false); }}>
+        <div className={`h-12 rounded-md px-3 flex items-center text-sm text-fg1 ${disabled ? 'opacity-50' : ''}`}>
+          <DateInput value={value} onChange={onChange} precision={precision} disabled={disabled} />
+        </div>
+        <fieldset aria-hidden
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} ${focused ? 'border-2' : ''}`}>
+          <legend className="ml-1 h-2.5 w-auto max-w-full whitespace-nowrap p-0 text-xs">
+            <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
+          </legend>
+        </fieldset>
+        <span className={`absolute left-2 top-[-8px] px-1 text-xs pointer-events-none transition-colors ${labelColor} block max-w-[calc(100%-1rem)] truncate`}>
+          {label}{required && <span className="ml-0.5 text-danger">*</span>}
+        </span>
+      </div>
+      {hint && <p className="mt-1 px-1 text-xs text-fg4">{hint}</p>}
+    </div>
+  );
+}

--- a/src/client/src/shared/ui/DateField.tsx
+++ b/src/client/src/shared/ui/DateField.tsx
@@ -28,16 +28,16 @@ export function DateField({
       <div className="relative"
         onFocus={() => setFocused(true)}
         onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocused(false); }}>
-        <div className={`h-12 rounded-md px-3 flex items-center text-sm text-fg1 ${disabled ? 'opacity-50' : ''}`}>
+        <div className={`h-14 rounded-md px-4 flex items-center text-sm text-fg1 ${disabled ? 'opacity-50' : ''}`}>
           <DateInput value={value} onChange={onChange} precision={precision} disabled={disabled} />
         </div>
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} ${focused ? 'border-2' : ''}`}>
-          <legend className="ml-1 h-2.5 w-auto max-w-full whitespace-nowrap p-0 text-xs">
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-3 transition-colors ${borderColor} ${focused ? 'border-2' : ''}`}>
+          <legend className="h-2.5 w-auto max-w-full whitespace-nowrap p-0 text-xs">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
           </legend>
         </fieldset>
-        <span className={`absolute left-2 top-[-8px] px-1 text-xs pointer-events-none transition-colors ${labelColor} block max-w-[calc(100%-1rem)] truncate`}>
+        <span className={`absolute left-3 top-[-8px] px-1 text-xs pointer-events-none transition-colors ${labelColor} block max-w-[calc(100%-1.5rem)] truncate`}>
           {label}{required && <span className="ml-0.5 text-danger">*</span>}
         </span>
       </div>

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -37,24 +37,24 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
       <div className="relative">
         <input
           ref={ref} id={inputId} placeholder=" " required={required}
-          className={`peer w-full h-12 rounded-md bg-transparent text-sm text-fg1 px-3 ` +
-            `outline-none disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${className}`}
+          className={`peer w-full h-14 rounded-md bg-transparent text-sm text-fg1 px-4 ` +
+            `outline-none disabled:opacity-50 ${trailing ? 'pr-11' : ''} ${className}`}
           {...rest}
         />
         {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
         {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
             вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2 ` +
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
             `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
-          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
+          <legend className="h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
           </legend>
         </fieldset>
         <label
           htmlFor={inputId}
-          className={`absolute left-2 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
-            `block max-w-[calc(100%-1rem)] truncate ` +
+          className={`absolute left-3 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
+            `block max-w-[calc(100%-1.5rem)] truncate ` +
             `peer-focus:top-[-8px] peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-[-8px] peer-[:not(:placeholder-shown)]:text-xs`}
         >
           {label}{required && <span className="ml-0.5 text-danger">*</span>}

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -42,9 +42,12 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
           {...rest}
         />
         {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
+        {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
+            вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2`}>
-          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100 peer-focus:max-w-full peer-[:not(:placeholder-shown)]:max-w-full">
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2 ` +
+            `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
+          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
           </legend>
         </fieldset>

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -45,7 +45,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
             вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
         <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
+          className={`pointer-events-none absolute inset-x-0 bottom-0 top-[-5px] m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
             `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
           <legend className="h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
             <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
@@ -55,7 +55,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
           htmlFor={inputId}
           className={`absolute left-3 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
             `block max-w-[calc(100%-1.5rem)] truncate ` +
-            `peer-focus:top-[-8px] peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-[-8px] peer-[:not(:placeholder-shown)]:text-xs`}
+            `peer-focus:top-0 peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:text-xs`}
         >
           {label}{required && <span className="ml-0.5 text-danger">*</span>}
         </label>

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -1,12 +1,12 @@
 import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
 
 /**
- * MD3 outlined-текстовое поле (issue #110, фаза 2e) с плавающей подписью: подпись сидит
- * внутри поля, когда оно пустое и без фокуса, и всплывает в вырез рамки при фокусе/заполнении.
- * Фокус — рамка primary + inset-кольцо (без сдвига раскладки). Тема light/dark через токены.
+ * MD3 outlined-текстовое поле (issue #110/#178) с плавающей подписью. Реализован НАСТОЯЩИЙ
+ * вырез рамки (MD3 notch) через fieldset+legend: контейнер прозрачный, верхняя рамка реально
+ * прерывается под меткой. Благодаря этому поле корректно выглядит на ЛЮБОМ фоне (surface/base/
+ * карточка), а не только на surface. Тема light/dark — через токены.
  *
  * Требует placeholder=" " (пробел) — по нему :placeholder-shown отличает пустое поле.
- * Фон подписи (bg-surface) «прорезает» рамку — поле должно лежать на surface (карточка/модалка).
  */
 export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
   label: string;
@@ -27,29 +27,36 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
   const autoId = useId();
   const inputId = id ?? autoId;
   const bad = !!error || invalid;
-  const border = bad
-    ? 'border-danger focus:border-danger focus:ring-1 focus:ring-inset focus:ring-danger'
-    : 'border-stroke-strong focus:border-brand focus:ring-1 focus:ring-inset focus:ring-brand';
-  const labelFocus = bad ? 'peer-focus:text-danger' : 'peer-focus:text-brand';
+  const borderColor = bad
+    ? 'border-danger peer-focus:border-danger'
+    : 'border-stroke-strong peer-focus:border-brand';
+  const labelColor = bad ? 'text-danger peer-focus:text-danger' : 'text-fg4 peer-focus:text-brand';
+
   return (
     <div className={containerClassName}>
       <div className="relative">
         <input
           ref={ref} id={inputId} placeholder=" " required={required}
-          className={`peer w-full h-12 rounded-md border bg-surface text-sm text-fg1 px-3 pt-4 pb-1 ` +
-            `outline-none transition-colors disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${border} ${className}`}
+          className={`peer w-full h-12 rounded-md bg-transparent text-sm text-fg1 px-3 ` +
+            `outline-none disabled:opacity-50 ${trailing ? 'pr-10' : ''} ${className}`}
           {...rest}
         />
+        {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
+        <fieldset aria-hidden
+          className={`pointer-events-none absolute inset-x-0 bottom-0 -top-2 m-0 rounded-md border px-2 transition-colors ${borderColor} peer-focus:border-2`}>
+          <legend className="ml-1 h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100 peer-focus:max-w-full peer-[:not(:placeholder-shown)]:max-w-full">
+            <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
+          </legend>
+        </fieldset>
         <label
           htmlFor={inputId}
-          className={`absolute left-2.5 top-3.5 px-1 text-sm bg-surface text-fg4 pointer-events-none transition-all ` +
-            `block max-w-[calc(100%-1.25rem)] truncate ` +
-            `peer-focus:top-[-7px] peer-focus:text-xs ${labelFocus} ` +
-            `peer-[:not(:placeholder-shown)]:top-[-7px] peer-[:not(:placeholder-shown)]:text-xs`}
+          className={`absolute left-2 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
+            `block max-w-[calc(100%-1rem)] truncate ` +
+            `peer-focus:top-[-8px] peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-[-8px] peer-[:not(:placeholder-shown)]:text-xs`}
         >
           {label}{required && <span className="ml-0.5 text-danger">*</span>}
         </label>
-        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2">{trailing}</div>}
+        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">{trailing}</div>}
       </div>
       {error
         ? <p className="mt-1 px-1 text-xs text-danger">{error}</p>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.58</Version>
+    <Version>0.23.59</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.23.59</Version>
+    <Version>0.23.60</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Привёл поля ввода даты к MD3 — единообразно с текстовыми полями (#178).

> ⚠️ **Стек на #180 (#178).** Мёржить после #178.

## Что вошло
- **`shared/ui/DateField`**: сегментный `DateInput` (ДД.ММ.ГГГГ) внутри той же outlined-рамки с
  **вырезом**, что и `TextField`. Т.к. у даты всегда видны плейсхолдеры сегментов, метка держится
  **постоянно во всплывшем положении** (штатный MD3-паттерн для полей с форматной подсказкой),
  контейнер прозрачный → корректно на любом фоне; focus — рамка 2px `brand`.
- **`PrimitiveInput`**: форменные date-поля (когда задан `label`) рендерятся через `DateField`;
  **инлайновые** (в ячейках табличного редактора, `label==null`) остаются бесшовным `DateInput`.

## Проверка
Скриншот: запись «Период действия» — поля «Начало»/«Окончание» в outlined-стиле рядом с
текстовыми полями (единый вид). `tsc -b` / `build` / `vitest` **115**, **keyboard smoke 11/11**.

Версия → 0.23.60. Закрывает #176.