### PR TITLE
feat(profile): изображение профиля пользователя (#245)

### DIFF
--- a/src/client/src/features/account/ProfilePage.tsx
+++ b/src/client/src/features/account/ProfilePage.tsx
@@ -1,22 +1,26 @@
-import { useState, useEffect } from 'react';
-import { useAccount, useUpdateAccount, useResendConfirmation, useChangeEmail } from '@/shared/api/account';
+import { useState, useEffect, useRef } from 'react';
+import { useAccount, useUpdateAccount, useResendConfirmation, useChangeEmail, useUpdateAvatar } from '@/shared/api/account';
 import { TextField } from '@/shared/ui/TextField';
 import { Button } from '@/shared/ui/Button';
+import { Avatar, downscaleToDataUri } from '@/shared/ui/Avatar';
 import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
 import { apiError } from '@/shared/utils/apiError';
-import { KeyRound, CheckCircle2, AlertCircle, Mail } from 'lucide-react';
+import { KeyRound, CheckCircle2, AlertCircle, Mail, Upload, Trash2 } from 'lucide-react';
 
 /** Профиль текущего пользователя (issue #148): просмотр учётных данных,
  *  редактирование отображаемого имени, смена пароля. Доступно любой роли. */
 export function ProfilePage() {
   const { data: account, isLoading } = useAccount();
   const update = useUpdateAccount();
+  const updateAvatar = useUpdateAvatar();
   const resend = useResendConfirmation();
   const changeEmail = useChangeEmail();
   const [displayName, setDisplayName] = useState('');
   const [pwOpen, setPwOpen] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
+  const [avatarError, setAvatarError] = useState('');
+  const avatarInput = useRef<HTMLInputElement>(null);
 
   const [resendMsg, setResendMsg] = useState('');
   const [newEmail, setNewEmail] = useState('');
@@ -44,6 +48,25 @@ export function ProfilePage() {
     }
   }
 
+  async function pickAvatar(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setAvatarError('');
+    try {
+      const dataUri = await downscaleToDataUri(file);
+      await updateAvatar.mutateAsync(dataUri);
+    } catch (err) {
+      setAvatarError(apiError(err, 'Не удалось загрузить изображение'));
+    }
+  }
+
+  async function removeAvatar() {
+    setAvatarError('');
+    try { await updateAvatar.mutateAsync(null); }
+    catch (err) { setAvatarError(apiError(err, 'Не удалось удалить изображение')); }
+  }
+
   async function save(e: React.FormEvent) {
     e.preventDefault();
     setError(''); setSaved(false);
@@ -65,6 +88,29 @@ export function ProfilePage() {
     <div className="px-6 py-4 max-w-lg">
       <h1 className="text-xl font-semibold text-fg1 mb-1">Профиль</h1>
       <p className="text-xs text-fg4 mb-5">Ваши учётные данные.</p>
+
+      {/* Аватар (issue #245) */}
+      <div className="flex items-center gap-4 mb-6">
+        <Avatar src={account.avatar} name={account.displayName} email={account.email}
+          className="w-16 h-16 text-xl" />
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outlined" size="sm" icon={<Upload size={14} />}
+              loading={updateAvatar.isPending} onClick={() => avatarInput.current?.click()}>
+              {account.avatar ? 'Заменить фото' : 'Загрузить фото'}
+            </Button>
+            {account.avatar && (
+              <Button type="button" variant="text" size="sm" icon={<Trash2 size={14} />}
+                loading={updateAvatar.isPending} onClick={removeAvatar}>
+                Удалить
+              </Button>
+            )}
+          </div>
+          <p className="text-xs text-fg4">PNG, JPG. Изображение уменьшится автоматически.</p>
+          {avatarError && <p className="text-xs text-danger">{avatarError}</p>}
+        </div>
+        <input ref={avatarInput} type="file" accept="image/*" className="hidden" onChange={pickAvatar} />
+      </div>
 
       <form onSubmit={save} className="space-y-5">
         <div>

--- a/src/client/src/shared/api/account.ts
+++ b/src/client/src/shared/api/account.ts
@@ -9,6 +9,8 @@ export interface Account {
   displayName: string;
   role: UserRole;
   emailConfirmed: boolean;
+  /** Аватар профиля (issue #245) — data-URI уменьшённой картинки, null = нет. */
+  avatar?: string | null;
 }
 
 /** Профиль текущего пользователя (issue #148). */
@@ -24,6 +26,16 @@ export function useUpdateAccount() {
   return useMutation({
     mutationFn: (dto: { displayName: string }) =>
       apiClient.put<Account>('/account', dto).then(r => r.data),
+    onSuccess: (data) => qc.setQueryData([QK], data),
+  });
+}
+
+/** Задать/удалить аватар профиля (issue #245). `avatar` = data-URI или null для удаления. */
+export function useUpdateAvatar() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (avatar: string | null) =>
+      apiClient.put<Account>('/account/avatar', { avatar }).then(r => r.data),
     onSuccess: (data) => qc.setQueryData([QK], data),
   });
 }

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -7,6 +7,7 @@ import { useTheme, type Theme } from '@/shared/ui/ThemeProvider';
 import { NotificationsCenter } from '@/features/notifications/NotificationsCenter';
 import { ActiveJobsIndicator } from '@/features/jobs/ActiveJobsIndicator';
 import { ChangePasswordModal } from '@/shared/ui/ChangePasswordModal';
+import { Avatar } from '@/shared/ui/Avatar';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
@@ -40,14 +41,6 @@ function ThemeToggle() {
       })}
     </div>
   );
-}
-
-/** Инициалы для аватара: 2 буквы из имени (или email). */
-function initialsOf(name?: string, email?: string): string {
-  const src = (name || email || '').trim();
-  const parts = src.split(/\s+/).filter(Boolean);
-  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-  return src.slice(0, 2).toUpperCase();
 }
 
 function NavSection({
@@ -94,6 +87,7 @@ function NavSection({
 
 export function AppShell() {
   const { user, logout } = useAuth();
+  const { data: account } = useAccount();
   const isAdmin = user?.role === 'Admin';
   const [pwOpen, setPwOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -149,9 +143,8 @@ export function AppShell() {
               className={({ isActive }) => `flex items-center gap-3 h-14 px-4 rounded-[28px] transition-colors ` +
                 `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
                 (isActive ? 'bg-tonal' : 'hover:bg-black/5 dark:hover:bg-white/10')}>
-              <span className="flex items-center justify-center w-10 h-10 rounded-full shrink-0 bg-brand-subtle text-on-brand-subtle text-[15px] font-medium">
-                {initialsOf(user?.displayName, user?.email)}
-              </span>
+              <Avatar src={account?.avatar} name={user?.displayName} email={user?.email} />
+
               <span className="flex-1 min-w-0">
                 <span className="block text-sm font-medium text-fg1 truncate">{user?.displayName || user?.email}</span>
                 <span className="block text-xs text-fg3">{isAdmin ? 'Администратор' : 'Пользователь'}</span>

--- a/src/client/src/shared/ui/Avatar.test.ts
+++ b/src/client/src/shared/ui/Avatar.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { initialsOf } from './Avatar';
+
+describe('initialsOf', () => {
+  it('две буквы из двух слов имени', () => {
+    expect(initialsOf('Иван Петров')).toBe('ИП');
+    expect(initialsOf('john doe')).toBe('JD');
+  });
+
+  it('одно слово — первые две буквы', () => {
+    expect(initialsOf('Админ')).toBe('АД');
+  });
+
+  it('падает на email, если имени нет', () => {
+    expect(initialsOf('', 'alex@bhs.local')).toBe('AL');
+    expect(initialsOf(null, 'bob@x.com')).toBe('BO');
+  });
+
+  it('пусто → пустая строка', () => {
+    expect(initialsOf()).toBe('');
+    expect(initialsOf('   ')).toBe('');
+  });
+});

--- a/src/client/src/shared/ui/Avatar.tsx
+++ b/src/client/src/shared/ui/Avatar.tsx
@@ -1,0 +1,61 @@
+/** Инициалы для аватара: 2 буквы из имени (или email). */
+export function initialsOf(name?: string | null, email?: string | null): string {
+  const src = (name || email || '').trim();
+  const parts = src.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return src.slice(0, 2).toUpperCase();
+}
+
+/**
+ * Аватар пользователя (issue #245): картинка src (data-URI), иначе инициалы на тональном фоне.
+ * Размер задаётся через className (классы w-…, h-…, text-…), по умолчанию 40px.
+ */
+export function Avatar({ src, name, email, className = 'w-10 h-10 text-[15px]', alt = '' }: {
+  src?: string | null;
+  name?: string | null;
+  email?: string | null;
+  className?: string;
+  alt?: string;
+}) {
+  const base = `inline-flex items-center justify-center rounded-full shrink-0 overflow-hidden ${className}`;
+  if (src) {
+    return <span className={base}><img src={src} alt={alt} className="w-full h-full object-cover" /></span>;
+  }
+  return (
+    <span className={`${base} bg-brand-subtle text-on-brand-subtle font-medium`}>
+      {initialsOf(name, email)}
+    </span>
+  );
+}
+
+/**
+ * Уменьшает выбранный файл до квадрата ≤ maxPx (обрезка по центру) и возвращает data-URI (JPEG).
+ * Держит аватар в несколько КБ — пригодно для хранения строкой в БД.
+ */
+export function downscaleToDataUri(file: File, maxPx = 256, quality = 0.85): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => {
+      try {
+        const side = Math.min(image.width, image.height);
+        const sx = (image.width - side) / 2;
+        const sy = (image.height - side) / 2;
+        const target = Math.min(maxPx, side);
+        const canvas = document.createElement('canvas');
+        canvas.width = target;
+        canvas.height = target;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { reject(new Error('Не удалось обработать изображение')); return; }
+        ctx.drawImage(image, sx, sy, side, side, 0, 0, target, target);
+        resolve(canvas.toDataURL('image/jpeg', quality));
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error('Ошибка обработки изображения'));
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    };
+    image.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Не удалось загрузить изображение')); };
+    image.src = url;
+  });
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Account/AccountEndpoints.cs
@@ -41,6 +41,35 @@ public static class AccountEndpoints
             return Results.Ok(ToDto(user, roles));
         });
 
+        // Аватар профиля (issue #245): data-URI уменьшённой на клиенте картинки; null — удалить.
+        g.MapPut("/avatar", async (UpdateAvatarRequest req,
+            UserManager<ApplicationUser> users, ClaimsPrincipal principal) =>
+        {
+            var user = await FindCurrent(users, principal);
+            if (user is null) return Results.Unauthorized();
+
+            var avatar = req.Avatar?.Trim();
+            if (string.IsNullOrEmpty(avatar))
+            {
+                user.AvatarDataUri = null;
+            }
+            else
+            {
+                if (!avatar.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase) || !avatar.Contains(";base64,"))
+                    return Results.BadRequest(new { error = "Ожидается изображение (data:image;base64)" });
+                // Аватар уменьшается на клиенте (~256px). Верхняя граница — защита от гигантских data-URI.
+                if (avatar.Length > MaxAvatarChars)
+                    return Results.BadRequest(new { error = "Изображение слишком большое" });
+                user.AvatarDataUri = avatar;
+            }
+
+            var result = await users.UpdateAsync(user);
+            if (!result.Succeeded) return Results.BadRequest(new { error = DescribeErrors(result) });
+
+            var roles = await users.GetRolesAsync(user);
+            return Results.Ok(ToDto(user, roles));
+        });
+
         // Смена пароля текущим пользователем (перенесено из /api/auth в #148).
         g.MapPost("/change-password", async (ChangePasswordRequest req,
             UserManager<ApplicationUser> users, RefreshTokenService refreshTokens,
@@ -101,6 +130,9 @@ public static class AccountEndpoints
         });
     }
 
+    // ~700 КБ строки data-URI (≈0.5 МБ бинарных) — с запасом для уменьшённого клиентом аватара.
+    private const int MaxAvatarChars = 700_000;
+
     private static async Task<ApplicationUser?> FindCurrent(UserManager<ApplicationUser> users, ClaimsPrincipal p)
     {
         var id = p.FindFirstValue(JwtRegisteredClaimNames.Sub)
@@ -109,13 +141,14 @@ public static class AccountEndpoints
     }
 
     private static AccountDto ToDto(ApplicationUser u, IList<string> roles) =>
-        new(u.Email ?? "", u.DisplayName, roles.FirstOrDefault() ?? "User", u.EmailConfirmed);
+        new(u.Email ?? "", u.DisplayName, roles.FirstOrDefault() ?? "User", u.EmailConfirmed, u.AvatarDataUri);
 
     private static string DescribeErrors(IdentityResult r) =>
         string.Join("; ", r.Errors.Select(e => e.Description));
 
-    record AccountDto(string Email, string DisplayName, string Role, bool EmailConfirmed);
+    record AccountDto(string Email, string DisplayName, string Role, bool EmailConfirmed, string? Avatar);
     record UpdateAccountRequest(string? DisplayName);
+    record UpdateAvatarRequest(string? Avatar);
     record ChangePasswordRequest(string CurrentPassword, string NewPassword);
     record ChangeEmailRequest(string? NewEmail, string CurrentPassword);
 }

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260718012153_AddUserAvatar.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260718012153_AddUserAvatar.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718012153_AddUserAvatar")]
+    partial class AddUserAvatar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260718012153_AddUserAvatar.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260718012153_AddUserAvatar.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserAvatar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AvatarDataUri",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AvatarDataUri",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/ApplicationUser.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/ApplicationUser.cs
@@ -5,4 +5,7 @@ namespace BHS.CRG.Infrastructure.Persistence;
 public class ApplicationUser : IdentityUser<Guid>
 {
     public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Аватар профиля (issue #245) — data-URI уменьшенной картинки (~256px), null = нет.</summary>
+    public string? AvatarDataUri { get; set; }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.42.0</Version>
+    <Version>0.43.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #245

Аватар профиля: загрузка/замена/удаление на странице **«Профиль»**, показ картинки вместо инициалов в пилюле пользователя (сайдбар).

## Хранение
Колонка `AspNetUsers.AvatarDataUri` (data-URI). Клиент уменьшает выбранную картинку до квадрата ≤256px (обрезка по центру, JPEG) перед отправкой — аватар весит несколько КБ. Backend валидирует `data:image;base64` и верхнюю границу размера (~700 КБ строки).

## Backend
- `ApplicationUser.AvatarDataUri` + EF-миграция `AddUserAvatar` (ADD COLUMN, применяется при старте).
- `PUT /api/account/avatar { avatar: string|null }` (null — удалить), `Avatar` в `AccountDto`.

## Frontend
- Общий компонент `Avatar` (картинка или инициалы) + `downscaleToDataUri`.
- `useUpdateAvatar`; секция аватара в `ProfilePage` (загрузить/заменить/удалить).
- Пилюля в `AppShell` берёт `avatar` из `useAccount`; локальный `initialsOf` вынесен в `Avatar`.

## Проверка
- Backend build + миграция применяется при старте (проверено на живой БД).
- `tsc -b` чисто; фронт 130 тестов (4 новых — `initialsOf`).
- Smoke эндпоинта: login → set → GET (avatar есть) → remove (null) — ок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)