### PR TITLE
fix(ui): «Сохранить и перейти» — показывать ошибку, не висеть молча

### DIFF
--- a/src/client/src/shared/ui/ListDetailShell.tsx
+++ b/src/client/src/shared/ui/ListDetailShell.tsx
@@ -143,8 +143,11 @@ export function useDirtyGuard<TKey>({ isDirty, saving, saveAll, onCommit }: {
     onCancel: () => setPending(null),
     onDiscard: () => { if (pending) onCommit(pending.next); setPending(null); },
     onSave: async () => {
-      try { await saveAll(); if (pending) onCommit(pending.next); setPending(null); }
-      catch { /* ошибка валидации показана в форме — остаёмся */ }
+      // При ошибке валидации/сохранения закрываем диалог, чтобы ошибка формы стала видна
+      // (иначе «Сохранить и перейти» молча висит и выглядит сломанным). Переход отменяется.
+      try { await saveAll(); if (pending) onCommit(pending.next); }
+      catch { /* ошибка уже показана в форме (setError) */ }
+      finally { setPending(null); }
     },
   };
   return { request, dialogProps };

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.46.0</Version>
+    <Version>0.46.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Симптом
Кнопка «Сохранить и перейти» в диалоге «Несохранённые изменения» выглядит сломанной — ничего не происходит.

## Причина
`useDirtyGuard.onSave` при ошибке валидации/сохранения **молча глотал** её (`catch {}`) и оставлял диалог открытым. Ошибка формы (`setError`) при этом скрыта за модалкой → пользователь не видит, почему не сохраняется.

## Фикс
При ошибке диалог **закрывается** (переход отменяется), баннер ошибки формы становится виден. `finally` гарантирует закрытие в обоих исходах, `catch` — против unhandled rejection.

Общий `useDirtyGuard` (ListDetailShell) — фикс распространяется на все list-detail страницы настроек.

`tsc -b` чисто, 130 фронт-тестов зелёные.

> NB: конкретный кейс пользователя — сохранение типа «Документ проекта» падает, т.к. у него собственное поле с ключом `Файл`, дублирующее унаследованное из родителя «Проект». Это отдельная правка данных (убрать/переименовать дубль); данный PR лишь делает ошибку видимой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)