### PR TITLE
feat(datasets): list-detail с рейлом по файлу — Фаза A (#237)

### DIFF
--- a/src/client/src/features/datasets/DataSetsPage.tsx
+++ b/src/client/src/features/datasets/DataSetsPage.tsx
@@ -11,7 +11,7 @@ export function DataSetsPage() {
   const [templatesOpen, setTemplatesOpen] = useState(false);
 
   return (
-    <div className="px-6 py-4 max-w-3xl">
+    <div className="px-6 py-4">
       <div className="flex items-center justify-between mb-1">
         <h1 className="text-xl font-semibold text-fg1">Наборы данных</h1>
         <button onClick={() => setTemplatesOpen(true)}

--- a/src/client/src/features/datasets/DataSetsResource.tsx
+++ b/src/client/src/features/datasets/DataSetsResource.tsx
@@ -1,44 +1,75 @@
-import { useRef, useState } from 'react';
-import { Upload, Trash2, Database, RefreshCw, Download } from 'lucide-react';
+import { useRef, useState, type ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Upload, Trash2, Database, RefreshCw, Download, FileText, LayoutGrid, ChevronRight } from 'lucide-react';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
 import type { CatalogScope, DataSetFile } from '@/shared/api/types';
 import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
-import { SourcesExpander } from './SourcesExpander';
+import { ruCount } from '@/shared/utils/pluralize';
+import { SourcesPanel } from './SourcesExpander';
 import { useDataSetFileActions } from './useDataSetFileActions';
 
 const ACCEPT = '.csv,.txt,.xlsx,.xls,.xml,.json,.zip,.gsfx,.pdf';
+const ALL = 'all';
 
-function FileRow({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogScope; scopeId?: string }) {
+const sourcesLabel = (n: number) => `${ruCount(n, 'источник', 'источника', 'источников')}`;
+
+/** Пункт рейла набора (issue #210, рейл-по-файлу): иконка формата + имя (2 строки: имя + «формат · N
+ *  источников»), подсветка активного как у каталога. */
+function FileNavItem({ icon, label, secondary, count, active, onClick }: {
+  icon: ReactNode; label: string; secondary?: string; count?: number; active?: boolean; onClick: () => void;
+}) {
+  return (
+    <button type="button" onClick={onClick} aria-current={active ? 'true' : undefined}
+      className={`w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left transition-colors ${
+        active ? 'bg-brand-subtle text-brand-hover' : 'text-fg2 hover:bg-muted'}`}>
+      <span className={`shrink-0 ${active ? 'text-brand-hover' : 'text-fg4'}`}>{icon}</span>
+      <span className="flex-1 min-w-0">
+        <span className={`block truncate text-sm ${active ? 'font-medium' : ''}`} title={label}>{label}</span>
+        {secondary && <span className="block truncate text-[11px] text-fg4">{secondary}</span>}
+      </span>
+      {count != null && <span className="text-xs text-fg4 tabular-nums shrink-0">{count}</span>}
+    </button>
+  );
+}
+
+/** Detail выбранного набора: шапка (имя + формат + дата + скачать/обновить/удалить) + панель источников. */
+function FileDetail({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogScope; scopeId?: string }) {
   const {
     update, confirming, setConfirming, downloading,
     updateInputRef, handleReplace, handleDownload, handleDelete,
   } = useDataSetFileActions(file, scope, scopeId);
 
   return (
-    <div className="flex flex-col gap-2 px-4 py-3 border-b border-stroke last:border-0">
-      <div className="flex items-center gap-3">
-        <Database size={16} className="text-brand shrink-0" />
-        <div className="flex-1 min-w-0">
-          <div className="font-medium text-sm text-fg1">{file.name}</div>
-          <div className="text-xs mt-0.5 text-fg4">{DATA_SET_FORMAT_LABELS[file.format]}</div>
+    <div className="rounded-lg border border-stroke bg-surface overflow-hidden">
+      <div className="flex items-start justify-between gap-3 px-4 py-3 border-b border-stroke bg-base">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-fg1 truncate" title={file.name}>{file.name}</span>
+            <span className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-muted text-fg3">{DATA_SET_FORMAT_LABELS[file.format]}</span>
+          </div>
+          <div className="text-xs text-fg4 mt-0.5">
+            {sourcesLabel(file.sources.length)} · загружен {new Date(file.createdAt).toLocaleDateString('ru-RU')}
+          </div>
         </div>
-        <input ref={updateInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleReplace} />
-        <IconButton label="Скачать оригинальный файл" size="sm" onClick={handleDownload} disabled={downloading}>
-          <Download size={14} className={downloading ? 'opacity-50' : ''} />
-        </IconButton>
-        <IconButton label="Обновить файл (привязки сохранятся)" size="sm"
-          onClick={() => updateInputRef.current?.click()} disabled={update.isPending}>
-          <RefreshCw size={14} className={update.isPending ? 'animate-spin' : ''} />
-        </IconButton>
-        <IconButton label="Удалить" size="sm" danger onClick={() => setConfirming(true)}>
-          <Trash2 size={14} />
-        </IconButton>
+        <div className="flex items-center gap-1 shrink-0">
+          <input ref={updateInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleReplace} />
+          <IconButton label="Скачать оригинальный файл" size="sm" onClick={handleDownload} disabled={downloading}>
+            <Download size={15} className={downloading ? 'opacity-50' : ''} />
+          </IconButton>
+          <IconButton label="Обновить файл (привязки сохранятся)" size="sm"
+            onClick={() => updateInputRef.current?.click()} disabled={update.isPending}>
+            <RefreshCw size={15} className={update.isPending ? 'animate-spin' : ''} />
+          </IconButton>
+          <IconButton label="Удалить файл" size="sm" danger onClick={() => setConfirming(true)}>
+            <Trash2 size={15} />
+          </IconButton>
+        </div>
       </div>
-      <div className="pl-7">
-        <SourcesExpander file={file} />
+      <div className="px-4 py-3">
+        <SourcesPanel file={file} />
       </div>
       <ConfirmDialog open={confirming} onOpenChange={o => { if (!o) setConfirming(false); }}
         title={`Удалить файл «${file.name}»?`}
@@ -48,10 +79,36 @@ function FileRow({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogSc
   );
 }
 
+/** Обзор «Все наборы»: карточки-сводки БЕЗ раскрытия источников (иначе «простыня» вернётся). */
+function AllFilesOverview({ files, onOpen }: { files: DataSetFile[]; onOpen: (id: string) => void }) {
+  return (
+    <div className="space-y-2">
+      {files.map(f => {
+        const names = f.sources.map(s => s.name).slice(0, 4).join(' · ');
+        return (
+          <div key={f.id} className="flex items-center gap-3 rounded-lg border border-stroke bg-surface px-4 py-3">
+            <FileText size={16} className="text-brand shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-fg1 truncate" title={f.name}>{f.name}</span>
+                <span className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-muted text-fg3">{DATA_SET_FORMAT_LABELS[f.format]}</span>
+              </div>
+              <div className="text-xs text-fg4 mt-0.5 truncate">
+                {sourcesLabel(f.sources.length)}{names && `: ${names}`}{f.sources.length > 4 ? ' …' : ''}
+              </div>
+            </div>
+            <Button variant="outlined" size="sm" onClick={() => onOpen(f.id)} icon={<ChevronRight size={14} />}>Открыть</Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 /**
- * Браузер наборов данных для ЛЮБОГО scope (issue #210, ось видимости): загрузка + список файлов
- * с источниками. Единый компонент для system-страницы и scoped-панелей — область выражается
- * положением, НЕ чипом. Заголовок/контекст даёт вызывающий.
+ * Браузер наборов данных для ЛЮБОГО scope (issue #210, ось видимости): list-detail с рейлом ПО ФАЙЛУ —
+ * слева «Все наборы» + файлы, справа detail выбранного набора (источники) или обзор-сводки. Рейл ради
+ * ФОКУСА (один файл = один экран), инлайн-«простыня» источников исключена. Выбор — в URL `?file=id`.
  */
 export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scopeId?: string }) {
   const { data: files = [], isLoading } = useListDataSetFiles(scope, scopeId);
@@ -60,13 +117,27 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState('');
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const fileParam = searchParams.get('file');
+  const setSelected = (v: string | null) => setSearchParams(prev => {
+    const next = new URLSearchParams(prev);
+    if (v) next.set('file', v); else next.delete('file');
+    return next;
+  }, { replace: true });
+
+  // Дефолт по числу файлов: без явного выбора — 1 файл открывается сразу, 2+ → «Все наборы».
+  const selected = fileParam ?? (files.length === 1 ? files[0].id : ALL);
+  const isAll = selected === ALL;
+  const selectedFile = !isAll ? files.find(f => f.id === selected) : undefined;
+
   async function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
     setUploadError('');
     try {
-      await upload.mutateAsync({ file, name: file.name.replace(/\.[^.]+$/, ''), scope, scopeId });
+      const created = await upload.mutateAsync({ file, name: file.name.replace(/\.[^.]+$/, ''), scope, scopeId });
+      if (created?.id) setSelected(created.id); // новый файл — открыть его
     } catch (err: unknown) {
       setUploadError(err instanceof Error ? err.message : 'Ошибка загрузки');
     } finally {
@@ -75,30 +146,58 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
     }
   }
 
-  return (
-    <div className="rounded-lg overflow-hidden border border-stroke bg-surface">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-stroke bg-base">
-        <span className="text-sm font-medium text-fg2">Наборы данных</span>
-        <div className="flex items-center gap-2">
-          {uploadError && <span className="text-xs text-danger">{uploadError}</span>}
-          <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
-          <Button variant="tonal" size="sm" onClick={() => fileInputRef.current?.click()}
-            loading={uploading} icon={<Upload size={14} />}>
-            {uploading ? 'Загрузка…' : 'Загрузить файл'}
-          </Button>
-        </div>
-      </div>
+  const uploadBtn = (
+    <>
+      <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
+      <Button variant="tonal" size="sm" onClick={() => fileInputRef.current?.click()}
+        loading={uploading} icon={<Upload size={14} />}>
+        {uploading ? 'Загрузка…' : 'Загрузить файл'}
+      </Button>
+    </>
+  );
 
-      {isLoading ? (
-        <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>
-      ) : files.length === 0 ? (
-        <EmptyState className="m-4 border-0" icon={<Database size={30} />} title="Пока нет наборов данных"
+  if (isLoading) return <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>;
+
+  if (files.length === 0) {
+    return (
+      <>
+        <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
+        <EmptyState icon={<Database size={30} />} title="Пока нет наборов данных"
           description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) — из него можно собирать источники для колонок и таблиц документов."
           action={<Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
             loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>} />
-      ) : (
-        files.map(f => <FileRow key={f.id} file={f} scope={scope} scopeId={scopeId} />)
-      )}
+        {uploadError && <p className="text-xs text-danger text-center mt-2">{uploadError}</p>}
+      </>
+    );
+  }
+
+  return (
+    <div className="flex gap-5 items-start">
+      {/* Рейл файлов */}
+      <aside className="w-56 shrink-0 sticky top-0 self-start space-y-0.5">
+        <FileNavItem icon={<LayoutGrid size={15} />} label="Все наборы" count={files.length}
+          active={isAll} onClick={() => setSelected(ALL)} />
+        {files.map(f => (
+          <FileNavItem key={f.id} icon={<FileText size={15} />} label={f.name}
+            secondary={`${DATA_SET_FORMAT_LABELS[f.format]} · ${sourcesLabel(f.sources.length)}`}
+            active={selected === f.id} onClick={() => setSelected(f.id)} />
+        ))}
+        <div className="pt-2">{uploadBtn}</div>
+        {uploadError && <p className="text-[11px] text-danger px-1 pt-1">{uploadError}</p>}
+      </aside>
+
+      {/* Detail */}
+      <div className="flex-1 min-w-0">
+        {isAll ? (
+          <AllFilesOverview files={files} onOpen={setSelected} />
+        ) : selectedFile ? (
+          <FileDetail file={selectedFile} scope={scope} scopeId={scopeId} />
+        ) : (
+          <div className="text-center py-10 text-fg4 text-sm">
+            Набор не найден. <button className="text-brand hover:text-brand-hover" onClick={() => setSelected(ALL)}>Ко всем наборам</button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  ChevronDown, ChevronRight, Plus, Pencil, Trash2, Copy, Eye, Filter, FunctionSquare, ArrowUpDown, Loader2,
+  Plus, Pencil, Trash2, Copy, Eye, Filter, FunctionSquare, ArrowUpDown, Loader2,
   BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes, LayoutGrid, Type,
 } from 'lucide-react';
 import { parseSourceColumnNames, countFilterConditions } from '@/shared/api/datasetHelpers';
@@ -240,18 +240,18 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
 }
 
 /**
- * Collapsible list of a file's data sources with a preview of their column names.
- * Обработка (Filter/Transformation/Sort) доступна для источников любого формата; для PDF Extraction —
- * распознавание (не builder). Все действия строки свёрнуты в меню «три точки» (см. SourceRow).
+ * Панель источников одного набора (detail в list-detail «Наборы данных», issue #210/рейл-по-файлу):
+ * заголовок с действиями уровня набора (распознать/разбиение/добавить) + плоский список источников +
+ * кандидаты. Раньше — сворачиваемый инлайн-блок (`SourcesExpander`); теперь всегда раскрыт как detail.
+ * Обработка (Filter/Transformation/Sort) — для любого формата; PDF Extraction — распознавание (не builder).
  */
-export function SourcesExpander({
+export function SourcesPanel({
   file,
   maxColumns = 8,
 }: {
   file: DataSetFile;
   maxColumns?: number;
 }) {
-  const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<DataSetSource | 'new' | null>(null);
   const { data: templates = [] } = useListProcessingTemplates();
   const isPdf = file.format === 'Pdf';
@@ -263,7 +263,7 @@ export function SourcesExpander({
   // Кандидаты на источник (issue #30/#34): для всех форматов — логические таблицы/листы набора,
   // которых ещё нет как источников, создаются в один клик. PDF — Обложка/Титул из распознанной
   // группировки; XLSX — листы; CSV — «весь файл»; JSON — верхнеуровневые массивы.
-  const { data: candidates = [] } = useSourceCandidates(open ? file.id : undefined);
+  const { data: candidates = [] } = useSourceCandidates(file.id);
   const createSource = useCreateDataSetSource();
   const availableCandidates = candidates.filter(c => !sources.some(s => s.sheetOrPath === c.sheetOrPath));
 
@@ -298,58 +298,57 @@ export function SourcesExpander({
 
   return (
     <div>
-      <div className="flex items-center gap-2">
-        <button onClick={() => setOpen(o => !o)} aria-expanded={open} className="flex items-center gap-1 text-xs text-brand">
-          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-          {sources.length > 0
-            ? `${sources.length} ${sources.length === 1 ? 'источник' : 'источника(-ов)'}`
-            : 'Нет источников'}
-        </button>
-        {/* PDF-набор: «Распознать» (уровень набора, issue #38) + «Добавить источник» рядом. */}
-        {isPdf && (
-          <button onClick={() => handleRecognizeDataset()} disabled={recognizeBusy || recognizing}
-            className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover disabled:opacity-50">
-            <ScanText size={11} /> {recognizing ? 'Распознаётся…' : profile ? 'Распознать заново' : 'Распознать'}
-          </button>
-        )}
-        {/* Редактор разбиения — на уровне НАБОРА (issue #40): доступен без создания источника «Документы». */}
-        {isPdf && isGostDataset && (
-          <button onClick={() => navigate(`/datasets/files/${file.id}/grouping`, { state: { sourceName: file.name } })}
-            className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover"
-            title="Перенести страницы между документами, задать тип таблицы, распознать таблицу — на уровне набора">
-            <LayoutGrid size={11} /> Разбиение
-          </button>
-        )}
-        {canManageExtraction && (
-          <button onClick={() => { setEditing('new'); setOpen(true); }}
-            className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover">
-            <Plus size={11} /> Добавить источник
-          </button>
-        )}
-      </div>
-      {open && (
-        <div className="mt-2 space-y-2 pl-3">
-          {sources.map(src => (
-            <SourceRow key={src.id} src={src} isPdf={isPdf} canManageExtraction={canManageExtraction}
-              templates={templates} maxColumns={maxColumns} onEdit={setEditing} />
-          ))}
-          {availableCandidates.length > 0 && (
-            <div className="border-t border-stroke pt-2 mt-1 space-y-1">
-              <p className="text-[11px] text-fg4">{isPdf ? 'Доступно из распознанного набора:' : 'Доступно из набора:'}</p>
-              {availableCandidates.map(c => (
-                <div key={c.sheetOrPath} className="flex items-center gap-2 text-xs">
-                  <span className="text-fg2">{c.name} <span className="text-fg4">· {c.rowCount} строк</span></span>
-                  <button type="button" disabled={createSource.isPending}
-                    onClick={() => createSource.mutate({ fileId: file.id, name: c.name, sheetOrPath: c.sheetOrPath })}
-                    className="flex items-center gap-0.5 text-brand hover:text-brand-hover disabled:opacity-50">
-                    <Plus size={11} /> Создать
-                  </button>
-                </div>
-              ))}
-            </div>
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-fg4">
+          Источники{sources.length > 0 ? ` · ${sources.length}` : ''}
+        </span>
+        <div className="flex items-center gap-3">
+          {/* PDF-набор: «Распознать» (уровень набора, issue #38). */}
+          {isPdf && (
+            <button onClick={() => handleRecognizeDataset()} disabled={recognizeBusy || recognizing}
+              className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover disabled:opacity-50">
+              <ScanText size={13} /> {recognizing ? 'Распознаётся…' : profile ? 'Распознать заново' : 'Распознать'}
+            </button>
+          )}
+          {/* Редактор разбиения — на уровне НАБОРА (issue #40): доступен без создания источника «Документы». */}
+          {isPdf && isGostDataset && (
+            <button onClick={() => navigate(`/datasets/files/${file.id}/grouping`, { state: { sourceName: file.name } })}
+              className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover"
+              title="Перенести страницы между документами, задать тип таблицы, распознать таблицу — на уровне набора">
+              <LayoutGrid size={13} /> Разбиение
+            </button>
+          )}
+          {canManageExtraction && (
+            <Button variant="outlined" size="sm" icon={<Plus size={14} />} onClick={() => setEditing('new')}>
+              Добавить источник
+            </Button>
           )}
         </div>
-      )}
+      </div>
+      <div className="space-y-2">
+        {sources.length === 0 && (
+          <p className="text-xs text-fg4 py-1">Источников пока нет — добавьте из набора или распознайте PDF.</p>
+        )}
+        {sources.map(src => (
+          <SourceRow key={src.id} src={src} isPdf={isPdf} canManageExtraction={canManageExtraction}
+            templates={templates} maxColumns={maxColumns} onEdit={setEditing} />
+        ))}
+        {availableCandidates.length > 0 && (
+          <div className="rounded-md border border-dashed border-stroke-strong bg-base px-3 py-2 space-y-1 mt-1">
+            <p className="text-[11px] text-fg4">{isPdf ? 'Доступно из распознанного набора:' : 'Доступно из набора:'}</p>
+            {availableCandidates.map(c => (
+              <div key={c.sheetOrPath} className="flex items-center gap-2 text-xs">
+                <span className="text-fg2">{c.name} <span className="text-fg4">· {c.rowCount} строк</span></span>
+                <button type="button" disabled={createSource.isPending}
+                  onClick={() => createSource.mutate({ fileId: file.id, name: c.name, sheetOrPath: c.sheetOrPath })}
+                  className="flex items-center gap-0.5 text-brand hover:text-brand-hover disabled:opacity-50">
+                  <Plus size={11} /> Создать
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {/* «Добавить источник» — обычный диалог создания источника для ВСЕХ форматов, включая PDF
           (выбор кандидата-проекции, как лист Excel). Диалог выбора профиля — только у «Распознать». */}

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -324,12 +324,13 @@ function SetDetail() {
 
   const detail = (
     <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
-      {/* Каталог — во всю ширину (рейл типов у левого края); прочие панели центрируем. */}
+      {/* Каталог и Наборы данных — во всю ширину (рейл у левого края); документы/подписчики центрируем. */}
       {activePanel === 'catalog'
         ? <CatalogResource scope="Set" scopeId={setId ?? null} allDocTypes={docTypes} />
+        : activePanel === 'datasets'
+        ? <DataSetsResource scope="Set" scopeId={setId} />
         : <div className="mx-auto max-w-5xl">
             {activePanel === 'documents' ? documentsContent
-              : activePanel === 'datasets' ? <DataSetsResource scope="Set" scopeId={setId} />
               : <SubscribersResource scope="Set" scopeId={setId!} />}
           </div>}
     </div>
@@ -510,9 +511,10 @@ function SectionDetail() {
     <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
       {activePanel === 'catalog'
         ? <CatalogResource scope="Section" scopeId={sectionId ?? null} allDocTypes={docTypes} />
+        : activePanel === 'datasets'
+        ? <DataSetsResource scope="Section" scopeId={sectionId} />
         : <div className="mx-auto max-w-5xl">
-            {activePanel === 'datasets' ? <DataSetsResource scope="Section" scopeId={sectionId} />
-              : <SubscribersResource scope="Section" scopeId={sectionId!} />}
+            <SubscribersResource scope="Section" scopeId={sectionId!} />
           </div>}
     </div>
   );
@@ -661,9 +663,10 @@ function ConstructionDetail() {
     <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
       {activePanel === 'catalog'
         ? <CatalogResource scope="Construction" scopeId={constructionId ?? null} allDocTypes={docTypes} />
+        : activePanel === 'datasets'
+        ? <DataSetsResource scope="Construction" scopeId={constructionId} />
         : <div className="mx-auto max-w-5xl">
-            {activePanel === 'datasets' ? <DataSetsResource scope="Construction" scopeId={constructionId} />
-              : <SubscribersResource scope="Construction" scopeId={constructionId!} />}
+            <SubscribersResource scope="Construction" scopeId={constructionId!} />
           </div>}
     </div>
   );

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.38.1</Version>
+    <Version>0.39.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #237 (Фаза A). Из разбора с другом + Дизайнером.

## Что

«Наборы данных» приведены к паттерну «Каталога»: **вертикальный рейл ПО ФАЙЛУ** + detail. Рейл ради **фокуса** (один файл = один экран) — инлайн-«простыня» источников исключена.

- **Рейл** слева: «Все наборы» + файлы (иконка формата + имя + «PDF · N источников»), подсветка активного как у каталога.
- **Detail файла:** шапка (имя + формат-chip + «N источников · загружен <дата>» + действия скачать/обновить/удалить) + `SourcesPanel` (бывший `SourcesExpander` — теперь всегда раскрыт: плоский список источников + Распознать/Разбиение/Добавить источник + кандидаты dashed-блоком).
- **«Все наборы»** = карточки-сводки БЕЗ раскрытия источников («3 источника: Титул · Документы · …» + «Открыть») — «простыня» не возвращается через чёрный ход.
- **Deep-link** `?file=id`; **дефолт по числу файлов** (0 → пусто, 1 → сразу файл, 2+ → «Все наборы»).
- **Плюрализация** «N источников» (ruCount).
- Наборы **во всю ширину** (снят `mx-auto max-w-5xl`, как каталог) на Set/Section/Construction + System.

## Проверка

- `tsc -b` чисто.
- Живой прогон (наборы раздела ЭОМ, 2 файла): рейл + «Все наборы»-сводки + открытие файла (`?file=…`) + detail (toolbar + плоские источники + кандидаты). Скриншоты — как макет друга (1a/1b).

## Отложено (Фаза B / NEW-поведение)

Статусы распознавания (рейл-точка/спиннер, баннер в шапке, chip источника), загрузка/drag-drop на уровень страницы, toolbar-иконки распознать/разбиение. NEW (проверить данные): уровень-владелец при наследовании, счётчик привязок источника, «Отменить» распознавание.

Версия → `0.39.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)