### PR TITLE
feat(editor): подтверждение при замене базового экземпляра (#223)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -35,6 +35,7 @@ import { QualityLinksTab } from './QualityLinksTab';
 import { DocumentTemplateParams } from './DocumentTemplateParams';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 
 type SaveRef = { current: (() => Promise<boolean>) | null };
 
@@ -109,6 +110,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   const [showValidation, setShowValidation] = useState(false);
   const [activeKey, setActiveKey] = useState<string>(''); // активный раздел (list-detail, issue #191)
   const [hintPicker, setHintPicker] = useState(false); // пикер «Основы» из строки-подсказки (issue #223)
+  const [pendingBase, setPendingBase] = useState<BaseCandidate | null>(null); // подтверждение замены базы
   const mutation = useUpdateRequisites();
 
   // Поля, заполняемые привязкой к набору данных при генерации — источник перезаписывает их,
@@ -171,6 +173,13 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     ? schemaFields.filter(f => ownFieldKeys.has(f.key) || !baseCoveredFields.has(f.key))
     : schemaFields;
   function selectBase(c: BaseCandidate) { setValue('_baseRef', { kind: c.kind, id: c.id }); }
+  // Замена уже выбранной базы на другую — сперва подтверждение (issue #223): набор предзаполняемых
+  // полей меняется. Значения НЕ удаляются (база мёржится в пустые/покрытые при генерации), поэтому
+  // диалог предупреждает, а не «перезаписывает». Первый выбор (базы ещё нет) — сразу, без диалога.
+  function requestSelectBase(c: BaseCandidate) {
+    if (baseRef && baseRef.id !== c.id) setPendingBase(c);
+    else selectBase(c);
+  }
   function clearBaseRef() {
     setValues(p => { const n = { ...p }; delete n._baseRef; return n; });
     onDirty(true);
@@ -186,7 +195,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     onBaseState({ hasBase, selected: selectedBase, missing: missingBase, candidates: baseCandidates, coveredCount: baseCoveredCount });
   }, [hasBase, selectedBase, missingBase, baseCandidates, baseCoveredCount, onBaseState]);
   useEffect(() => {
-    baseControlRef.current = { select: selectBase, clear: clearBaseRef };
+    baseControlRef.current = { select: requestSelectBase, clear: clearBaseRef };
     return () => { baseControlRef.current = null; };
   });
 
@@ -522,7 +531,17 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
           <p className="text-sm text-danger">{error}</p>
         </div>
       )}
-      <BaseCandidatePicker open={hintPicker} onOpenChange={setHintPicker} candidates={baseCandidates} onSelect={selectBase} />
+      <BaseCandidatePicker open={hintPicker} onOpenChange={setHintPicker} candidates={baseCandidates} onSelect={requestSelectBase} />
+      <ConfirmDialog
+        open={!!pendingBase}
+        onOpenChange={o => { if (!o) setPendingBase(null); }}
+        title="Заменить основу?"
+        description={
+          <>Набор предзаполняемых полей изменится: часть значений может перестать наследоваться от текущей основы, а другие поля станут обязательными. Введённые вручную значения не удаляются.</>
+        }
+        confirmLabel="Заменить"
+        onConfirm={() => { if (pendingBase) selectBase(pendingBase); setPendingBase(null); }}
+      />
     </div>
   );
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.35.0</Version>
+    <Version>0.35.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Доработка к #223 (по просьбе пользователя после слияния Фазы 1 #224).

## Что

Замена уже выбранной «Основы» на другую теперь спрашивает подтверждение (`ConfirmDialog` «Заменить основу?»): набор предзаполняемых полей меняется. **Первый выбор** (базы ещё нет) применяется сразу, без диалога.

Важно: в текущей модели значения реквизитов при смене базы **не удаляются** (база мёржится только в пустые/покрытые поля при генерации, свои значения перекрывают базу). Поэтому диалог **предупреждает о смене набора наследуемых полей**, а не предлагает «перезаписать/сохранить» — так честнее к реальному поведению.

## Реализация

- `requestSelectBase(c)`: если база уже выбрана и `id` другой → `pendingBase` (диалог); иначе `selectBase` сразу.
- Все точки входа выбора идут через `requestSelectBase`: меню chip «Заменить основу…», строка-подсказка первого раздела, канал управления шапки (`baseControlRef`).

## Проверка

`tsc -b` — чисто. Путь замены на реальных данных не воспроизвести (у тестовых документов нет кандидатов-основ), изменение маленькое и изолированное.

Версия → `0.35.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)