### PR TITLE
feat(types): кнопка «Отмена» (revert) в шапке detail (#210 Этап 2)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -230,7 +230,8 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
       throw err;
     }
   }
-  useRegisterEditor('props', dirty, save);
+  useRegisterEditor('props', dirty, save,
+    () => { setName(docType.name); setCode(docType.code); setParentId(docType.parentId ?? ''); setError(''); });
 
   return (
     <form onSubmit={e => { e.preventDefault(); save().catch(() => { /* ошибка показана в форме */ }); }}
@@ -510,7 +511,15 @@ function SchemaEditor({ docType, allDocTypes }: {
       throw err;
     }
   }
-  useRegisterEditor('schema', dirty, save);
+  useRegisterEditor('schema', dirty, save, () => {
+    setFields(parseSchemaFields(docType.schema));
+    setGroups(normalizeGroupMembership(schemaDef.groups ?? []));
+    setExcludedFields(schemaDef.excludedFields ?? []);
+    setFieldOverrides(schemaDef.fieldOverrides ?? {});
+    setTypstRenders(schemaDef.typstRenders ?? []);
+    setDocTypeTags(schemaDef.tags ?? []);
+    setError(''); setDirty(false);
+  });
 
   return (
     <div className="space-y-4">
@@ -626,9 +635,9 @@ function findReferencingTypes(id: string, allDocTypes: DocumentType[]): Document
 }
 
 /** Правая панель list-detail (issue #197 Фаза A): шапка типа (метрики+действия) + редактор как есть. */
-function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving, onSaveAll }: {
+function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving, onSaveAll, onRevert }: {
   docType: DocumentType; allDocTypes: DocumentType[]; allGroups: string[]; onDeleted: () => void;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void;
 }) {
   const deleteMutation = useDeleteDocumentType();
   const groupMutation = useSetDocumentTypeGroup();
@@ -661,7 +670,7 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
   return (
     <div className="flex flex-col min-h-0 flex-1">
       {/* Шапка типа — доменные heading/actions поверх общего DetailHeader (issue #210 Этап 1b) */}
-      <DetailHeader dirty={dirty} saving={saving} onSaveAll={onSaveAll}
+      <DetailHeader dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert}
         heading={
           <>
             <div className="flex items-center gap-2 flex-wrap">
@@ -749,7 +758,7 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
   const { data: allDocTypes = [], isLoading } = useListDocumentTypes();
 
   // Реестр незасохранённых форм текущего типа (явное сохранение, issue #197 / #210 — общий).
-  const { registry, anyDirty, saving, saveAll } = useTypeEditorRegistry();
+  const { registry, anyDirty, saving, saveAll, resetAll } = useTypeEditorRegistry();
 
   // Гард при уходе с типа с несохранёнными правками (общий useDirtyGuard, issue #210 Этап 1b).
   const { request, dialogProps } = useDirtyGuard<string | null>({
@@ -805,7 +814,7 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
           detail={selected ? (
             <TypeDetail key={selected.id} docType={selected} allDocTypes={allDocTypes}
               allGroups={allGroups} onDeleted={() => setSelectedId(null)}
-              dirty={anyDirty} saving={saving} onSaveAll={saveAll} />
+              dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll} />
           ) : (
             <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Ничего не найдено</div>
           )} />

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -303,15 +303,15 @@ function PrimitiveCreateForm({ onSaved, onCancel }: { onSaved: () => void; onCan
 
 // ─── Detail header (доменные heading/actions поверх общего DetailHeader) ──────────
 
-function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, allGroups, group, onGroup, onDelete, deleteBlock }: {
+function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, onRevert, allGroups, group, onGroup, onDelete, deleteBlock }: {
   name: string; code: string; chip: string; usedBy: number;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void;
   allGroups: string[]; group: string | null; onGroup: (g: string | null) => void;
   onDelete: () => void; deleteBlock: string | null;
 }) {
   const badge = 'text-xs px-2 py-0.5 rounded-full font-medium';
   return (
-    <DetailHeader dirty={dirty} saving={saving} onSaveAll={onSaveAll}
+    <DetailHeader dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert}
       heading={
         <>
           <div className="flex items-center gap-2 flex-wrap">
@@ -336,9 +336,9 @@ function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, 
 
 // ─── Primitive detail ────────────────────────────────────────────────────────────
 
-function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onDeleted }: {
+function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onRevert, onDeleted }: {
   type: PrimitiveTypeDef; allGroups: string[]; usedBy: number;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onDeleted: () => void;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDeleted: () => void;
 }) {
   const [name, setName] = useState(type.name);
   const [description, setDescription] = useState(type.description ?? '');
@@ -367,13 +367,14 @@ function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll
       setError(e instanceof Error ? e.message : 'Ошибка сохранения'); throw e;
     }
   }
-  useRegisterEditor('primitive', localDirty, save);
+  const reset = () => { setName(type.name); setDescription(type.description ?? ''); setConstraints(type.constraints ?? {}); setAllowedTags(type.allowedTags ?? []); setError(''); };
+  useRegisterEditor('primitive', localDirty, save, reset);
 
   const deleteBlock = usedBy > 0 ? `Нельзя удалить: используется в ${usedBy} типах` : null;
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <TypeDetailHeader name={name} code={type.code} chip={BASE_TYPE_LABEL[type.baseType] ?? type.baseType} usedBy={usedBy}
-        dirty={dirty} saving={saving} onSaveAll={onSaveAll}
+        dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert}
         allGroups={allGroups} group={type.group} onGroup={g => groupMutation.mutate({ id: type.id, group: g })}
         onDelete={() => setConfirmDelete(true)} deleteBlock={deleteBlock} />
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
@@ -431,9 +432,9 @@ function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll
 
 // ─── Enum detail ──────────────────────────────────────────────────────────────────
 
-function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onDeleted }: {
+function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onRevert, onDeleted }: {
   type: EnumTypeDef; allGroups: string[]; usedBy: number;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onDeleted: () => void;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDeleted: () => void;
 }) {
   const [name, setName] = useState(type.name);
   const [description, setDescription] = useState(type.description ?? '');
@@ -465,13 +466,14 @@ function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onD
       setError(e instanceof Error ? e.message : 'Ошибка сохранения'); throw e;
     }
   }
-  useRegisterEditor('enum', localDirty, save);
+  const reset = () => { setName(type.name); setDescription(type.description ?? ''); setValues(type.values ?? []); setError(''); };
+  useRegisterEditor('enum', localDirty, save, reset);
 
   const deleteBlock = usedBy > 0 ? `Нельзя удалить: используется в ${usedBy} типах` : null;
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <TypeDetailHeader name={name} code={type.code} chip="Перечисление" usedBy={usedBy}
-        dirty={dirty} saving={saving} onSaveAll={onSaveAll}
+        dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert}
         allGroups={allGroups} group={type.group} onGroup={g => groupMutation.mutate({ id: type.id, group: g })}
         onDelete={() => setConfirmDelete(true)} deleteBlock={deleteBlock} />
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
@@ -576,7 +578,7 @@ export function PrimitiveTypesPage() {
   const allGroups = [...new Set([...sortedPrim, ...sortedEnum].map(t => t.group).filter((g): g is string => !!g))]
     .sort((a, b) => a.localeCompare(b, 'ru'));
 
-  const { registry, anyDirty, saving, saveAll } = useTypeEditorRegistry();
+  const { registry, anyDirty, saving, saveAll, resetAll } = useTypeEditorRegistry();
 
   // Общий гард несохранённых изменений (ключ = {mode,id}) — issue #210 Этап 1 (ListDetailShell).
   const { request, dialogProps } = useDirtyGuard<{ mode: Mode; id: string | null }>({
@@ -593,11 +595,11 @@ export function PrimitiveTypesPage() {
   const detail = mode === 'primitive' && selectedPrim ? (
     <PrimitiveTypeDetail key={selectedPrim.id} type={selectedPrim} allGroups={allGroups}
       usedBy={countTypeRefs(selectedPrim.id, 'primitive', allDocTypes)}
-      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onDeleted={() => setSelectedId(null)} />
+      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll} onDeleted={() => setSelectedId(null)} />
   ) : mode === 'enum' && selectedEnum ? (
     <EnumTypeDetail key={selectedEnum.id} type={selectedEnum} allGroups={allGroups}
       usedBy={countTypeRefs(selectedEnum.id, 'enum', allDocTypes)}
-      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onDeleted={() => setSelectedId(null)} />
+      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll} onDeleted={() => setSelectedId(null)} />
   ) : (
     <div className="flex-1 flex items-center justify-center text-fg4 text-sm">
       {mode === 'primitive' ? 'Типов полей ещё нет' : 'Перечислений ещё нет'} — создайте первый.

--- a/src/client/src/features/settings/typeEditorShell.tsx
+++ b/src/client/src/features/settings/typeEditorShell.tsx
@@ -9,34 +9,40 @@ import { Button } from '@/shared/ui/Button';
 // «Сохранить» в шапке, бейдж «есть изменения» и диалог-гард при уходе. Сохранение может бросить —
 // тогда переход не выполняется. Полноценный ListDetailShell извлечём позже (после 3-й страницы).
 export interface TypeEditorRegistry {
-  publish: (key: string, dirty: boolean, save: () => Promise<void>) => void;
+  publish: (key: string, dirty: boolean, save: () => Promise<void>, reset?: () => void) => void;
   unpublish: (key: string) => void;
 }
 const TypeEditorContext = createContext<TypeEditorRegistry | null>(null);
 export const TypeEditorProvider = TypeEditorContext.Provider;
 
-/** Публикует dirty/save текущей формы в реестр страницы (save всегда берётся свежий через ref). */
-export function useRegisterEditor(key: string, dirty: boolean, save: () => Promise<void>) {
+/** Публикует dirty/save/reset текущей формы в реестр страницы (save/reset всегда берутся свежими через
+ *  ref). `reset` откатывает локальное состояние формы к сохранённому — для кнопки «Отмена» (issue #210). */
+export function useRegisterEditor(key: string, dirty: boolean, save: () => Promise<void>, reset?: () => void) {
   const ctx = useContext(TypeEditorContext);
   const saveRef = useRef(save);
   saveRef.current = save;
+  const resetRef = useRef(reset);
+  resetRef.current = reset;
   useEffect(() => {
-    ctx?.publish(key, dirty, () => saveRef.current());
+    ctx?.publish(key, dirty, () => saveRef.current(), () => resetRef.current?.());
   }, [ctx, key, dirty]);
   useEffect(() => () => ctx?.unpublish(key), [ctx, key]);
 }
 
-/** Агрегатор реестра для корня list-detail страницы: dirty-состояние + saveAll + provider value. */
+/** Агрегатор реестра для корня list-detail страницы: dirty-состояние + saveAll + resetAll + provider value. */
 export function useTypeEditorRegistry() {
   const [dirtyMap, setDirtyMap] = useState<Record<string, boolean>>({});
   const saversRef = useRef<Record<string, () => Promise<void>>>({});
+  const resettersRef = useRef<Record<string, () => void>>({});
   const registry = useMemo<TypeEditorRegistry>(() => ({
-    publish: (key, dirty, save) => {
+    publish: (key, dirty, save, reset) => {
       saversRef.current[key] = save;
+      if (reset) resettersRef.current[key] = reset;
       setDirtyMap(m => m[key] === dirty ? m : { ...m, [key]: dirty });
     },
     unpublish: (key) => {
       delete saversRef.current[key];
+      delete resettersRef.current[key];
       setDirtyMap(m => (key in m ? (() => { const n = { ...m }; delete n[key]; return n; })() : m));
     },
   }), []);
@@ -47,7 +53,8 @@ export function useTypeEditorRegistry() {
     try { for (const s of Object.values(saversRef.current)) await s(); }
     finally { setSaving(false); }
   };
-  return { registry, anyDirty, saving, saveAll };
+  const resetAll = () => { for (const r of Object.values(resettersRef.current)) r(); };
+  return { registry, anyDirty, saving, saveAll, resetAll };
 }
 
 /** MD3-диалог-гард при уходе с выбранного элемента с несохранёнными правками. */

--- a/src/client/src/shared/ui/ListDetailShell.tsx
+++ b/src/client/src/shared/ui/ListDetailShell.tsx
@@ -59,9 +59,11 @@ export function NavSearchInput({ value, onChange, placeholder = 'Поиск…' 
 /** Sticky-шапка detail: слева доменный `heading` (имя+бейджи+код), справа dirty-бейдж + «Сохранить»
  *  (единственный общий концерн) + доменные `actions` (group-picker/delete). Инвариант: «Сохранить»
  *  ТОЛЬКО здесь. */
-export function DetailHeader({ heading, dirty, saving, onSaveAll, actions }: {
+export function DetailHeader({ heading, dirty, saving, onSaveAll, onRevert, actions }: {
   heading: ReactNode;
   dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>;
+  /** Откат несохранённых правок; если задан — показывается кнопка «Отмена» (активна при dirty). */
+  onRevert?: () => void;
   actions?: ReactNode;
 }) {
   return (
@@ -70,6 +72,9 @@ export function DetailHeader({ heading, dirty, saving, onSaveAll, actions }: {
         <div className="min-w-0 flex-1">{heading}</div>
         <div className="flex items-center gap-1.5 shrink-0">
           {dirty && <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-warning-subtle text-warning">есть изменения</span>}
+          {onRevert && (
+            <Button variant="text" size="sm" disabled={!dirty || saving} onClick={onRevert}>Отмена</Button>
+          )}
           <Button variant="filled" size="sm" disabled={!dirty} loading={saving}
             onClick={() => { onSaveAll().catch(() => { /* ошибки показаны в формах */ }); }}>
             Сохранить

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.31.3</Version>
+    <Version>0.31.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Этап 2 — обогащение шапки detail: «Отмена» (revert)

По разбору с Дизайнером. Первая (и главная) часть Этапа 2.

### Что сделано
- **`DetailHeader`** (shared): кнопка **«Отмена»** перед «Сохранить» (активна при dirty) — откат несохранённых правок. Порядок = инвариант Дизайнера: `есть изменения → Отмена → Сохранить → действия`.
- **Реестр редакторов** расширен reset-функциями: `useRegisterEditor(key, dirty, save, reset?)` + `resetAll` в `useTypeEditorRegistry`. Каждая detail-форма публикует `reset` (откат локального состояния к сохранённому). Обе страницы: Типы документов/Составные (props + schema), Типы полей (primitive/enum).

### Проверка
- `npx tsc -b` — чисто.
- Playwright: правка поля → «Отмена» активна → откат к исходному имени + dirty уходит (обе страницы). Скриншот в треде.

### Отложено (нужно твоё решение)
**`⋮`-меню (группа/дублировать/удалить)** — вынес отдельно, т.к.:
- **дублирование** типа — это *новая фича* (нет backend-endpoint'а; клонирование типа со схемой — отдельная задача);
- **group-picker в ⋮-меню** неудобен (это dropdown внутри dropdown);
- **удаление** в шапке detail — осознанная кнопка (не hover-иконка списка, ради которой Дизайнер и вводил правило), уже безопасно через `ConfirmDialog`.

Если хочешь ⋮-консолидацию и/или фичу «дублировать» — обсудим отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)