### PR TITLE
feat(jobs): панель фоновых задач → MD3 (#188)

### DIFF
--- a/src/client/src/features/jobs/ActiveJobsIndicator.tsx
+++ b/src/client/src/features/jobs/ActiveJobsIndicator.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ComponentType } from 'react';
 import * as Popover from '@radix-ui/react-popover';
-import { Loader2, X } from 'lucide-react';
+import { Loader2, X, ScanText, FileText, Layers, Activity } from 'lucide-react';
 import { useActiveJobs, useCancelJob, type ActiveJob } from '@/shared/api/jobs';
 
-/** Русское склонение «N задача/задачи/задач». */
-function jobsWord(n: number): string {
-  const m10 = n % 10, m100 = n % 100;
-  if (m10 === 1 && m100 !== 11) return 'задача';
-  if (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20)) return 'задачи';
-  return 'задач';
+/** Иконка типа задачи по kind (для аватара-статуса). */
+function kindIcon(kind: string): ComponentType<{ size?: number; className?: string }> {
+  if (/recogni|распозн/i.test(kind)) return ScanText;
+  if (/generat|генер/i.test(kind)) return FileText;
+  if (/assembl|сбор|kit/i.test(kind)) return Layers;
+  return Activity;
 }
 
 /** Прошедшее время задачи m:ss (от старта, иначе от постановки). */
@@ -29,16 +29,17 @@ function useNow(): number {
 }
 
 /**
- * Индикатор активных фоновых задач сессии — пилюля слева от колокольчика, видима только при активных
- * задачах. «Идёт сейчас» (transient, нейтральный, спиннер, без badge серьёзности) — в отличие от
- * колокольчика справа («уже случилось», persist, цвета). По завершении задача уходит отсюда и всплывает
- * в колокольчике (handoff, см. useActiveJobs). Клик — Radix-поповер со списком и живым elapsed-таймером.
+ * Индикатор активных фоновых задач сессии (issue #188, MD3) — чип слева от колокольчика, видим только при
+ * активных задачах. «Идёт сейчас» (transient, спиннер) — в отличие от колокольчика справа («уже случилось»,
+ * persist, статусы). По завершении задача уходит отсюда и всплывает в колокольчике (handoff). Поэтому
+ * панель показывает ТОЛЬКО живые задачи — без done/failed/clear_all/retry из макета (это роль колокольчика).
+ * Клик — Radix-поповер со списком, аватаром-статусом и живым elapsed-таймером.
  */
 export function ActiveJobsIndicator() {
   const jobs = useActiveJobs();
   if (jobs.length === 0) return null;
 
-  const label = jobs.length === 1 ? jobs[0].title : `${jobs.length} ${jobsWord(jobs.length)}`;
+  const label = jobs.length === 1 ? jobs[0].title : `Задач выполняется: ${jobs.length}`;
 
   return (
     <Popover.Root>
@@ -46,10 +47,10 @@ export function ActiveJobsIndicator() {
         <button
           type="button"
           aria-label={`Активные задачи: ${jobs.length}`}
-          className="flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs text-fg2 hover:text-fg1 hover:bg-base transition-colors"
+          className="flex items-center gap-2 h-9 pl-3 pr-3.5 rounded-full text-sm font-medium text-fg2 hover:bg-muted transition-colors data-[state=open]:bg-brand-subtle data-[state=open]:text-brand"
         >
-          <Loader2 size={13} className="animate-spin motion-reduce:animate-none text-fg3 shrink-0" />
-          <span className="max-w-[160px] truncate">{label}</span>
+          <Loader2 size={16} className="animate-spin motion-reduce:animate-none shrink-0" />
+          <span className="max-w-[180px] truncate">{label}</span>
         </button>
       </Popover.Trigger>
       <Popover.Portal>
@@ -57,15 +58,20 @@ export function ActiveJobsIndicator() {
           align="end"
           sideOffset={8}
           role="status"
-          className="w-80 rounded-xl border border-stroke bg-surface shadow-lg z-50 overflow-hidden focus:outline-none"
+          className="w-96 max-w-[calc(100vw-2rem)] rounded-2xl border border-stroke bg-surface z-50 overflow-hidden focus:outline-none"
+          style={{ boxShadow: 'var(--f-shadow16)' }}
         >
-          <div className="px-4 py-2.5 border-b border-stroke text-sm font-semibold text-fg1">
-            Выполняется
+          <div className="flex items-center gap-2 pl-5 pr-2 py-2.5 border-b border-stroke">
+            <span className="text-base font-medium text-fg1 flex-1">Фоновые задачи</span>
+            <Popover.Close
+              aria-label="Закрыть"
+              className="flex items-center justify-center w-9 h-9 rounded-full text-fg4 hover:text-fg1 hover:bg-muted transition-colors"
+            >
+              <X size={18} />
+            </Popover.Close>
           </div>
-          <div className="max-h-[60vh] overflow-y-auto divide-y divide-stroke">
-            {jobs.map(job => (
-              <JobRow key={job.id} job={job} />
-            ))}
+          <div className="max-h-[calc(100vh-9rem)] overflow-y-auto py-1">
+            {jobs.map(job => <JobRow key={job.id} job={job} />)}
           </div>
         </Popover.Content>
       </Popover.Portal>
@@ -77,16 +83,25 @@ function JobRow({ job }: { job: ActiveJob }) {
   const now = useNow();
   const cancel = useCancelJob();
   const queued = job.status === 'Queued';
+  const Icon = kindIcon(job.kind);
   return (
-    <div className="group flex items-center gap-3 px-4 py-3">
-      <Loader2 size={14} className="animate-spin motion-reduce:animate-none text-fg4 shrink-0" />
+    <div className="group flex items-center gap-3.5 pl-5 pr-3 py-3 hover:bg-muted/60 transition-colors">
+      {/* Аватар-статус: иконка типа в круге + вращающийся спиннер-кольцо (indeterminate). */}
+      <div className="relative w-10 h-10 shrink-0">
+        <div className="absolute inset-0 rounded-full bg-muted flex items-center justify-center text-fg3">
+          <Icon size={18} />
+        </div>
+        <Loader2 size={40} className="absolute inset-0 animate-spin motion-reduce:animate-none text-brand" strokeWidth={2} />
+      </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-fg1 truncate">{job.title}</p>
-        <p className="text-[11px] text-fg4">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium text-fg1 truncate flex-1">{job.title}</p>
+          <span className="text-xs tabular-nums text-fg4 shrink-0">{elapsed(job, now)}</span>
+        </div>
+        <p className="text-[13px] text-fg4 truncate">
           {queued ? 'В очереди' : (job.progress ?? 'Выполняется…')}
         </p>
       </div>
-      <span className="text-xs tabular-nums text-fg3 shrink-0">{elapsed(job, now)}</span>
       {/* Отмена — только пока задача в очереди; выполняемые добегают до конца. */}
       {queued && (
         <button
@@ -94,9 +109,9 @@ function JobRow({ job }: { job: ActiveJob }) {
           onClick={() => cancel.mutate(job.id)}
           disabled={cancel.isPending}
           title="Отменить (задача ещё в очереди)"
-          className="shrink-0 p-1 rounded text-fg4 hover:text-danger disabled:opacity-40 transition-colors"
+          className="shrink-0 flex items-center justify-center w-9 h-9 rounded-full text-fg4 hover:text-danger hover:bg-black/5 dark:hover:bg-white/10 disabled:opacity-40 transition-colors"
         >
-          <X size={13} />
+          <X size={16} />
         </button>
       )}
     </div>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.27.1</Version>
+    <Version>0.27.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Редизайн индикатора активных фоновых задач по хендоффу друга (issue #188), адаптирован под нашу **active-only** модель.

## Что
- **Чип-триггер** (слева от колокольчика): `rounded-full`, спиннер + «Задач выполняется: N» (или название одной задачи); открытое состояние — тональный `bg-brand-subtle`.
- **Popover**: `rounded-2xl` + `shadow16`, шапка «Фоновые задачи» + крестик.
- **Элемент задачи**: **аватар-статус** (иконка типа по `kind` в круге + вращающееся спиннер-кольцо), название + прошедшее время (m:ss, `tabular-nums`), подстрока-прогресс, отмена (× у `Queued`).
- `kindIcon`: распознавание→`ScanText`, генерация→`FileText`, сборка→`Layers`, иначе `Activity`.

## Осознанное отклонение от макета
НЕ берём done/failed/clear_all/retry — завершённые/упавшие задачи уходят в **колокольчик** (наша архитектура handoff, память `project_background_jobs`/`project_notifications`); панель задач показывает только **живое** состояние. Индикатор скрыт при отсутствии активных задач (transient). Токены — наши, не hex друга; dark-тема ок.

## Проверка
- `tsc -b` чистый, 115 frontend-тестов зелёные.
- Визуально (мок `/jobs/active`, 3 задачи: running с прогрессом + queued с отменой), light+dark.

Версия PATCH `0.27.1 → 0.27.2`. **Closes #188**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)