### PR TITLE
fix(catalog): комплексный поиск + кнопка очистки (#249)

### DIFF
--- a/src/client/src/features/document-sets/catalog/CatalogResource.tsx
+++ b/src/client/src/features/document-sets/catalog/CatalogResource.tsx
@@ -3,12 +3,13 @@ import { useSearchParams } from 'react-router-dom';
 import { Plus, Search, ChevronDown, ChevronUp, Database, FileText, Layers, X } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { SearchInput } from '@/shared/ui/SearchInput';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useListCommonData, useDeleteCommonDataEntry, useCommonDataForScope } from '@/shared/api/commonData';
 import type { CommonDataEntry, CatalogScope, DocumentType } from '@/shared/api/types';
 import { CatalogEntryForm } from './index';
-import { groupObjectsByType, ObjectRow } from './ObjectsByTypeList';
+import { groupObjectsByType, entryMatchesQuery, ObjectRow } from './ObjectsByTypeList';
 
 const NO_TYPE = '__no_type__';
 /** Порог, с которого над списком типов появляется мини-поиск (NN/g: фасеты с поиском при большом числе). */
@@ -66,8 +67,11 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
     !filterTypeId ? true
       : filterTypeId === NO_TYPE ? !allSelectableTypes.some(t => t.id === e.compositeTypeId)
         : e.compositeTypeId === filterTypeId;
-  const filtered = entries.filter(e =>
-    (!search || e.displayName.toLowerCase().includes(search.toLowerCase())) && matchType(e))
+  // Текстовый матч комплексный (issue #249): имя записи + имя типа + значения скалярных полей — см.
+  // entryMatchesQuery. Раньше искали только по displayName (искали «орга» → тип «Организация» не находился).
+  const matchText = (e: CommonDataEntry) =>
+    entryMatchesQuery(e, allSelectableTypes.find(t => t.id === e.compositeTypeId)?.name, search);
+  const filtered = entries.filter(e => matchText(e) && matchType(e))
     .sort((a, b) => {
       const typeCmp = (allSelectableTypes.find(t => t.id === a.compositeTypeId)?.name ?? '').localeCompare(
         allSelectableTypes.find(t => t.id === b.compositeTypeId)?.name ?? '');
@@ -114,11 +118,9 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
       {/* Записи */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-3 mb-4">
-          <div className="relative flex-1 max-w-sm">
-            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-fg4" />
-            <input value={search} onChange={e => setSearch(e.target.value)}
-              placeholder={selectedType ? `Поиск: ${selectedType.name}…` : 'Поиск по каталогу…'}
-              className="w-full border border-stroke-strong rounded-md pl-9 pr-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface" />
+          <div className="flex-1 max-w-sm">
+            <SearchInput value={search} onChange={setSearch}
+              placeholder={selectedType ? `Поиск: ${selectedType.name}…` : 'Поиск по каталогу…'} />
           </div>
           <span className="flex-1" />
           <Button variant="filled" size="sm" icon={<Plus size={16} />} onClick={() => setAddOpen(true)}>Добавить запись</Button>

--- a/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
+++ b/src/client/src/features/document-sets/catalog/ObjectsByTypeList.tsx
@@ -7,6 +7,22 @@ import type { CommonDataEntry, DocumentType } from '@/shared/api/types';
 // групп (карточка-страница vs рейл-панель) намеренно разные (issue #8, три канала иерархии) и остаются
 // на стороне страниц; здесь — группировка, строка объекта и метка роли/прокси.
 
+/**
+ * Комплексный текстовый матч записи каталога (issue #249). Ищем подстроку `query` (регистронезависимо)
+ * в: имени записи, её алиасах, имени её типа (искали «орга» → находим тип «Организация») и значениях
+ * собственных скалярных полей. Служебные ключи (`_baseRef` и пр., префикс `_`) и составные значения
+ * (объекты/массивы) пропускаем — как в превью строки. Пустой запрос матчит всё.
+ */
+export function entryMatchesQuery(entry: CommonDataEntry, typeName: string | undefined, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  if (entry.displayName.toLowerCase().includes(q)) return true;
+  if (entry.aliases?.some(a => a.toLowerCase().includes(q))) return true;
+  if (typeName && typeName.toLowerCase().includes(q)) return true;
+  return Object.entries(entry.data).some(([k, v]) =>
+    !k.startsWith('_') && v != null && typeof v !== 'object' && String(v).toLowerCase().includes(q));
+}
+
 /** Группировка записей по составному типу (+ «без типа»). Порядок внутри группы — как во входе. */
 export function groupObjectsByType(entries: CommonDataEntry[], types: DocumentType[]) {
   const groups = types

--- a/src/client/src/features/document-sets/catalog/entryMatchesQuery.test.ts
+++ b/src/client/src/features/document-sets/catalog/entryMatchesQuery.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { entryMatchesQuery } from './ObjectsByTypeList';
+import type { CommonDataEntry } from '@/shared/api/types';
+
+function entry(over: Partial<CommonDataEntry>): CommonDataEntry {
+  return {
+    id: 'e1', displayName: 'ООО Ромашка', aliases: [], compositeTypeId: 't1',
+    data: {}, scope: 'System', scopeId: null, createdAt: '', updatedAt: '', ...over,
+  };
+}
+
+describe('entryMatchesQuery (issue #249)', () => {
+  it('пустой запрос матчит всё', () => {
+    expect(entryMatchesQuery(entry({}), 'Организация', '')).toBe(true);
+    expect(entryMatchesQuery(entry({}), 'Организация', '   ')).toBe(true);
+  });
+
+  it('находит по имени записи (регистронезависимо)', () => {
+    expect(entryMatchesQuery(entry({ displayName: 'ООО Ромашка' }), 'Организация', 'ромашка')).toBe(true);
+  });
+
+  it('находит по имени ТИПА — «орга» → «Организация» (основной баг)', () => {
+    expect(entryMatchesQuery(entry({ displayName: 'ООО Ромашка' }), 'Организация', 'орга')).toBe(true);
+  });
+
+  it('находит по алиасам', () => {
+    expect(entryMatchesQuery(entry({ aliases: ['Ромашка ООО', 'RML'] }), 'Организация', 'rml')).toBe(true);
+  });
+
+  it('находит по значению скалярного поля', () => {
+    expect(entryMatchesQuery(entry({ data: { ИНН: '7701234567' } }), 'Организация', '77012')).toBe(true);
+  });
+
+  it('игнорирует служебные ключи (префикс _) и составные значения', () => {
+    const e = entry({ displayName: 'X', data: { _baseRef: 'match-uuid', nested: { k: 'match' }, arr: ['match'] } });
+    expect(entryMatchesQuery(e, 'Тип', 'match')).toBe(false);
+  });
+
+  it('не матчит при отсутствии совпадений', () => {
+    expect(entryMatchesQuery(entry({ displayName: 'ООО Ромашка', data: { ИНН: '7701' } }), 'Организация', 'персона')).toBe(false);
+  });
+
+  it('typeName undefined не роняет', () => {
+    expect(entryMatchesQuery(entry({ displayName: 'Ромашка' }), undefined, 'ромашка')).toBe(true);
+    expect(entryMatchesQuery(entry({ displayName: 'Ромашка' }), undefined, 'орга')).toBe(false);
+  });
+});

--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { Loader2, Link2, Unlink, ShieldCheck, Search, Globe, ExternalLink, Download, Eye, Check } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { SearchInput } from '@/shared/ui/SearchInput';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import { usePreviewDataSetBindings } from '@/shared/api/datasets';
 import {
@@ -185,11 +186,7 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
 
       {tab === 'pick' && (
         <div className="space-y-2">
-          <div className="flex items-center gap-2 border border-stroke-strong rounded-md px-2 transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
-            <Search size={14} className="text-fg4" />
-            <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Поиск по материалу / названию..."
-              className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />
-          </div>
+          <SearchInput value={query} onChange={setQuery} placeholder="Поиск по материалу / названию..." />
           <label className="flex items-center gap-1.5 text-xs text-fg3 cursor-pointer">
             <input type="checkbox" checked={includeExpired} onChange={e => setIncludeExpired(e.target.checked)}
               className="w-3.5 h-3.5 rounded border-stroke-strong text-brand" />

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -4,6 +4,7 @@ import { Plus, Pencil, Trash2, ShieldCheck, FileText, Search, Globe, ExternalLin
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { SearchInput } from '@/shared/ui/SearchInput';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
@@ -165,10 +166,8 @@ export function QualityDocsPage() {
       </div>
 
       <div className="flex items-center gap-3 mb-4 flex-wrap">
-        <div className="flex items-center gap-2 border border-stroke-strong rounded-md px-2 flex-1 min-w-[220px] max-w-md transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
-          <Search size={14} className="text-fg4" />
-          <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Поиск по названию..."
-            className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />
+        <div className="flex-1 min-w-[220px] max-w-md">
+          <SearchInput value={search} onChange={setSearch} placeholder="Поиск по названию..." />
         </div>
         <Select value={scopeFilter} onValueChange={v => setScopeFilter(v as 'all' | 'System')}
           aria-label="Область" className="w-48">

--- a/src/client/src/shared/ui/ListDetailShell.tsx
+++ b/src/client/src/shared/ui/ListDetailShell.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from 'react';
-import { Search, ChevronRight } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
 import { Button } from './Button';
+import { SearchInput } from './SearchInput';
 
 /**
  * Тонкий layout-примитив «list-detail со вторичной навигацией» (issue #210, разбор с Архитектором+
@@ -57,11 +58,7 @@ export function NavSearchInput({ value, onChange, placeholder = 'Поиск…' 
 }) {
   return (
     <div className="p-3 shrink-0">
-      <div className="relative">
-        <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-fg4 pointer-events-none" />
-        <input value={value} onChange={e => onChange(e.target.value)} placeholder={placeholder} aria-label="Поиск"
-          className="w-full h-10 pl-9 pr-3 rounded-full text-sm bg-surface border border-stroke-strong text-fg1 outline-none focus-visible:ring-2 focus-visible:ring-brand placeholder:text-fg4" />
-      </div>
+      <SearchInput value={value} onChange={onChange} placeholder={placeholder} rounded="full" />
     </div>
   );
 }

--- a/src/client/src/shared/ui/SearchInput.tsx
+++ b/src/client/src/shared/ui/SearchInput.tsx
@@ -1,0 +1,45 @@
+import { Search, X } from 'lucide-react';
+
+/**
+ * Единое поле поиска списка (issue #249): иконка-лупа слева, кнопка очистки (✕) справа при непустом
+ * значении, Escape очищает. Один источник правды для всех текстовых поисков — чтобы «очистка» была
+ * везде одинаковой. Форма настраивается через `rounded`/`className` (прямоугольная в тулбарах,
+ * пилюля в шапке рейла). Для комбобокс-пикеров с автофокусом использовать НЕ обязательно.
+ */
+export function SearchInput({
+  value, onChange, placeholder = 'Поиск…', ariaLabel, className = '',
+  rounded = 'md', autoFocus,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  ariaLabel?: string;
+  className?: string;
+  rounded?: 'md' | 'full';
+  autoFocus?: boolean;
+}) {
+  return (
+    <div className="relative">
+      <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-fg4 pointer-events-none" />
+      <input
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onKeyDown={e => { if (e.key === 'Escape' && value) { e.preventDefault(); onChange(''); } }}
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? 'Поиск'}
+        autoFocus={autoFocus}
+        className={`w-full h-10 pl-9 pr-9 text-sm bg-surface border border-stroke-strong text-fg1 outline-none focus-visible:ring-2 focus-visible:ring-brand placeholder:text-fg4 ${rounded === 'full' ? 'rounded-full' : 'rounded-md'} ${className}`}
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label="Очистить поиск"
+          className="absolute right-2.5 top-1/2 -translate-y-1/2 text-fg4 hover:text-fg2 transition-colors"
+        >
+          <X size={15} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.40.3</Version>
+    <Version>0.41.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #249

## Баг
Поиск в каталогах общих данных матчил **только `displayName`** записи. Поэтому «орга» (фрагмент имени типа «Организация») давал «Ничего не найдено», хотя тип с записью есть — неожиданный результат на скринах issue.

## Что сделано
**1. Комплексный матч** (`entryMatchesQuery`, чистый хелпер + 8 юнит-тестов): подстрока ищется в
- имени записи,
- её алиасах,
- **имени типа** (искали «орга» → находим «Организация»),
- значениях собственных скалярных полей.

Служебные `_`-ключи (`_baseRef` и пр.) и составные значения (объекты/массивы) пропускаются — как в превью строки.

**2. Кнопка очистки поиска.** Новый общий компонент `SearchInput` (иконка-лупа + ввод + ✕-очистка при непустом значении, Escape очищает) — единый вид «очистки» для всех текстовых поисков. Внедрён в:
- каталог общих данных (основной поиск),
- `NavSearchInput` → страницы «Типы документов» и «Типы полей»,
- «Документы качества»,
- вкладку привязок документов качества.

У поиска по комплектам и мини-поиска типов очистка уже была — оставлены как есть.

## Проверка
- `tsc -b` — чисто; `vitest run` — 126 тестов зелёные (в т.ч. 8 новых).

🤖 Generated with [Claude Code](https://claude.com/claude-code)