### PR TITLE
feat(editor): панель живого предпросмотра документа (реальный Typst-PDF) (#193)

### DIFF
--- a/src/client/src/features/document-sets/editor/DocumentPreviewPanel.tsx
+++ b/src/client/src/features/document-sets/editor/DocumentPreviewPanel.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, RefreshCw, PanelRightClose, PanelRightOpen, FileWarning, FileText } from 'lucide-react';
+import { previewDocument, type PreviewResult } from '@/shared/api/documentSets';
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'pdf'; url: string }
+  | { kind: 'no-template' }
+  | { kind: 'error'; message: string };
+
+const LS_KEY = 'doc-preview-open';
+
+/**
+ * Панель живого предпросмотра документа (issue #193): справа от формы, реальный PDF по дефолтному
+ * шаблону. Перегенерация с дебаунсом при правках + «Обновить»; single-flight (отмена устаревшего
+ * ответа); сворачивается в тонкую полосу (выбор запоминается в localStorage).
+ */
+export function DocumentPreviewPanel({ instanceId, requisites }: {
+  instanceId: string;
+  requisites: unknown;
+}) {
+  const [open, setOpen] = useState(() => localStorage.getItem(LS_KEY) !== '0');
+  const [state, setState] = useState<State>({ kind: 'idle' });
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+  const reqId = useRef(0);
+  const urlRef = useRef<string | null>(null);
+
+  const setOpenPersist = (v: boolean) => { setOpen(v); localStorage.setItem(LS_KEY, v ? '1' : '0'); };
+
+  const run = useCallback(async () => {
+    const id = ++reqId.current;
+    setState(s => s.kind === 'pdf' ? s : { kind: 'loading' }); // при первом — спиннер; при рефреше держим старый PDF
+    let res: PreviewResult;
+    try { res = await previewDocument(instanceId, requisites); }
+    catch (e) { res = { kind: 'error', message: e instanceof Error ? e.message : 'Ошибка' }; }
+    if (id !== reqId.current) { if (res.kind === 'pdf') URL.revokeObjectURL(res.url); return; } // устарел
+    if (res.kind === 'pdf') {
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+      urlRef.current = res.url;
+      setState({ kind: 'pdf', url: res.url });
+      setUpdatedAt(Date.now());
+    } else {
+      setState(res);
+    }
+  }, [instanceId, requisites]);
+
+  // Дебаунс перегенерации при изменении реквизитов (пока панель открыта).
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => void run(), 1500);
+    return () => clearTimeout(t);
+  }, [open, run]);
+
+  // Освобождаем blob-URL при размонтировании.
+  useEffect(() => () => { if (urlRef.current) URL.revokeObjectURL(urlRef.current); }, []);
+
+  if (!open) {
+    return (
+      <button type="button" onClick={() => setOpenPersist(true)}
+        title="Показать предпросмотр"
+        className="hidden xl:flex flex-col items-center gap-2 w-11 shrink-0 border-l border-stroke pt-4 text-fg4 hover:text-brand hover:bg-muted transition-colors">
+        <PanelRightOpen size={18} />
+        <span className="text-xs [writing-mode:vertical-rl] rotate-180 tracking-wide">Предпросмотр</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="hidden xl:flex flex-col w-[44%] min-w-[380px] shrink-0 border-l border-stroke bg-muted/40">
+      <div className="flex items-center gap-2 shrink-0 px-3 h-11 border-b border-stroke bg-surface">
+        <FileText size={16} className="text-fg4 shrink-0" />
+        <span className="text-sm font-medium text-fg1 flex-1">Предпросмотр документа</span>
+        {updatedAt && state.kind === 'pdf' && (
+          <span className="text-xs text-fg4">обновлено {timeAgo(updatedAt)}</span>
+        )}
+        <button type="button" onClick={() => void run()} disabled={state.kind === 'loading'}
+          title="Обновить" className="p-1.5 rounded-full text-fg4 hover:text-brand hover:bg-black/5 dark:hover:bg-white/10 transition-colors disabled:opacity-50">
+          <RefreshCw size={15} className={state.kind === 'loading' ? 'animate-spin' : ''} />
+        </button>
+        <button type="button" onClick={() => setOpenPersist(false)}
+          title="Скрыть предпросмотр" className="p-1.5 rounded-full text-fg4 hover:text-fg1 hover:bg-black/5 dark:hover:bg-white/10 transition-colors">
+          <PanelRightClose size={16} />
+        </button>
+      </div>
+      <div className="flex-1 min-h-0 relative">
+        {state.kind === 'pdf' && (
+          <iframe title="Предпросмотр документа" src={state.url} className="w-full h-full border-0 bg-white" />
+        )}
+        {state.kind === 'loading' && (
+          <div className="absolute inset-0 flex items-center justify-center text-fg4">
+            <Loader2 size={22} className="animate-spin" />
+          </div>
+        )}
+        {state.kind === 'no-template' && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center px-6 text-fg4">
+            <FileWarning size={28} />
+            <p className="text-sm">Нет шаблона для предпросмотра</p>
+            <p className="text-xs">Добавьте шаблон типа документа и отметьте его по умолчанию.</p>
+          </div>
+        )}
+        {state.kind === 'error' && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center px-6 text-fg4">
+            <FileWarning size={28} className="text-danger" />
+            <p className="text-sm text-danger">Не удалось построить предпросмотр</p>
+            <p className="text-xs break-words max-w-full">{state.message}</p>
+            <button type="button" onClick={() => void run()} className="text-xs text-brand hover:text-brand-hover mt-1">Повторить</button>
+          </div>
+        )}
+        {state.kind === 'idle' && (
+          <div className="absolute inset-0 flex items-center justify-center text-fg4 text-sm">Предпросмотр появится здесь</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function timeAgo(ts: number): string {
+  const s = Math.round((Date.now() - ts) / 1000);
+  if (s < 5) return 'только что';
+  if (s < 60) return `${s} сек назад`;
+  const m = Math.round(s / 60);
+  return `${m} мин назад`;
+}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -27,6 +27,7 @@ import {
   BaseInstancePanel, SCOPE_TIER, ancestorTypeIds, parseBaseRef, type BaseCandidate,
 } from '../fields';
 import { DataSetsTab } from './DataSetsTab';
+import { DocumentPreviewPanel } from './DocumentPreviewPanel';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
 import { mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
 import { QualityLinksTab } from './QualityLinksTab';
@@ -502,6 +503,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
             )}
           </div>
         </div>
+        <DocumentPreviewPanel instanceId={instance.id} requisites={values} />
       </div>
       {error && (
         <div className="shrink-0 px-6 py-2 bg-surface border-t border-stroke">

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -202,6 +202,36 @@ export interface ResolutionDiagnostic {
   message: string;
 }
 
+export type PreviewResult =
+  | { kind: 'pdf'; url: string }
+  | { kind: 'no-template' }
+  | { kind: 'error'; message: string };
+
+/**
+ * Живой предпросмотр документа (issue #193): POST текущих (несохранённых) реквизитов →
+ * эфемерный PDF по дефолтному шаблону. Успех → blob-URL PDF; нет шаблона / ошибка → маркер.
+ * Ответ приходит как blob (и PDF, и JSON-статус) — различаем по content-type.
+ */
+export async function previewDocument(instanceId: string, requisites: unknown): Promise<PreviewResult> {
+  async function parseJsonBlob(b: Blob): Promise<PreviewResult> {
+    try {
+      const j = JSON.parse(await b.text());
+      if (j.noTemplate) return { kind: 'no-template' };
+      return { kind: 'error', message: j.error ?? 'Ошибка предпросмотра' };
+    } catch { return { kind: 'error', message: 'Ошибка предпросмотра' }; }
+  }
+  try {
+    const res = await apiClient.post(`/generate/preview/${instanceId}`, requisites, { responseType: 'blob' });
+    const ct = String(res.headers['content-type'] ?? '');
+    if (ct.includes('application/pdf')) return { kind: 'pdf', url: URL.createObjectURL(res.data as Blob) };
+    return await parseJsonBlob(res.data as Blob);
+  } catch (e: unknown) {
+    const data = (e as { response?: { data?: unknown } })?.response?.data;
+    if (data instanceof Blob) return await parseJsonBlob(data);
+    return { kind: 'error', message: e instanceof Error ? e.message : 'Ошибка предпросмотра' };
+  }
+}
+
 /** Проверяет разрешение ссылок экземпляра «по требованию» (warning/error). */
 export async function validateResolution(instanceId: string): Promise<ResolutionDiagnostic[]> {
   const r = await apiClient.get<ResolutionDiagnostic[]>(`/generate/validate/${instanceId}`);

--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -40,6 +40,25 @@ public static class GenerationEndpoints
             }
         });
 
+        // Живой предпросмотр (issue #193): рендер ДЕФОЛТНОГО шаблона на переданных (несохранённых)
+        // реквизитах в PDF. Эфемерно — ничего не персистит. PDF → 200 application/pdf;
+        // нет шаблона → 200 {noTemplate:true}; ошибка резолва/Typst → 422 {error, diagnostics}.
+        g.MapPost("/preview/{instanceId:guid}", async (
+            Guid instanceId, System.Text.Json.JsonElement requisites, IMediator m, CancellationToken ct) =>
+        {
+            var raw = requisites.ValueKind == System.Text.Json.JsonValueKind.Undefined ? "{}" : requisites.GetRawText();
+            var result = await m.Send(new PreviewDocumentQuery(instanceId, System.Text.Json.JsonDocument.Parse(raw)), ct);
+            if (result.Pdf is not null)
+                return Results.File(result.Pdf, "application/pdf");
+            if (result.NoTemplate)
+                return Results.Ok(new { noTemplate = true });
+            return Results.UnprocessableEntity(new
+            {
+                error = result.Error ?? "Не удалось построить предпросмотр",
+                diagnostics = result.Diagnostics?.Select(ToDto),
+            });
+        });
+
         // Проверка разрешения ссылок «по требованию» — возвращает все проблемы (warning/error).
         g.MapGet("/validate/{instanceId:guid}", async (Guid instanceId, IMediator m) =>
         {

--- a/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
+++ b/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Application.Templates;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
+using BHS.CRG.Domain.Templates;
+using MediatR;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>Результат предпросмотра: либо PDF-байты, либо причина (нет шаблона / ошибка резолва/Typst).</summary>
+public sealed record PreviewDocumentResult
+{
+    public byte[]? Pdf { get; init; }
+    public bool NoTemplate { get; init; }
+    public string? Error { get; init; }
+    public IReadOnlyList<ResolutionDiagnostic>? Diagnostics { get; init; }
+
+    public static PreviewDocumentResult Ok(byte[] pdf) => new() { Pdf = pdf };
+    public static PreviewDocumentResult NoTpl() => new() { NoTemplate = true };
+    public static PreviewDocumentResult Fail(string error, IReadOnlyList<ResolutionDiagnostic>? diags = null)
+        => new() { Error = error, Diagnostics = diags };
+}
+
+/// <summary>
+/// Живой предпросмотр документа (issue #193): рендерит ДЕФОЛТНЫЙ шаблон на ПЕРЕДАННЫХ (возможно
+/// несохранённых) реквизитах в PDF. Read-only by contract: НЕ персистит файл, НЕ меняет статус,
+/// НЕ пишет метаданные, НЕ шлёт уведомления — эфемерный рендер для панели предпросмотра.
+/// </summary>
+public sealed record PreviewDocumentQuery(Guid InstanceId, JsonDocument Requisites)
+    : IRequest<PreviewDocumentResult>;
+
+public class PreviewDocumentHandler(
+    IRepository<DomainObject> instanceRepo,
+    IRepository<Template> templateRepo,
+    IRepository<DocumentType> docTypeRepo,
+    IRepository<TypstUserLib> userLibRepo,
+    IEntityResolver entityResolver,
+    IDataSetResolver dataSetResolver,
+    IQualityLinkResolver qualityLinkResolver,
+    ITemplateAssetResolver templateAssetResolver,
+    IDocumentGeneratorFactory generatorFactory
+) : IRequestHandler<PreviewDocumentQuery, PreviewDocumentResult>
+{
+    private static List<Guid> ParseGuidList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return [];
+        try { return JsonSerializer.Deserialize<List<Guid>>(json) ?? []; } catch { return []; }
+    }
+
+    public async Task<PreviewDocumentResult> Handle(PreviewDocumentQuery q, CancellationToken ct)
+    {
+        var instance = await instanceRepo.GetByIdAsync(q.InstanceId, ct);
+        if (instance is null) return PreviewDocumentResult.Fail("Документ не найден.");
+
+        // Выбор ОДНОГО шаблона (как в GenerateDocumentHandler): явно выбранный → дефолтный → первый активный.
+        var candidates = (await templateRepo.FindAsync(t => t.DocumentTypeId == instance.CompositeTypeId, ct)).ToList();
+        var selectedIds = ParseGuidList(instance.TemplateIds);
+        var template = (selectedIds.Count > 0 ? candidates.FirstOrDefault(t => selectedIds.Contains(t.Id) && t.IsActive) : null)
+            ?? (instance.TemplateId.HasValue ? candidates.FirstOrDefault(t => t.Id == instance.TemplateId.Value) : null)
+            ?? candidates.FirstOrDefault(t => t.IsDefault && t.IsActive)
+            ?? candidates.FirstOrDefault(t => t.IsActive);
+        if (template is null) return PreviewDocumentResult.NoTpl();
+
+        // Проекция генерации с ПОДМЕНЁННЫМИ реквизитами (несохранённые правки формы), без записи в БД.
+        var view = DocumentView.From(instance) with { Requisites = q.Requisites };
+
+        try
+        {
+            // ── Пайплайн контекста — ЗЕРКАЛИТ GenerateDocumentHandler (менять синхронно; там нет тестов). ──
+            var allDocTypes = await docTypeRepo.GetAllAsync(ct);
+            var diagnostics = new List<ResolutionDiagnostic>();
+            var context = await entityResolver.ResolveAsync(view, ct);
+            await dataSetResolver.InjectAsync(context, view, diagnostics, ct);
+            await entityResolver.ApplyDefaultsAsync(context, view, ct);
+            await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
+            await qualityLinkResolver.InjectAsync(context, view, ct);
+            await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
+            ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                return PreviewDocumentResult.Fail("Не все ссылки разрешены — предпросмотр недоступен.", diagnostics);
+
+            var preamble = TypstPreambleBuilder.Build(allDocTypes);
+            var lib = (await userLibRepo.GetAllAsync(ct)).FirstOrDefault();
+            var userLib = lib is not null && !string.IsNullOrWhiteSpace(lib.Content) ? lib.Content : null;
+
+            context.Set("params", TemplateParams.Effective(template.Parameters,
+                TemplateParams.OverridesForTemplate(instance.TemplateParams, template.Id)));
+            var assets = await templateAssetResolver.ResolveAsync(template.Id, instance.CompositeTypeId, ct);
+
+            var generator = generatorFactory.Create(OutputFormat.Pdf);
+            var request = new GenerationRequest(template.Content, OutputFormat.Pdf, context,
+                TypeBlocksContent: string.IsNullOrEmpty(preamble) ? null : preamble,
+                UserLibContent: userLib,
+                ImageOptions: SchemaImageOptions.Collect(allDocTypes),
+                TemplateAssets: assets);
+            var bytes = await generator.GenerateAsync(request, ct);
+            return PreviewDocumentResult.Ok(bytes);
+        }
+        catch (ResolutionValidationException ex)
+        {
+            return PreviewDocumentResult.Fail("Не все ссылки разрешены — предпросмотр недоступен.", ex.Diagnostics);
+        }
+        catch (Exception ex)
+        {
+            return PreviewDocumentResult.Fail(ex.Message);
+        }
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.26.0</Version>
+    <Version>0.27.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Правая **сворачиваемая** панель живого предпросмотра в редакторе (вариант 1c поверх 1b list-detail). Закрывает потерю «обзора всей формы» при list-detail — превью показывает итоговый документ целиком.

## Backend
- **`PreviewDocumentQuery`/Handler**: рендерит **дефолтный шаблон** на **переданных (несохранённых)** реквизитах в PDF через **реальный пайплайн** (`EntityResolver→DataSet→Quality→TypstGenerator`). **Read-only by contract**: НЕ персистит файл, НЕ меняет статус, НЕ пишет метаданные/уведомления. Пайплайн **зеркалит** `GenerateDocumentHandler` (менять синхронно — генерация без тестов из-за Typst-зависимости).
- **Endpoint** `POST /api/generate/preview/{id}` (тело = реквизиты): PDF → `200 application/pdf`; нет шаблона → `200 {noTemplate:true}`; ошибка резолва/Typst → `422 {error, diagnostics}`.

## Frontend
- `previewDocument()` — blob, различает PDF/JSON по content-type.
- **`DocumentPreviewPanel`**: справа, iframe с PDF; **дебаунс 1.5с** + «Обновить» + **single-flight** (отмена устаревшего ответа); состояния loading / no-template / error; **сворачивание в полосу** (выбор в localStorage). Только на xl-экранах (3 колонки).
- `RequisitesTab`: третья колонка — drawer · форма · предпросмотр.

## Проверка
- **Живой смоук**: POST реквизитов → валидный **35 КБ PDF «АОСР»** (Typst компилирует, без MinIO/персиста).
- `tsc -b` чистый, 115 frontend-тестов зелёные, backend build ок.
- PDF рендерит реальный браузер; `chrome-headless-shell` PDF в iframe не показывает (ограничение харнесса, не бага) — на скриншоте панель с заголовком «Предпросмотр документа · обновлено только что», тело пустое.

## Заметки
- Превью не покрыто backend-тестом (Typst-зависимо, как и генерация); проверено живым смоуком.
- Нет дефолтного шаблона у типа → «Нет шаблона для предпросмотра».

Версия MINOR `0.26.0 → 0.27.0`. **Closes #193**. Откат = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)