### PR TITLE
chore: gitignore ds-bundle/ (вывод design-sync)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ dp-keys/
 .ds-sync/
 .ds-css/
 .ds-entry.tsx
+ds-bundle/


### PR DESCRIPTION
`ds-bundle/` — каталог сборки конвертера `/design-sync`. Добавлен в `.gitignore` к остальным sync-артефактам (`.design-sync/`, `.ds-sync/`, `.ds-css/`, `.ds-entry.tsx`), чтобы вывод синхронизации не попадал в git.

Одна строка, кода не касается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)