### PR TITLE
feat(catalog): вертикальный рейл типов + deep-link ?type=id (#235)

### DIFF
--- a/src/client/src/features/common-data/SystemCommonDataPage.tsx
+++ b/src/client/src/features/common-data/SystemCommonDataPage.tsx
@@ -8,7 +8,7 @@ import { CatalogResource } from '../document-sets/catalog/CatalogResource';
 export function SystemCommonDataPage() {
   const { data: allDocTypes = [] } = useListDocumentTypes();
   return (
-    <div className="px-6 py-4 max-w-4xl mx-auto">
+    <div className="px-6 py-4">
       <div className="mb-4">
         <h1 className="text-xl font-semibold text-fg1">Системный каталог</h1>
         <p className="text-xs text-fg3 mt-0.5">Общие данные, доступные во всех проектах (приоритет 5)</p>

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -324,12 +324,14 @@ function SetDetail() {
 
   const detail = (
     <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
-      <div className="mx-auto max-w-5xl">
-        {activePanel === 'documents' ? documentsContent
-          : activePanel === 'catalog' ? <CatalogResource scope="Set" scopeId={setId ?? null} allDocTypes={docTypes} />
-          : activePanel === 'datasets' ? <DataSetsResource scope="Set" scopeId={setId} />
-          : <SubscribersResource scope="Set" scopeId={setId!} />}
-      </div>
+      {/* Каталог — во всю ширину (рейл типов у левого края); прочие панели центрируем. */}
+      {activePanel === 'catalog'
+        ? <CatalogResource scope="Set" scopeId={setId ?? null} allDocTypes={docTypes} />
+        : <div className="mx-auto max-w-5xl">
+            {activePanel === 'documents' ? documentsContent
+              : activePanel === 'datasets' ? <DataSetsResource scope="Set" scopeId={setId} />
+              : <SubscribersResource scope="Set" scopeId={setId!} />}
+          </div>}
     </div>
   );
 
@@ -506,11 +508,12 @@ function SectionDetail() {
 
   const detail = (
     <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
-      <div className="mx-auto max-w-5xl">
-        {activePanel === 'catalog' ? <CatalogResource scope="Section" scopeId={sectionId ?? null} allDocTypes={docTypes} />
-          : activePanel === 'datasets' ? <DataSetsResource scope="Section" scopeId={sectionId} />
-          : <SubscribersResource scope="Section" scopeId={sectionId!} />}
-      </div>
+      {activePanel === 'catalog'
+        ? <CatalogResource scope="Section" scopeId={sectionId ?? null} allDocTypes={docTypes} />
+        : <div className="mx-auto max-w-5xl">
+            {activePanel === 'datasets' ? <DataSetsResource scope="Section" scopeId={sectionId} />
+              : <SubscribersResource scope="Section" scopeId={sectionId!} />}
+          </div>}
     </div>
   );
 
@@ -656,11 +659,12 @@ function ConstructionDetail() {
 
   const detail = (
     <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
-      <div className="mx-auto max-w-5xl">
-        {activePanel === 'catalog' ? <CatalogResource scope="Construction" scopeId={constructionId ?? null} allDocTypes={docTypes} />
-          : activePanel === 'datasets' ? <DataSetsResource scope="Construction" scopeId={constructionId} />
-          : <SubscribersResource scope="Construction" scopeId={constructionId!} />}
-      </div>
+      {activePanel === 'catalog'
+        ? <CatalogResource scope="Construction" scopeId={constructionId ?? null} allDocTypes={docTypes} />
+        : <div className="mx-auto max-w-5xl">
+            {activePanel === 'datasets' ? <DataSetsResource scope="Construction" scopeId={constructionId} />
+              : <SubscribersResource scope="Construction" scopeId={constructionId!} />}
+          </div>}
     </div>
   );
 

--- a/src/client/src/features/document-sets/catalog/CatalogResource.tsx
+++ b/src/client/src/features/document-sets/catalog/CatalogResource.tsx
@@ -1,22 +1,24 @@
-import { useState } from 'react';
-import { Plus, Search, ChevronDown, ChevronUp, Database } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Plus, Search, ChevronDown, ChevronUp, Database, FileText, Layers, X } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
-import { Select, SelectItem, SelectGroup } from '@/shared/ui/Select';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListCommonData, useDeleteCommonDataEntry, useCommonDataForScope } from '@/shared/api/commonData';
 import type { CommonDataEntry, CatalogScope, DocumentType } from '@/shared/api/types';
 import { CatalogEntryForm } from './index';
 import { groupObjectsByType, ObjectRow } from './ObjectsByTypeList';
 
-/** Sentinel для «Все типы» — Radix Select запрещает пустую строку как value. */
-const ALL_TYPES = '__all__';
+const NO_TYPE = '__no_type__';
+/** Порог, с которого над списком типов появляется мини-поиск (NN/g: фасеты с поиском при большом числе). */
+const TYPE_SEARCH_THRESHOLD = 12;
 
 /**
- * Богатый браузер каталога общих данных для ЛЮБОГО scope (issue #210, ось видимости): поиск + фильтр по
- * типу + группы по типу + add/edit/delete. Единый компонент для system-страницы и scoped-панелей — область
- * выражается положением (страница/панель), НЕ чипом. Заголовок/контекст даёт вызывающий.
+ * Богатый браузер каталога общих данных для ЛЮБОГО scope (issue #210, ось видимости): слева — вертикальный
+ * рейл типов со счётчиками («Все записи» + типы, мини-поиск при большом числе; вариант B — рейл живёт ВНУТРИ
+ * компонента, один на всех 4 уровнях), справа — поиск + записи (все группами / выбранный тип плоско).
+ * Выбранный тип — в URL (`?type=id`, deep-link). Область выражается положением, заголовок даёт вызывающий.
  */
 export function CatalogResource({ scope, scopeId, allDocTypes }: {
   scope: CatalogScope; scopeId: string | null; allDocTypes: DocumentType[];
@@ -24,124 +26,162 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
   const [addOpen, setAddOpen] = useState(false);
   const [editEntry, setEditEntry] = useState<CommonDataEntry | null>(null);
   const [search, setSearch] = useState('');
-  const [filterTypeId, setFilterTypeId] = useState('');
+  const [typeSearch, setTypeSearch] = useState('');
   const [expandedTypes, setExpandedTypes] = useState<Set<string>>(new Set());
   const [deleteTarget, setDeleteTarget] = useState<CommonDataEntry | null>(null);
+
+  // Выбранный тип — в URL (?type=id), deep-link/back-forward. Пустой = «Все записи».
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filterTypeId = searchParams.get('type') ?? '';
+  const setFilterTypeId = (id: string) => setSearchParams(prev => {
+    const next = new URLSearchParams(prev);
+    if (id) next.set('type', id); else next.delete('type');
+    return next;
+  }, { replace: true });
 
   function toggleType(id: string) {
     setExpandedTypes(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
   }
 
   const { data: entries = [], isLoading } = useListCommonData({ scope, scopeId: scopeId ?? undefined });
-  // Пул для резолва прокси-цели: записи всей scope-цепочки (текущий уровень + предки) — чтобы прокси,
-  // ссылающийся на реальный объект уровнем ВЫШЕ, всё равно показывал «→ цель» (issue #89, уточнение).
+  // Пул для резолва прокси-цели: вся scope-цепочка (текущий уровень + предки) — кросс-scope прокси (#89).
   const { data: scopeChain = [] } = useCommonDataForScope({ scope, scopeId });
   const deleteMutation = useDeleteCommonDataEntry();
 
   const compositeTypes = allDocTypes.filter(dt => dt.kind === 'Composite');
   const documentTypes = allDocTypes.filter(dt => dt.kind === 'Document' && !dt.isAbstract);
   const allSelectableTypes = [...compositeTypes, ...documentTypes];
+  const isDocType = (id: string) => documentTypes.some(dt => dt.id === id);
 
-  const filtered = entries.filter(e => {
-    const matchSearch = !search || e.displayName.toLowerCase().includes(search.toLowerCase());
-    const matchType = !filterTypeId || e.compositeTypeId === filterTypeId;
-    return matchSearch && matchType;
-  }).sort((a, b) => {
-    const typeCmp = (allSelectableTypes.find(t => t.id === a.compositeTypeId)?.name ?? '').localeCompare(
-      allSelectableTypes.find(t => t.id === b.compositeTypeId)?.name ?? '');
-    return typeCmp !== 0 ? typeCmp : a.displayName.localeCompare(b.displayName);
-  });
+  // Рейл типов: счётчики по всем записям уровня (независимо от текстового поиска и выбранного типа).
+  const rail = groupObjectsByType(entries, allSelectableTypes);
+  const tq = typeSearch.trim().toLowerCase();
+  const railGroups = tq ? rail.groups.filter(g => g.type.name.toLowerCase().includes(tq)) : rail.groups;
+
+  const selectedType = filterTypeId && filterTypeId !== NO_TYPE
+    ? allSelectableTypes.find(t => t.id === filterTypeId) : undefined;
+
+  // Записи справа: фильтр по тексту + выбранному типу.
+  const matchType = (e: CommonDataEntry) =>
+    !filterTypeId ? true
+      : filterTypeId === NO_TYPE ? !allSelectableTypes.some(t => t.id === e.compositeTypeId)
+        : e.compositeTypeId === filterTypeId;
+  const filtered = entries.filter(e =>
+    (!search || e.displayName.toLowerCase().includes(search.toLowerCase())) && matchType(e))
+    .sort((a, b) => {
+      const typeCmp = (allSelectableTypes.find(t => t.id === a.compositeTypeId)?.name ?? '').localeCompare(
+        allSelectableTypes.find(t => t.id === b.compositeTypeId)?.name ?? '');
+      return typeCmp !== 0 ? typeCmp : a.displayName.localeCompare(b.displayName);
+    });
   const { groups, noType } = groupObjectsByType(filtered, allSelectableTypes);
 
-  return (
-    <div>
-      {/* Панель инструментов: поиск + фильтр по типу + «Добавить» */}
-      <div className="flex items-center gap-3 mb-4">
-        <div className="relative flex-1 max-w-sm">
-          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-fg4" />
-          <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск по названию..."
-            className="w-full border border-stroke-strong rounded-md pl-9 pr-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
-        </div>
-        {allSelectableTypes.length > 0 && (
-          <Select value={filterTypeId || ALL_TYPES} onValueChange={v => setFilterTypeId(v === ALL_TYPES ? '' : v)}
-            aria-label="Фильтр по типу" className="w-56">
-            <SelectItem value={ALL_TYPES}>Все типы</SelectItem>
-            {compositeTypes.length > 0 && (
-              <SelectGroup label="Составные типы">
-                {compositeTypes.map(ct => <SelectItem key={ct.id} value={ct.id}>{ct.name}</SelectItem>)}
-              </SelectGroup>
-            )}
-            {documentTypes.length > 0 && (
-              <SelectGroup label="Типы документов">
-                {documentTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>)}
-              </SelectGroup>
-            )}
-          </Select>
-        )}
-        <span className="flex-1" />
-        <Button variant="filled" size="sm" icon={<Plus size={16} />} onClick={() => setAddOpen(true)}>Добавить запись</Button>
-      </div>
+  const row = (entry: CommonDataEntry, siblings: CommonDataEntry[], border: boolean) => (
+    <ObjectRow key={entry.id} entry={entry} siblings={siblings} resolvePool={scopeChain}
+      onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
+      showPreview className={border ? 'border-t border-muted' : ''} />
+  );
 
-      {isLoading ? (
-        <div className="text-center py-12 text-fg4 text-sm">Загрузка...</div>
-      ) : entries.length === 0 ? (
-        <EmptyState icon={<Database size={30} />} title="Каталог пуст"
-          description="Добавьте справочные данные (организации, лица, объекты) этого уровня."
-          action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setAddOpen(true)}>Добавить запись</Button>} />
-      ) : filtered.length === 0 ? (
-        <div className="text-center py-10 text-fg4 text-sm">Ничего не найдено</div>
-      ) : (
-        <div className="space-y-2">
-          {groups.map(({ type: t, items }) => {
-            const isOpen = expandedTypes.has(t.id);
-            return (
-              <div key={t.id} className="border border-stroke rounded-xl overflow-hidden">
-                <button type="button" onClick={() => toggleType(t.id)} aria-expanded={isOpen}
-                  className="w-full flex items-center gap-2 px-4 py-3 bg-surface hover:bg-base transition-colors text-left">
-                  {isOpen ? <ChevronUp size={14} className="text-fg4 shrink-0" /> : <ChevronDown size={14} className="text-fg4 shrink-0" />}
-                  <span className="flex-1 text-sm font-medium text-fg2">{t.name}</span>
-                  {t.kind === 'Document' && (
-                    <span className="text-xs bg-warning-subtle text-warning border border-warning-border px-1.5 py-0.5 rounded-full">внеш. документ</span>
-                  )}
-                  <span className="text-xs text-fg4 font-mono">{t.code}</span>
-                  <span className="text-xs text-fg4 ml-1">{items.length}</span>
-                </button>
-                {isOpen && (
-                  <div className="border-t border-stroke">
-                    {items.map((entry, idx) => (
-                      <ObjectRow key={entry.id} entry={entry} siblings={items} resolvePool={scopeChain}
-                        onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
-                        showPreview className={idx > 0 ? 'border-t border-muted' : ''} />
-                    ))}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-          {noType.length > 0 && (() => {
-            const isOpen = expandedTypes.has('__no_type__');
-            return (
-              <div className="border border-stroke rounded-xl overflow-hidden">
-                <button type="button" onClick={() => toggleType('__no_type__')} aria-expanded={isOpen}
-                  className="w-full flex items-center gap-2 px-4 py-3 bg-surface hover:bg-base transition-colors text-left">
-                  {isOpen ? <ChevronUp size={14} className="text-fg4 shrink-0" /> : <ChevronDown size={14} className="text-fg4 shrink-0" />}
-                  <span className="flex-1 text-sm font-medium text-fg3 italic">Без типа</span>
-                  <span className="text-xs text-fg4">{noType.length}</span>
-                </button>
-                {isOpen && (
-                  <div className="border-t border-stroke">
-                    {noType.map((entry, idx) => (
-                      <ObjectRow key={entry.id} entry={entry} siblings={noType} resolvePool={scopeChain}
-                        onEdit={setEditEntry} onDelete={setDeleteTarget} deleteDisabled={deleteMutation.isPending}
-                        className={idx > 0 ? 'border-t border-muted' : ''} />
-                    ))}
-                  </div>
-                )}
-              </div>
-            );
-          })()}
+  return (
+    <div className="flex gap-5 items-start">
+      {/* Рейл типов */}
+      <aside className="w-48 shrink-0 sticky top-0 self-start space-y-0.5">
+        {rail.groups.length > TYPE_SEARCH_THRESHOLD && (
+          <div className="relative mb-1">
+            <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-fg4 pointer-events-none" />
+            <input value={typeSearch} onChange={e => setTypeSearch(e.target.value)} placeholder="Тип…" aria-label="Поиск типа"
+              className="w-full h-8 pl-7 pr-6 rounded-md text-xs bg-surface border border-stroke text-fg1 outline-none focus-visible:ring-2 focus-visible:ring-brand placeholder:text-fg4" />
+            {typeSearch && (
+              <button onClick={() => setTypeSearch('')} aria-label="Очистить" className="absolute right-1.5 top-1/2 -translate-y-1/2 text-fg4 hover:text-fg2">
+                <X size={12} />
+              </button>
+            )}
+          </div>
+        )}
+        <TypeNavItem icon={<Layers size={15} />} label="Все записи" count={entries.length}
+          active={!filterTypeId} onClick={() => setFilterTypeId('')} />
+        {railGroups.map(({ type: t, items }) => (
+          <TypeNavItem key={t.id}
+            icon={isDocType(t.id) ? <FileText size={15} /> : <Database size={15} />}
+            label={t.name} count={items.length} doc={isDocType(t.id)}
+            active={filterTypeId === t.id} onClick={() => setFilterTypeId(t.id)} />
+        ))}
+        {rail.noType.length > 0 && !tq && (
+          <TypeNavItem label="Без типа" count={rail.noType.length} muted
+            active={filterTypeId === NO_TYPE} onClick={() => setFilterTypeId(NO_TYPE)} />
+        )}
+      </aside>
+
+      {/* Записи */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="relative flex-1 max-w-sm">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-fg4" />
+            <input value={search} onChange={e => setSearch(e.target.value)}
+              placeholder={selectedType ? `Поиск: ${selectedType.name}…` : 'Поиск по каталогу…'}
+              className="w-full border border-stroke-strong rounded-md pl-9 pr-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
+          </div>
+          <span className="flex-1" />
+          <Button variant="filled" size="sm" icon={<Plus size={16} />} onClick={() => setAddOpen(true)}>Добавить запись</Button>
         </div>
-      )}
+
+        {isLoading ? (
+          <div className="text-center py-12 text-fg4 text-sm">Загрузка...</div>
+        ) : entries.length === 0 ? (
+          <EmptyState icon={<Database size={30} />} title="Каталог пуст"
+            description="Добавьте справочные данные (организации, лица, объекты) этого уровня."
+            action={<Button variant="filled" icon={<Plus size={16} />} onClick={() => setAddOpen(true)}>Добавить запись</Button>} />
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-10 text-fg4 text-sm">Ничего не найдено</div>
+        ) : filterTypeId ? (
+          // Выбран один тип — плоский список без аккордеона (тип уже виден в рейле).
+          <div className="border border-stroke rounded-xl overflow-hidden">
+            <div className="flex items-center gap-2 px-4 py-3 bg-surface border-b border-stroke">
+              <span className="flex-1 text-sm font-medium text-fg2">{selectedType?.name ?? 'Без типа'}</span>
+              {selectedType && isDocType(selectedType.id) && (
+                <span className="text-xs bg-warning-subtle text-warning border border-warning-border px-1.5 py-0.5 rounded-full">внеш. документ</span>
+              )}
+              <span className="text-xs text-fg4">{filtered.length}</span>
+            </div>
+            <div>{filtered.map((e, idx) => row(e, filtered, idx > 0))}</div>
+          </div>
+        ) : (
+          // «Все записи» — группы-аккордеоны по типу.
+          <div className="space-y-2">
+            {groups.map(({ type: t, items }) => {
+              const isOpen = expandedTypes.has(t.id);
+              return (
+                <div key={t.id} className="border border-stroke rounded-xl overflow-hidden">
+                  <button type="button" onClick={() => toggleType(t.id)} aria-expanded={isOpen}
+                    className="w-full flex items-center gap-2 px-4 py-3 bg-surface hover:bg-base transition-colors text-left">
+                    {isOpen ? <ChevronUp size={14} className="text-fg4 shrink-0" /> : <ChevronDown size={14} className="text-fg4 shrink-0" />}
+                    <span className="flex-1 text-sm font-medium text-fg2">{t.name}</span>
+                    {isDocType(t.id) && (
+                      <span className="text-xs bg-warning-subtle text-warning border border-warning-border px-1.5 py-0.5 rounded-full">внеш. документ</span>
+                    )}
+                    <span className="text-xs text-fg4 font-mono">{t.code}</span>
+                    <span className="text-xs text-fg4 ml-1">{items.length}</span>
+                  </button>
+                  {isOpen && <div className="border-t border-stroke">{items.map((e, idx) => row(e, items, idx > 0))}</div>}
+                </div>
+              );
+            })}
+            {noType.length > 0 && (() => {
+              const isOpen = expandedTypes.has(NO_TYPE);
+              return (
+                <div className="border border-stroke rounded-xl overflow-hidden">
+                  <button type="button" onClick={() => toggleType(NO_TYPE)} aria-expanded={isOpen}
+                    className="w-full flex items-center gap-2 px-4 py-3 bg-surface hover:bg-base transition-colors text-left">
+                    {isOpen ? <ChevronUp size={14} className="text-fg4 shrink-0" /> : <ChevronDown size={14} className="text-fg4 shrink-0" />}
+                    <span className="flex-1 text-sm font-medium text-fg3 italic">Без типа</span>
+                    <span className="text-xs text-fg4">{noType.length}</span>
+                  </button>
+                  {isOpen && <div className="border-t border-stroke">{noType.map((e, idx) => row(e, noType, idx > 0))}</div>}
+                </div>
+              );
+            })()}
+          </div>
+        )}
+      </div>
 
       <Modal open={addOpen} onOpenChange={setAddOpen} title="Новая запись" wide flushBody>
         {addOpen && (
@@ -159,5 +199,21 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
         title={`Удалить «${deleteTarget?.displayName ?? ''}»?`} confirmLabel="Удалить"
         onConfirm={() => { if (deleteTarget) deleteMutation.mutate(deleteTarget.id); }} />
     </div>
+  );
+}
+
+/** Пункт вертикального рейла типов (issue #210, вариант B). Активный — заливка brand-subtle;
+ *  документные типы (внешний каталог) — приглушённая иконка; счётчик tabular. */
+function TypeNavItem({ icon, label, count, active, doc, muted, onClick }: {
+  icon?: ReactNode; label: string; count: number; active?: boolean; doc?: boolean; muted?: boolean; onClick: () => void;
+}) {
+  return (
+    <button type="button" onClick={onClick} aria-current={active ? 'true' : undefined}
+      className={`w-full flex items-center gap-2 px-2.5 h-9 rounded-lg text-left transition-colors ${
+        active ? 'bg-brand-subtle text-brand-hover font-medium' : 'text-fg2 hover:bg-muted'}`}>
+      {icon && <span className={`shrink-0 ${active ? 'text-brand-hover' : doc ? 'text-warning' : 'text-fg4'}`}>{icon}</span>}
+      <span className={`flex-1 truncate text-sm ${muted ? 'italic text-fg3' : ''}`}>{label}</span>
+      <span className="text-xs text-fg4 tabular-nums shrink-0">{count}</span>
+    </button>
   );
 }

--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -68,7 +68,7 @@ export function ObjectRow({
   return (
     <div className={`group flex items-center transition-colors ${dense ? 'gap-3 px-3 py-2 hover:bg-muted' : 'gap-4 px-4 py-3 hover:bg-base'} ${className}`}>
       {docKind && dense && <FileText size={12} className="text-warning shrink-0" />}
-      <span className={`flex-1 text-sm truncate ${dense ? 'text-fg1' : 'font-medium text-fg1'}`}>{entry.displayName}</span>
+      <span className={`flex-1 min-w-[8rem] text-sm truncate ${dense ? 'text-fg1' : 'font-medium text-fg1'}`}>{entry.displayName}</span>
       <ProxyRoleMarker entry={entry} siblings={siblings} resolvePool={resolvePool} onOpen={onEdit} />
       {docKind && dense && (
         <span className="text-xs px-1.5 py-0.5 rounded bg-warning-subtle text-warning font-medium shrink-0">внеш. документ</span>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.37.2</Version>
+    <Version>0.38.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.38.0</Version>
+    <Version>0.38.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #235. Пункт 3 разбора «Улучшение страниц каталога» (вариант B).

## Что

Дропдаун-фильтр по типу (Select в тулбаре) не масштабируется на много типов. Заменён на **вертикальный рейл типов внутри `CatalogResource`** — один компонент на всех 4 уровнях оси видимости (System не трогаем).

- **Слева** — столбец типов: «Все записи» + непустые типы со счётчиками (документные типы — иконкой внеш.документа в цвете warning); **мини-поиск по типам** при их числе больше порога (NN/g faceted — не «на всякий случай», а по факту).
- **Выбранный тип — в URL** `?type=id` (deep-link, back/forward; паттерн как `?doc=`).
- **Справа**: выбран тип → плоский список этого типа (тип уже виден в рейле); «Все записи» → группы-аккордеоны; контекстный placeholder поиска «Поиск: {тип}…».
- Убран дублирующий Select из тулбара (не держим два места выбора типа — рекомендация Дизайнера).
- `ObjectRow`: имя `min-w-[8rem]` — не схлопывается в более узкой колонке рядом с превью реквизитов.

Токены наши (активный тип — `bg-brand-subtle`), плотность сохранена (без 40px-аватаров).

## Проверка

- `tsc -b` чисто.
- Живой прогон (Playwright, каталог стройки ДНС ЕЦДМ): рейл со счётчиками («Все записи 21», типы 5/8/1/4/3), клик по «Организация» → `?type=51aef07e…` + плоский список из 8 организаций с чистыми реквизитами и прокси-маркерами (в т.ч. кросс-scope «→ Техногид»); контекстный поиск; мини-поиск скрыт при 6 типах.

Версия → `0.38.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)