### PR TITLE
feat(editor): форма документа → MD3 full-screen + просторная раскладка (#189)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -284,10 +284,14 @@ function SetDetail() {
         const liveInstance = set.instances.find(i => i.id === editInstance.id) ?? editInstance;
         return (
           <Modal open={!!editInstance} onOpenChange={open => { if (!open) { setEditInstance(null); setEditDirty(false); } }}
-            title="Редактировать документ" wide isDirty={editDirty} flushBody>
-            <InstanceEditor key={liveInstance.id} instance={liveInstance} setId={setId} docType={docTypeMap[liveInstance.documentTypeId]}
-              allDocTypes={docTypes} otherInstances={otherInstances}
-              onClose={() => { setEditInstance(null); setEditDirty(false); }} onDirtyChange={setEditDirty} />
+            title={liveInstance.name || docTypeMap[liveInstance.documentTypeId]?.name || 'Редактировать документ'}
+            fullScreen headerless isDirty={editDirty} flushBody>
+            {requestClose => (
+              <InstanceEditor key={liveInstance.id} instance={liveInstance} setId={setId} docType={docTypeMap[liveInstance.documentTypeId]}
+                allDocTypes={docTypes} otherInstances={otherInstances}
+                onClose={() => { setEditInstance(null); setEditDirty(false); }} onDirtyChange={setEditDirty}
+                requestClose={requestClose} />
+            )}
           </Modal>
         );
       })()}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -293,7 +293,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
             return (
               <div key={field.key} className="col-span-2">
                 {field.type !== 'boolean' && field.type !== 'complex' && field.type !== 'array' && (
-                  <label className="block text-[13px] font-medium text-fg2 mb-0.5 leading-tight">
+                  <label className="block text-xs font-medium text-fg2 mb-1">
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
                     {!field.required && <span className="ml-1 text-[10px] text-fg4 font-normal">опц.</span>}
@@ -302,8 +302,8 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                 )}
                 {field.type === 'complex' ? (
                   <div>
-                    <div className="flex items-center justify-between mb-0.5">
-                      <label className="block text-[13px] font-medium text-fg2 leading-tight">
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-xs font-medium text-fg2">
                         {field.title}
                         {field.required && <span className="ml-0.5 text-danger">*</span>}
                       </label>
@@ -354,7 +354,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
             <div key={field.key} className="col-span-1 min-w-0">
               {bound ? (
                 <>
-                  <label className="block text-[13px] font-medium text-fg2 mb-0.5 leading-tight">
+                  <label className="block text-xs font-medium text-fg2 mb-1">
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
                     {primitiveDef && <span className="ml-1 text-[10px] text-fg4 font-normal">· {primitiveDef.name}</span>}
@@ -388,7 +388,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       if (auto.length === 0) return fieldGrid(fields);
       const normal = fields.filter(f => !sourceBoundFields.has(f.key));
       return (
-        <div className="space-y-2.5">
+        <div className="space-y-4">
           {normal.length > 0 && fieldGrid(normal)}
           <AutoFieldsSection count={auto.length}>{fieldGrid(auto)}</AutoFieldsSection>
         </div>
@@ -445,7 +445,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
               {isExpanded ? <ChevronUp size={16} className="text-fg4 shrink-0" /> : <ChevronDown size={16} className="text-fg4 shrink-0" />}
             </button>
             {isExpanded && (
-              <div className="px-4 pb-4 pt-1">
+              <div className="px-4 pb-4 pt-2">
                 {renderFields(section.fields)}
               </div>
             )}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database } from 'lucide-react';
+import { Loader2, FileText, Download, Eye, Pencil, ChevronDown, ChevronUp, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Mail, Database, X } from 'lucide-react';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
 import { EmailSendDialog } from '../EmailSendDialog';
@@ -378,7 +378,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     }
 
     function fieldGrid(fields: SchemaField[]) {
-      return <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">{fields.map(renderCell)}</div>;
+      return <div className="grid grid-cols-2 gap-x-4 gap-y-4">{fields.map(renderCell)}</div>;
     }
 
     // Поля, заполняемые из источника данных (read-only), прячем под сворачиваемую секцию
@@ -397,7 +397,8 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
 
   return (
     <div className="flex flex-col min-h-0 flex-1">
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className={`mx-auto px-6 py-6 ${showRail ? 'max-w-4xl' : 'max-w-3xl'}`}>
       <div className={showRail ? 'flex gap-5 items-start' : ''}>
       {showRail && (
         <SectionRail
@@ -432,27 +433,26 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
         const hasMissing = showValidation && section.fields.some(f => isFieldMissing(f, values[f.key]));
         return (
           <div key={section.key} id={`req-section-${section.key}`}
-            className="border border-stroke rounded-lg overflow-hidden scroll-mt-2">
+            className="bg-surface border border-stroke rounded-xl overflow-hidden scroll-mt-2">
             <button type="button"
               onClick={() => toggleGroup(section.key)}
-              className="w-full flex items-center gap-2 px-3 py-2.5 bg-base hover:bg-muted transition-colors text-left">
-              {isExpanded ? <ChevronUp size={13} className="text-fg4 shrink-0" /> : <ChevronDown size={13} className="text-fg4 shrink-0" />}
-              <span className="text-xs font-semibold uppercase tracking-wide text-fg2 flex-1">
-                {section.title}
-              </span>
-              <span className="text-xs text-fg4">{section.fields.length} п.</span>
+              className="w-full flex items-center gap-2.5 px-4 py-3 hover:bg-muted transition-colors text-left">
+              <span className="text-sm font-medium text-fg1 flex-1">{section.title}</span>
+              <span className="text-xs text-fg4 bg-muted rounded-full px-2 py-0.5">{section.fields.length} п.</span>
               {hasMissing && (
                 <span className="text-xs text-danger font-medium">! не заполнено</span>
               )}
+              {isExpanded ? <ChevronUp size={16} className="text-fg4 shrink-0" /> : <ChevronDown size={16} className="text-fg4 shrink-0" />}
             </button>
             {isExpanded && (
-              <div className="px-3 py-3">
+              <div className="px-4 pb-4 pt-1">
                 {renderFields(section.fields)}
               </div>
             )}
           </div>
         );
       })}
+      </div>
       </div>
       </div>
       </div>
@@ -751,10 +751,12 @@ function InstanceNameEditor({ instance, setId, docType }: {
 
 type InstanceTab = 'requisites' | 'datasets' | 'quality' | 'generation';
 
-export function InstanceEditor({ instance, setId, docType, allDocTypes, otherInstances, onClose, onDirtyChange }: {
+export function InstanceEditor({ instance, setId, docType, allDocTypes, otherInstances, onClose, onDirtyChange, requestClose }: {
   instance: DocumentInstance; setId: string; docType: DocumentType | undefined;
   allDocTypes: DocumentType[]; otherInstances: DocumentInstance[]; onClose: () => void;
   onDirtyChange?: (dirty: boolean) => void;
+  /** Закрытие с guard несохранённых изменений (крестик top app bar). */
+  requestClose?: () => void;
 }) {
   const schemaFields = docType ? resolveEffectiveFields(docType, allDocTypes) : [];
   const [tab, setTab] = useState<InstanceTab>('requisites');
@@ -836,19 +838,35 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           void doSaveAndClose();
         }
       }}>
-      <div className="shrink-0 px-6 pt-1 bg-surface">
-        <div className="flex items-center gap-2 mb-1 min-w-0">
+      {/* MD3 top app bar: крестик слева, имя+подзаголовок, статус, действия справа */}
+      <div className="shrink-0 bg-surface">
+        <div className="flex items-center gap-3 h-16 px-3 sm:px-4">
+          <button type="button" onClick={() => (requestClose ?? onClose)()} aria-label="Закрыть"
+            className="flex items-center justify-center w-11 h-11 shrink-0 rounded-full text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">
+            <X size={20} />
+          </button>
           <div className="flex-1 min-w-0">
             <InstanceNameEditor instance={instance} setId={setId} docType={docType} />
-            {instance.name && (
-              <p className="text-xs text-fg4 mt-0.5">{docType?.name}</p>
-            )}
+            <p className="text-xs text-fg4 mt-0.5 truncate">
+              {docType?.name ? `${docType.name} · Редактирование` : 'Редактирование'}
+            </p>
           </div>
-          <span className={`text-xs px-2 py-0.5 rounded font-medium shrink-0 ${STATUS_COLORS[instance.status] ?? 'bg-muted text-fg2'}`}>
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${STATUS_COLORS[instance.status] ?? 'bg-brand-subtle text-brand'}`}>
             {STATUS_LABELS[instance.status] ?? instance.status}
           </span>
+          {editable && (
+            <div className="flex items-center gap-2 shrink-0">
+              {savedFlash && <span className="text-sm text-success hidden sm:inline">Сохранено</span>}
+              <Button variant="text" onClick={() => void doSave()} disabled={saving}>
+                {saving ? 'Сохранение…' : 'Сохранить'}
+              </Button>
+              <Button variant="filled" onClick={() => void doSaveAndClose()} loading={saving} title="Ctrl+Enter">
+                Сохранить и закрыть
+              </Button>
+            </div>
+          )}
         </div>
-        <div role="tablist" aria-label="Разделы документа" className="flex border-b border-stroke gap-0">
+        <div role="tablist" aria-label="Разделы документа" className="flex border-b border-stroke gap-0 px-3 sm:px-4">
           {tabs.map(([key, label], i) => (
             <button key={key} role="tab" aria-selected={tab === key} tabIndex={tab === key ? 0 : -1}
               ref={el => { tabRefs.current[i] = el; }}
@@ -881,25 +899,6 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           <GenerationTab instance={instance} setId={setId} />
         </div>
       )}
-
-      {/* Основные действия диалога — только на редактируемых вкладках; на остальных — информационное сообщение */}
-      <div className="shrink-0 px-6 py-3 bg-surface border-t border-stroke flex items-center gap-2 flex-wrap">
-        {editable ? (
-          <>
-            <Button variant="filled" onClick={() => void doSaveAndClose()} loading={saving}
-              title="Ctrl+Enter">
-              Сохранить и закрыть
-            </Button>
-            <Button variant="text" onClick={() => void doSave()} disabled={saving}>
-              {saving ? 'Сохранение…' : 'Сохранить'}
-            </Button>
-            <Button variant="text" onClick={onClose} disabled={saving}>Отмена</Button>
-            {savedFlash && <span className="text-sm text-success">Сохранено</span>}
-          </>
-        ) : (
-          <span className="text-xs text-fg4">Изменения на этой вкладке применяются сразу</span>
-        )}
-      </div>
 
       {pendingTab && (
         <Modal

--- a/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
+++ b/src/client/src/features/document-sets/fields/BaseCandidatePicker.tsx
@@ -137,10 +137,10 @@ export function BaseInstancePanel({ title, candidates, selected, missing = false
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   return (
-    <div className="rounded-lg border border-stroke p-3 space-y-2">
-      <p className="text-xs font-semibold text-fg3 uppercase tracking-wide">
+    <div className="rounded-xl border border-stroke bg-surface p-4 space-y-2">
+      <p className="text-sm font-medium text-fg1">
         {selected?.proxy ? 'Роль — ссылка на реальный объект' : 'Базовый экземпляр'}
-        {title && !selected?.proxy && <span className="normal-case font-normal ml-1 text-fg4">({title})</span>}
+        {title && !selected?.proxy && <span className="font-normal ml-1 text-fg4">({title})</span>}
       </p>
       {selected ? (
         <>

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
-  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Link2, Pencil, Plus, Trash2, Unlink, X,
+  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Link2, Pencil, Plus, RefreshCw, Trash2, Unlink, X,
 } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
@@ -657,20 +657,38 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
 
+  const picker = (
+    <RefPickerModal
+      open={pickerOpen} onOpenChange={setPickerOpen}
+      compositeType={compositeType}
+      setId={setId} scope={scope} scopeId={scopeId}
+      otherInstances={otherInstances}
+      allDocTypes={allDocTypes}
+      onSelect={ref => onChange(ref)}
+    />
+  );
+
   if (isFieldRef(value)) {
+    // Link-строка (issue #189): нейтральный контейнер, имя — ссылка primary, тональный chip источника,
+    // два действия — «заменить» (открыть пикер) и «снять».
     return (
-      <div className="flex items-center gap-2 border border-brand-subtle rounded-lg px-3 py-2 bg-brand-subtle">
-        <Link2 size={14} className="text-brand shrink-0" />
-        <span className="flex-1 text-sm text-brand-hover font-medium">{value.displayName}</span>
+      <div className="flex items-center gap-1.5 border border-stroke rounded-lg pl-3 pr-1.5 py-1.5 bg-base">
+        <Link2 size={16} className="text-fg4 shrink-0" />
+        <span className="flex-1 text-sm text-brand font-medium truncate">{value.displayName}</span>
         {value.scope && (
-          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${SCOPE_COLORS[value.scope]}`}>
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${SCOPE_COLORS[value.scope]}`}>
             {SCOPE_LABELS[value.scope]}
           </span>
         )}
-        <button type="button" onClick={() => onChange({})}
-          className="p-1 text-brand hover:text-danger transition-colors" title="Снять ссылку">
-          <Unlink size={13} />
+        <button type="button" onClick={() => setPickerOpen(true)}
+          className="p-1.5 rounded-full text-fg4 hover:text-brand hover:bg-black/5 dark:hover:bg-white/10 transition-colors shrink-0" title="Заменить ссылку">
+          <RefreshCw size={14} />
         </button>
+        <button type="button" onClick={() => onChange({})}
+          className="p-1.5 rounded-full text-fg4 hover:text-danger hover:bg-black/5 dark:hover:bg-white/10 transition-colors shrink-0" title="Снять ссылку">
+          <Unlink size={14} />
+        </button>
+        {picker}
       </div>
     );
   }
@@ -738,17 +756,6 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
         );
       })}
     </div>
-  );
-
-  const picker = (
-    <RefPickerModal
-      open={pickerOpen} onOpenChange={setPickerOpen}
-      compositeType={compositeType}
-      setId={setId} scope={scope} scopeId={scopeId}
-      otherInstances={otherInstances}
-      allDocTypes={allDocTypes}
-      onSelect={ref => onChange(ref)}
-    />
   );
 
   // Вложенное составное (глубина ≥1): строка-сводка + правка в модалке — глубина формы не растёт.

--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -57,7 +57,7 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
   // Обёртка «подпись сверху» для не-floating контролов (textarea/select/date).
   const withLabel = (control: ReactNode) => label == null ? <>{control}</> : (
     <div>
-      <label className="block text-[13px] font-medium text-fg2 mb-0.5 leading-tight">
+      <label className="block text-xs font-medium text-fg2 mb-1">
         {label}{field.required && <span className="ml-0.5 text-danger">*</span>}
       </label>
       {control}

--- a/src/client/src/features/document-sets/fields/SectionRail.tsx
+++ b/src/client/src/features/document-sets/fields/SectionRail.tsx
@@ -1,5 +1,3 @@
-import { List } from 'lucide-react';
-
 export interface RailSection {
   key: string;
   title: string;
@@ -9,10 +7,10 @@ export interface RailSection {
 }
 
 /**
- * Rail разделов формы (issue #102 P3, #110 итерация): в диалогах свёрнут до узкой
- * полоски-аффорданса (иконка + точки по числу разделов) и раскрывается оверлеем по
- * наведению/фокусу — не отъедает ширину формы и не сдвигает раскладку.
- * Клавиатурой доступен: кнопки в tab-порядке, focus-within раскрывает панель.
+ * Rail разделов формы (issue #102 P3). В full-screen-редакторе (issue #189) — постоянная
+ * развёрнутая панель навигации с подписями разделов, sticky слева (места достаточно). Раньше
+ * (в тесной модалке, #110) была свёрнута до полоски-с-точками с раскрытием по наведению —
+ * теперь развёрнута обратно.
  */
 export function SectionRail({ sections, isActive, onSelect }: {
   sections: RailSection[];
@@ -20,40 +18,21 @@ export function SectionRail({ sections, isActive, onSelect }: {
   onSelect: (key: string) => void;
 }) {
   return (
-    <div className="group/rail relative hidden lg:block w-8 shrink-0 self-start sticky top-0">
-      {/* Свёрнутый аффорданс — исчезает при раскрытии */}
-      <div aria-hidden="true"
-        className="flex flex-col items-center gap-1 py-1.5 rounded-lg bg-muted/60 transition-opacity
-                   group-hover/rail:opacity-0 group-focus-within/rail:opacity-0">
-        <List size={14} className="text-fg4" />
-        {sections.map(s => (
-          <span key={s.key}
-            className={`w-1.5 h-1.5 rounded-full ${
-              s.missing ? 'bg-danger' : isActive(s.key) ? 'bg-fg2' : 'bg-fg4/40'}`} />
-        ))}
-      </div>
-
-      {/* Раскрываемая панель — оверлей, без сдвига раскладки */}
-      <nav aria-label="Разделы"
-        className="absolute left-0 top-0 z-20 w-52 space-y-0.5 rounded-lg border border-stroke bg-surface p-1.5
-                   shadow-[var(--f-shadow4)] transition -translate-x-1 opacity-0 pointer-events-none
-                   group-hover/rail:opacity-100 group-hover/rail:pointer-events-auto group-hover/rail:translate-x-0
-                   group-focus-within/rail:opacity-100 group-focus-within/rail:pointer-events-auto group-focus-within/rail:translate-x-0">
-        <div className="text-[10px] font-semibold uppercase tracking-wide text-fg4 px-2 pb-1">Разделы</div>
-        {sections.map(section => (
-          <button key={section.key} type="button" onClick={() => onSelect(section.key)}
-            aria-current={isActive(section.key) ? 'true' : undefined}
-            className={`w-full flex items-center gap-1.5 text-left text-xs px-2 py-1 rounded transition-colors
-              ${isActive(section.key) ? 'bg-base text-fg1 font-medium' : 'text-fg3 hover:bg-base hover:text-fg1'}`}>
-            <span className="flex-1 truncate">{section.title}</span>
-            {section.missing && <>
-              <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" aria-hidden="true" />
-              <span className="sr-only">не заполнено</span>
-            </>}
-            <span className="text-[10px] text-fg4 shrink-0">{section.count}</span>
-          </button>
-        ))}
-      </nav>
-    </div>
+    <nav aria-label="Разделы" className="hidden lg:block w-56 shrink-0 self-start sticky top-0 space-y-0.5">
+      <div className="text-xs font-medium text-fg4 px-2.5 pb-1">Разделы</div>
+      {sections.map(section => (
+        <button key={section.key} type="button" onClick={() => onSelect(section.key)}
+          aria-current={isActive(section.key) ? 'true' : undefined}
+          className={`w-full flex items-center gap-2 text-left text-sm px-2.5 py-1.5 rounded-lg transition-colors
+            ${isActive(section.key) ? 'bg-surface text-fg1 font-medium' : 'text-fg3 hover:bg-surface hover:text-fg1'}`}>
+          <span className="flex-1 truncate">{section.title}</span>
+          {section.missing && <>
+            <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" aria-hidden="true" />
+            <span className="sr-only">не заполнено</span>
+          </>}
+          <span className="text-xs text-fg4 shrink-0">{section.count}</span>
+        </button>
+      ))}
+    </nav>
   );
 }

--- a/src/client/src/shared/ui/Modal.tsx
+++ b/src/client/src/shared/ui/Modal.tsx
@@ -7,9 +7,16 @@ interface ModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
-  children: ReactNode;
+  /** Тело диалога. Функция-форма получает requestClose (с isDirty-guard) — содержимое само
+   *  рисует свою шапку/крестик (для full-screen top app bar). */
+  children: ReactNode | ((requestClose: () => void) => ReactNode);
   wide?: boolean;
   extraWide?: boolean;
+  /** Полноэкранный диалог-оверлей (на весь вьюпорт) — для крупных форм. Рендерится НАД
+   *  текущей страницей (она остаётся смонтированной): закрытие возвращает в прежний контекст. */
+  fullScreen?: boolean;
+  /** Не рисовать заголовок по умолчанию (содержимое рисует собственный top app bar). */
+  headerless?: boolean;
   isDirty?: boolean;
   /** Не добавлять собственный скролл и паддинг тела — содержимое само управляет
    *  раскладкой (фиксированный футер, прокрутка только области полей). */
@@ -19,7 +26,7 @@ interface ModalProps {
   footer?: ReactNode;
 }
 
-export function Modal({ open, onOpenChange, title, children, wide, extraWide, isDirty, flushBody, footer }: ModalProps) {
+export function Modal({ open, onOpenChange, title, children, wide, extraWide, fullScreen, headerless, isDirty, flushBody, footer }: ModalProps) {
   const [confirmClose, setConfirmClose] = useState(false);
 
   useEffect(() => {
@@ -39,10 +46,12 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
           style={{ backdropFilter: 'blur(2px)' }}
         />
         <Dialog.Content
-          className={`fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-[28px] max-h-[90vh] flex flex-col overflow-hidden focus:outline-none bg-surface border border-stroke ${
-            extraWide ? 'w-full max-w-5xl' : wide ? 'w-full max-w-2xl' : 'w-full max-w-lg'
-          }`}
-          style={{ boxShadow: 'var(--f-shadow28)' }}
+          className={fullScreen
+            ? 'fixed inset-0 z-50 flex flex-col overflow-hidden focus:outline-none bg-base'
+            : `fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-[28px] max-h-[90vh] flex flex-col overflow-hidden focus:outline-none bg-surface border border-stroke ${
+              extraWide ? 'w-full max-w-5xl' : wide ? 'w-full max-w-2xl' : 'w-full max-w-lg'
+            }`}
+          style={fullScreen ? undefined : { boxShadow: 'var(--f-shadow28)' }}
           onEscapeKeyDown={e => {
             if (isDirty) {
               e.preventDefault();
@@ -56,26 +65,27 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
             }
           }}
         >
-          <div className="flex items-center justify-between shrink-0 px-6 pt-6 pb-5">
-            <Dialog.Title className="text-base font-semibold text-fg1">
-              {title}
-            </Dialog.Title>
-            <button
-              type="button"
-              onClick={attemptClose}
-              aria-label="Закрыть"
-              className="flex items-center justify-center w-9 h-9 rounded-full transition-colors text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-            >
-              <X size={18} />
-            </button>
-          </div>
+          <Dialog.Title className="sr-only">{title}</Dialog.Title>
+          {!headerless && (
+            <div className="flex items-center justify-between shrink-0 px-6 pt-6 pb-5">
+              <span className="text-base font-semibold text-fg1">{title}</span>
+              <button
+                type="button"
+                onClick={attemptClose}
+                aria-label="Закрыть"
+                className="flex items-center justify-center w-9 h-9 rounded-full transition-colors text-fg3 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              >
+                <X size={18} />
+              </button>
+            </div>
+          )}
           {flushBody ? (
             <div className="flex-1 min-h-0 flex flex-col">
-              {children}
+              {typeof children === 'function' ? children(attemptClose) : children}
             </div>
           ) : (
             <div className={`overflow-y-auto flex-1 px-6 ${footer ? 'pb-4' : 'pb-6'}`}>
-              {children}
+              {typeof children === 'function' ? children(attemptClose) : children}
             </div>
           )}
 
@@ -86,7 +96,7 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, is
           )}
 
           {confirmClose && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-[28px] bg-black/40">
+            <div className={`absolute inset-0 z-10 flex items-center justify-center bg-black/40 ${fullScreen ? '' : 'rounded-[28px]'}`}>
               <div className="rounded-3xl p-5 w-80 bg-surface border border-stroke" style={{ boxShadow: 'var(--f-shadow28)' }}>
                 <p className="text-sm font-semibold mb-1 text-fg1">
                   Закрыть без сохранения?

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.24.3</Version>
+    <Version>0.25.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Редизайн формы редактирования документа под Material Design 3 по мотивам хендоффа друга + разбора Дизайнера. Для большой формы АОСР осознанно вернулись к **comfortable-простору MD3** (не к общей ультра-плотности).

## Что
- **`Modal`**: вариант `fullScreen` (оверлей на весь вьюпорт **над** страницей комплекта — закрытие возвращает в комплект, контекст сохраняется, `isDirty`-guard/Esc работают) + `headerless` + функция-children (передаёт `requestClose` содержимому).
- **`InstanceEditor`**: единый MD3 **top app bar** — крестик слева · имя+подзаголовок «Тип · Редактирование» · chip статуса · «Сохранить» (text) + «Сохранить и закрыть» (filled) справа. **Убран двойной заголовок** (title модалки + внутренний) и нижний футер.
- **`RequisitesTab`**: центрированная просторная колонка (max-w-3xl/4xl), карточки-секции `bg-surface rounded-xl`, **sentence-case вместо CAPS** + счётчик-пилюля, gap полей 16px.
- **Link-строка**: нейтральный контейнер вместо залитого brand + имя-ссылка primary + тональный chip источника (`SCOPE_COLORS`) + **два действия «заменить»/«снять»**.
- Панель базового экземпляра — sentence-case + карточка.
- Токены — только наши, dark-тема проверена.

## Проверка
- `tsc -b` чистый, 115 frontend-тестов зелёные, backend без изменений.
- Живая проверка через deep-link (light + dark) — скриншоты снял.

## Что осталось опционально (Phase C)
Пустые табличные массивы («Другие организации · 0 строк» и т.п.) → dashed-рамка + inline text-кнопки — Дизайнер советовал взвесить с плотностью; можно добавить после ревью, если направление ок.

Версия: MINOR `0.24.3 → 0.25.0`. **Closes #189**. Откат = revert PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)