### PR TITLE
fix(catalog): прокси-маркер резолвит цель по scope-цепочке (кросс-scope)

### DIFF
--- a/src/client/src/features/document-sets/catalog/CatalogResource.tsx
+++ b/src/client/src/features/document-sets/catalog/CatalogResource.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
-import { useListCommonData, useDeleteCommonDataEntry } from '@/shared/api/commonData';
+import { useListCommonData, useDeleteCommonDataEntry, useCommonDataForScope } from '@/shared/api/commonData';
 import type { CommonDataEntry, CatalogScope, DocumentType } from '@/shared/api/types';
 import { CatalogEntryForm } from './index';
 import { groupObjectsByType, ObjectRow } from './ObjectsByTypeList';
@@ -33,6 +33,9 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
   }
 
   const { data: entries = [], isLoading } = useListCommonData({ scope, scopeId: scopeId ?? undefined });
+  // Пул для резолва прокси-цели: записи всей scope-цепочки (текущий уровень + предки) — чтобы прокси,
+  // ссылающийся на реальный объект уровнем ВЫШЕ, всё равно показывал «→ цель» (issue #89, уточнение).
+  const { data: scopeChain = [] } = useCommonDataForScope({ scope, scopeId });
   const deleteMutation = useDeleteCommonDataEntry();
 
   const compositeTypes = allDocTypes.filter(dt => dt.kind === 'Composite');
@@ -106,7 +109,7 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
                 {isOpen && (
                   <div className="border-t border-stroke">
                     {items.map((entry, idx) => (
-                      <ObjectRow key={entry.id} entry={entry} siblings={items}
+                      <ObjectRow key={entry.id} entry={entry} siblings={items} resolvePool={scopeChain}
                         onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
                         showPreview className={idx > 0 ? 'border-t border-muted' : ''} />
                     ))}
@@ -128,7 +131,7 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
                 {isOpen && (
                   <div className="border-t border-stroke">
                     {noType.map((entry, idx) => (
-                      <ObjectRow key={entry.id} entry={entry} siblings={noType}
+                      <ObjectRow key={entry.id} entry={entry} siblings={noType} resolvePool={scopeChain}
                         onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
                         className={idx > 0 ? 'border-t border-muted' : ''} />
                     ))}

--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -17,15 +17,18 @@ export function groupObjectsByType(entries: CommonDataEntry[], types: DocumentTy
 }
 
 /** Метка роли/прокси (issue #89): если запись ссылается (`_baseRef`) на объект ТОГО ЖЕ типа —
- *  показываем «→ реальный» и открываем его по клику. Цель ищется среди siblings. */
-export function ProxyRoleMarker({ entry, siblings, onOpen }: {
+ *  показываем «→ реальный» и открываем его по клику. Цель ищется среди `resolvePool` (если задан —
+ *  вся scope-цепочка, чтобы находить прокси-цель уровнем ВЫШЕ; иначе — `siblings` того же scope). */
+export function ProxyRoleMarker({ entry, siblings, resolvePool, onOpen }: {
   entry: CommonDataEntry;
   siblings: CommonDataEntry[];
+  /** Пул для резолва цели (обычно scope-цепочка `useCommonDataForScope`) — покрывает кросс-scope прокси. */
+  resolvePool?: CommonDataEntry[];
   onOpen: (e: CommonDataEntry) => void;
 }) {
   const br = (entry.data as Record<string, unknown>)?._baseRef;
   const tid = typeof br === 'string' ? br : (br && typeof br === 'object' && 'id' in br ? (br as { id?: string }).id : undefined);
-  const target = tid ? siblings.find(e => e.id === tid) : undefined;
+  const target = tid ? (resolvePool ?? siblings).find(e => e.id === tid) : undefined;
   if (!target || target.compositeTypeId !== entry.compositeTypeId) return null;
   return (
     <button type="button" onClick={e => { e.stopPropagation(); onOpen(target); }}
@@ -40,11 +43,13 @@ export function ProxyRoleMarker({ entry, siblings, onOpen }: {
  *  <paramref name="dense"/> — компактный вид (панель) vs просторный (страница). Разделитель/фон —
  *  через <paramref name="className"/> на стороне вызывающего. */
 export function ObjectRow({
-  entry, siblings, onEdit, onDelete, deleteDisabled = false,
+  entry, siblings, resolvePool, onEdit, onDelete, deleteDisabled = false,
   dense = false, showPreview = false, docKind = false, className = '',
 }: {
   entry: CommonDataEntry;
   siblings: CommonDataEntry[];
+  /** Пул для резолва прокси-цели (scope-цепочка) — покрывает кросс-scope прокси; см. ProxyRoleMarker. */
+  resolvePool?: CommonDataEntry[];
   onEdit: (e: CommonDataEntry) => void;
   onDelete: (e: CommonDataEntry) => void;
   deleteDisabled?: boolean;
@@ -64,7 +69,7 @@ export function ObjectRow({
     <div className={`group flex items-center transition-colors ${dense ? 'gap-3 px-3 py-2 hover:bg-muted' : 'gap-4 px-4 py-3 hover:bg-base'} ${className}`}>
       {docKind && dense && <FileText size={12} className="text-warning shrink-0" />}
       <span className={`flex-1 text-sm truncate ${dense ? 'text-fg1' : 'font-medium text-fg1'}`}>{entry.displayName}</span>
-      <ProxyRoleMarker entry={entry} siblings={siblings} onOpen={onEdit} />
+      <ProxyRoleMarker entry={entry} siblings={siblings} resolvePool={resolvePool} onOpen={onEdit} />
       {docKind && dense && (
         <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>
       )}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.37.1</Version>
+    <Version>0.37.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Уточнение пользователя по разбору каталога: если прокси (#89) ссылается на реальный объект в **другом (вышестоящем) scope**, маркер «→ цель» не показывался.

## Проблема

`ProxyRoleMarker` искал цель `_baseRef` только среди `siblings` того же scope. Прокси уровня Стройки, ссылающийся на организацию уровня **Системы** («Субподрядчик» → ООО «Техногид»), не находил цель → тихо рендерил `null`.

## Фикс

- `ObjectRow`/`ProxyRoleMarker`: опциональный `resolvePool` — пул для резолва цели; если задан, ищем в нём (вся scope-цепочка), иначе — `siblings` (как было).
- `CatalogResource`: грузит `useCommonDataForScope({scope, scopeId})` (#82 — мёржит цепочку предков одним запросом) и передаёт как `resolvePool`.
- Тип-ограничение прокси (same-type) сохранено; редактирование цели идёт по id (scope не переназначается — безопасно для кросс-scope).

## Проверка

- `tsc -b` чисто.
- Живой прогон (Playwright, каталог стройки ДНС ЕЦДМ): «Субподрядчик → ООО «Техногид»» (цель на уровне System) теперь показывает маркер; same-scope прокси (Заказчик/Подрядчик/Проектировщик) без регресса; P0-фикс превью держится (ИНН·КПП·ОГРН, без `_baseRef`/`[object Object]`).

Версия → `0.37.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)