### PR TITLE
feat(images): размер картинки задаётся в инстансе, не в типе (#246)

### DIFF
--- a/src/client/src/features/document-sets/fields/ImageField.tsx
+++ b/src/client/src/features/document-sets/fields/ImageField.tsx
@@ -1,39 +1,101 @@
-import { Image as ImageIcon, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Image as ImageIcon, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import type { ImageValue } from '@/shared/api/schema';
 
+/**
+ * Поле-изображение. Значение — объект `{ src: data-URI, width?, height?, align?, fit? }` (issue #246):
+ * размер/выравнивание задаются здесь, в инстансе (раньше — в определении типа). Легаси-значение
+ * (голая data-URI строка) читается как `{ src }` без размера.
+ */
 export function ImageField({ value, onChange }: {
-  value: unknown; onChange: (val: string | null) => void;
+  value: unknown; onChange: (val: ImageValue | null) => void;
 }) {
-  const dataUri = typeof value === 'string' && value.startsWith('data:image') ? value : null;
+  const [sizeOpen, setSizeOpen] = useState(false);
+  const img = normalize(value);
+  const hasSize = !!(img && (img.width || img.height || img.align || img.fit));
 
   function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
     const reader = new FileReader();
-    reader.onload = () => { if (typeof reader.result === 'string') onChange(reader.result); };
+    reader.onload = () => {
+      if (typeof reader.result === 'string') onChange({ ...(img ?? {}), src: reader.result });
+    };
     reader.readAsDataURL(file);
     e.target.value = '';
   }
 
-  if (dataUri) {
+  const patch = (p: Partial<ImageValue>) => {
+    if (!img) return;
+    const next: ImageValue = { ...img, ...p };
+    // Пустые строки в опциях убираем, чтобы значение не тащило пустышки.
+    (['width', 'height', 'align', 'fit'] as const).forEach(k => { if (!next[k]) delete next[k]; });
+    onChange(next);
+  };
+
+  if (!img) {
     return (
-      <div className="space-y-2">
-        <div className="border border-stroke rounded-lg overflow-hidden bg-base flex items-center justify-center p-2 max-h-52">
-          <img src={dataUri} alt="" className="max-h-48 max-w-full object-contain" />
-        </div>
-        <button type="button" onClick={() => onChange(null)}
-          className="flex items-center gap-1.5 text-xs text-danger hover:text-danger transition-colors">
-          <Trash2 size={12} /> Удалить изображение
-        </button>
-      </div>
+      <label className="flex flex-col items-center justify-center gap-2 border-2 border-dashed border-stroke-strong rounded-lg py-6 cursor-pointer hover:border-brand hover:bg-brand-subtle transition-colors">
+        <ImageIcon size={20} className="text-fg4" />
+        <span className="text-sm text-fg3">Нажмите для выбора изображения</span>
+        <span className="text-xs text-fg4">PNG, JPG, SVG, WEBP</span>
+        <input type="file" accept="image/*" className="hidden" onChange={handleFile} />
+      </label>
     );
   }
 
   return (
-    <label className="flex flex-col items-center justify-center gap-2 border-2 border-dashed border-stroke-strong rounded-lg py-6 cursor-pointer hover:border-brand hover:bg-brand-subtle transition-colors">
-      <ImageIcon size={20} className="text-fg4" />
-      <span className="text-sm text-fg3">Нажмите для выбора изображения</span>
-      <span className="text-xs text-fg4">PNG, JPG, SVG, WEBP</span>
-      <input type="file" accept="image/*" className="hidden" onChange={handleFile} />
-    </label>
+    <div className="space-y-2">
+      <div className="border border-stroke rounded-lg overflow-hidden bg-base flex items-center justify-center p-2 max-h-52">
+        <img src={img.src} alt="" className="max-h-48 max-w-full object-contain" />
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button type="button" onClick={() => onChange(null)}
+          className="flex items-center gap-1.5 text-xs text-danger hover:text-danger transition-colors">
+          <Trash2 size={12} /> Удалить изображение
+        </button>
+        <button type="button" onClick={() => setSizeOpen(o => !o)}
+          className="flex items-center gap-1 text-xs text-fg3 hover:text-fg1 transition-colors">
+          {sizeOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          Размер и выравнивание{!sizeOpen && hasSize ? ' ·' : ''}
+        </button>
+      </div>
+
+      {sizeOpen && (
+        <div className="flex flex-wrap items-center gap-2 pl-1">
+          <input value={img.width ?? ''} onChange={e => patch({ width: e.target.value })}
+            placeholder="ширина (напр. 4cm)"
+            className="w-36 border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand" />
+          <input value={img.height ?? ''} onChange={e => patch({ height: e.target.value })}
+            placeholder="высота"
+            className="w-24 border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand" />
+          <select value={img.align ?? ''} onChange={e => patch({ align: (e.target.value || undefined) as ImageValue['align'] })}
+            className="border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand">
+            <option value="">выравнивание</option>
+            <option value="left">слева</option>
+            <option value="center">по центру</option>
+            <option value="right">справа</option>
+          </select>
+          <select value={img.fit ?? ''} onChange={e => patch({ fit: (e.target.value || undefined) as ImageValue['fit'] })}
+            className="border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand">
+            <option value="">fit (вписывание)</option>
+            <option value="contain">contain</option>
+            <option value="cover">cover</option>
+            <option value="stretch">stretch</option>
+          </select>
+        </div>
+      )}
+    </div>
   );
+}
+
+/** Приводит значение к объекту {src, ...} или null. Понимает легаси-строку data-URI. */
+function normalize(value: unknown): ImageValue | null {
+  if (typeof value === 'string') return value.startsWith('data:image') ? { src: value } : null;
+  if (value && typeof value === 'object') {
+    const src = (value as { src?: unknown }).src;
+    if (typeof src === 'string' && src.startsWith('data:image')) return value as ImageValue;
+  }
+  return null;
 }

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -151,11 +151,6 @@ export function FieldCard({
   // Легаси enum-поле (issue #59): options инлайн, typeId не выбран.
   const isLegacyEnum = field.type === 'enum' && !field.typeId && (field.options?.length ?? 0) > 0;
   const enumTypeDef = field.type === 'enum' ? enumTypes.find(et => et.id === field.typeId) : undefined;
-  const setImageOpt = (patch: Partial<NonNullable<SchemaField['image']>>) => {
-    const merged = { ...(field.image ?? {}), ...patch };
-    const cleaned = Object.fromEntries(Object.entries(merged).filter(([, v]) => v !== undefined && v !== ''));
-    onChange({ image: Object.keys(cleaned).length ? cleaned : undefined });
-  };
   // Ключ «автоматический», пока совпадает с toCamelKey(title) — тогда перегенерируем при вводе названия.
   const updateTitle = (title: string) => {
     const isKeyAuto = !field.key.trim() || field.key === toCamelKey(field.title);
@@ -329,44 +324,6 @@ export function FieldCard({
             className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover">
             <Plus size={11} /> Добавить вариант
           </button>
-        </div>
-      )}
-      {/* Опции изображения (размер/выравнивание) */}
-      {field.type === 'image' && (
-        <div className="ml-[calc(33%+0.5rem)] mr-[calc(5rem)] flex flex-wrap items-center gap-2">
-          <span className="text-xs text-fg4 shrink-0 w-28">Изображение:</span>
-          <input
-            value={field.image?.width ?? ''}
-            onChange={e => setImageOpt({ width: e.target.value })}
-            placeholder="ширина (напр. 4cm)"
-            className="w-32 border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand"
-          />
-          <input
-            value={field.image?.height ?? ''}
-            onChange={e => setImageOpt({ height: e.target.value })}
-            placeholder="высота"
-            className="w-24 border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand"
-          />
-          <select
-            value={field.image?.align ?? ''}
-            onChange={e => setImageOpt({ align: (e.target.value || undefined) as 'left' | 'center' | 'right' | undefined })}
-            className="border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand"
-          >
-            <option value="">выравнивание</option>
-            <option value="left">слева</option>
-            <option value="center">по центру</option>
-            <option value="right">справа</option>
-          </select>
-          <select
-            value={field.image?.fit ?? ''}
-            onChange={e => setImageOpt({ fit: (e.target.value || undefined) as 'cover' | 'contain' | 'stretch' | undefined })}
-            className="border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand"
-          >
-            <option value="">fit (вписывание)</option>
-            <option value="contain">contain</option>
-            <option value="cover">cover</option>
-            <option value="stretch">stretch</option>
-          </select>
         </div>
       )}
       {/* Функциональные тэги поля (для primitive — из типа поля, иначе из реестра) */}

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -14,16 +14,21 @@ export interface SchemaField {
   defaultValue?: unknown;
   /** Functional tags binding this field to hard-coded behaviour (registry: GET /api/tags). */
   tags?: string[];
-  /** Render options for image fields (used by the generator: image() width/height/align/fit). */
-  image?: ImageOptions;
 }
 
+/** Опции отображения картинки (width/height/align/fit). Задаются в значении инстанса (issue #246). */
 export interface ImageOptions {
   /** Typst length, e.g. "4cm", "100%". */
   width?: string;
   height?: string;
   align?: 'left' | 'center' | 'right';
   fit?: 'cover' | 'contain' | 'stretch';
+}
+
+/** Значение поля-картинки: data-URI + опции размера/выравнивания (issue #246). */
+export interface ImageValue extends ImageOptions {
+  /** data:image/...;base64,... */
+  src: string;
 }
 
 export interface FieldGroup {
@@ -109,7 +114,6 @@ export function parseSchemaFields(schema: Record<string, unknown>): SchemaField[
     required: f.required ?? false,
     defaultValue: f.defaultValue,
     tags: f.tags,
-    image: f.image,
   }));
 }
 

--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -130,7 +130,7 @@ public static class GenerationEndpoints
                     Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 };
                 dataJson = BHS.CRG.Infrastructure.Generation.TypstImageMaterializer
-                    .MaterializeJson(bundle.DataJson, tmpDir, "assets", prettyOpts, bundle.ImageOptions);
+                    .MaterializeJson(bundle.DataJson, tmpDir, "assets", prettyOpts);
 
                 // Вложения ({$type:"file"}) скачиваем в те же assets/ (att_N) — bundle воспроизводит ВХОД
                 // для внешнего `typst compile`. blob-доступ на сервере есть; так внешний Typst найдёт файлы.

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -294,6 +294,10 @@ using (var scope = app.Services.CreateScope())
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     await db.Database.MigrateAsync();
 
+    // Разовый перенос размеров изображений из схем типов в значения инстансов (issue #246).
+    // Идемпотентно: после первого прогона схемы очищены, карта пустеет — обход не запускается.
+    await BHS.CRG.Infrastructure.DataFixups.ImageSizeToInstanceFixup.RunAsync(db);
+
     // Зависшие фоновые задачи (in-process очередь потеряна при рестарте) — помечаем Failed, чтобы
     // индикатор не «висел» вечно (тот же приём восстановления, что и сид ролей ниже).
     var stuckJobs = await db.Jobs.Where(j => j.Status == JobStatus.Queued || j.Status == JobStatus.Running).ToListAsync();

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -104,7 +104,6 @@ public class GenerateDocumentHandler(
             var contentType = cmd.Format == OutputFormat.Pdf
                 ? "application/pdf"
                 : "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-            var imageOptions = SchemaImageOptions.Collect(allDocTypes);
             var docType = allDocTypes.FirstOrDefault(dt => dt.Id == instance.CompositeTypeId);
 
             // По PDF на каждый выбранный шаблон. Контекст (реквизиты/наборы/каталог) общий — строится
@@ -123,7 +122,7 @@ public class GenerateDocumentHandler(
                 var generator = generatorFactory.Create(cmd.Format);
                 var request = new GenerationRequest(template.Content, cmd.Format, context,
                     TypeBlocksContent: typeBlocksContent, UserLibContent: userLibContent,
-                    ImageOptions: imageOptions, TemplateAssets: templateAssets);
+                    TemplateAssets: templateAssets);
                 var bytes = await generator.GenerateAsync(request, ct);
 
                 // Обратная запись метаданных — только с ПЕРВОГО файла (репрезентативно: число листов и т.п.).

--- a/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
+++ b/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
@@ -20,7 +20,6 @@ public record GenerationDebugBundle(
     string DataJson,
     string TypeBlocks,
     string UserLib,
-    IReadOnlyDictionary<string, BHS.CRG.Application.Schema.ImageRenderOptions> ImageOptions,
     ResolvedTemplateAssets TemplateAssets);
 
 public record GetGenerationDebugBundleQuery(Guid InstanceId) : IRequest<GenerationDebugBundle?>;
@@ -77,8 +76,7 @@ public class GetGenerationDebugBundleHandler(
         var allLibs = await userLibRepo.GetAllAsync(ct);
         var userLib = allLibs.FirstOrDefault()?.Content ?? "";
 
-        var imageOptions = BHS.CRG.Application.Schema.SchemaImageOptions.Collect(allDocTypes);
         var templateAssets = await templateAssetResolver.ResolveAsync(template.Id, instance.CompositeTypeId, ct);
-        return new GenerationDebugBundle(template.Content, dataJson, typeBlocks, userLib, imageOptions, templateAssets);
+        return new GenerationDebugBundle(template.Content, dataJson, typeBlocks, userLib, templateAssets);
     }
 }

--- a/src/server/BHS.CRG.Application/Generation/IDocumentGenerator.cs
+++ b/src/server/BHS.CRG.Application/Generation/IDocumentGenerator.cs
@@ -1,4 +1,3 @@
-using BHS.CRG.Application.Schema;
 using BHS.CRG.Application.Templates;
 using BHS.CRG.Domain.Documents;
 
@@ -15,6 +14,5 @@ public record GenerationRequest(
     GenerationContext Context,
     string? TypeBlocksContent = null,
     string? UserLibContent = null,
-    IReadOnlyDictionary<string, ImageRenderOptions>? ImageOptions = null,
     ResolvedTemplateAssets? TemplateAssets = null
 );

--- a/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
+++ b/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
@@ -100,7 +100,6 @@ public class PreviewDocumentHandler(
             var request = new GenerationRequest(template.Content, OutputFormat.Pdf, context,
                 TypeBlocksContent: string.IsNullOrEmpty(preamble) ? null : preamble,
                 UserLibContent: userLib,
-                ImageOptions: SchemaImageOptions.Collect(allDocTypes),
                 TemplateAssets: assets);
             var bytes = await generator.GenerateAsync(request, ct);
             return PreviewDocumentResult.Ok(bytes);

--- a/src/server/BHS.CRG.Infrastructure/DataFixups/ImageSizeToInstanceFixup.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataFixups/ImageSizeToInstanceFixup.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Infrastructure.Generation;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.DataFixups;
+
+/// <summary>
+/// Разовый перенос размеров изображений из определения типа в инстансы (issue #246). Раньше
+/// width/height/align/fit задавались в схеме типа (fields[].image) и подмешивались генератором по имени
+/// поля; теперь размер живёт в самом значении-картинке инстанса (<c>{ src, width, ... }</c>).
+/// <para>
+/// Миграция: по глобальной карте (имя поля → опции из схем) обходит JSONB каждого объекта и заменяет
+/// голые data-URI строки на объекты со снятыми из схемы размерами; затем вычищает блок <c>image</c>
+/// из схем типов, чтобы источник размера окончательно съехал в инстанс. Идемпотентна: значения-объекты
+/// не трогает, а после вычистки схем карта пустеет и обход больше не запускается.
+/// </para>
+/// </summary>
+public static class ImageSizeToInstanceFixup
+{
+    public static async Task RunAsync(AppDbContext db, CancellationToken ct = default)
+    {
+        var types = await db.DocumentTypes.ToListAsync(ct);
+        var options = SchemaImageOptions.Collect(types);
+        if (options.Count == 0) return; // размеры в схемах не заданы — переносить нечего (в т.ч. свежая БД).
+
+        // 1. Инстансы: голые data-URI под известным по имени поля ключом → объект с размером.
+        var objects = await db.DomainObjects.ToListAsync(ct);
+        var changed = 0;
+        foreach (var obj in objects)
+        {
+            var migrated = MigrateDataJson(obj.Data.RootElement.GetRawText(), options);
+            if (migrated is not null)
+            {
+                obj.SetData(JsonDocument.Parse(migrated));
+                changed++;
+            }
+        }
+
+        // 2. Схемы типов: убираем блок image (размер съехал в инстансы) — финализирует перенос.
+        var typesStripped = 0;
+        foreach (var t in types)
+        {
+            var stripped = StripImageFromSchema(t.Schema.RootElement.GetRawText());
+            if (stripped is not null)
+            {
+                t.UpdateSchema(JsonDocument.Parse(stripped));
+                typesStripped++;
+            }
+        }
+
+        if (changed > 0 || typesStripped > 0) await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Заменяет в JSON инстанса голые data-URI на объекты-значения с размером из <paramref name="options"/>
+    /// (по имени поля-ключа). Уже-объектные значения-картинки не трогает. Возвращает изменённый JSON или
+    /// <c>null</c>, если менять нечего. Чистая функция — тестируется напрямую.
+    /// </summary>
+    public static string? MigrateDataJson(string dataJson, IReadOnlyDictionary<string, ImageRenderOptions> options)
+    {
+        var root = JsonNode.Parse(dataJson);
+        if (root is null) return null;
+        return MigrateNode(root, options) ? root.ToJsonString() : null;
+    }
+
+    /// <summary>Убирает <c>image</c> из каждого поля схемы. Возвращает очищенный JSON или <c>null</c>, если убирать нечего.</summary>
+    public static string? StripImageFromSchema(string schemaJson)
+    {
+        var root = JsonNode.Parse(schemaJson);
+        if (root is not JsonObject obj || obj["fields"] is not JsonArray fields) return null;
+
+        var removed = false;
+        foreach (var f in fields)
+            if (f is JsonObject fo && fo.Remove("image")) removed = true;
+
+        return removed ? root.ToJsonString() : null;
+    }
+
+    /// <summary>Рекурсивно заменяет голые data-URI на объекты-значения с размером; уже-объектные картинки
+    /// не трогает. Возвращает true, если что-то изменил.</summary>
+    private static bool MigrateNode(JsonNode? node, IReadOnlyDictionary<string, ImageRenderOptions> options)
+    {
+        var mutated = false;
+        switch (node)
+        {
+            case JsonObject obj:
+                // Уже мигрированное значение-картинка ({src: data-URI, ...}) — не рекурсируем внутрь.
+                if (ImageValues.TryGetImageObjectSrc(obj, out _)) return false;
+                foreach (var key in obj.Select(kv => kv.Key).ToList())
+                {
+                    var child = obj[key];
+                    if (child is JsonValue val && val.TryGetValue<string>(out var s) && ImageValues.IsDataImage(s)
+                        && options.TryGetValue(key, out var opt))
+                    {
+                        obj[key] = ToImageObject(s, opt);
+                        mutated = true;
+                    }
+                    else
+                    {
+                        mutated |= MigrateNode(child, options);
+                    }
+                }
+                break;
+            case JsonArray arr:
+                // Элементы массива не имеют имени-ключа → размер не переносим (как и генератор раньше),
+                // но спускаемся внутрь ради вложенных объектов.
+                foreach (var item in arr) mutated |= MigrateNode(item, options);
+                break;
+        }
+        return mutated;
+    }
+
+    private static JsonObject ToImageObject(string src, ImageRenderOptions o)
+    {
+        var node = new JsonObject { ["src"] = src };
+        if (!string.IsNullOrEmpty(o.Width)) node["width"] = o.Width;
+        if (!string.IsNullOrEmpty(o.Height)) node["height"] = o.Height;
+        if (!string.IsNullOrEmpty(o.Align)) node["align"] = o.Align;
+        if (!string.IsNullOrEmpty(o.Fit)) node["fit"] = o.Fit;
+        return node;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/ImageValues.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/ImageValues.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Nodes;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Общие правила распознавания значений полей-изображений (issue #246). Значение бывает двух форм:
+///  • голая data-URI строка (<c>data:image/...;base64,...</c>) — легаси / только что загруженная картинка;
+///  • объект <c>{ src: data-URI, width?, height?, align?, fit? }</c> — размер/выравнивание задаются в
+///    инстансе (перенесены из схемы типа). Служебные ключи размера — те же, что прежде брались из схемы.
+/// Обе формы понимают и материализатор Typst, и разовая миграция размеров.
+/// </summary>
+public static class ImageValues
+{
+    public static readonly string[] OptionKeys = ["width", "height", "align", "fit"];
+
+    /// <summary>data-URI картинки: <c>data:image/*;base64,...</c>.</summary>
+    public static bool IsDataImage(string? s) =>
+        s is not null
+        && s.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)
+        && s.Contains(";base64,", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Объект-значение картинки: есть строковый <c>src</c> с data-URI. Возвращает сам src.</summary>
+    public static bool TryGetImageObjectSrc(JsonObject obj, out string src)
+    {
+        src = "";
+        if (obj["src"] is JsonValue v && v.TryGetValue<string>(out var s) && IsDataImage(s))
+        {
+            src = s;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
@@ -28,9 +28,9 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
         try
         {
             // Поля-изображения (data-URI) декодируем в файлы assets/ и подставляем пути,
-            // чтобы шаблон мог обращаться к ним через image(it.Поле).
-            var dataJson = TypstImageMaterializer.Materialize(request.Context.Data, tmpDir,
-                imageOptions: request.ImageOptions);
+            // чтобы шаблон мог обращаться к ним через image(it.Поле). Размер/выравнивание — из самого
+            // значения-объекта {src, width, ...} (issue #246).
+            var dataJson = TypstImageMaterializer.Materialize(request.Context.Data, tmpDir);
 
             // Поля-вложения ({$type:"file"}) скачиваем из blob-хранилища в assets/ и подставляем путь+
             // pageCount, чтобы шаблон вставлял их через image(it.Поле.src[, page: n]) — в т.ч. страницы PDF.

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstImageMaterializer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstImageMaterializer.cs
@@ -1,15 +1,19 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using BHS.CRG.Application.Schema;
 
 namespace BHS.CRG.Infrastructure.Generation;
 
 /// <summary>
-/// Готовит данные для Typst: поля-изображения хранятся как data-URI
-/// (<c>data:image/png;base64,...</c>). Typst не умеет их загружать напрямую,
-/// поэтому каждое изображение декодируется в файл (<c>assets/img_N.ext</c>) внутри
-/// каталога компиляции, а в JSON значение заменяется на относительный путь к файлу.
-/// В шаблоне такое поле используется как <c>image(it.Поле)</c>.
+/// Готовит данные для Typst: поля-изображения хранятся как data-URI (<c>data:image/png;base64,...</c>).
+/// Typst не умеет их загружать напрямую, поэтому каждое изображение декодируется в файл
+/// (<c>assets/img_N.ext</c>) внутри каталога компиляции, а в JSON значение заменяется на объект
+/// <c>{ src, width, height, align, fit }</c> (путь к файлу + размер/выравнивание).
+/// <para>
+/// Размер/выравнивание берутся из САМОГО значения (issue #246): если значение — объект
+/// <c>{ src: data-URI, width?, ... }</c>, опции читаются из него; если голая data-URI строка (легаси) —
+/// опций нет. Раньше опции задавались в схеме типа и подмешивались по имени поля.
+/// </para>
+/// В шаблоне такое поле используется через хелпер <c>img(it.Поле)</c> (или <c>image(it.Поле.src)</c>).
 /// </summary>
 public static class TypstImageMaterializer
 {
@@ -17,29 +21,26 @@ public static class TypstImageMaterializer
     /// Возвращает JSON для data.json, попутно записав изображения в <paramref name="targetDir"/>/<paramref name="assetsSubdir"/>.
     /// </summary>
     public static string Materialize(IReadOnlyDictionary<string, object?> data, string targetDir,
-        string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null,
-        IReadOnlyDictionary<string, ImageRenderOptions>? imageOptions = null)
-        => MaterializeNode(JsonSerializer.SerializeToNode(data) ?? new JsonObject(), targetDir, assetsSubdir, outputOptions, imageOptions);
+        string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null)
+        => MaterializeNode(JsonSerializer.SerializeToNode(data) ?? new JsonObject(), targetDir, assetsSubdir, outputOptions);
 
     /// <summary>То же, но на входе готовый JSON-текст (для отладочного комплекта).</summary>
     public static string MaterializeJson(string json, string targetDir,
-        string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null,
-        IReadOnlyDictionary<string, ImageRenderOptions>? imageOptions = null)
-        => MaterializeNode(JsonNode.Parse(json) ?? new JsonObject(), targetDir, assetsSubdir, outputOptions, imageOptions);
+        string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null)
+        => MaterializeNode(JsonNode.Parse(json) ?? new JsonObject(), targetDir, assetsSubdir, outputOptions);
 
     private static string MaterializeNode(JsonNode root, string targetDir, string assetsSubdir,
-        JsonSerializerOptions? outputOptions, IReadOnlyDictionary<string, ImageRenderOptions>? imageOptions)
+        JsonSerializerOptions? outputOptions)
     {
-        var ctx = new Context(Path.Combine(targetDir, assetsSubdir), assetsSubdir, imageOptions);
+        var ctx = new Context(Path.Combine(targetDir, assetsSubdir), assetsSubdir);
         Walk(root, ctx);
         return outputOptions is null ? root.ToJsonString() : root.ToJsonString(outputOptions);
     }
 
-    private sealed class Context(string assetsDir, string assetsSubdir, IReadOnlyDictionary<string, ImageRenderOptions>? options)
+    private sealed class Context(string assetsDir, string assetsSubdir)
     {
         public string AssetsDir { get; } = assetsDir;
         public string AssetsSubdir { get; } = assetsSubdir;
-        public IReadOnlyDictionary<string, ImageRenderOptions>? Options { get; } = options;
         public int Count;
     }
 
@@ -49,49 +50,51 @@ public static class TypstImageMaterializer
         {
             case JsonObject obj:
                 foreach (var key in obj.Select(kv => kv.Key).ToList())
-                    Replace(ctx, key, v => obj[key] = v, obj[key]);
+                    Replace(ctx, v => obj[key] = v, obj[key]);
                 break;
             case JsonArray arr:
                 for (var i = 0; i < arr.Count; i++)
                 {
                     var idx = i;
-                    Replace(ctx, null, v => arr[idx] = v, arr[idx]);
+                    Replace(ctx, v => arr[idx] = v, arr[idx]);
                 }
                 break;
         }
     }
 
-    private static void Replace(Context ctx, string? propertyKey, Action<JsonNode?> set, JsonNode? child)
+    private static void Replace(Context ctx, Action<JsonNode?> set, JsonNode? child)
     {
-        if (child is JsonValue val && val.TryGetValue<string>(out var s) && IsDataImage(s))
+        // Голая data-URI строка (легаси / только что загруженная) — без размера.
+        if (child is JsonValue val && val.TryGetValue<string>(out var s) && ImageValues.IsDataImage(s))
         {
             var path = WriteImage(s, ctx);
-            if (path is not null) set(BuildImageNode(path, propertyKey, ctx));
+            if (path is not null) set(BuildImageNode(path, null));
+            return;
         }
-        else
+        // Объект-значение картинки {src, width, ...} — размер из него самого (issue #246).
+        if (child is JsonObject obj && ImageValues.TryGetImageObjectSrc(obj, out var src))
         {
-            Walk(child, ctx);
+            var path = WriteImage(src, ctx);
+            if (path is not null) set(BuildImageNode(path, obj));
+            return; // не спускаемся внутрь — это лист-значение
         }
+        Walk(child, ctx);
     }
 
-    // Изображение отдаём объектом {src, width, height, align, fit} — опции из схемы (по имени поля).
-    private static JsonObject BuildImageNode(string path, string? propertyKey, Context ctx)
+    // Изображение отдаём объектом {src, width, height, align, fit}; размерные ключи — из значения-объекта
+    // (null, если не заданы или значение было голой строкой). Форма стабильна для хелпера img() в userlib.
+    private static JsonObject BuildImageNode(string path, JsonObject? source)
     {
-        ImageRenderOptions? o = null;
-        if (propertyKey is not null) ctx.Options?.TryGetValue(propertyKey, out o);
+        string? Opt(string k) => source?[k] is JsonValue v && v.TryGetValue<string>(out var s) && s.Length > 0 ? s : null;
         return new JsonObject
         {
             ["src"] = path,
-            ["width"] = o?.Width,
-            ["height"] = o?.Height,
-            ["align"] = o?.Align,
-            ["fit"] = o?.Fit,
+            ["width"] = Opt("width"),
+            ["height"] = Opt("height"),
+            ["align"] = Opt("align"),
+            ["fit"] = Opt("fit"),
         };
     }
-
-    private static bool IsDataImage(string s) =>
-        s.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase) &&
-        s.Contains(";base64,", StringComparison.OrdinalIgnoreCase);
 
     private static string? WriteImage(string dataUri, Context ctx)
     {

--- a/src/server/BHS.CRG.Tests/DataFixups/ImageSizeToInstanceFixupTests.cs
+++ b/src/server/BHS.CRG.Tests/DataFixups/ImageSizeToInstanceFixupTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Infrastructure.DataFixups;
+
+namespace BHS.CRG.Tests.DataFixups;
+
+public class ImageSizeToInstanceFixupTests
+{
+    private const string Png = "data:image/png;base64,AAAA";
+
+    private static readonly IReadOnlyDictionary<string, ImageRenderOptions> Opts =
+        new Dictionary<string, ImageRenderOptions>
+        {
+            ["Логотип"] = new("4cm", null, "center", null),
+            ["Фото"] = new(null, "3cm", null, "contain"),
+        };
+
+    [Fact]
+    public void MigrateDataJson_WrapsBareDataUri_WithSchemaSize()
+    {
+        var json = $$"""{"Логотип":"{{Png}}","Имя":"ООО"}""";
+        var result = ImageSizeToInstanceFixup.MigrateDataJson(json, Opts);
+        Assert.NotNull(result);
+        var root = JsonDocument.Parse(result!).RootElement;
+        var logo = root.GetProperty("Логотип");
+        Assert.Equal(Png, logo.GetProperty("src").GetString());
+        Assert.Equal("4cm", logo.GetProperty("width").GetString());
+        Assert.Equal("center", logo.GetProperty("align").GetString());
+        Assert.False(logo.TryGetProperty("height", out _)); // пустые опции не пишем
+        Assert.Equal("ООО", root.GetProperty("Имя").GetString());
+    }
+
+    [Fact]
+    public void MigrateDataJson_MigratesNestedObjectFields()
+    {
+        var json = "{\"Орг\":{\"Фото\":\"" + Png + "\",\"Имя\":\"X\"}}";
+        var result = ImageSizeToInstanceFixup.MigrateDataJson(json, Opts);
+        Assert.NotNull(result);
+        var foto = JsonDocument.Parse(result!).RootElement.GetProperty("Орг").GetProperty("Фото");
+        Assert.Equal("3cm", foto.GetProperty("height").GetString());
+        Assert.Equal("contain", foto.GetProperty("fit").GetString());
+    }
+
+    [Fact]
+    public void MigrateDataJson_ArrayElementImages_HaveNoKey_NotSized_ButUnchangedStaysBare()
+    {
+        // Элемент массива под ключом "Фото" внутри объекта строки — ключ есть → мигрируется.
+        var json = $$"""{"Материалы":[{"Фото":"{{Png}}"}]}""";
+        var result = ImageSizeToInstanceFixup.MigrateDataJson(json, Opts);
+        Assert.NotNull(result);
+        var foto = JsonDocument.Parse(result!).RootElement.GetProperty("Материалы")[0].GetProperty("Фото");
+        Assert.Equal(Png, foto.GetProperty("src").GetString());
+        Assert.Equal("3cm", foto.GetProperty("height").GetString());
+    }
+
+    [Fact]
+    public void MigrateDataJson_UnknownKey_LeavesBareString()
+    {
+        var json = $$"""{"Прочее":"{{Png}}"}""";
+        // "Прочее" нет в карте → не мигрируем → изменений нет.
+        Assert.Null(ImageSizeToInstanceFixup.MigrateDataJson(json, Opts));
+    }
+
+    [Fact]
+    public void MigrateDataJson_AlreadyObjectValue_Idempotent()
+    {
+        var json = "{\"Логотип\":{\"src\":\"" + Png + "\",\"width\":\"4cm\"}}";
+        // Уже объект-значение → не трогаем, повторная миграция ничего не меняет.
+        Assert.Null(ImageSizeToInstanceFixup.MigrateDataJson(json, Opts));
+    }
+
+    [Fact]
+    public void StripImageFromSchema_RemovesImageBlocks()
+    {
+        var schema = """
+        {"fields":[
+          {"key":"Логотип","type":"image","image":{"width":"4cm"}},
+          {"key":"Имя","type":"string"}
+        ]}
+        """;
+        var result = ImageSizeToInstanceFixup.StripImageFromSchema(schema);
+        Assert.NotNull(result);
+        var fields = JsonDocument.Parse(result!).RootElement.GetProperty("fields");
+        Assert.False(fields[0].TryGetProperty("image", out _));
+        Assert.Equal("image", fields[0].GetProperty("type").GetString()); // тип поля не трогаем
+    }
+
+    [Fact]
+    public void StripImageFromSchema_NoImage_ReturnsNull()
+    {
+        Assert.Null(ImageSizeToInstanceFixup.StripImageFromSchema("""{"fields":[{"key":"Имя","type":"string"}]}"""));
+        Assert.Null(ImageSizeToInstanceFixup.StripImageFromSchema("""{"noFields":true}"""));
+    }
+}

--- a/src/server/BHS.CRG.Tests/Generation/TypstImageMaterializerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/TypstImageMaterializerTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using BHS.CRG.Application.Schema;
 using BHS.CRG.Infrastructure.Generation;
 
 namespace BHS.CRG.Tests.Generation;
@@ -21,32 +20,38 @@ public class TypstImageMaterializerTests
         {
             var data = new Dictionary<string, object?>
             {
-                ["Логотип"] = El(Png),
+                // Значение-объект с размером (issue #246) — размер из самого значения.
+                ["Логотип"] = El(new { src = Png, width = "4cm", align = "center" }),
+                // Голая data-URI строка (легаси) — без размера.
+                ["Печать"] = El(Png),
                 ["Орг"] = El(new { СканПечати = Png, Имя = "ООО" }),
                 ["Материалы"] = El(new[] { new { Фото = Png }, new { Фото = "нет" } }),
                 ["Текст"] = El("обычная строка"),
             };
 
-            var opts = new Dictionary<string, ImageRenderOptions>
-            {
-                ["Логотип"] = new("4cm", null, "center", null),
-            };
-            var json = TypstImageMaterializer.Materialize(data, dir, imageOptions: opts);
+            var json = TypstImageMaterializer.Materialize(data, dir);
 
-            // записаны три файла-изображения
+            // записаны четыре файла-изображения (Логотип, Печать, СканПечати, Материалы[0].Фото)
             var files = Directory.GetFiles(Path.Combine(dir, "assets"));
-            Assert.Equal(3, files.Length);
+            Assert.Equal(4, files.Length);
             Assert.All(files, f => Assert.EndsWith(".png", f));
 
             // в JSON больше нет data-URI; изображение — объект {src, width, ...}
             Assert.DoesNotContain("data:image", json);
             var root = JsonDocument.Parse(json).RootElement;
 
+            // размер взят из значения-объекта
             var logo = root.GetProperty("Логотип");
             Assert.StartsWith("assets/img_", logo.GetProperty("src").GetString());
             Assert.Equal("4cm", logo.GetProperty("width").GetString());
             Assert.Equal("center", logo.GetProperty("align").GetString());
             Assert.Equal(JsonValueKind.Null, logo.GetProperty("height").ValueKind);
+
+            // голая строка → объект без размера (все опции null)
+            var seal = root.GetProperty("Печать");
+            Assert.StartsWith("assets/img_", seal.GetProperty("src").GetString());
+            Assert.Equal(JsonValueKind.Null, seal.GetProperty("width").ValueKind);
+            Assert.Equal(JsonValueKind.Null, seal.GetProperty("align").ValueKind);
 
             Assert.StartsWith("assets/img_", root.GetProperty("Орг").GetProperty("СканПечати").GetProperty("src").GetString());
             Assert.StartsWith("assets/img_", root.GetProperty("Материалы")[0].GetProperty("Фото").GetProperty("src").GetString());

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.41.0</Version>
+    <Version>0.42.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #246

Раньше размер/выравнивание картинки (width/height/align/fit) задавались в **определении типа** (составного/документа) и подмешивались генератором по имени поля. Теперь размер живёт в **самом значении-картинке инстанса**.

## Хранение
Значение поля-картинки — объект `{ src: data-URI, width?, height?, align?, fit? }` (было — голая строка data-URI; читается как легаси без размера). **Форма `data.json` неизменна** (`{src,width,height,align,fit}`) → шаблоны и хелпер `img()` в userlib работают без правок.

## Backend
- `TypstImageMaterializer` берёт размер из значения-объекта, а не из схемы; голая data-URI строка → объект без размера.
- Убрано плечо `ImageOptions` (`IDocumentGenerator`/`GenerationRequest`, debug-bundle, три вызова `SchemaImageOptions.Collect`).
- **Разовая идемпотентная миграция** `ImageSizeToInstanceFixup` (запуск при старте после `MigrateAsync`): переносит размеры из схем типов в значения инстансов (обход JSONB по имени поля, вкл. вложенные объекты/массивы) и вычищает блок `image` из схем. После первого прогона карта размеров пустеет → обход больше не запускается.

## Frontend
- `ImageField`: значение-объект + свёрнутый блок **«Размер и выравнивание»** (ширина/высота/выравнивание/fit).
- Убран блок опций картинки из `FieldBuilder`; `SchemaField.image` удалён из типа схемы.

## Миграция
Выбор пользователя — **перенести** текущие размеры типов в инстансы (best-effort), UI размера — **свёрнутый блок**.

## Проверка
- Backend build + 9 тестов (материализатор: объект-форма и легаси-строка; миграция: перенос/вложенные/идемпотентность/вычистка схемы).
- `tsc -b` чисто, фронт 126 тестов зелёные.
- API стартует чисто (миграция при загрузке отрабатывает без ошибок).

🤖 Generated with [Claude Code](https://claude.com/claude-code)