### PR TITLE
fix(catalog): превью строки не протекает _baseRef и [object Object] (#232, P0)

### DIFF
--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -54,7 +54,11 @@ export function ObjectRow({
   className?: string;
 }) {
   const icon = dense ? 12 : 13;
-  const preview = Object.entries(entry.data).filter(([, v]) => v != null && v !== '')
+  // Превью строки: только собственные скалярные поля. Исключаем служебные ключи (`_baseRef` и пр.,
+  // с префиксом `_`) — иначе в UI протекал сырой uuid; и составные/массивные значения (объекты) —
+  // иначе рендерился `[object Object]` (их содержимое смотрят в редакторе записи).
+  const preview = Object.entries(entry.data)
+    .filter(([k, v]) => !k.startsWith('_') && v != null && v !== '' && typeof v !== 'object')
     .slice(0, 3).map(([k, v]) => `${k}: ${v}`).join(' · ');
   return (
     <div className={`group flex items-center transition-colors ${dense ? 'gap-3 px-3 py-2 hover:bg-muted' : 'gap-4 px-4 py-3 hover:bg-base'} ${className}`}>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.37.0</Version>
+    <Version>0.37.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #232. **P0** из разбора «Улучшение страниц каталога».

## Проблема

`ObjectRow` (`ObjectsByTypeList.tsx:57`) строил превью как первые 3 непустых поля `entry.data` (`k: v`), не исключая служебные ключи и не обрабатывая объекты:
- служебный `_baseRef` протекал в UI сырым uuid / `[object Object]`;
- составные/массивные значения полей → `[object Object]`.

## Фикс

В превью исключить `_`-ключи (служебные) и не-примитивные значения (их содержимое — в редакторе записи). Одна строка, чистый фронт, нулевой риск.

## Проверка

- `tsc -b` чисто.
- Живой прогон (Playwright, каталог стройки ДНС ЕЦДМ — 21 запись с ролями и составными полями): превью стали осмысленными — «Роль: Производитель работ», «ИНН · КПП · ОГРН», прокси-цель как имя «→ ООО …»; `_baseRef` и `[object Object]` в UI отсутствуют (проверка по innerText — false/false).

## Отложено (следующие фазы, нужны ответы пользователя)

Роль→сущность как chip с резолвом цели по scope-цепочке (обобщить `ProxyRoleMarker` с same-type на child-type + явное «связь не найдена»); вертикальный тип-рейл `?type=id`; hover-card превью цели; preview-поля в схеме.

Версия → `0.37.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)