### PR TITLE
feat(datasets): статусы распознавания + drag-drop загрузка — Фаза B (#237)

### DIFF
--- a/src/client/src/features/datasets/DataSetsResource.tsx
+++ b/src/client/src/features/datasets/DataSetsResource.tsx
@@ -1,10 +1,11 @@
 import { useRef, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Upload, Trash2, Database, RefreshCw, Download, FileText, LayoutGrid, ChevronRight } from 'lucide-react';
+import { Upload, Trash2, Database, RefreshCw, Download, FileText, LayoutGrid, ChevronRight, Loader2 } from 'lucide-react';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
+import { useRecognitionJobs, useCancelJob, type ActiveJob } from '@/shared/api/jobs';
 import type { CatalogScope, DataSetFile } from '@/shared/api/types';
 import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
 import { ruCount } from '@/shared/utils/pluralize';
@@ -16,31 +17,40 @@ const ALL = 'all';
 
 const sourcesLabel = (n: number) => `${ruCount(n, 'источник', 'источника', 'источников')}`;
 
-/** Пункт рейла набора (issue #210, рейл-по-файлу): иконка формата + имя (2 строки: имя + «формат · N
- *  источников»), подсветка активного как у каталога. */
-function FileNavItem({ icon, label, secondary, count, active, onClick }: {
-  icon: ReactNode; label: string; secondary?: string; count?: number; active?: boolean; onClick: () => void;
+/** Пункт рейла набора (issue #210, рейл-по-файлу): иконка формата ИЛИ спиннер (идёт распознавание) +
+ *  имя (2 строки: имя + «формат · N источников»), amber-точка при устаревших источниках, подсветка как
+ *  у каталога. Статус в рейле — спокойный: только спиннер/точка, без текста (один факт — один раз). */
+function FileNavItem({ icon, label, secondary, count, active, recognizing, stale, onClick }: {
+  icon: ReactNode; label: string; secondary?: string; count?: number; active?: boolean;
+  recognizing?: boolean; stale?: boolean; onClick: () => void;
 }) {
   return (
     <button type="button" onClick={onClick} aria-current={active ? 'true' : undefined}
       className={`w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left transition-colors ${
         active ? 'bg-brand-subtle text-brand-hover' : 'text-fg2 hover:bg-muted'}`}>
-      <span className={`shrink-0 ${active ? 'text-brand-hover' : 'text-fg4'}`}>{icon}</span>
+      <span className={`shrink-0 ${active ? 'text-brand-hover' : 'text-fg4'}`}>
+        {recognizing ? <Loader2 size={15} className="animate-spin text-brand" /> : icon}
+      </span>
       <span className="flex-1 min-w-0">
         <span className={`block truncate text-sm ${active ? 'font-medium' : ''}`} title={label}>{label}</span>
         {secondary && <span className="block truncate text-[11px] text-fg4">{secondary}</span>}
       </span>
+      {stale && <span title="Есть устаревшие источники — распознайте набор заново" className="w-1.5 h-1.5 rounded-full bg-warning shrink-0" />}
       {count != null && <span className="text-xs text-fg4 tabular-nums shrink-0">{count}</span>}
     </button>
   );
 }
 
-/** Detail выбранного набора: шапка (имя + формат + дата + скачать/обновить/удалить) + панель источников. */
-function FileDetail({ file, scope, scopeId }: { file: DataSetFile; scope: CatalogScope; scopeId?: string }) {
+/** Detail выбранного набора: шапка (имя + формат + дата + скачать/обновить/удалить) + баннер статуса
+ *  распознавания (если идёт) + панель источников. */
+function FileDetail({ file, scope, scopeId, job }: {
+  file: DataSetFile; scope: CatalogScope; scopeId?: string; job?: ActiveJob;
+}) {
   const {
     update, confirming, setConfirming, downloading,
     updateInputRef, handleReplace, handleDownload, handleDelete,
   } = useDataSetFileActions(file, scope, scopeId);
+  const cancel = useCancelJob();
 
   return (
     <div className="rounded-lg border border-stroke bg-surface overflow-hidden">
@@ -68,6 +78,16 @@ function FileDetail({ file, scope, scopeId }: { file: DataSetFile; scope: Catalo
           </IconButton>
         </div>
       </div>
+      {job && (
+        <div className="flex items-center gap-2 px-4 py-2 text-xs bg-brand-subtle/50 border-b border-stroke text-fg2">
+          <Loader2 size={13} className="animate-spin text-brand shrink-0" />
+          <span className="flex-1 min-w-0 truncate">{job.progress ?? job.title ?? 'Распознаётся…'}</span>
+          {job.status === 'Queued' && (
+            <button onClick={() => cancel.mutate(job.id)} disabled={cancel.isPending}
+              className="text-brand hover:text-brand-hover shrink-0 disabled:opacity-50">Отменить</button>
+          )}
+        </div>
+      )}
       <div className="px-4 py-3">
         <SourcesPanel file={file} />
       </div>
@@ -113,9 +133,11 @@ function AllFilesOverview({ files, onOpen }: { files: DataSetFile[]; onOpen: (id
 export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scopeId?: string }) {
   const { data: files = [], isLoading } = useListDataSetFiles(scope, scopeId);
   const upload = useUploadDataSetFile();
+  const recogJobs = useRecognitionJobs();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState('');
+  const [dragOver, setDragOver] = useState(false);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const fileParam = searchParams.get('file');
@@ -130,9 +152,12 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
   const isAll = selected === ALL;
   const selectedFile = !isAll ? files.find(f => f.id === selected) : undefined;
 
-  async function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  // Статус набора: активная задача распознавания (targetId = file.id для ГОСТ, иначе id источника).
+  const jobForFile = (f: DataSetFile) =>
+    recogJobs.find(j => j.targetId === f.id || f.sources.some(s => s.id === j.targetId));
+  const fileStale = (f: DataSetFile) => f.sources.some(s => s.recognitionStale);
+
+  async function uploadFile(file: File) {
     setUploading(true);
     setUploadError('');
     try {
@@ -145,6 +170,23 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
       if (fileInputRef.current) fileInputRef.current.value = '';
     }
   }
+  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) void uploadFile(file);
+  }
+
+  // Drag-drop загрузка — вся панель drop-target с dashed-оверлеем при dragover.
+  function onDragOver(e: React.DragEvent) {
+    if ([...e.dataTransfer.types].includes('Files')) { e.preventDefault(); setDragOver(true); }
+  }
+  function onDragLeave(e: React.DragEvent) {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOver(false);
+  }
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault(); setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) void uploadFile(file);
+  }
 
   const uploadBtn = (
     <>
@@ -156,48 +198,56 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
     </>
   );
 
-  if (isLoading) return <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>;
-
-  if (files.length === 0) {
-    return (
-      <>
-        <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
-        <EmptyState icon={<Database size={30} />} title="Пока нет наборов данных"
-          description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) — из него можно собирать источники для колонок и таблиц документов."
-          action={<Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
-            loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>} />
-        {uploadError && <p className="text-xs text-danger text-center mt-2">{uploadError}</p>}
-      </>
-    );
-  }
+  const overlay = dragOver && (
+    <div className="absolute inset-0 z-10 rounded-lg border-2 border-dashed border-brand bg-brand-subtle/60 flex items-center justify-center pointer-events-none">
+      <span className="text-sm font-medium text-brand-hover">Отпустите файл — загрузим в набор</span>
+    </div>
+  );
 
   return (
-    <div className="flex gap-5 items-start">
-      {/* Рейл файлов */}
-      <aside className="w-56 shrink-0 sticky top-0 self-start space-y-0.5">
-        <FileNavItem icon={<LayoutGrid size={15} />} label="Все наборы" count={files.length}
-          active={isAll} onClick={() => setSelected(ALL)} />
-        {files.map(f => (
-          <FileNavItem key={f.id} icon={<FileText size={15} />} label={f.name}
-            secondary={`${DATA_SET_FORMAT_LABELS[f.format]} · ${sourcesLabel(f.sources.length)}`}
-            active={selected === f.id} onClick={() => setSelected(f.id)} />
-        ))}
-        <div className="pt-2">{uploadBtn}</div>
-        {uploadError && <p className="text-[11px] text-danger px-1 pt-1">{uploadError}</p>}
-      </aside>
+    <div className="relative" onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}>
+      {overlay}
+      {isLoading ? (
+        <div className="p-8 text-center text-sm text-fg4">Загрузка...</div>
+      ) : files.length === 0 ? (
+        <>
+          <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
+          <EmptyState icon={<Database size={30} />} title="Пока нет наборов данных"
+            description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) или перетащите его сюда — из него можно собирать источники для колонок и таблиц документов."
+            action={<Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
+              loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>} />
+          {uploadError && <p className="text-xs text-danger text-center mt-2">{uploadError}</p>}
+        </>
+      ) : (
+        <div className="flex gap-5 items-start">
+          {/* Рейл файлов */}
+          <aside className="w-56 shrink-0 sticky top-0 self-start space-y-0.5">
+            <FileNavItem icon={<LayoutGrid size={15} />} label="Все наборы" count={files.length}
+              active={isAll} onClick={() => setSelected(ALL)} />
+            {files.map(f => (
+              <FileNavItem key={f.id} icon={<FileText size={15} />} label={f.name}
+                secondary={`${DATA_SET_FORMAT_LABELS[f.format]} · ${sourcesLabel(f.sources.length)}`}
+                active={selected === f.id} recognizing={!!jobForFile(f)} stale={fileStale(f)}
+                onClick={() => setSelected(f.id)} />
+            ))}
+            <div className="pt-2">{uploadBtn}</div>
+            {uploadError && <p className="text-[11px] text-danger px-1 pt-1">{uploadError}</p>}
+          </aside>
 
-      {/* Detail */}
-      <div className="flex-1 min-w-0">
-        {isAll ? (
-          <AllFilesOverview files={files} onOpen={setSelected} />
-        ) : selectedFile ? (
-          <FileDetail file={selectedFile} scope={scope} scopeId={scopeId} />
-        ) : (
-          <div className="text-center py-10 text-fg4 text-sm">
-            Набор не найден. <button className="text-brand hover:text-brand-hover" onClick={() => setSelected(ALL)}>Ко всем наборам</button>
+          {/* Detail */}
+          <div className="flex-1 min-w-0">
+            {isAll ? (
+              <AllFilesOverview files={files} onOpen={setSelected} />
+            ) : selectedFile ? (
+              <FileDetail file={selectedFile} scope={scope} scopeId={scopeId} job={jobForFile(selectedFile)} />
+            ) : (
+              <div className="text-center py-10 text-fg4 text-sm">
+                Набор не найден. <button className="text-brand hover:text-brand-hover" onClick={() => setSelected(ALL)}>Ко всем наборам</button>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/src/shared/api/jobs.ts
+++ b/src/client/src/shared/api/jobs.ts
@@ -65,6 +65,17 @@ export function useSourceRecognizing(sourceId: string): boolean {
   return (data ?? []).some(j => j.targetId === sourceId && RECOGNITION_KINDS.includes(j.kind));
 }
 
+/** Активные задачи распознавания текущего пользователя (для статуса набора: спиннер в рейле, баннер
+ *  прогресса «лист N из M» в шапке). Тот же кэш `['jobs','active']`, что и индикатор. */
+export function useRecognitionJobs(): ActiveJob[] {
+  const { data } = useQuery<ActiveJob[]>({
+    queryKey: ['jobs', 'active'],
+    queryFn: () => apiClient.get('/jobs/active').then(r => r.data as ActiveJob[]),
+    refetchInterval: q => ((q.state.data?.length ?? 0) > 0 ? 2000 : 10000),
+  });
+  return (data ?? []).filter(j => RECOGNITION_KINDS.includes(j.kind));
+}
+
 /** Отмена задачи из очереди (только Queued — 409 для выполняемых). После — обновляем список активных. */
 export function useCancelJob() {
   const qc = useQueryClient();

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.39.0</Version>
+    <Version>0.39.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Продолжение #237 (Фаза A — #238). Из разбора с другом.

## Что

**Статус распознавания — три уровня зума** (друг: «один факт — один раз на уровень»):
- **рейл:** спиннер вместо иконки формата (идёт распознавание) + amber-точка при устаревших источниках — без текста;
- **шапка detail:** тонкий баннер под шапкой — спиннер + прогресс «лист N из M» + «Отменить» (для Queued-задач);
- **строка источника:** chip «устарело» (уже был).

Данные — из активных фоновых задач: новый `useRecognitionJobs()` (targetId = file.id для ГОСТ, иначе id источника; `ActiveJob.progress` = «лист N из M»), отмена — `useCancelJob` (только Queued, 409 для Running).

**Drag-drop загрузка:** вся панель наборов — drop-target с dashed-оверлеем «Отпустите файл» при dragover; загрузка нового файла открывает его в рейле. Пустое состояние — тоже drop-target.

## Проверка

- `tsc -b` чисто.
- Живой прогон: drag-overlay появляется на всю панель (скриншот), detail без активной задачи — баннер скрыт. Статус-визуалы (спиннер/точка/баннер) в текущих данных не воспроизвести (нет активных задач/устаревших источников) — код прямой, повторяет существующий паттерн `useSourceRecognizing`.

## Отложено

- Полировка: вынос «Распознать»/«Разбиение» из заголовка списка источников в toolbar-иконки шапки файла (scan/scissors).
- NEW-поведение (нужны данные/бэкенд): уровень-владелец при наследовании + блокировка действий; счётчик привязок источника «→ N привязок» + в подтверждении удаления.

Версия → `0.39.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)