### PR TITLE
feat(document-sets): страница Комплекта → ListDetailShell (#210 ось видимости, PR4)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
 import {
   Plus, Trash2, ChevronRight, Download, Pencil, ChevronDown, ChevronUp, FolderOpen, Eye,
-  ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail,
+  ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail, Database, Table2, Users,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
@@ -10,6 +10,10 @@ import { TextField } from '@/shared/ui/TextField';
 import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
+import { ListDetailShell, NavItem, NavSection } from '@/shared/ui/ListDetailShell';
+import { CatalogResource } from './catalog/CatalogResource';
+import { DataSetsResource } from '@/features/datasets/DataSetsResource';
+import { SubscribersResource } from './SubscribersResource';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import {
@@ -34,8 +38,12 @@ import { useAuth } from '@/shared/hooks/useAuth';
 
 // ─── Set detail (documents) ───────────────────────────────────────────────────
 
+type SetPanel = 'documents' | 'catalog' | 'datasets' | 'subscribers';
+
 function SetDetail() {
-  const { constructionId, setId } = useParams<{ constructionId: string; setId: string }>();
+  const { constructionId, setId, panel } = useParams<{ constructionId: string; setId: string; panel?: string }>();
+  const navigate = useNavigate();
+  const activePanel: SetPanel = (['catalog', 'datasets', 'subscribers'].includes(panel ?? '') ? panel : 'documents') as SetPanel;
   const { data: set, isLoading } = useGetDocumentSet(setId);
   const { data: construction } = useGetConstruction(constructionId!);
   const { data: availableInstances = [] } = useGetAvailableInstances(setId);
@@ -117,52 +125,59 @@ function SetDetail() {
     : availableInstances;
   const sectionName = construction?.sections.find(s => s.id === set.sectionId)?.name;
 
-  return (
-    <div className="p-6">
-      <nav className="flex items-center gap-1 text-sm text-fg4 mb-5">
-        <Link to="/document-sets" className="hover:text-fg2 transition-colors">Стройки</Link>
-        <ChevronRight size={14} />
-        <Link to={`/document-sets/${constructionId}`} className="hover:text-fg2 transition-colors">{construction?.name ?? 'Разделы и комплекты'}</Link>
-        {sectionName && (
-          <>
-            <ChevronRight size={14} />
-            <Link to={`/document-sets/${constructionId}?section=${set.sectionId}`} className="hover:text-fg2 transition-colors">{sectionName}</Link>
-          </>
-        )}
-        <ChevronRight size={14} />
-        <span className="text-fg2 font-medium">{set.name}</span>
-      </nav>
+  const base = `/document-sets/${constructionId}/sets/${setId}`;
+  const goPanel = (p: SetPanel) => navigate(p === 'documents' ? base : `${base}/${p}`);
 
-      <div className="flex items-center justify-between mb-1 gap-3 flex-wrap">
-        <h1 className="text-xl font-semibold text-fg1">{set.name}</h1>
-        <div className="flex items-center gap-2">
-          {output && (
-            <Button variant="outlined" icon={<Download size={15} />}
-              onClick={() => downloadSetOutput(set.id, set.name)}
-              title={`Собран ${new Date(output.generatedAt).toLocaleString('ru-RU')}`}>
-              Скачать комплект
-            </Button>
-          )}
-          {isAdmin && output && (
-            <Button variant="outlined" icon={<Mail size={15} />} onClick={() => setEmailKitOpen(true)}
-              title="Отправить собранный комплект по почте (подписчикам и/или на внешние адреса)">
-              Отправить по почте
-            </Button>
-          )}
-          <Button variant="tonal" icon={<Layers size={15} />} loading={assembleMutation.isPending || watching}
-            disabled={assembleMutation.isPending || watching || set.instances.length === 0}
-            onClick={handleAssemble}
-            title="Собрать все документы комплекта в один PDF в заданном порядке">
-            Собрать комплект
-          </Button>
-          <Button variant="filled" icon={<Plus size={16} />} onClick={() => setAddDocOpen(true)}>
-            Добавить документ
-          </Button>
-        </div>
-      </div>
+  const contextCrumbs = (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      <Link to="/document-sets" className="text-xs text-fg4 hover:text-fg2 transition-colors">Стройки</Link>
+      {construction && (
+        <Link to={`/document-sets/${constructionId}`}
+          className="text-[11px] px-2 py-0.5 rounded-full border border-stroke text-fg3 hover:border-stroke-strong hover:text-fg1 transition-colors">
+          Стройка: {construction.name}
+        </Link>
+      )}
+      {sectionName && (
+        <Link to={`/document-sets/${constructionId}?section=${set.sectionId}`}
+          className="text-[11px] px-2 py-0.5 rounded-full border border-stroke text-fg3 hover:border-stroke-strong hover:text-fg1 transition-colors">
+          Раздел: {sectionName}
+        </Link>
+      )}
+    </div>
+  );
+
+  const nav = (
+    <div className="flex-1 overflow-y-auto px-2 pb-3 pt-2 space-y-0.5">
+      <NavItem icon={<FileText size={17} />} label="Документы" count={set.instances.length}
+        active={activePanel === 'documents'} onClick={() => goPanel('documents')} />
+      <NavSection label="Этот комплект" />
+      <NavItem icon={<Database size={17} />} label="Каталог" active={activePanel === 'catalog'} onClick={() => goPanel('catalog')} />
+      <NavItem icon={<Table2 size={17} />} label="Наборы данных" active={activePanel === 'datasets'} onClick={() => goPanel('datasets')} />
+      <NavItem icon={<Users size={17} />} label="Подписчики" active={activePanel === 'subscribers'} onClick={() => goPanel('subscribers')} />
+    </div>
+  );
+
+  const headerAction = activePanel === 'documents' ? (
+    <div className="flex items-center gap-2 shrink-0">
+      {output && (
+        <Button variant="outlined" size="sm" icon={<Download size={15} />} onClick={() => downloadSetOutput(set.id, set.name)}
+          title={`Собран ${new Date(output.generatedAt).toLocaleString('ru-RU')}`}>Скачать</Button>
+      )}
+      {isAdmin && output && (
+        <Button variant="outlined" size="sm" icon={<Mail size={15} />} onClick={() => setEmailKitOpen(true)}
+          title="Отправить собранный комплект по почте">Почта</Button>
+      )}
+      <Button variant="tonal" size="sm" icon={<Layers size={15} />} loading={assembleMutation.isPending || watching}
+        disabled={assembleMutation.isPending || watching || set.instances.length === 0} onClick={handleAssemble}
+        title="Собрать все документы комплекта в один PDF">Собрать</Button>
+      <Button variant="filled" size="sm" icon={<Plus size={16} />} onClick={() => setAddDocOpen(true)}>Добавить документ</Button>
+    </div>
+  ) : null;
+
+  const documentsContent = (
+    <>
       {addError && <p className="text-xs text-danger mb-3">{addError}</p>}
       {!addError && assembleMsg && <p className="text-xs text-fg4 mb-3">{assembleMsg}</p>}
-      {!addError && !assembleMsg && <div className="mb-3" />}
 
       <div className="bg-surface border border-stroke rounded-xl overflow-hidden">
         {set.instances.length === 0 ? (
@@ -252,15 +267,24 @@ function SetDetail() {
           </table>
         )}
       </div>
+    </>
+  );
 
-      {setId && (
-        <div className="mt-6 pt-5 border-t border-stroke space-y-3">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-fg4">Область: комплект</h2>
-          <ScopedCatalogPanel scope="Set" scopeId={setId} allDocTypes={docTypes} setId={setId} />
-          <ScopedDataSetsPanel scope="Set" scopeId={setId} />
-          <SubscribersPanel scope="Set" scopeId={setId} />
-        </div>
-      )}
+  const detail = (
+    <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+      <div className="mx-auto max-w-5xl">
+        {activePanel === 'documents' ? documentsContent
+          : activePanel === 'catalog' ? <CatalogResource scope="Set" scopeId={setId ?? null} allDocTypes={docTypes} />
+          : activePanel === 'datasets' ? <DataSetsResource scope="Set" scopeId={setId} />
+          : <SubscribersResource scope="Set" scopeId={setId!} />}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <ListDetailShell title={set.name} titleIcon={<FolderOpen size={20} />} breadcrumb={contextCrumbs}
+        headerAction={headerAction} nav={nav} detail={detail} />
 
       {isAdmin && (
         <EmailSendDialog open={emailKitOpen} onClose={() => setEmailKitOpen(false)}
@@ -307,7 +331,7 @@ function SetDetail() {
           deleteMutation.mutate({ setId: set.id, instanceId: deleteTarget.id });
         }}
       />
-    </div>
+    </>
   );
 }
 
@@ -804,6 +828,7 @@ export function DocumentSetsPage() {
       <Route index element={<ConstructionsList />} />
       <Route path=":constructionId" element={<ConstructionDetail />} />
       <Route path=":constructionId/sets/:setId" element={<SetDetail />} />
+      <Route path=":constructionId/sets/:setId/:panel" element={<SetDetail />} />
     </Routes>
   );
 }

--- a/src/client/src/shared/ui/ListDetailShell.tsx
+++ b/src/client/src/shared/ui/ListDetailShell.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import { Search } from 'lucide-react';
+import { Search, ChevronRight } from 'lucide-react';
 import { Button } from './Button';
 
 /**
@@ -9,14 +9,20 @@ import { Button } from './Button';
  * per-page слоты; реестр агрегации dirty — отдельный модуль (features/settings/typeEditorShell).
  * НЕ клиент этого shell: редактор документа (#192) — там навигация ВНУТРИ сущности + preview-панель.
  */
-export function ListDetailShell({ title, subtitle, headerAction, overlay, nav, detail }: {
+export function ListDetailShell({ title, subtitle, titleIcon, breadcrumb, headerAction, overlay, nav, navWidth = 'w-80', detail }: {
   title: string;
   subtitle?: string;
+  /** Иконка уровня слева от заголовка (scope-страницы: стройка/раздел/комплект). */
+  titleIcon?: ReactNode;
+  /** Хлебные крошки над заголовком (scope-страницы). */
+  breadcrumb?: ReactNode;
   headerAction?: ReactNode;
   /** Полноэкранное состояние вместо сплита (загрузка / пустая коллекция). */
   overlay?: ReactNode;
   /** Содержимое левой колонки (табы/поиск/список) — per-page. Рамку/ширину задаёт shell. */
   nav: ReactNode;
+  /** Ширина левой колонки (Tailwind-класс): по умолчанию w-80 (320px); w-64 (260) для вырожденных. */
+  navWidth?: string;
   /** Detail-панель или EmptyState «выберите …». */
   detail: ReactNode;
 }) {
@@ -24,14 +30,18 @@ export function ListDetailShell({ title, subtitle, headerAction, overlay, nav, d
     <div className="h-full flex flex-col">
       <div className="flex items-center justify-between gap-3 px-6 py-3 shrink-0 border-b border-stroke">
         <div className="min-w-0">
-          <h1 className="text-xl font-semibold text-fg1">{title}</h1>
+          {breadcrumb && <div className="mb-0.5">{breadcrumb}</div>}
+          <div className="flex items-center gap-2 min-w-0">
+            {titleIcon && <span className="text-fg3 shrink-0">{titleIcon}</span>}
+            <h1 className="text-xl font-semibold text-fg1 truncate">{title}</h1>
+          </div>
           {subtitle && <p className="text-xs text-fg3 mt-0.5">{subtitle}</p>}
         </div>
         {headerAction}
       </div>
       {overlay ?? (
         <div className="flex-1 min-h-0 flex">
-          <nav aria-label={title} className="w-80 shrink-0 border-r border-stroke flex flex-col bg-base">
+          <nav aria-label={title} className={`${navWidth} shrink-0 border-r border-stroke flex flex-col bg-base`}>
             {nav}
           </nav>
           {detail}
@@ -53,6 +63,40 @@ export function NavSearchInput({ value, onChange, placeholder = 'Поиск…' 
           className="w-full h-10 pl-9 pr-3 rounded-full text-sm bg-surface border border-stroke-strong text-fg1 outline-none focus-visible:ring-2 focus-visible:ring-brand placeholder:text-fg4" />
       </div>
     </div>
+  );
+}
+
+/** Микрозаголовок секции левой навигации scope-страницы («КОМПЛЕКТЫ», «ЭТОТ РАЗДЕЛ», …). */
+export function NavSection({ label }: { label: string }) {
+  return <div className="px-3 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wide text-fg4">{label}</div>;
+}
+
+/**
+ * Пилюля левой навигации scope-страницы (issue #210, ось видимости). Два рода (аффорданс кодирует scope):
+ * `chevron` — «ребёнок» (уводит вглубь/роут): счётчик перед chevron, НИКОГДА не подсвечивается;
+ * без `chevron` — ресурс/контент уровня (меняет detail на месте): тональный бейдж-счётчик, подсветка при active.
+ */
+export function NavItem({ icon, label, count, active, chevron, onClick }: {
+  icon: ReactNode; label: string; count?: number; active?: boolean; chevron?: boolean; onClick: () => void;
+}) {
+  const highlight = active && !chevron;
+  return (
+    <button type="button" onClick={onClick} aria-current={active ? 'true' : undefined}
+      className={`w-full flex items-center gap-2.5 px-3 h-11 rounded-full text-left transition-colors ${
+        highlight ? 'bg-brand-subtle text-brand-hover font-medium' : 'text-fg2 hover:bg-muted'}`}>
+      <span className={`shrink-0 ${highlight ? 'text-brand-hover' : 'text-fg4'}`}>{icon}</span>
+      <span className="flex-1 truncate text-sm">{label}</span>
+      {chevron ? (
+        <>
+          {count != null && <span className="text-xs text-fg4 shrink-0">{count}</span>}
+          <ChevronRight size={14} className="shrink-0 text-fg4" />
+        </>
+      ) : (
+        count != null && count > 0 && (
+          <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${highlight ? 'bg-white/50 text-brand-hover' : 'bg-brand-subtle text-brand'}`}>{count}</span>
+        )
+      )}
+    </button>
   );
 }
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.31.8</Version>
+    <Version>0.32.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## PR4 — страница Комплекта на `ListDetailShell` (ось видимости, шаг 4/6)

**Первая видимая scope-страница** (после унификации ресурсов PR1-3). По мокапу друга (1d), подтверждённому Дизайнером+Архитектором.

### Что сделано
- **Страница Комплекта = `ListDetailShell`** со вторичной навигацией:
  - Слева: **«Документы N»** (контент уровня, подсветка) + секция **«ЭТОТ КОМПЛЕКТ»** с ресурсами **Каталог / Наборы данных / Подписчики** (подсветка → меняют detail).
  - Справа: документы **таблицей** ИЛИ `CatalogResource` / `DataSetsResource` / `SubscribersResource` (scope=Set).
  - **Контекстные chips** (Стройка / Раздел — кликабельны) + **иконка уровня** в заголовке — вместо крошек с чипом области.
  - **Единая URL-модель:** `/document-sets/:cId/sets/:setId/{catalog|datasets|subscribers}` — deep-link, back/forward.
  - Инлайн-аккордеоны «Область: комплект» убраны.
- **`ListDetailShell` расширен:** слоты `breadcrumb` + `titleIcon`, проп `navWidth`; компоненты **`NavItem`** (дети=chevron/без подсветки, ресурсы=бейдж/подсветка — инвариант друга) + **`NavSection`**.

### Проверка
- `npx tsc -b` — чисто.
- Playwright: страница Комплекта — 4 nav-пилюли, таблица документов + действия (Собрать/Добавить); переключение на «Каталог» → `CatalogResource` в detail + URL `.../catalog` (deep-link). Скриншоты в треде.

### Дальше
- **PR5** Раздел (новый роут `/sections/:sId`: комплекты как «дети» с chevron + ресурсы раздела), **PR6** Стройка (разделы + ресурсы стройки). Там `ScopedCatalogPanel`/`ScopedDataSetsPanel`/`SubscribersPanel` (инлайн-коллапсы) уйдут окончательно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)