### PR TITLE
fix(templates): вкладки режима — в одну строку

### DIFF
--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -140,10 +140,10 @@ export function TemplatesPage() {
       <div className="px-6 py-3 border-b border-stroke bg-surface">
         <div className="flex items-center justify-between gap-4">
           {/* Mode tabs */}
-          <div className="flex items-center gap-1 bg-muted rounded-lg p-0.5">
+          <div className="flex items-center gap-1 bg-muted rounded-lg p-0.5 shrink-0">
             <button
               onClick={() => setMode('templates')}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors ${
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md whitespace-nowrap transition-colors ${
                 mode === 'templates'
                   ? 'bg-surface text-fg1 font-medium shadow-sm'
                   : 'text-fg3 hover:text-fg2'
@@ -153,13 +153,13 @@ export function TemplatesPage() {
             </button>
             <button
               onClick={() => setMode('userlib')}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors ${
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md whitespace-nowrap transition-colors ${
                 mode === 'userlib'
                   ? 'bg-surface text-fg1 font-medium shadow-sm'
                   : 'text-fg3 hover:text-fg2'
               }`}
             >
-              <Library size={14} />
+              <Library size={14} className="shrink-0" />
               Общие функции Typst
             </button>
           </div>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.30.2</Version>
+    <Version>0.30.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Кнопки-вкладки «Шаблоны документов» / «Общие функции Typst» на странице «Шаблоны» переносились на две строки при недостатке ширины (рядом — селектор типа документа).

Добавлен `whitespace-nowrap` кнопкам + `shrink-0` контейнеру табов и иконке `Library`.

Проверка: `tsc -b` чисто; скриншот — обе вкладки в одну строку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)