### PR TITLE
refactor(subscribers): извлечён SubscribersResource (#210 ось видимости, PR3)

### DIFF
--- a/src/client/src/features/document-sets/SubscribersPanel.tsx
+++ b/src/client/src/features/document-sets/SubscribersPanel.tsx
@@ -1,41 +1,18 @@
 import { useState } from 'react';
-import { Users, ChevronDown, ChevronRight, Trash2, Mail, Plus, AlertTriangle } from 'lucide-react';
-import { useAuth } from '@/shared/hooks/useAuth';
-import { Select, SelectItem } from '@/shared/ui/Select';
-import { useListUsers } from '@/shared/api/users';
-import {
-  useSubscribers, useRecipients, useAddSubscriber, useRemoveSubscriber, type SubscriptionScope,
-} from '@/shared/api/subscriptions';
-import { SendMessageDialog } from '@/shared/ui/SendMessageDialog';
+import { Users, ChevronDown, ChevronRight } from 'lucide-react';
+import { useSubscribers, type SubscriptionScope } from '@/shared/api/subscriptions';
 import { SCOPE_LABELS } from '@/shared/api/types';
 import { SCOPE_COLORS } from './fields/constants';
+import { SubscribersResource } from './SubscribersResource';
 
 /**
- * Подписчики уровня стройка/раздел/комплект. Управление (добавить/удалить/отправить) — только Admin
- * (как и отправка почты); список видят все. Отправка идёт эффективным получателям (прямые +
- * унаследованные с вышестоящих уровней).
+ * Инлайн-коллапс «Подписчики» уровня стройка/раздел/комплект (внутри DocumentSetsPage). Тонкая обёртка
+ * над общим `SubscribersResource` (issue #210). При постройке scope-страниц коллапс+чип уйдут, останется
+ * `SubscribersResource` как detail-панель.
  */
 export function SubscribersPanel({ scope, scopeId }: { scope: SubscriptionScope; scopeId: string }) {
-  const { user } = useAuth();
-  const isAdmin = user?.role === 'Admin';
   const [expanded, setExpanded] = useState(false);
-  const [sendOpen, setSendOpen] = useState(false);
-  const [addUserId, setAddUserId] = useState('');
-
   const { data: subscribers = [] } = useSubscribers(scope, scopeId);
-  const { data: users = [] } = useListUsers();
-  const { data: recipients = [] } = useRecipients(scope, scopeId, sendOpen);
-  const add = useAddSubscriber();
-  const remove = useRemoveSubscriber();
-
-  const subscribedIds = new Set(subscribers.map(s => s.userId));
-  const available = users.filter(u => !subscribedIds.has(u.id));
-
-  function handleAdd() {
-    if (!addUserId) return;
-    add.mutate({ userId: addUserId, scope, scopeId });
-    setAddUserId('');
-  }
 
   return (
     <div className="mt-3 rounded-xl overflow-hidden border border-stroke">
@@ -51,60 +28,13 @@ export function SubscribersPanel({ scope, scopeId }: { scope: SubscriptionScope;
           Подписчики
           {subscribers.length > 0 && <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded-full bg-brand-subtle text-brand">{subscribers.length}</span>}
         </span>
-        {isAdmin && (
-          <button onClick={e => { e.stopPropagation(); setSendOpen(true); }}
-            className="flex items-center gap-1 text-xs px-2 py-1 rounded text-brand hover:bg-brand-subtle transition-colors">
-            <Mail size={11} /> Сообщение
-          </button>
-        )}
         {expanded ? <ChevronDown size={13} className="text-fg4" /> : <ChevronRight size={13} className="text-fg4" />}
       </div>
 
       {expanded && (
-        <div className="border-t border-stroke bg-surface px-3 py-3 space-y-2">
-          {subscribers.length === 0 ? (
-            <p className="text-xs text-fg4">Нет подписчиков этого уровня. Получатели наследуются с вышестоящих.</p>
-          ) : (
-            <div className="rounded-md border border-stroke divide-y divide-muted">
-              {subscribers.map(s => (
-                <div key={s.id} className="flex items-center gap-2 px-2.5 py-1.5 text-sm group">
-                  <span className="text-fg1 flex-1 min-w-0 truncate">{s.displayName}</span>
-                  <span className="text-xs text-fg4 min-w-0 truncate">{s.email || '—'}</span>
-                  {!s.validEmail && (
-                    <span title="Нет валидного email — писем не получит" className="shrink-0">
-                      <AlertTriangle size={13} className="text-warning" />
-                    </span>
-                  )}
-                  {isAdmin && (
-                    <button onClick={() => remove.mutate({ id: s.id, scope, scopeId })}
-                      className="p-0.5 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all" title="Убрать из подписчиков">
-                      <Trash2 size={13} />
-                    </button>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-
-          {isAdmin && (
-            <div className="flex items-center gap-2">
-              <Select value={addUserId || undefined} onValueChange={setAddUserId}
-                placeholder="Добавить подписчика…" aria-label="Подписчик" className="flex-1">
-                {available.map(u => <SelectItem key={u.id} value={u.id}>{u.displayName || u.email}</SelectItem>)}
-              </Select>
-              <button onClick={handleAdd} disabled={!addUserId || add.isPending}
-                className="flex items-center gap-1 text-sm px-3 py-1.5 border border-stroke-strong rounded-md hover:bg-base transition-colors disabled:opacity-50">
-                <Plus size={13} /> Добавить
-              </button>
-            </div>
-          )}
+        <div className="border-t border-stroke bg-surface px-3 py-3">
+          <SubscribersResource scope={scope} scopeId={scopeId} />
         </div>
-      )}
-
-      {isAdmin && (
-        <SendMessageDialog open={sendOpen} onClose={() => setSendOpen(false)}
-          title="Сообщение подписчикам"
-          candidates={recipients.map(r => ({ id: r.userId, displayName: r.displayName, email: r.email }))} />
       )}
     </div>
   );

--- a/src/client/src/features/document-sets/SubscribersResource.tsx
+++ b/src/client/src/features/document-sets/SubscribersResource.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { Trash2, Mail, Plus, AlertTriangle } from 'lucide-react';
+import { useAuth } from '@/shared/hooks/useAuth';
+import { Select, SelectItem } from '@/shared/ui/Select';
+import { useListUsers } from '@/shared/api/users';
+import {
+  useSubscribers, useRecipients, useAddSubscriber, useRemoveSubscriber, type SubscriptionScope,
+} from '@/shared/api/subscriptions';
+import { SendMessageDialog } from '@/shared/ui/SendMessageDialog';
+
+/**
+ * Содержимое «Подписчики» для ЛЮБОГО scope (issue #210, ось видимости): тулбар «Сообщение» (Admin) +
+ * список подписчиков + добавление. Без чипа области и без внешнего коллапса — область выражается
+ * положением. Единый компонент для scoped-панелей и будущих scope-страниц. Заголовок даёт вызывающий.
+ * Управление (добавить/удалить/отправить) — только Admin; список видят все. Отправка идёт эффективным
+ * получателям (прямые + унаследованные с вышестоящих уровней).
+ */
+export function SubscribersResource({ scope, scopeId }: { scope: SubscriptionScope; scopeId: string }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'Admin';
+  const [sendOpen, setSendOpen] = useState(false);
+  const [addUserId, setAddUserId] = useState('');
+
+  const { data: subscribers = [] } = useSubscribers(scope, scopeId);
+  const { data: users = [] } = useListUsers();
+  const { data: recipients = [] } = useRecipients(scope, scopeId, sendOpen);
+  const add = useAddSubscriber();
+  const remove = useRemoveSubscriber();
+
+  const subscribedIds = new Set(subscribers.map(s => s.userId));
+  const available = users.filter(u => !subscribedIds.has(u.id));
+
+  function handleAdd() {
+    if (!addUserId) return;
+    add.mutate({ userId: addUserId, scope, scopeId });
+    setAddUserId('');
+  }
+
+  return (
+    <div className="space-y-2">
+      {isAdmin && (
+        <div className="flex justify-end">
+          <button onClick={() => setSendOpen(true)}
+            className="flex items-center gap-1 text-xs px-2 py-1 rounded text-brand hover:bg-brand-subtle transition-colors">
+            <Mail size={12} /> Сообщение
+          </button>
+        </div>
+      )}
+
+      {subscribers.length === 0 ? (
+        <p className="text-xs text-fg4">Нет подписчиков этого уровня. Получатели наследуются с вышестоящих.</p>
+      ) : (
+        <div className="rounded-md border border-stroke divide-y divide-muted">
+          {subscribers.map(s => (
+            <div key={s.id} className="flex items-center gap-2 px-2.5 py-1.5 text-sm group">
+              <span className="text-fg1 flex-1 min-w-0 truncate">{s.displayName}</span>
+              <span className="text-xs text-fg4 min-w-0 truncate">{s.email || '—'}</span>
+              {!s.validEmail && (
+                <span title="Нет валидного email — писем не получит" className="shrink-0">
+                  <AlertTriangle size={13} className="text-warning" />
+                </span>
+              )}
+              {isAdmin && (
+                <button onClick={() => remove.mutate({ id: s.id, scope, scopeId })}
+                  className="p-0.5 text-stroke-strong hover:text-danger opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all" title="Убрать из подписчиков">
+                  <Trash2 size={13} />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {isAdmin && (
+        <div className="flex items-center gap-2">
+          <Select value={addUserId || undefined} onValueChange={setAddUserId}
+            placeholder="Добавить подписчика…" aria-label="Подписчик" className="flex-1">
+            {available.map(u => <SelectItem key={u.id} value={u.id}>{u.displayName || u.email}</SelectItem>)}
+          </Select>
+          <button onClick={handleAdd} disabled={!addUserId || add.isPending}
+            className="flex items-center gap-1 text-sm px-3 py-1.5 border border-stroke-strong rounded-md hover:bg-base transition-colors disabled:opacity-50">
+            <Plus size={13} /> Добавить
+          </button>
+        </div>
+      )}
+
+      {isAdmin && (
+        <SendMessageDialog open={sendOpen} onClose={() => setSendOpen(false)}
+          title="Сообщение подписчикам"
+          candidates={recipients.map(r => ({ id: r.userId, displayName: r.displayName, email: r.email }))} />
+      )}
+    </div>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.31.7</Version>
+    <Version>0.31.8</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## PR3 — `SubscribersResource` (ось видимости, шаг 3/6)

Третий (последний) ресурс оси scope. Завершает унификацию ресурсов (после PR1 `CatalogResource`, PR2 `DataSetsResource`).

### Что сделано
- Извлечён **`SubscribersResource({scope, scopeId})`** — тулбар «Сообщение» (Admin) + список подписчиков + добавление + `SendMessageDialog`. **Без чипа области и внешнего коллапса.**
- `SubscribersPanel` сведён к тонкой коллапс-обёртке над ним (коллапс+чип уйдут при постройке scope-страниц). «Сообщение» переехала из шапки коллапса в тулбар ресурса.

### Дальше
Все три ресурса — единые компоненты. Далее **scope-страницы** (PR4 Комплект → PR5 Раздел → PR6 Стройка) на `ListDetailShell` с левой навигацией «дети (chevron→роут) + ресурсы (подсветка→detail)»; `*Resource` станут detail-панелями, инлайн-аккордеоны/чипы уйдут.

### Проверка
- `npx tsc -b` — чисто.
- Playwright: панель «Подписчики» на странице стройки раскрывается — «Сообщение» в тулбаре + список/добавление; паритет. Скриншот в треде.

🤖 Generated with [Claude Code](https://claude.com/claude-code)