### PR TITLE
feat(notifications): цвет бейджа колокольчика по наличию ошибок

### DIFF
--- a/src/client/src/features/notifications/NotificationsCenter.tsx
+++ b/src/client/src/features/notifications/NotificationsCenter.tsx
@@ -121,6 +121,8 @@ export function NotificationsCenter() {
 
   const items = data?.items ?? [];
   const unread = data?.unreadCount ?? 0;
+  // Цвет бейджа: красный, если среди непрочитанных есть ошибка, иначе зелёный.
+  const hasUnreadError = items.some(n => !n.isRead && n.severity === 'Error');
 
   return (
     <Popover.Root>
@@ -133,7 +135,7 @@ export function NotificationsCenter() {
         >
           <Bell size={22} />
           {unread > 0 && (
-            <span className="absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full text-[11px] font-medium flex items-center justify-center text-white bg-danger">
+            <span className={`absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full text-[11px] font-medium flex items-center justify-center text-white ${hasUnreadError ? 'bg-danger' : 'bg-success'}`}>
               {unread > 99 ? '99+' : unread}
             </span>
           )}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.43.0</Version>
+    <Version>0.43.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Бейдж-счётчик непрочитанных уведомлений у колокольчика теперь:
- **зелёный** (`bg-success`), если среди непрочитанных нет ошибок;
- **красный** (`bg-danger`), если есть хотя бы одно `Error`.

Раньше бейдж был всегда красным. Цвет привязан к непрочитанным (как и сам счётчик), поэтому счётчик и его цвет согласованы: `items.some(n => !n.isRead && n.severity === 'Error')`.

`tsc -b` чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)