### PR TITLE
fix(datasets): просмотр источника — горизонтальный скролл и угол (#240)

### DIFF
--- a/src/client/src/features/datasets/SourcePreviewDialog.tsx
+++ b/src/client/src/features/datasets/SourcePreviewDialog.tsx
@@ -96,31 +96,36 @@ export function SourcePreviewDialog({ source, onClose }: { source: DataSetSource
       ) : isGostDocuments ? (
         <GostDocumentsPreview data={data} />
       ) : (
-        <div className={dtCard}>
-          <table className={dtTable}>
-            <thead>
-              <tr>
-                {data.columns.map(c => (
-                  <th key={c} className={dtTh}>{c}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {data.rows.map((row, i) => (
-                <tr key={i} className={dtRow}>
-                  {row.map((v, j) => (
-                    <td key={j} className={`${dtTd} whitespace-nowrap ${v == null ? 'text-fg4' : 'text-fg1'}`}>
-                      {v ?? <em>null</em>}
-                    </td>
+        <>
+          {/* Ограниченная по высоте карточка — единый скролл-контейнер (sticky-шапка + горизонтальный
+              скролл ВНУТРИ него); иначе таблица растягивала тело модалки и горизонтальный скроллбар
+              «уезжал» к дну длинной таблицы, а на стыке со скроллом модалки был глюк (issue #240). */}
+          <div className={`${dtCard} max-h-[65vh]`}>
+            <table className={dtTable}>
+              <thead>
+                <tr>
+                  {data.columns.map(c => (
+                    <th key={c} className={dtTh}>{c}</th>
                   ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-          <div className="px-3 py-1.5 border-t border-stroke text-xs text-fg4">
+              </thead>
+              <tbody>
+                {data.rows.map((row, i) => (
+                  <tr key={i} className={dtRow}>
+                    {row.map((v, j) => (
+                      <td key={j} className={`${dtTd} whitespace-nowrap ${v == null ? 'text-fg4' : 'text-fg1'}`}>
+                        {v ?? <em>null</em>}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="px-1 pt-2 text-xs text-fg4">
             {data.totalRows} строк{data.totalRows > data.rows.length ? ` (показано первых ${data.rows.length})` : ''}
           </div>
-        </div>
+        </>
       )}
     </Modal>
   );

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.39.2</Version>
+    <Version>0.39.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #240.

## Проблема

В `SourcePreviewDialog` («Результат обработки») таблица-`dtCard` не имела ограничения высоты → росла на все ~150 строк, вертикально скроллилось **тело модалки**, а горизонтальный скроллбар таблицы «уезжал» к дну очень длинной таблицы (доступен только в самом низу); на стыке со скроллом модалки в правом нижнем углу — глюк двух скроллбаров.

## Фикс

- `dtCard` ограничен `max-h-[65vh]` → становится **единым скролл-контейнером**: sticky-шапка держится, вертикальный и горизонтальный скролл — внутри него (горизонтальный всегда у дна видимой области, не уезжает);
- футер «N строк» вынесен из `dtCard` наружу — всегда виден, не скроллится с таблицей.

## Проверка

- `tsc -b` чисто.
- Живой прогон (просмотр «Материалы ЭОМ», 152 строки): модалка — чистая карточка, sticky-шапка, таблица скроллится внутри, футер «152 строк» виден снизу; уехавшего скроллбара и глюка в углу нет.

Версия → `0.39.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)