### PR TITLE
fix(editor): предпросмотр свёрнут по умолчанию + шаблон как при генерации (#193 follow-up)

### DIFF
--- a/src/client/src/features/document-sets/editor/DocumentPreviewPanel.tsx
+++ b/src/client/src/features/document-sets/editor/DocumentPreviewPanel.tsx
@@ -20,7 +20,8 @@ export function DocumentPreviewPanel({ instanceId, requisites }: {
   instanceId: string;
   requisites: unknown;
 }) {
-  const [open, setOpen] = useState(() => localStorage.getItem(LS_KEY) !== '0');
+  // По умолчанию свёрнута (issue #193 follow-up): открыта только если пользователь явно её открывал.
+  const [open, setOpen] = useState(() => localStorage.getItem(LS_KEY) === '1');
   const [state, setState] = useState<State>({ kind: 'idle' });
   const [updatedAt, setUpdatedAt] = useState<number | null>(null);
   const reqId = useRef(0);

--- a/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
+++ b/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
@@ -54,10 +54,17 @@ public class PreviewDocumentHandler(
         var instance = await instanceRepo.GetByIdAsync(q.InstanceId, ct);
         if (instance is null) return PreviewDocumentResult.Fail("Документ не найден.");
 
-        // Выбор ОДНОГО шаблона (как в GenerateDocumentHandler): явно выбранный → дефолтный → первый активный.
+        // Шаблон предпросмотра = как пользователь бы СГЕНЕРИРОВАЛ (issue #193 follow-up):
+        // выбранный набор (ПЕРВЫЙ выбранный в порядке TemplateIds, активный) → одиночный выбор
+        // (TemplateId) → дефолтный → первый активный. Зеркалит выбор в GenerateDocumentHandler.
         var candidates = (await templateRepo.FindAsync(t => t.DocumentTypeId == instance.CompositeTypeId, ct)).ToList();
-        var selectedIds = ParseGuidList(instance.TemplateIds);
-        var template = (selectedIds.Count > 0 ? candidates.FirstOrDefault(t => selectedIds.Contains(t.Id) && t.IsActive) : null)
+        Template? bySelected = null;
+        foreach (var id in ParseGuidList(instance.TemplateIds))
+        {
+            bySelected = candidates.FirstOrDefault(t => t.Id == id && t.IsActive);
+            if (bySelected is not null) break;
+        }
+        var template = bySelected
             ?? (instance.TemplateId.HasValue ? candidates.FirstOrDefault(t => t.Id == instance.TemplateId.Value) : null)
             ?? candidates.FirstOrDefault(t => t.IsDefault && t.IsActive)
             ?? candidates.FirstOrDefault(t => t.IsActive);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.27.0</Version>
+    <Version>0.27.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Две доделки по панели предпросмотра (#193).

1. **Свёрнута по умолчанию.** `DocumentPreviewPanel` открыта только если пользователь её явно открывал (localStorage `'1'`); раньше была открыта по умолчанию. Свёрнутая — тонкая полоса «Предпросмотр» справа.
2. **Шаблон предпросмотра = как при генерации.** Приоритет: выбранный набор (**первый выбранный** в порядке `TemplateIds`, активный) → одиночный выбор `TemplateId` → дефолтный → первый активный. Раньше «первый выбранный» брался в порядке кандидатов из БД, а не в порядке выбора пользователя. Зеркалит выбор в `GenerateDocumentHandler`.

`tsc -b` чистый, Application build ок. Версия PATCH `0.27.0 → 0.27.1`. Follow-up к #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)