### PR TITLE
feat(profile): профиль уровня — фаза C (guards + discoverability) (#258)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/shared/api/schema';
 import { TypstRendersEditor } from './TypstRendersEditor';
 import { schemaToJson, validateFields, TYPE_LABELS, toCamelKey } from './schemaConstants';
-import { useTagRegistry, typeTags as typeTagDefs } from '@/shared/api/tags';
+import { useTagRegistry, typeTags as typeTagDefs, FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { GroupedFieldsEditor } from './GroupedFieldsEditor';
 import { JsonPreview, FieldBuilder, DefaultValueCell, type FieldRegistries } from './FieldBuilder';
 import {
@@ -614,6 +614,21 @@ function SchemaEditor({ docType, allDocTypes }: {
               );
             })}
           </div>
+          {(() => {
+            // issue #258: если тип назначен профилем уровня — read-only заметка «где редактируется + ключ».
+            const p = [
+              { code: FUNCTIONAL_TAG.profileConstruction, level: 'Стройка', key: 'стройка' },
+              { code: FUNCTIONAL_TAG.profileSection, level: 'Раздел', key: 'раздел' },
+              { code: FUNCTIONAL_TAG.profileSet, level: 'Комплект', key: 'комплект' },
+            ].find(x => docTypeTags.includes(x.code));
+            return p ? (
+              <p className="mt-2 text-xs text-fg3">
+                Используется как <span className="text-brand-hover font-medium">профиль уровня «{p.level}»</span>:
+                его объект редактируется в «Общие данные» уровня, поля доступны в шаблоне как{' '}
+                <code className="font-mono bg-muted text-fg1 px-1 rounded">data.уровень.{p.key}.*</code>.
+              </p>
+            ) : null;
+          })()}
         </SectionCard>
       )}
 

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
@@ -87,6 +87,7 @@ public static class CommonDataEndpoints
         {
             try { await m.Send(new DeleteCommonDataEntryCommand(id)); return Results.NoContent(); }
             catch (KeyNotFoundException) { return Results.NotFound(); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
     }
 

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -6,6 +6,7 @@ using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 using BHS.CRG.Domain.Objects;
+using BHS.CRG.Domain.Schema;
 using BHS.CRG.Domain.Templates;
 using MediatR;
 
@@ -148,6 +149,12 @@ public class DocumentTypeHandlers(
         var all = await repo.GetAllAsync(ct);
         if (all.Any(x => x.ParentId == cmd.Id))
             throw new InvalidOperationException("Нельзя удалить тип, от которого наследуются другие типы.");
+
+        // issue #258: тип, назначенный профилем уровня (несёт тэг profile-*), удалять нельзя — снять тэг.
+        if (SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileConstruction)
+            || SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileSection)
+            || SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileSet))
+            throw new InvalidOperationException("Нельзя удалить тип — он назначен профилем уровня. Снимите тэг «Профиль …» перед удалением.");
 
         if ((await objectRepo.FindAsync(o => o.CompositeTypeId == cmd.Id, ct)).Count > 0)
             throw new InvalidOperationException("Нельзя удалить тип — по нему уже созданы объекты (документы или записи общих данных).");
@@ -432,6 +439,7 @@ public class CommonDataHandlers(
     IRepository<DomainObject> repo,
     IRepository<DocumentSet> setRepo,
     IRepository<Section> sectionRepo,
+    IRepository<Construction> constructionRepo,
     IDataSetResolver dataSetResolver,
     ILevelProfileService levelProfiles) :
     IRequestHandler<CreateCommonDataEntryCommand, DomainObject>,
@@ -467,6 +475,11 @@ public class CommonDataHandlers(
     public async Task Handle(DeleteCommonDataEntryCommand cmd, CancellationToken ct)
     {
         var entry = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
+        // issue #258: объект-профиль (на который ссылается FK контейнера) — синглтон, удалять нельзя.
+        if ((await constructionRepo.FindAsync(c => c.ProfileObjectId == cmd.Id, ct)).Count > 0
+            || (await sectionRepo.FindAsync(s => s.ProfileObjectId == cmd.Id, ct)).Count > 0
+            || (await setRepo.FindAsync(s => s.ProfileObjectId == cmd.Id, ct)).Count > 0)
+            throw new InvalidOperationException("Это профиль уровня — его нельзя удалить. Он редактируется на странице «Общие данные» уровня.");
         repo.Remove(entry);
         await repo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Tests/Integration/LevelProfileTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/LevelProfileTests.cs
@@ -89,4 +89,30 @@ public class LevelProfileTests(IntegrationTestFixture fixture) : IAsyncLifetime
         var construction = await m.Send(new GetConstructionQuery(cId));
         Assert.NotNull(construction!.ProfileObjectId);
     }
+
+    [Fact]
+    public async Task DeletingProfileType_IsBlocked()
+    {
+        var profType = await CompositeTypeAsync("Профиль стройки", "{'tags':['profile.construction'],'fields':[]}");
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => m.Send(new DeleteDocumentTypeCommand(profType)));
+        Assert.Contains("профиль", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeletingProfileObject_IsBlocked()
+    {
+        var (cId, _, _) = await SetupAsync();
+        var profType = await CompositeTypeAsync("Профиль стройки", "{'tags':['profile.construction'],'fields':[]}");
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var list = await m.Send(new ListCommonDataEntriesQuery(CatalogScope.Construction, cId, null)); // ensure
+        var profileId = list.First(o => o.CompositeTypeId == profType).Id;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => m.Send(new DeleteCommonDataEntryCommand(profileId)));
+        Assert.Contains("профиль", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.45.0</Version>
+    <Version>0.45.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #258. Финальная фаза — lifecycle-защита + обнаружимость. Требует Фазы A (#259) и B (#260, слиты).

## Guards (409 Conflict)
- **Нельзя удалить составной тип, назначенный профилем уровня** (несёт тэг `profile-*`) — снять тэг перед удалением.
- **Нельзя удалить объект-профиль** (на который ссылается FK контейнера) — синглтон; редактируется на странице «Общие данные» уровня. `CommonDataHandlers` получил `IRepository<Construction>`; common-data delete endpoint маппит `InvalidOperationException → 409`.

## Frontend (`DocumentTypesPage`)
- На detail типа с профиль-тэгом — **read-only заметка**: «Используется как профиль уровня «X»: редактируется в Общие данные уровня, ключ `data.уровень.<key>.*`».

## Смена профиль-типа
Без ретро-перезаписи: старые контейнеры сохраняют объект старого типа, новые/ленивое создание берут новый — безопасный дефолт (ручное пересоздание — отдельная будущая полировка, данные не теряются).

## Тесты
- Удаление профиль-типа и объекта-профиля блокируются (2 новых).
- **419 backend + 130 frontend зелёные.**

Итог по #258: тэг-ограничения (A) + инжект `data.уровень.*` в шаблон (A) + UI профиля/дизейбл тэга (B) + guards/discoverability (C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)