### PR TITLE
fix(types): «Без группы» — первой в редакторе полей (#197)

### DIFF
--- a/src/client/src/features/settings/GroupedFieldsEditor.tsx
+++ b/src/client/src/features/settings/GroupedFieldsEditor.tsx
@@ -177,6 +177,29 @@ export function GroupedFieldsEditor({
 
   return (
     <div className="space-y-3">
+      {/* Без группы (катч-олл) — первой: эти поля идут первыми в формах редактирования (#197) */}
+      {(() => {
+        const zone = dropZoneProps(null);
+        return (
+          <div className={`border rounded-lg overflow-hidden transition-colors ${zone.highlighted ? 'border-brand bg-brand-subtle/30' : 'border-stroke border-dashed bg-base'}`}>
+            <div className="flex items-center gap-2 px-3 py-2 bg-surface border-b border-stroke">
+              <span className="text-sm font-medium text-fg3">Без группы</span>
+              <span className="text-xs text-fg4">{ownUngrouped.length + inhUngrouped.length}</span>
+            </div>
+            <div className="p-2 space-y-2 min-h-[3rem]" onDragOver={zone.onDragOver} onDrop={zone.onDrop}>
+              {(() => {
+                const ownKeys = ownUngrouped.map(f => f.key);
+                return ownUngrouped.map((f, i) => renderOwn(f, null, ownKeys, i));
+              })()}
+              {inhUngrouped.map(f => renderInherited(f, null))}
+              <Button type="button" variant="tonal" onClick={addField} icon={<Plus size={14} />} className="w-full justify-center">
+                Добавить поле
+              </Button>
+            </div>
+          </div>
+        );
+      })()}
+
       {/* Группы-карточки */}
       {groups.map((group, gi) => {
         const zone = dropZoneProps(group.key);
@@ -229,29 +252,6 @@ export function GroupedFieldsEditor({
           Группа
         </Button>
       </div>
-
-      {/* Без группы (катч-олл) */}
-      {(() => {
-        const zone = dropZoneProps(null);
-        return (
-          <div className={`border rounded-lg overflow-hidden transition-colors ${zone.highlighted ? 'border-brand bg-brand-subtle/30' : 'border-stroke border-dashed bg-base'}`}>
-            <div className="flex items-center gap-2 px-3 py-2 bg-surface border-b border-stroke">
-              <span className="text-sm font-medium text-fg3">Без группы</span>
-              <span className="text-xs text-fg4">{ownUngrouped.length + inhUngrouped.length}</span>
-            </div>
-            <div className="p-2 space-y-2 min-h-[3rem]" onDragOver={zone.onDragOver} onDrop={zone.onDrop}>
-              {(() => {
-                const ownKeys = ownUngrouped.map(f => f.key);
-                return ownUngrouped.map((f, i) => renderOwn(f, null, ownKeys, i));
-              })()}
-              {inhUngrouped.map(f => renderInherited(f, null))}
-              <Button type="button" variant="tonal" onClick={addField} icon={<Plus size={14} />} className="w-full justify-center">
-                Добавить поле
-              </Button>
-            </div>
-          </div>
-        );
-      })()}
     </div>
   );
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.29.2</Version>
+    <Version>0.29.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## «Без группы» — первой в редакторе полей типа

По просьбе: в редакторе полей (Документы и Составные типы) катч-олл **«Без группы»** перенесён **наверх**, перед группами-карточками — эти поля идут первыми в формах редактирования документов.

- `GroupedFieldsEditor`: порядок стал **Без группы → группы-карточки → «Добавить группу»**.
- Закрывает мой открытый вопрос (ранее «Без группы» была снизу) — теперь как в исходном мокапе друга.

Проверка: `tsc -b` чисто; скриншот подтвердил «Без группы» первой (перед «Реквизиты»/«Организации»), «Добавить группу» — внизу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)