### PR TITLE
feat(profile): профиль уровня — фаза A (тэг-ограничения + инжект в шаблон) (#258)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -36,8 +36,12 @@ public static class DocumentTypeEndpoints
                 "Composite" => DocumentTypeKind.Composite,
                 _           => DocumentTypeKind.Document,
             };
-            return Results.Ok(await m.Send(new CreateDocumentTypeCommand(
-                req.Name, req.Code, kind, req.ParentId, JsonDocument.Parse(req.Schema), req.IsAbstract)));
+            try
+            {
+                return Results.Ok(await m.Send(new CreateDocumentTypeCommand(
+                    req.Name, req.Code, kind, req.ParentId, JsonDocument.Parse(req.Schema), req.IsAbstract)));
+            }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
         admin.MapPut("/{id:guid}", async (Guid id, UpdateTypeRequest req, IMediator m) =>
@@ -46,9 +50,11 @@ public static class DocumentTypeEndpoints
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
-        admin.MapPut("/{id:guid}/schema", async (Guid id, UpdateSchemaRequest req, IMediator m)
-            => Results.Ok(await m.Send(new UpdateDocumentTypeSchemaCommand(
-                id, JsonDocument.Parse(req.Schema)))));
+        admin.MapPut("/{id:guid}/schema", async (Guid id, UpdateSchemaRequest req, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new UpdateDocumentTypeSchemaCommand(id, JsonDocument.Parse(req.Schema)))); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
 
         admin.MapPut("/{id:guid}/abstract", async (Guid id, SetAbstractRequest req, IMediator m)
             => Results.Ok(await m.Send(new SetDocumentTypeAbstractCommand(id, req.IsAbstract))));

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -198,6 +198,7 @@ builder.Services.AddScoped<BackupService>();
 
 // ── Generation ────────────────────────────────────────────────────────────────
 builder.Services.AddScoped<IEntityResolver, EntityResolver>();
+builder.Services.AddScoped<BHS.CRG.Application.Documents.ILevelProfileService, BHS.CRG.Infrastructure.Generation.LevelProfileService>();
 builder.Services.AddScoped<IMetadataExtractor, MetadataExtractor>();
 builder.Services.AddScoped<IDataSetResolver, DataSetResolver>();
 builder.Services.AddScoped<IObjectResolver, ObjectResolver>();

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -31,6 +31,8 @@ public class DocumentTypeHandlers(
     {
         var all = await repo.GetAllAsync(ct);
         EnsureUnique(all, cmd.Name, cmd.Code, excludeId: null);
+        // Ограничения тэгов (issue #258): новый тип может сразу нести restricted-тэг (POST несёт схему).
+        ValidateTagRestrictions(cmd.Schema, Guid.Empty, cmd.Name.Trim(), all);
 
         var dt = DocumentType.Create(cmd.Name.Trim(), cmd.Code.Trim(), cmd.Kind, cmd.ParentId, cmd.Schema, cmd.IsAbstract);
         await repo.AddAsync(dt, ct);
@@ -89,10 +91,22 @@ public class DocumentTypeHandlers(
     {
         var dt = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"DocumentType {cmd.Id} not found");
+        // Ограничения тэгов (issue #258): считаем носителей среди прочих типов + входящей схемы.
+        var all = await repo.GetAllAsync(ct);
+        ValidateTagRestrictions(cmd.Schema, dt.Id, dt.Name, all);
         dt.UpdateSchema(cmd.Schema);
         repo.Update(dt);
         await repo.SaveChangesAsync(ct);
         return dt;
+    }
+
+    // Бросает InvalidOperationException (маппится в 409) со списком занятых мест — issue #258.
+    private static void ValidateTagRestrictions(JsonDocument schema, Guid savingId, string savingName,
+        IReadOnlyList<DocumentType> all)
+    {
+        var violations = TagRestrictionValidator.Validate(schema, savingId, savingName, all);
+        if (violations.Count > 0)
+            throw new InvalidOperationException(string.Join(" ", violations.Select(v => v.Describe())));
     }
 
     public async Task<DocumentType> Handle(SetDocumentTypeAbstractCommand cmd, CancellationToken ct)
@@ -418,7 +432,8 @@ public class CommonDataHandlers(
     IRepository<DomainObject> repo,
     IRepository<DocumentSet> setRepo,
     IRepository<Section> sectionRepo,
-    IDataSetResolver dataSetResolver) :
+    IDataSetResolver dataSetResolver,
+    ILevelProfileService levelProfiles) :
     IRequestHandler<CreateCommonDataEntryCommand, DomainObject>,
     IRequestHandler<UpdateCommonDataEntryCommand, DomainObject>,
     IRequestHandler<DeleteCommonDataEntryCommand>,
@@ -456,13 +471,17 @@ public class CommonDataHandlers(
         await repo.SaveChangesAsync(ct);
     }
 
-    public Task<IReadOnlyList<DomainObject>> Handle(ListCommonDataEntriesQuery q, CancellationToken ct)
+    public async Task<IReadOnlyList<DomainObject>> Handle(ListCommonDataEntriesQuery q, CancellationToken ct)
     {
         var scope = q.Scope;
         var scopeId = q.ScopeId;
         var typeId = q.CompositeTypeId;
+        // Ленивое создание профиля уровня (issue #258): при открытии общих данных контейнерного уровня
+        // гарантируем объект-профиль (если профиль-тип сконфигурирован) — он попадёт в список ниже.
+        if (scope is { } s && s != CatalogScope.System && scopeId is { } sid)
+            await levelProfiles.EnsureProfileAsync(s, sid, ct);
         // Только общие данные (без документной фасеты).
-        return repo.FindAsync(e => e.Facet == null &&
+        return await repo.FindAsync(e => e.Facet == null &&
             (!scope.HasValue || e.ScopeLevel == scope.Value) &&
             (!scopeId.HasValue || e.ScopeId == scopeId.Value) &&
             (!typeId.HasValue || e.CompositeTypeId == typeId.Value), ct);

--- a/src/server/BHS.CRG.Application/Documents/ILevelProfileService.cs
+++ b/src/server/BHS.CRG.Application/Documents/ILevelProfileService.cs
@@ -1,0 +1,19 @@
+using BHS.CRG.Domain.Catalog;
+
+namespace BHS.CRG.Application.Documents;
+
+/// <summary>
+/// Профиль уровня (issue #258): объект-синглтон составного типа, помеченного тэгом
+/// profile-construction/section/set, на scope контейнера. Ленивое создание — при обращении к общим
+/// данным уровня. Реализация в Infrastructure (нужен доступ к DomainObject + контейнерам + типам).
+/// </summary>
+public interface ILevelProfileService
+{
+    /// <summary>
+    /// Гарантирует наличие объекта-профиля для контейнера уровня (Construction/Section/Set), если для
+    /// уровня сконфигурирован профиль-тип (тип с соответствующим тэгом). Создаёт пустой объект и
+    /// проставляет FK контейнера. Идемпотентно; no-op, если профиль-тип не задан или уровень не
+    /// контейнерный. Возвращает id объекта-профиля (или null).
+    /// </summary>
+    Task<Guid?> EnsureProfileAsync(CatalogScope level, Guid containerId, CancellationToken ct = default);
+}

--- a/src/server/BHS.CRG.Application/Schema/TagRegistry.cs
+++ b/src/server/BHS.CRG.Application/Schema/TagRegistry.cs
@@ -10,13 +10,22 @@ public enum TagScope { Field, Type, Dataset, GostDocument }
 /// для Type — допустимые виды типа ("Document"/"Composite"); для Dataset не используется
 /// (пустой = любой формат источника).
 /// </summary>
+/// <summary>
+/// Внутреннее ограничение назначения тэга (issue #258) — пользователь им не управляет. Сейчас одно
+/// поле: <paramref name="MaxBearers"/> — глобальный максимум РАЗЛИЧНЫХ носителей тэга по всем типам
+/// (носитель: тип для Type-тэга, пара тип+поле для Field-тэга; считается по СОБСТВЕННЫМ схемам).
+/// Сам record — точка расширения (взаимоисключения/обязательность добавляются позже, не ломая контракт).
+/// </summary>
+public record TagRestriction(int? MaxBearers);
+
 public record TagDefinition(
     string Code,
     string Label,
     string Description,
     TagScope Scope,
     string[] AppliesTo,
-    bool Multiple);
+    bool Multiple,
+    TagRestriction? Restriction = null);
 
 /// <summary>Реестр функциональных тэгов — единый источник правды (см. <see cref="FunctionalTag"/>).</summary>
 public static class TagRegistry
@@ -61,6 +70,17 @@ public static class TagRegistry
         new(FunctionalTag.TypeProjectDocumentation, "Проектная документация",
             "Тип документа относится к проектной документации (ГОСТ Р 21.101-2020).",
             TagScope.Type, ["Document"], Multiple: false),
+
+        // ── Type: профиль уровня (issue #258) — ровно один тип на уровень (MaxBearers=1) ──
+        new(FunctionalTag.ProfileConstruction, "Профиль стройки",
+            "Составной тип — профиль уровня «Стройка». Его поля доступны во всех документах стройки в шаблоне: data.уровень.стройка.*. Может быть только один такой тип.",
+            TagScope.Type, ["Composite"], Multiple: false, Restriction: new(MaxBearers: 1)),
+        new(FunctionalTag.ProfileSection, "Профиль раздела",
+            "Составной тип — профиль уровня «Раздел». Его поля доступны во всех документах раздела в шаблоне: data.уровень.раздел.*. Может быть только один такой тип.",
+            TagScope.Type, ["Composite"], Multiple: false, Restriction: new(MaxBearers: 1)),
+        new(FunctionalTag.ProfileSet, "Профиль комплекта",
+            "Составной тип — профиль уровня «Комплект». Его поля доступны во всех документах комплекта в шаблоне: data.уровень.комплект.*. Может быть только один такой тип.",
+            TagScope.Type, ["Composite"], Multiple: false, Restriction: new(MaxBearers: 1)),
 
         // ── Dataset: структура PDF-источника ──
         new(FunctionalTag.DatasetHasCover, "Имеет обложку",

--- a/src/server/BHS.CRG.Application/Schema/TagRestrictionValidator.cs
+++ b/src/server/BHS.CRG.Application/Schema/TagRestrictionValidator.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Schema;
+
+/// <summary>Носитель тэга: тип (Type-scope) или пара тип+поле (Field-scope).</summary>
+public record TagBearer(Guid TypeId, string TypeName, string? FieldKey);
+
+/// <summary>Нарушение ограничения тэга — где тэг уже используется сверх лимита.</summary>
+public record TagRestrictionViolation(string TagCode, string TagLabel, int MaxBearers, IReadOnlyList<TagBearer> Bearers)
+{
+    /// <summary>Человекочитаемое сообщение со списком занятых мест (для 409).</summary>
+    public string Describe()
+    {
+        var places = string.Join(", ", Bearers.Select(b =>
+            b.FieldKey is null ? $"«{b.TypeName}»" : $"«{b.TypeName}».{b.FieldKey}"));
+        return $"Тэг «{TagLabel}» допускает не более {MaxBearers} носител{(MaxBearers == 1 ? "я" : "ей")} " +
+               $"во всей системе — уже используется: {places}.";
+    }
+}
+
+/// <summary>
+/// Проверка внутренних ограничений тэгов (issue #258) при сохранении схемы типа. Чистая функция без I/O:
+/// считает РАЗЛИЧНЫХ носителей restricted-тэга по СОБСТВЕННЫМ схемам среди прочих типов + входящей схемы;
+/// превышение <see cref="TagRestriction.MaxBearers"/> → нарушение. Носитель — тип (Type-scope) или
+/// (тип, ключ поля) (Field-scope). Наследованные тэги НЕ считаются (только own-схема) — иначе первый же
+/// подтип «унаследовал» бы тэг и сломал лимит. Вызывается из Create и UpdateSchema (обе точки несут схему).
+/// </summary>
+public static class TagRestrictionValidator
+{
+    /// <param name="savingTypeId">Id сохраняемого типа; при создании — <c>Guid.Empty</c> (не совпадёт ни с одним типом).</param>
+    public static IReadOnlyList<TagRestrictionViolation> Validate(
+        JsonDocument incomingSchema, Guid savingTypeId, string savingTypeName,
+        IReadOnlyList<DocumentType> allDocTypes)
+    {
+        var violations = new List<TagRestrictionViolation>();
+        foreach (var def in TagRegistry.All)
+        {
+            if (def.Restriction?.MaxBearers is not { } max) continue;
+            // Механизм по каталогу типов покрывает Type/Field. Dataset/GostDocument живут на других
+            // сущностях — их restriction (если появится) валидируется отдельным энумератором.
+            if (def.Scope is not (TagScope.Type or TagScope.Field)) continue;
+
+            var bearers = new List<TagBearer>();
+            foreach (var t in allDocTypes)
+            {
+                if (t.Id == savingTypeId) continue; // сохраняемый тип берём из входящей схемы, не из старой
+                bearers.AddRange(BearersOf(def, t.Id, t.Name, t.Schema));
+            }
+            bearers.AddRange(BearersOf(def, savingTypeId, savingTypeName, incomingSchema));
+
+            var distinct = bearers
+                .GroupBy(b => (b.TypeId, b.FieldKey))
+                .Select(g => g.First())
+                .ToList();
+            if (distinct.Count > max)
+                violations.Add(new(def.Code, def.Label, max, distinct));
+        }
+        return violations;
+    }
+
+    private static IEnumerable<TagBearer> BearersOf(TagDefinition def, Guid typeId, string typeName, JsonDocument schema)
+    {
+        if (def.Scope == TagScope.Type)
+        {
+            if (SchemaTags.SchemaHasTypeTag(schema, def.Code))
+                yield return new(typeId, typeName, null);
+        }
+        else // Field
+        {
+            foreach (var key in SchemaTags.FieldKeysWithTag(schema, def.Code))
+                yield return new(typeId, typeName, key);
+        }
+    }
+}

--- a/src/server/BHS.CRG.Domain/Documents/Construction.cs
+++ b/src/server/BHS.CRG.Domain/Documents/Construction.cs
@@ -7,6 +7,11 @@ public class Construction : Entity
     public string Name { get; private set; } = default!;
     public Guid CreatedByUserId { get; private set; }
 
+    /// <summary>Объект-профиль уровня (issue #258) — DomainObject профиль-типа на scope стройки, если создан.
+    /// Простой nullable-указатель (не DB-FK: объект — часть агрегата контейнера, каскад по scope).</summary>
+    public Guid? ProfileObjectId { get; private set; }
+    public void SetProfileObject(Guid objectId) { ProfileObjectId = objectId; TouchUpdatedAt(); }
+
     private readonly List<Section> _sections = [];
     public IReadOnlyList<Section> Sections => _sections.AsReadOnly();
 

--- a/src/server/BHS.CRG.Domain/Documents/DocumentSet.cs
+++ b/src/server/BHS.CRG.Domain/Documents/DocumentSet.cs
@@ -11,6 +11,10 @@ public class DocumentSet : Entity
     public string Name { get; private set; } = default!;
     public Guid SectionId { get; private set; }
 
+    /// <summary>Объект-профиль уровня (issue #258) — DomainObject профиль-типа на scope комплекта, если создан.</summary>
+    public Guid? ProfileObjectId { get; private set; }
+    public void SetProfileObject(Guid objectId) { ProfileObjectId = objectId; TouchUpdatedAt(); }
+
     private DocumentSet() { }
 
     public static DocumentSet Create(Guid sectionId, string name)

--- a/src/server/BHS.CRG.Domain/Documents/Section.cs
+++ b/src/server/BHS.CRG.Domain/Documents/Section.cs
@@ -7,6 +7,10 @@ public class Section : Entity
     public string Name { get; private set; } = default!;
     public Guid ConstructionId { get; private set; }
 
+    /// <summary>Объект-профиль уровня (issue #258) — DomainObject профиль-типа на scope раздела, если создан.</summary>
+    public Guid? ProfileObjectId { get; private set; }
+    public void SetProfileObject(Guid objectId) { ProfileObjectId = objectId; TouchUpdatedAt(); }
+
     private readonly List<DocumentSet> _documentSets = [];
     public IReadOnlyList<DocumentSet> DocumentSets => _documentSets.AsReadOnly();
 

--- a/src/server/BHS.CRG.Domain/Schema/FunctionalTag.cs
+++ b/src/server/BHS.CRG.Domain/Schema/FunctionalTag.cs
@@ -47,6 +47,17 @@ public static class FunctionalTag
     /// <summary>Тип документа относится к проектной документации (ГОСТ Р 21.101-2020).</summary>
     public const string TypeProjectDocumentation = "type.projectDocumentation";
 
+    // ── Тэги типа: профиль уровня (issue #258) ──────────────────────────────────
+    // Составной тип, помеченный тэгом, — «профиль» соответствующего уровня-контейнера: его поля
+    // амбиентно попадают в шаблон всех документов уровня (data.уровень.стройка/раздел/комплект).
+    // Ограничение MaxBearers=1 (TagRegistry): ровно один тип во всей системе может нести каждый тэг.
+    /// <summary>Составной тип — профиль уровня «Стройка».</summary>
+    public const string ProfileConstruction = "profile.construction";
+    /// <summary>Составной тип — профиль уровня «Раздел».</summary>
+    public const string ProfileSection = "profile.section";
+    /// <summary>Составной тип — профиль уровня «Комплект».</summary>
+    public const string ProfileSet = "profile.set";
+
     // ── Тэги набора данных (структура PDF-источника) ────────────────────────────
     /// <summary>PDF содержит обложку (первая страница пропускается при распознавании).</summary>
     public const string DatasetHasCover = "dataset.hasCover";

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -39,8 +39,48 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
             ctx = GenerationContext.FromJson(instance.Requisites, instance.PluginData);
         }
 
+        // Профили уровней (issue #258) — амбиентные данные стройки/раздела/комплекта под ключом
+        // data.уровень.{стройка,раздел,комплект}. ДО resolve-refs: вложенные $ref/_baseRef профилей
+        // резолвятся тем же проходом ниже.
+        await InjectScopeProfilesAsync(ctx, instance.DocumentSetId, ct);
+
         await ResolveContextRefsAsync(ctx, instance.DocumentSetId, ct);
         return ctx;
+    }
+
+    /// <summary>
+    /// Инжектит профили уровней в контекст под ключом «уровень» = { стройка, раздел, комплект } (issue #258).
+    /// Read-only: находит объект-профиль (профиль-тип по тэгу × scope контейнера), резолвит его через
+    /// <see cref="ResolveEntryByIdAsync"/> (с _baseRef-мержем); отсутствующий уровень → пустой объект
+    /// (не отсутствие ключа — чтобы шаблонам было проще). Каскад: доступны все три уровня-предка документа.
+    /// </summary>
+    private async Task InjectScopeProfilesAsync(GenerationContext ctx, Guid documentSetId, CancellationToken ct)
+    {
+        var scope = await ScopeChains.LoadAsync(db, documentSetId, ct);
+        var types = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var empty = JsonDocument.Parse("{}").RootElement.Clone();
+
+        var profiles = new Dictionary<string, JsonElement>();
+        foreach (var (level, tag, key) in LevelProfiles.Levels)
+        {
+            var containerId = level switch
+            {
+                CatalogScope.Construction => scope.ConstructionId,
+                CatalogScope.Section => scope.SectionId,
+                CatalogScope.Set => scope.SetId,
+                _ => Guid.Empty,
+            };
+            var value = empty;
+            if (containerId != Guid.Empty && LevelProfiles.ResolveProfileTypeId(types, tag) is { } typeId)
+            {
+                var profileObj = await db.DomainObjects.AsNoTracking().FirstOrDefaultAsync(
+                    o => o.ScopeLevel == level && o.ScopeId == containerId && o.CompositeTypeId == typeId, ct);
+                if (profileObj is not null)
+                    value = await ResolveEntryByIdAsync(profileObj.Id, scope, [], ct);
+            }
+            profiles[key] = value;
+        }
+        ctx.Set("уровень", JsonSerializer.SerializeToElement(profiles));
     }
 
     public async Task ResolveContextRefsAsync(GenerationContext ctx, Guid documentSetId, CancellationToken ct = default)

--- a/src/server/BHS.CRG.Infrastructure/Generation/LevelProfileService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/LevelProfileService.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Objects;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Ленивое создание объекта-профиля уровня (issue #258). Идемпотентно: если профиль-тип не задан или
+/// контейнер уже несёт профиль — no-op. Иначе создаёт пустой DomainObject профиль-типа на scope
+/// контейнера и проставляет FK. Вызывается при обращении к общим данным уровня (CommonDataHandlers).
+/// </summary>
+public class LevelProfileService(AppDbContext db) : ILevelProfileService
+{
+    public async Task<Guid?> EnsureProfileAsync(CatalogScope level, Guid containerId, CancellationToken ct = default)
+    {
+        var tag = LevelProfiles.TagFor(level);
+        if (tag is null) return null; // не контейнерный уровень (System)
+
+        var types = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var typeId = LevelProfiles.ResolveProfileTypeId(types, tag);
+        if (typeId is null) return null; // профиль-тип не сконфигурирован
+
+        // Текущий FK контейнера (tracked — понадобится проставить).
+        var currentFk = await GetContainerProfileIdAsync(level, containerId, ct);
+        if (currentFk is { } fk && await db.DomainObjects.AsNoTracking().AnyAsync(o => o.Id == fk, ct))
+            return fk; // валидный профиль уже есть
+
+        // Мог быть объект профиль-типа на этом scope без FK (напр. создан вручную) — переиспользуем.
+        var existing = await db.DomainObjects.FirstOrDefaultAsync(
+            o => o.ScopeLevel == level && o.ScopeId == containerId && o.CompositeTypeId == typeId.Value, ct);
+
+        var profile = existing;
+        if (profile is null)
+        {
+            profile = DomainObject.Create(typeId.Value, null, JsonDocument.Parse("{}"), level, containerId);
+            db.DomainObjects.Add(profile);
+        }
+        await SetContainerProfileAsync(level, containerId, profile.Id, ct);
+        await db.SaveChangesAsync(ct);
+        return profile.Id;
+    }
+
+    private async Task<Guid?> GetContainerProfileIdAsync(CatalogScope level, Guid id, CancellationToken ct) => level switch
+    {
+        CatalogScope.Construction => (await db.Constructions.AsNoTracking().FirstOrDefaultAsync(c => c.Id == id, ct))?.ProfileObjectId,
+        CatalogScope.Section => (await db.Sections.AsNoTracking().FirstOrDefaultAsync(s => s.Id == id, ct))?.ProfileObjectId,
+        CatalogScope.Set => (await db.DocumentSets.AsNoTracking().FirstOrDefaultAsync(s => s.Id == id, ct))?.ProfileObjectId,
+        _ => null,
+    };
+
+    private async Task SetContainerProfileAsync(CatalogScope level, Guid id, Guid objectId, CancellationToken ct)
+    {
+        switch (level)
+        {
+            case CatalogScope.Construction:
+                (await db.Constructions.FirstOrDefaultAsync(c => c.Id == id, ct))?.SetProfileObject(objectId);
+                break;
+            case CatalogScope.Section:
+                (await db.Sections.FirstOrDefaultAsync(s => s.Id == id, ct))?.SetProfileObject(objectId);
+                break;
+            case CatalogScope.Set:
+                (await db.DocumentSets.FirstOrDefaultAsync(s => s.Id == id, ct))?.SetProfileObject(objectId);
+                break;
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/LevelProfiles.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/LevelProfiles.cs
@@ -1,0 +1,35 @@
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Schema;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Профиль уровня (issue #258): сопоставление контейнерных уровней с тэгами профиль-типов и ключами в
+/// data.уровень, плюс резолв профиль-типа по тэгу (единственный тип с profile-* в СОБСТВЕННОЙ схеме).
+/// </summary>
+public static class LevelProfiles
+{
+    /// <summary>Три контейнерных уровня: (уровень, тэг профиль-типа, ключ в data.уровень).</summary>
+    public static readonly (CatalogScope Level, string Tag, string Key)[] Levels =
+    [
+        (CatalogScope.Construction, FunctionalTag.ProfileConstruction, "стройка"),
+        (CatalogScope.Section, FunctionalTag.ProfileSection, "раздел"),
+        (CatalogScope.Set, FunctionalTag.ProfileSet, "комплект"),
+    ];
+
+    public static string? TagFor(CatalogScope level)
+    {
+        foreach (var l in Levels) if (l.Level == level) return l.Tag;
+        return null;
+    }
+
+    /// <summary>Id профиль-типа для тэга: единственный тип с тэгом в СОБСТВЕННОЙ схеме. При >1 —
+    /// детерминированно первый по имени (лимит MaxBearers=1 обычно не даёт >1, но подстраховка).</summary>
+    public static Guid? ResolveProfileTypeId(IEnumerable<DocumentType> allTypes, string tag) =>
+        allTypes.Where(t => SchemaTags.SchemaHasTypeTag(t.Schema, tag))
+                .OrderBy(t => t.Name, StringComparer.Ordinal)
+                .Select(t => (Guid?)t.Id)
+                .FirstOrDefault();
+}

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260718051133_AddLevelProfileFk.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260718051133_AddLevelProfileFk.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718051133_AddLevelProfileFk")]
+    partial class AddLevelProfileFk
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260718051133_AddLevelProfileFk.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260718051133_AddLevelProfileFk.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLevelProfileFk : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProfileObjectId",
+                table: "sections",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProfileObjectId",
+                table: "document_sets",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProfileObjectId",
+                table: "constructions",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProfileObjectId",
+                table: "sections");
+
+            migrationBuilder.DropColumn(
+                name: "ProfileObjectId",
+                table: "document_sets");
+
+            migrationBuilder.DropColumn(
+                name: "ProfileObjectId",
+                table: "constructions");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/LevelProfileTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/LevelProfileTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>Профиль уровня (issue #258): амбиентный инжект data.уровень.* + ленивое создание объекта.</summary>
+[Collection("Integration")]
+public class LevelProfileTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+    private readonly Guid _userId = Guid.NewGuid();
+
+    private async Task<(Guid ConstructionId, Guid SectionId, Guid SetId)> SetupAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var c = await m.Send(new CreateConstructionCommand("Стройка", _userId));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "Раздел"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, "Комплект"));
+        return (c.Id, s.Id, set.Id);
+    }
+
+    private async Task<Guid> CompositeTypeAsync(string name, string schema)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await scope.ServiceProvider.GetRequiredService<IMediator>()
+            .Send(new CreateDocumentTypeCommand(name, name, DocumentTypeKind.Composite, null, J(schema)));
+        return dt.Id;
+    }
+
+    private async Task<Guid> CommonDataAsync(Guid typeId, string data, CatalogScope scope, Guid scopeId)
+    {
+        using var s = fixture.Services.CreateScope();
+        var e = await s.ServiceProvider.GetRequiredService<IMediator>()
+            .Send(new CreateCommonDataEntryCommand("Профиль", typeId, J(data), scope, scopeId));
+        return e.Id;
+    }
+
+    private async Task<GenerationContext> ResolveDocAsync(Guid setId, Guid docTypeId, string requisites)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var inst = await m.Send(new AddDocumentToSetCommand(setId, docTypeId));
+        await m.Send(new UpdateRequisitesCommand(inst.Id, J(requisites)));
+        var full = await m.Send(new GetDocumentInstanceQuery(inst.Id));
+        var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
+        return await resolver.ResolveAsync(DocumentView.From(full!));
+    }
+
+    [Fact]
+    public async Task Profile_InjectedUnderУровеньKey_WithCascadeAndEmptyForUnset()
+    {
+        var (cId, _, setId) = await SetupAsync();
+        var profType = await CompositeTypeAsync("Профиль стройки",
+            "{'tags':['profile.construction'],'fields':[{'key':'Проект','title':'Проект','type':'string'}]}");
+        await CommonDataAsync(profType, "{'Проект':'ЭОМ РД'}", CatalogScope.Construction, cId);
+
+        var docType = await CompositeTypeAsync("АОСР", "{'fields':[]}");
+        var ctx = await ResolveDocAsync(setId, docType, "{'Наименование':'Акт'}");
+
+        var уровень = (JsonElement)ctx.Data["уровень"]!;
+        // Стройка — заполнена данными профиля.
+        Assert.Equal("ЭОМ РД", уровень.GetProperty("стройка").GetProperty("Проект").GetString());
+        // Раздел/комплект — пустые объекты (профиль-типов нет), не отсутствие ключа.
+        Assert.Equal(JsonValueKind.Object, уровень.GetProperty("раздел").ValueKind);
+        Assert.Equal(JsonValueKind.Object, уровень.GetProperty("комплект").ValueKind);
+        Assert.Empty(уровень.GetProperty("комплект").EnumerateObject());
+    }
+
+    [Fact]
+    public async Task OpeningLevelCatalog_LazilyCreatesProfileObject()
+    {
+        var (cId, _, _) = await SetupAsync();
+        var profType = await CompositeTypeAsync("Профиль стройки", "{'tags':['profile.construction'],'fields':[]}");
+
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var list = await m.Send(new ListCommonDataEntriesQuery(CatalogScope.Construction, cId, null));
+
+        Assert.Contains(list, o => o.CompositeTypeId == profType);
+        var construction = await m.Send(new GetConstructionQuery(cId));
+        Assert.NotNull(construction!.ProfileObjectId);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Schema/TagRestrictionValidatorTests.cs
+++ b/src/server/BHS.CRG.Tests/Schema/TagRestrictionValidatorTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Schema;
+
+namespace BHS.CRG.Tests.Schema;
+
+public class TagRestrictionValidatorTests
+{
+    private const string Tag = FunctionalTag.ProfileConstruction; // Type-scope, MaxBearers=1
+
+    private static DocumentType Type(string name, string schema, Guid? parentId = null) =>
+        DocumentType.Create(name, name, DocumentTypeKind.Composite, parentId,
+            JsonDocument.Parse(schema.Replace('\'', '"')));
+
+    private static JsonDocument Schema(string json) => JsonDocument.Parse(json.Replace('\'', '"'));
+
+    [Fact]
+    public void SecondBearer_IsBlocked_AndListsExisting()
+    {
+        var a = Type("Профиль-А", "{'tags':['profile.construction'],'fields':[]}");
+        var incoming = Schema("{'tags':['profile.construction'],'fields':[]}");
+
+        var v = TagRestrictionValidator.Validate(incoming, Guid.Empty, "Новый", [a]);
+
+        Assert.Single(v);
+        Assert.Equal(1, v[0].MaxBearers);
+        Assert.Contains("Профиль-А", v[0].Describe());
+    }
+
+    [Fact]
+    public void ReSavingTheOnlyBearer_IsAllowed()
+    {
+        var a = Type("Профиль-А", "{'tags':['profile.construction'],'fields':[]}");
+        var incoming = Schema("{'tags':['profile.construction'],'fields':[]}");
+
+        // Сохраняем сам тип A (savingId = a.Id) — не считаем против себя.
+        var v = TagRestrictionValidator.Validate(incoming, a.Id, "Профиль-А", [a]);
+
+        Assert.Empty(v);
+    }
+
+    [Fact]
+    public void InheritedTag_IsNotCounted_AsBearer()
+    {
+        var parent = Type("Профиль-Родитель", "{'tags':['profile.construction'],'fields':[]}");
+        var child = Type("Дочерний", "{'fields':[]}", parentId: parent.Id); // наследует тэг, но НЕ несёт own
+
+        // Новый тип с тэгом: носители — только parent (own), child (inherited) НЕ считается → total 2 > 1.
+        var incoming = Schema("{'tags':['profile.construction'],'fields':[]}");
+        var v = TagRestrictionValidator.Validate(incoming, Guid.Empty, "Новый", [parent, child]);
+
+        Assert.Single(v);
+        var msg = v[0].Describe();
+        Assert.Contains("Профиль-Родитель", msg);
+        Assert.DoesNotContain("Дочерний", msg); // унаследованный не носитель
+    }
+
+    [Fact]
+    public void SingleBearer_NoViolation()
+    {
+        var incoming = Schema("{'tags':['profile.construction'],'fields':[]}");
+        var v = TagRestrictionValidator.Validate(incoming, Guid.Empty, "Единственный", []);
+        Assert.Empty(v);
+    }
+
+    [Fact]
+    public void UnrestrictedTags_NeverViolate()
+    {
+        // type.qualityDocument без Restriction — сколько угодно носителей.
+        var a = Type("К1", "{'tags':['type.qualityDocument'],'fields':[]}");
+        var b = Type("К2", "{'tags':['type.qualityDocument'],'fields':[]}");
+        var incoming = Schema("{'tags':['type.qualityDocument'],'fields':[]}");
+        var v = TagRestrictionValidator.Validate(incoming, Guid.Empty, "К3", [a, b]);
+        Assert.Empty(v);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.43.2</Version>
+    <Version>0.44.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза A issue #258. Backend: амбиентные данные контейнера (стройка/раздел/комплект) → в шаблон всех документов уровня, без явной ссылки в каждом документе.

## Механизм ограничений тэга (внутренний, пользователь не управляет)
- `TagDefinition.Restriction: TagRestriction?` (сейчас одно поле `int? MaxBearers`) — глобальный максимум **различных носителей** тэга (тип для Type-scope, тип+поле для Field-scope). `null` = как сейчас.
- `TagRestrictionValidator` (чистый): считает носителей по **собственным** схемам (унаследованные не в счёт — иначе первый подтип ломает лимит) среди прочих типов + входящей схемы; превышение → нарушение со списком **где занято**. Врезан в `CreateDocumentType` **и** `UpdateSchema` → **409 Conflict**.

## Профиль уровня
- Тэги `profile.construction`/`section`/`set` (Type-scope, Composite, `MaxBearers: 1`).
- FK `ProfileObjectId` (nullable) на `Construction`/`Section`/`DocumentSet` — **1 миграция** (3 колонки, без DB-FK и бэкфилла).
- `LevelProfileService.EnsureProfileAsync` — ленивое создание объекта-профиля при открытии общих данных уровня.
- `EntityResolver.InjectScopeProfilesAsync` — инжект `data.уровень.{стройка,раздел,комплект}` **до** resolve-refs (вложенные `$ref`/`_baseRef` резолвятся тем же проходом); каскад = все три уровня-предка; отсутствующий уровень → пустой объект.

## Тесты
- Валидатор (5): второй носитель блокируется, само-пересохранение ок, унаследованный не считается, без ограничения не блокирует.
- Инжект (2): `data.уровень` с каскадом + пустыми объектами; ленивое создание + FK.
- **417 backend-тестов зелёные.**

`/api/tags` отдаёт `restriction` автоматически (для UI Фазы B). Дальше: **Фаза B** (UI: пункт-профиль в общих данных, дизейбл занятого тэга), **Фаза C** (lifecycle/guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)