### PR TITLE
fix(settings): отступы кнопок действий в строке поля (FieldBuilder)

### DIFF
--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -191,7 +191,7 @@ export function FieldCard({
       </div>
       {open && (
       <div className="px-3 pb-3 pt-2 border-t border-stroke space-y-2">
-      <div className="grid grid-cols-[1fr_1fr_160px_72px_48px] gap-2 items-center">
+      <div className="grid grid-cols-[1fr_1fr_160px_72px_76px] gap-2 items-center">
         {/* Title */}
         <input
           value={field.title}
@@ -233,7 +233,7 @@ export function FieldCard({
           <span className="text-xs text-fg3">да</span>
         </label>
         {/* Actions */}
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center justify-end gap-0.5">
           <button type="button" onClick={onMoveUp} disabled={isFirst}
             className="p-1 text-fg4 hover:text-fg2 disabled:opacity-25">
             <ArrowUp size={12} />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.35.1</Version>
+    <Version>0.35.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Проблема

В раскрытой строке поля (редактор схемы, `FieldBuilder`) колонка действий в гриде была **48px**, а вмещает **три** кнопки (↑ ↓ 🗑, ~64px) — они переполняли ячейку и прижимались к правому краю карточки (замечено пользователем).

## Фикс

Колонка `grid-cols-[1fr_1fr_160px_72px_48px]` → `…_76px`, кнопкам добавлен `justify-end`. Теперь три кнопки помещаются с ровными отступами и не липнут к границе.

## Проверка

`tsc -b` — чисто. Скриншот раскрытой строки: ↑ ↓ 🗑 выровнены вправо с воздухом от края.

Версия → `0.35.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)