### PR TITLE
feat(types): дублирование типов + ⋮-меню действий (#210 Этап 2)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
-  Plus, ChevronRight, Trash2, Folder, FileText, Boxes, EyeOff, Check,
+  Plus, ChevronRight, Trash2, Copy, Folder, FileText, Boxes, EyeOff, Check,
   Braces, RotateCcw, Code, Database, Cpu,
 } from 'lucide-react';
 import { Switch } from '@/shared/ui/Switch';
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
-import { Button, IconButton } from '@/shared/ui/Button';
+import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -43,6 +43,8 @@ import {
   TypeEditorProvider, useRegisterEditor, useTypeEditorRegistry, LeaveGuardDialog, SectionCard,
 } from './typeEditorShell';
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
+import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
+import { uniqueCode } from './PrimitiveTypesPage';
 
 /** Единственное членство (issue #197 Фаза C): каждый ключ поля остаётся только в первой группе,
  *  где встречается. Легаси-схемы могли класть поле в несколько групп — нормализуем при загрузке. */
@@ -635,9 +637,9 @@ function findReferencingTypes(id: string, allDocTypes: DocumentType[]): Document
 }
 
 /** Правая панель list-detail (issue #197 Фаза A): шапка типа (метрики+действия) + редактор как есть. */
-function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving, onSaveAll, onRevert }: {
+function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving, onSaveAll, onRevert, onDuplicate }: {
   docType: DocumentType; allDocTypes: DocumentType[]; allGroups: string[]; onDeleted: () => void;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDuplicate: () => void;
 }) {
   const deleteMutation = useDeleteDocumentType();
   const groupMutation = useSetDocumentTypeGroup();
@@ -704,19 +706,16 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
         }
         actions={
           <>
-            {docType.kind === 'Document' && (
-              <IconButton label="Шаблоны данных" size="sm" onClick={() => setTemplatesOpen(true)} title="Шаблоны данных">
-                <Database size={15} />
-              </IconButton>
-            )}
             <GroupPicker groups={allGroups} value={docType.group}
               onChange={group => groupMutation.mutate({ id: docType.id, group })} />
-            <IconButton label="Удалить тип" size="sm" danger
-              onClick={() => { if (!deleteBlock) setDeleteConfirmOpen(true); }}
-              disabled={deleteMutation.isPending || !!deleteBlock}
-              title={deleteBlock ?? 'Удалить тип'}>
-              <Trash2 size={15} />
-            </IconButton>
+            <RowActionsMenu ariaLabel="Действия типа" actions={[
+              { key: 'dup', label: 'Дублировать', icon: <Copy size={14} />, onSelect: onDuplicate },
+              ...(docType.kind === 'Document'
+                ? [{ key: 'tpl', label: 'Шаблоны данных', icon: <Database size={14} />, onSelect: () => setTemplatesOpen(true) }]
+                : []),
+              { key: 'del', label: deleteBlock ?? 'Удалить тип', danger: true, disabled: deleteMutation.isPending || !!deleteBlock,
+                icon: <Trash2 size={14} />, onSelect: () => { if (!deleteBlock) setDeleteConfirmOpen(true); } },
+            ]} />
           </>
         } />
       {/* Тело редактора (существующие редакторы как есть — Фаза A) */}
@@ -791,6 +790,14 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
   // Выбранный тип: из выбора (если ещё в отфильтрованных) иначе первый.
   const selected = filtered.find(t => t.id === selectedId) ?? filtered[0];
 
+  // Дублирование типа со схемой (клиентский клон, issue #210 Этап 2).
+  const createDoc = useCreateDocumentType();
+  const duplicateType = (dt: DocumentType) => createDoc.mutate({
+    name: `Копия ${dt.name}`, code: uniqueCode(dt.code, new Set(allDocTypes.map(x => x.code))),
+    kind: dt.kind, parentId: dt.parentId ?? null,
+    schema: JSON.stringify(dt.schema), isAbstract: dt.kind === 'Document' ? dt.isAbstract : false,
+  });
+
   const overlay = isLoading
     ? <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Загрузка...</div>
     : filtered.length === 0
@@ -814,7 +821,8 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
           detail={selected ? (
             <TypeDetail key={selected.id} docType={selected} allDocTypes={allDocTypes}
               allGroups={allGroups} onDeleted={() => setSelectedId(null)}
-              dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll} />
+              dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll}
+              onDuplicate={() => duplicateType(selected)} />
           ) : (
             <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Ничего не найдено</div>
           )} />

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import {
-  Plus, Trash2, CaseSensitive, Hash, Calendar, List as ListIcon,
+  Plus, Trash2, Copy, CaseSensitive, Hash, Calendar, List as ListIcon,
   CheckCircle2, AlertCircle,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { Button, IconButton } from '@/shared/ui/Button';
+import { Button } from '@/shared/ui/Button';
+import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
 import { TextField } from '@/shared/ui/TextField';
 import { DateInput } from '@/shared/ui/DateInput';
@@ -23,6 +24,7 @@ import {
 } from '@/shared/api/primitiveTypes';
 import {
   useListEnumTypes,
+  useCreateEnumType,
   useUpdateEnumType,
   useDeleteEnumType,
   useSetEnumTypeGroup,
@@ -60,6 +62,13 @@ const baseTypeIcon = (bt: string) => bt === 'number' ? Hash : bt === 'date' ? Ca
 /** Число типов, ссылающихся на данный тип поля (primitive/enum) полем с этим typeId (по своим схемам). */
 function countTypeRefs(typeId: string, kind: 'primitive' | 'enum', allDocTypes: DocumentType[]): number {
   return allDocTypes.filter(dt => parseSchemaFields(dt.schema).some(f => f.type === kind && f.typeId === typeId)).length;
+}
+
+/** Уникальный код на базе исходного: base2, base3 … (для дублирования типа, issue #210 Этап 2). */
+export function uniqueCode(base: string, existing: Set<string>): string {
+  if (!existing.has(base)) return base;
+  let i = 2; while (existing.has(`${base}${i}`)) i++;
+  return `${base}${i}`;
 }
 
 /** Человекочитаемое превью ограничений для строки списка. Regex не «переводим» (нельзя надёжно) —
@@ -303,9 +312,9 @@ function PrimitiveCreateForm({ onSaved, onCancel }: { onSaved: () => void; onCan
 
 // ─── Detail header (доменные heading/actions поверх общего DetailHeader) ──────────
 
-function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, onRevert, allGroups, group, onGroup, onDelete, deleteBlock }: {
+function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, onRevert, onDuplicate, allGroups, group, onGroup, onDelete, deleteBlock }: {
   name: string; code: string; chip: string; usedBy: number;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDuplicate: () => void;
   allGroups: string[]; group: string | null; onGroup: (g: string | null) => void;
   onDelete: () => void; deleteBlock: string | null;
 }) {
@@ -325,10 +334,10 @@ function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, 
       actions={
         <>
           <GroupPicker groups={allGroups} value={group} onChange={onGroup} />
-          <IconButton label="Удалить" size="sm" danger onClick={() => { if (!deleteBlock) onDelete(); }}
-            disabled={!!deleteBlock} title={deleteBlock ?? 'Удалить тип'}>
-            <Trash2 size={15} />
-          </IconButton>
+          <RowActionsMenu ariaLabel="Действия типа" actions={[
+            { key: 'dup', label: 'Дублировать', icon: <Copy size={14} />, onSelect: onDuplicate },
+            { key: 'del', label: deleteBlock ?? 'Удалить', danger: true, disabled: !!deleteBlock, icon: <Trash2 size={14} />, onSelect: () => { if (!deleteBlock) onDelete(); } },
+          ]} />
         </>
       } />
   );
@@ -336,9 +345,9 @@ function TypeDetailHeader({ name, code, chip, usedBy, dirty, saving, onSaveAll, 
 
 // ─── Primitive detail ────────────────────────────────────────────────────────────
 
-function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onRevert, onDeleted }: {
+function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onRevert, onDuplicate, onDeleted }: {
   type: PrimitiveTypeDef; allGroups: string[]; usedBy: number;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDeleted: () => void;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDuplicate: () => void; onDeleted: () => void;
 }) {
   const [name, setName] = useState(type.name);
   const [description, setDescription] = useState(type.description ?? '');
@@ -374,7 +383,7 @@ function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <TypeDetailHeader name={name} code={type.code} chip={BASE_TYPE_LABEL[type.baseType] ?? type.baseType} usedBy={usedBy}
-        dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert}
+        dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert} onDuplicate={onDuplicate}
         allGroups={allGroups} group={type.group} onGroup={g => groupMutation.mutate({ id: type.id, group: g })}
         onDelete={() => setConfirmDelete(true)} deleteBlock={deleteBlock} />
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
@@ -432,9 +441,9 @@ function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll
 
 // ─── Enum detail ──────────────────────────────────────────────────────────────────
 
-function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onRevert, onDeleted }: {
+function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onRevert, onDuplicate, onDeleted }: {
   type: EnumTypeDef; allGroups: string[]; usedBy: number;
-  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDeleted: () => void;
+  dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDuplicate: () => void; onDeleted: () => void;
 }) {
   const [name, setName] = useState(type.name);
   const [description, setDescription] = useState(type.description ?? '');
@@ -473,7 +482,7 @@ function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onR
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <TypeDetailHeader name={name} code={type.code} chip="Перечисление" usedBy={usedBy}
-        dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert}
+        dirty={dirty} saving={saving} onSaveAll={onSaveAll} onRevert={onRevert} onDuplicate={onDuplicate}
         allGroups={allGroups} group={type.group} onGroup={g => groupMutation.mutate({ id: type.id, group: g })}
         onDelete={() => setConfirmDelete(true)} deleteBlock={deleteBlock} />
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
@@ -592,14 +601,24 @@ export function PrimitiveTypesPage() {
   const selectedEnum = mode === 'enum' ? (sortedEnum.find(t => t.id === selectedId) ?? sortedEnum[0]) : undefined;
   const addLabel = mode === 'primitive' ? 'Добавить тип' : 'Добавить перечисление';
 
+  // Дублирование типа (клиентский клон, issue #210 Этап 2): имя «Копия …», код с суффиксом.
+  const createPrim = useCreatePrimitiveType();
+  const createEnum = useCreateEnumType();
+  const duplicatePrim = (t: PrimitiveTypeDef) => createPrim.mutate(
+    buildPrimitiveTypeDto(`Копия ${t.name}`, uniqueCode(t.code, new Set(sortedPrim.map(x => x.code))), t.baseType, t.description, t.constraints, t.allowedTags));
+  const duplicateEnum = (t: EnumTypeDef) => createEnum.mutate(
+    buildEnumTypeDto(`Копия ${t.name}`, uniqueCode(t.code, new Set(sortedEnum.map(x => x.code))), t.description, t.values));
+
   const detail = mode === 'primitive' && selectedPrim ? (
     <PrimitiveTypeDetail key={selectedPrim.id} type={selectedPrim} allGroups={allGroups}
       usedBy={countTypeRefs(selectedPrim.id, 'primitive', allDocTypes)}
-      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll} onDeleted={() => setSelectedId(null)} />
+      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll}
+      onDuplicate={() => duplicatePrim(selectedPrim)} onDeleted={() => setSelectedId(null)} />
   ) : mode === 'enum' && selectedEnum ? (
     <EnumTypeDetail key={selectedEnum.id} type={selectedEnum} allGroups={allGroups}
       usedBy={countTypeRefs(selectedEnum.id, 'enum', allDocTypes)}
-      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll} onDeleted={() => setSelectedId(null)} />
+      dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll}
+      onDuplicate={() => duplicateEnum(selectedEnum)} onDeleted={() => setSelectedId(null)} />
   ) : (
     <div className="flex-1 flex items-center justify-center text-fg4 text-sm">
       {mode === 'primitive' ? 'Типов полей ещё нет' : 'Перечислений ещё нет'} — создайте первый.

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.31.4</Version>
+    <Version>0.31.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Этап 2 (завершение) — «Дублировать» + `⋮`-меню действий

По итогам обсуждения: **дублирование — обе страницы**, **`⋮`-меню — да**.

### Что сделано
- **Дублирование типа** (клиентский клон, без бэкенда):
  - Типы полей — primitive (baseType+ограничения+тэги) и enum (варианты);
  - Типы документов/составные — с копией схемы (`JSON.stringify(schema)`) + `parentId`.
  - Имя «Копия …», уникальный код через `uniqueCode` (суффикс `2/3/…`).
- **`⋮`-`RowActionsMenu`** в шапке detail: `Дублировать → [док-ты] Шаблоны данных → разделитель → Удалить (danger)`. `GroupPicker` остаётся inline (это picker, не пункт меню). Удаление используемого типа — disabled с причиной прямо в пункте («Нельзя удалить: используется в N типах»). Прямые delete/`Database`-иконки убраны из шапки.

### Проверка
- `npx tsc -b` — чисто.
- Playwright: `⋮` открывается (Дублировать + Удалить); «Дублировать» создаёт «Копия ИНН» в списке; удаление копии через `⋮` + `ConfirmDialog` — работает (заодно очистка тест-копии). Скриншот меню в треде.

С этим **Этап 2 полностью закрыт** (Отмена/revert #215 + дублирование/`⋮` здесь). Эпик #210 — весь редизайн + shell + полировка — готов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)