### PR TITLE
feat(datasets): @@ref-резолв только Name/IdentityKey — бэкенд (#243, Фаза 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ Thumbs.db
 # Data Protection keys (issue #148) — секрет, не коммитить
 src/server/BHS.CRG.Api/dp-keys/
 dp-keys/
+
+# Agent sync artifacts
+.design-sync/
+.ds-sync/

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -59,7 +59,13 @@ public static class DataSetDtoMapper
         var refMap = DataSetMappingValue.ParseRef(mapVal);
         if (refMap is not null)
         {
-            var v = row != null && row.TryGetValue(refMap.Column, out var lv) ? lv : null;
+            string? v;
+            if (refMap.IsIdentity)
+                v = string.Join(" · ", refMap.IdentityColumns!.Values
+                    .Select(c => row != null && row.TryGetValue(c, out var cv) ? cv : null)
+                    .Where(s => !string.IsNullOrWhiteSpace(s)));
+            else
+                v = row != null && refMap.Column != null && row.TryGetValue(refMap.Column, out var lv) ? lv : null;
             return string.IsNullOrWhiteSpace(v) ? null : $"🔗 {v}";
         }
         return row != null && row.TryGetValue(mapVal, out var val) ? val : null;

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingValue.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingValue.cs
@@ -3,15 +3,28 @@ using System.Text.Json;
 namespace BHS.CRG.Infrastructure.DataSets;
 
 /// <summary>
-/// Значение маппинга колонки в привязке набора данных может быть двух видов:
-///  • обычное — имя колонки файла (скалярное поле);
-///  • ссылочное — составное поле, заполняемое ссылкой на запись каталога. Кодируется
-///    строкой вида <c>@@ref:{"column":"ИНН","match":"ИНН","typeId":"&lt;guid&gt;"}</c>,
-///    где column — колонка с искомым значением, match — поле записи каталога для
-///    сопоставления (пусто = по отображаемому имени), typeId — составной тип каталога.
-/// Формат разделяется с фронтендом (MappingEditor).
+/// Значение маппинга колонки-ссылки на запись каталога (составное поле). Два вида резолва «строка→объект»
+/// (issue #243, сходимость к решению #183 — только Name или IdentityKey):
+///  • <b>по имени</b>: <c>@@ref:{"strategy":"Name","column":"Наименование","typeId":"&lt;guid&gt;"}</c> —
+///    матч по DisplayName ∪ Aliases значения колонки;
+///  • <b>по идентификатору</b>: <c>@@ref:{"strategy":"Identity","identityColumns":{"ИНН":"КолонкаИНН",
+///    "КПП":"КолонкаКПП"},"typeId":"&lt;guid&gt;"}</c> — матч по составному ключу identity-полей типа
+///    (по колонке на каждое identity-поле).
+/// <b>Legacy</b> (создание через UI больше не даётся, но старые маппинги читаются вечно):
+/// <c>{"column":"ИНН","match":"ИНН","typeId":…}</c> — непустой <c>match</c> = стратегия Field (произвольное
+/// поле), пустой = Name. Формат разделяется с фронтендом (MappingEditor).
 /// </summary>
-public record DataSetRefMapping(string Column, string Match, Guid TypeId);
+public record DataSetRefMapping(
+    string? Column,
+    string? Match,
+    Guid TypeId,
+    string? Strategy = null,
+    Dictionary<string, string>? IdentityColumns = null)
+{
+    /// <summary>Резолв по составному identity-ключу (новый формат): задан IdentityColumns.</summary>
+    public bool IsIdentity => string.Equals(Strategy, "Identity", StringComparison.OrdinalIgnoreCase)
+        && IdentityColumns is { Count: > 0 };
+}
 
 /// <summary>
 /// Файловый маппинг — поле типа "file" заполняется вложением, синтезированным из колонок ТОЙ ЖЕ
@@ -40,9 +53,10 @@ public static class DataSetMappingValue
         {
             var json = value![RefPrefix.Length..];
             var parsed = JsonSerializer.Deserialize<DataSetRefMapping>(json, JsonOpts);
-            return parsed is null || parsed.TypeId == Guid.Empty || string.IsNullOrWhiteSpace(parsed.Column)
-                ? null
-                : parsed;
+            // Валиден, если задан typeId И есть чем резолвить: колонка (Name/legacy) ИЛИ identityColumns (Identity).
+            var noSource = string.IsNullOrWhiteSpace(parsed?.Column)
+                && (parsed?.IdentityColumns is null || parsed.IdentityColumns.Count == 0);
+            return parsed is null || parsed.TypeId == Guid.Empty || noSource ? null : parsed;
         }
         catch
         {

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -182,22 +182,39 @@ public class DataSetResolver(
         if (refMap is null)
             return row.TryGetValue(mapVal, out var val) ? val : null;
 
-        // Ссылочное поле: резолвим значение колонки в существующий объект каталога.
-        if (!row.TryGetValue(refMap.Column, out var lookup) || string.IsNullOrWhiteSpace(lookup))
-            return null;
+        // Ссылочное поле: резолвим строку в существующий объект каталога по одной из двух стратегий
+        // (issue #243): Identity (составной ключ identity-полей) либо Name (по имени/алиасам); legacy
+        // с непустым match — Field (произвольное поле, из UI больше не создаётся, читается вечно).
+        ObjectMatchRequest req;
+        string lookupDisplay; // для WARNING
+        if (refMap.IsIdentity)
+        {
+            var fields = new Dictionary<string, string?>();
+            foreach (var (idField, col) in refMap.IdentityColumns!)
+                fields[idField] = row.TryGetValue(col, out var cv) ? cv : null;
+            if (fields.Values.All(string.IsNullOrWhiteSpace)) return null; // нечего искать
+            req = ObjectMatchRequest.ByIdentity(refMap.TypeId, fields);
+            lookupDisplay = string.Join(" · ", fields.Values.Where(s => !string.IsNullOrWhiteSpace(s)));
+        }
+        else
+        {
+            if (refMap.Column is null || !row.TryGetValue(refMap.Column, out var lookup) || string.IsNullOrWhiteSpace(lookup))
+                return null;
+            req = string.IsNullOrEmpty(refMap.Match)
+                ? ObjectMatchRequest.ByName(refMap.TypeId, lookup)
+                : ObjectMatchRequest.ByField(refMap.TypeId, refMap.Match, lookup);
+            lookupDisplay = lookup;
+        }
 
-        var req = string.IsNullOrEmpty(refMap.Match)
-            ? ObjectMatchRequest.ByName(refMap.TypeId, lookup)
-            : ObjectMatchRequest.ByField(refMap.TypeId, refMap.Match, lookup);
         var entryId = await objectResolver.ResolveAsync(req, scopeLevel, scopeId, ct);
         if (entryId is null)
         {
             logger.LogWarning(
-                "Запись каталога не найдена при маппинге набора данных. TypeId={TypeId}, Match={Match}, Value={Value}, Owner={OwnerId}",
-                refMap.TypeId, refMap.Match, lookup, ownerId);
+                "Запись каталога не найдена при маппинге набора данных. TypeId={TypeId}, Strategy={Strategy}, Value={Value}, Owner={OwnerId}",
+                refMap.TypeId, req.Strategy, lookupDisplay, ownerId);
             diagnostics?.Add(new ResolutionDiagnostic(
                 DiagnosticSeverity.Warning, path,
-                $"Значение «{lookup}» не найдено в каталоге — ссылка не подставлена."));
+                $"Значение «{lookupDisplay}» не найдено в каталоге — ссылка не подставлена."));
             return null;
         }
 

--- a/src/server/BHS.CRG.Tests/DataSets/DataSetMappingValueTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/DataSetMappingValueTests.cs
@@ -35,14 +35,59 @@ public class DataSetMappingValueTests
         Assert.Equal("", parsed!.Match);
     }
 
+    [Fact]
+    public void RefValue_NameStrategy_ParsesColumn_NotIdentity()
+    {
+        var typeId = Guid.NewGuid();
+        var value = $$"""@@ref:{"strategy":"Name","column":"Наименование","typeId":"{{typeId}}"}""";
+        var parsed = DataSetMappingValue.ParseRef(value);
+        Assert.NotNull(parsed);
+        Assert.False(parsed!.IsIdentity);
+        Assert.Equal("Наименование", parsed.Column);
+        Assert.Equal("Name", parsed.Strategy);
+    }
+
+    [Fact]
+    public void RefValue_IdentityStrategy_ParsesIdentityColumns()
+    {
+        var typeId = Guid.NewGuid();
+        var value = $$"""@@ref:{"strategy":"Identity","identityColumns":{"ИНН":"КолИНН","КПП":"КолКПП"},"typeId":"{{typeId}}"}""";
+        var parsed = DataSetMappingValue.ParseRef(value);
+        Assert.NotNull(parsed);
+        Assert.True(parsed!.IsIdentity);
+        Assert.Null(parsed.Column);
+        Assert.Equal(2, parsed.IdentityColumns!.Count);
+        Assert.Equal("КолИНН", parsed.IdentityColumns["ИНН"]);
+        Assert.Equal("КолКПП", parsed.IdentityColumns["КПП"]);
+    }
+
+    [Fact]
+    public void RefValue_IdentityWithEmptyColumns_IsNotIdentity()
+    {
+        var typeId = Guid.NewGuid();
+        // strategy=Identity, но identityColumns пуст → нечем резолвить как identity; и column есть → валиден как Name-подобный.
+        var value = $$"""@@ref:{"strategy":"Identity","column":"Наименование","identityColumns":{},"typeId":"{{typeId}}"}""";
+        var parsed = DataSetMappingValue.ParseRef(value);
+        Assert.NotNull(parsed);
+        Assert.False(parsed!.IsIdentity);
+    }
+
     [Theory]
     [InlineData("@@ref:not-json")]
     [InlineData("@@ref:{\"column\":\"X\"}")]                       // нет typeId
     [InlineData("@@ref:{\"typeId\":\"00000000-0000-0000-0000-000000000000\",\"column\":\"X\"}")] // пустой Guid
-    [InlineData("@@ref:{\"typeId\":\"11111111-1111-1111-1111-111111111111\",\"column\":\"\"}")]  // нет column
+    [InlineData("@@ref:{\"typeId\":\"11111111-1111-1111-1111-111111111111\",\"column\":\"\"}")]  // нет column и нет identityColumns
     public void Malformed_ReturnsNull(string value)
     {
         Assert.Null(DataSetMappingValue.ParseRef(value));
+    }
+
+    [Fact]
+    public void RefValue_IdentityColumnsWithoutColumn_IsValid()
+    {
+        var typeId = Guid.NewGuid();
+        var value = $$"""@@ref:{"strategy":"Identity","identityColumns":{"ИНН":"КолИНН"},"typeId":"{{typeId}}"}""";
+        Assert.NotNull(DataSetMappingValue.ParseRef(value)); // нет column, но есть identityColumns → валиден
     }
 
     [Fact]

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.39.3</Version>
+    <Version>0.40.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #243 (Фаза 1, бэкенд). План согласован с Архитектором.

## Что

Сходимость к решению #183: резолв «строка→объект» — **только** по имени/алиасам (`Name`) или по составному **identity-ключу** (`IdentityKey`). Произвольное поле (`Field`) больше не user-facing (но остаётся в резолвере для legacy read-path и Paste).

- **`DataSetRefMapping`** — дискриминированный формат `@@ref`: `{strategy:"Name",column}` | `{strategy:"Identity",identityColumns:{identityПоле→колонка}}`. **Legacy** `{column,match}` читается вечно (непустой `match` = Field, пустой = Name) — старые маппинги работают, форс-миграции нет.
- **`DataSetResolver.MapValueAsync`**: ветка Identity — собирает значения identity-полей из строки по `identityColumns` → `ObjectMatchRequest.ByIdentity`; Name/legacy — как раньше. Строгий composite-ключ → нет ложных матчей (пустая компонента → no-match + WARNING, как сегодня).
- **`DataSetDtoMapper.PreviewCell`**: превью Identity — конкатенация колонок.
- `ObjectMatchStrategy.Field` **не удалён** (нужен legacy read-path + Paste).

Миграций БД нет (маппинг — JSON-строка).

## Проверка

- `dotnet build` — 0 ошибок.
- Тесты: парсинг нового формата (Identity/Name) + legacy + невалидность; резолвер — **27 зелёных**.

## Дальше

Фаза 2 (фронт `MappingEditor`): убрать выбор произвольного поля, оставить «по имени / по идентификатору», для Identity — N пикеров колонок; эмит нового формата.

Версия → `0.40.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)