### PR TITLE
refactor(datasets): извлечён DataSetsResource + системные наборы на нём (#210 ось видимости, PR2)

### DIFF
--- a/src/client/src/features/datasets/DataSetsPage.tsx
+++ b/src/client/src/features/datasets/DataSetsPage.tsx
@@ -1,85 +1,19 @@
-import { useRef, useState } from 'react';
-import { Button, IconButton } from '@/shared/ui/Button';
-import { EmptyState } from '@/shared/ui/EmptyState';
-import { Upload, Trash2, Database, RefreshCw, Download, Layers } from 'lucide-react';
-import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
-import type { DataSetFile } from '@/shared/api/types';
-import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
-import { SourcesExpander } from './SourcesExpander';
-import { useDataSetFileActions } from './useDataSetFileActions';
+import { useState } from 'react';
+import { Layers } from 'lucide-react';
+import { DataSetsResource } from './DataSetsResource';
 import { ProcessingTemplatesDialog } from './ProcessingTemplatesDialog';
-import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 
-function FileRow({ file }: { file: DataSetFile }) {
-  const {
-    update, confirming, setConfirming, downloading,
-    updateInputRef, handleReplace, handleDownload, handleDelete,
-  } = useDataSetFileActions(file, 'System');
-
-  return (
-    <div className="flex flex-col gap-2 px-4 py-3 border-b border-stroke last:border-0">
-      <div className="flex items-center gap-3">
-        <Database size={16} className="text-brand shrink-0" />
-        <div className="flex-1 min-w-0">
-          <div className="font-medium text-sm text-fg1">{file.name}</div>
-          <div className="text-xs mt-0.5 text-fg4">{DATA_SET_FORMAT_LABELS[file.format]}</div>
-        </div>
-        <input ref={updateInputRef} type="file" accept=".csv,.txt,.xlsx,.xls,.xml,.json,.zip,.gsfx,.pdf" className="hidden" onChange={handleReplace} />
-        <IconButton label="Скачать оригинальный файл" size="sm" onClick={handleDownload} disabled={downloading}>
-          <Download size={14} className={downloading ? 'opacity-50' : ''} />
-        </IconButton>
-        <IconButton label="Обновить файл (привязки сохранятся)" size="sm"
-          onClick={() => updateInputRef.current?.click()} disabled={update.isPending}>
-          <RefreshCw size={14} className={update.isPending ? 'animate-spin' : ''} />
-        </IconButton>
-        <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
-          <Trash2 size={14} />
-        </IconButton>
-      </div>
-      <div className="pl-7">
-        <SourcesExpander file={file} />
-      </div>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={o => { if (!o) setConfirming(false); }}
-        title={`Удалить файл «${file.name}»?`}
-        description={<p>Файл и все его источники будут удалены. Привязки, ссылающиеся на него, перестанут работать.</p>}
-        confirmLabel="Удалить файл"
-        onConfirm={() => { void handleDelete(); }}
-      />
-    </div>
-  );
-}
-
+/**
+ * Системные наборы данных (scope='System'). Тонкая обёртка над общим `DataSetsResource`
+ * (issue #210, ось видимости — единый браузер наборов на всех уровнях scope) + «Шаблоны обработки».
+ */
 export function DataSetsPage() {
-  const { data: files = [], isLoading } = useListDataSetFiles('System');
-  const upload = useUploadDataSetFile();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [uploading, setUploading] = useState(false);
-  const [uploadError, setUploadError] = useState('');
   const [templatesOpen, setTemplatesOpen] = useState(false);
-
-  async function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploading(true);
-    setUploadError('');
-    try {
-      await upload.mutateAsync({ file, name: file.name.replace(/\.[^.]+$/, ''), scope: 'System' });
-    } catch (err: unknown) {
-      setUploadError(err instanceof Error ? err.message : 'Ошибка загрузки');
-    } finally {
-      setUploading(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
-    }
-  }
 
   return (
     <div className="px-6 py-4 max-w-3xl">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="text-xl font-semibold text-fg1">
-          Наборы данных
-        </h1>
+        <h1 className="text-xl font-semibold text-fg1">Наборы данных</h1>
         <button onClick={() => setTemplatesOpen(true)}
           className="flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-md transition-colors text-fg2 bg-muted hover:bg-brand-subtle hover:text-brand">
           <Layers size={14} /> Шаблоны обработки
@@ -89,40 +23,9 @@ export function DataSetsPage() {
         Системные наборы доступны во всех комплектах. Наборы уровня стройки, раздела и комплекта управляются на соответствующих страницах.
       </p>
 
-      <div className="rounded-lg overflow-hidden border border-stroke bg-surface">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-stroke bg-base">
-          <span className="text-sm font-medium text-fg2">Системный уровень</span>
-          <div className="flex items-center gap-2">
-            {uploadError && <span className="text-xs text-danger">{uploadError}</span>}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".csv,.txt,.xlsx,.xls,.xml,.json,.zip,.gsfx,.pdf"
-              className="hidden"
-              onChange={handleFileInput}
-            />
-            <Button variant="tonal" size="sm" onClick={() => fileInputRef.current?.click()}
-              loading={uploading} icon={<Upload size={14} />}>
-              {uploading ? 'Загрузка…' : 'Загрузить файл'}
-            </Button>
-          </div>
-        </div>
+      <DataSetsResource scope="System" />
 
-        {isLoading ? (
-          <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>
-        ) : files.length === 0 ? (
-          <EmptyState className="m-4 border-0" icon={<Database size={30} />} title="Пока нет наборов данных"
-            description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) — из него можно собирать источники для колонок и таблиц документов."
-            action={<Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
-              loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>} />
-        ) : (
-          files.map(f => <FileRow key={f.id} file={f} />)
-        )}
-      </div>
-
-      <p className="mt-3 text-xs text-fg4">
-        Поддерживаемые форматы: CSV, TXT, XLSX, XLS, XML, JSON, ZIP, PDF.
-      </p>
+      <p className="mt-3 text-xs text-fg4">Поддерживаемые форматы: CSV, TXT, XLSX, XLS, XML, JSON, ZIP, PDF.</p>
 
       {templatesOpen && <ProcessingTemplatesDialog onClose={() => setTemplatesOpen(false)} />}
     </div>

--- a/src/client/src/features/datasets/DataSetsResource.tsx
+++ b/src/client/src/features/datasets/DataSetsResource.tsx
@@ -1,0 +1,104 @@
+import { useRef, useState } from 'react';
+import { Upload, Trash2, Database, RefreshCw, Download } from 'lucide-react';
+import { Button, IconButton } from '@/shared/ui/Button';
+import { EmptyState } from '@/shared/ui/EmptyState';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
+import type { CatalogScope, DataSetFile } from '@/shared/api/types';
+import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
+import { SourcesExpander } from './SourcesExpander';
+import { useDataSetFileActions } from './useDataSetFileActions';
+
+const ACCEPT = '.csv,.txt,.xlsx,.xls,.xml,.json,.zip,.gsfx,.pdf';
+
+function FileRow({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogScope; scopeId?: string }) {
+  const {
+    update, confirming, setConfirming, downloading,
+    updateInputRef, handleReplace, handleDownload, handleDelete,
+  } = useDataSetFileActions(file, scope, scopeId);
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3 border-b border-stroke last:border-0">
+      <div className="flex items-center gap-3">
+        <Database size={16} className="text-brand shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm text-fg1">{file.name}</div>
+          <div className="text-xs mt-0.5 text-fg4">{DATA_SET_FORMAT_LABELS[file.format]}</div>
+        </div>
+        <input ref={updateInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleReplace} />
+        <IconButton label="Скачать оригинальный файл" size="sm" onClick={handleDownload} disabled={downloading}>
+          <Download size={14} className={downloading ? 'opacity-50' : ''} />
+        </IconButton>
+        <IconButton label="Обновить файл (привязки сохранятся)" size="sm"
+          onClick={() => updateInputRef.current?.click()} disabled={update.isPending}>
+          <RefreshCw size={14} className={update.isPending ? 'animate-spin' : ''} />
+        </IconButton>
+        <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
+          <Trash2 size={14} />
+        </IconButton>
+      </div>
+      <div className="pl-7">
+        <SourcesExpander file={file} />
+      </div>
+      <ConfirmDialog open={confirming} onOpenChange={o => { if (!o) setConfirming(false); }}
+        title={`Удалить файл «${file.name}»?`}
+        description={<p>Файл и все его источники будут удалены. Привязки, ссылающиеся на него, перестанут работать.</p>}
+        confirmLabel="Удалить файл" onConfirm={() => { void handleDelete(); }} />
+    </div>
+  );
+}
+
+/**
+ * Браузер наборов данных для ЛЮБОГО scope (issue #210, ось видимости): загрузка + список файлов
+ * с источниками. Единый компонент для system-страницы и scoped-панелей — область выражается
+ * положением, НЕ чипом. Заголовок/контекст даёт вызывающий.
+ */
+export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scopeId?: string }) {
+  const { data: files = [], isLoading } = useListDataSetFiles(scope, scopeId);
+  const upload = useUploadDataSetFile();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+
+  async function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setUploadError('');
+    try {
+      await upload.mutateAsync({ file, name: file.name.replace(/\.[^.]+$/, ''), scope, scopeId });
+    } catch (err: unknown) {
+      setUploadError(err instanceof Error ? err.message : 'Ошибка загрузки');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="rounded-lg overflow-hidden border border-stroke bg-surface">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-stroke bg-base">
+        <span className="text-sm font-medium text-fg2">Наборы данных</span>
+        <div className="flex items-center gap-2">
+          {uploadError && <span className="text-xs text-danger">{uploadError}</span>}
+          <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
+          <Button variant="tonal" size="sm" onClick={() => fileInputRef.current?.click()}
+            loading={uploading} icon={<Upload size={14} />}>
+            {uploading ? 'Загрузка…' : 'Загрузить файл'}
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>
+      ) : files.length === 0 ? (
+        <EmptyState className="m-4 border-0" icon={<Database size={30} />} title="Пока нет наборов данных"
+          description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) — из него можно собирать источники для колонок и таблиц документов."
+          action={<Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
+            loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>} />
+      ) : (
+        files.map(f => <FileRow key={f.id} file={f} scope={scope} scopeId={scopeId} />)
+      )}
+    </div>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.31.6</Version>
+    <Version>0.31.7</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## PR2 — `DataSetsResource` (ось видимости, шаг 2/6)

Второй шаг унификации ресурсов оси scope (после PR1 `CatalogResource`).

### Что сделано
- Извлечён **`DataSetsResource({scope, scopeId})`** — браузер наборов данных (загрузка + список файлов с источниками через `SourcesExpander`), scope-параметризованный, **без чипа области**. Канонический `FileRow` (System-размер) с scope-параметрами.
- `DataSetsPage` сведён к тонкой обёртке (h1 + «Шаблоны обработки» + `<DataSetsResource scope="System" />`).

### Дальше
- PR3 `SubscribersResource`; затем scope-страницы на `ListDetailShell`, где `*Resource` становятся detail-панелями, а `ScopedDataSetsPanel`/`ScopedCatalogPanel` заменяются.

### Проверка
- `npx tsc -b` — чисто.
- Playwright: `/datasets` рендерится через новый компонент — паритет (загрузка/пустое состояние/шаблоны). Скриншот в треде.

🤖 Generated with [Claude Code](https://claude.com/claude-code)