### PR TITLE
feat(ui): TypePickerField — единый пикер выбора типа (#266)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -9,7 +9,8 @@ import { Markdown } from '@/shared/ui/Markdown';
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
-import { Select, SelectItem } from '@/shared/ui/Select';
+import { TypePickerField } from '@/shared/ui/TypePickerField';
+import type { PickType } from '@/shared/ui/TypePicker';
 import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { apiError } from '@/shared/utils/apiError';
@@ -57,8 +58,10 @@ function normalizeGroupMembership(gs: FieldGroup[]): FieldGroup[] {
   }));
 }
 
-/** Sentinel для «— без родителя —» — Radix Select запрещает пустую строку как value. */
-const NO_PARENT = '__none__';
+/** Родительский тип как `PickType` для `TypePickerField` (section — единая шапка группы пикера). */
+function toParentPickTypes(types: DocumentType[]): PickType[] {
+  return types.map(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Родительский тип' }));
+}
 
 // Реестр редакторов / диалог-гард / карточка-секция — общие для list-detail страниц (см. typeEditorShell).
 
@@ -247,13 +250,10 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
       </div>
       <div>
         <label className="block text-xs font-medium text-fg2 mb-1">Родительский тип</label>
-        <Select value={parentId || NO_PARENT} aria-label="Родительский тип"
-          onValueChange={v => setParentId(v === NO_PARENT ? '' : v)}>
-          <SelectItem value={NO_PARENT}>— без родителя —</SelectItem>
-          {eligibleParents.map(dt => (
-            <SelectItem key={dt.id} value={dt.id}>{dt.name} ({dt.code})</SelectItem>
-          ))}
-        </Select>
+        <TypePickerField className="w-full" aria-label="Родительский тип" title="Родительский тип"
+          placeholder="— без родителя —" clearable={{ label: 'Без родителя' }}
+          types={toParentPickTypes(eligibleParents)} value={parentId || undefined}
+          onChange={id => setParentId(id ?? '')} />
       </div>
       {/* Прокси/абстрактность — отдельные мгновенные переключатели (не часть формы «Сохранить
           параметры»): каждый — своя мутация, применяется сразу по щелчку (issue #197 Фаза C). */}
@@ -355,13 +355,10 @@ function CreateForm({
           <label className="block text-sm font-medium text-fg2 mb-1">
             Родительский тип (наследование)
           </label>
-          <Select value={parentId || NO_PARENT} aria-label="Родительский тип"
-            onValueChange={v => setParentId(v === NO_PARENT ? '' : v)}>
-            <SelectItem value={NO_PARENT}>— без родителя —</SelectItem>
-            {sameKindTypes.map(dt => (
-              <SelectItem key={dt.id} value={dt.id}>{dt.name} ({dt.code})</SelectItem>
-            ))}
-          </Select>
+          <TypePickerField className="w-full" aria-label="Родительский тип" title="Родительский тип"
+            placeholder="— без родителя —" clearable={{ label: 'Без родителя' }}
+            types={toParentPickTypes(sameKindTypes)} value={parentId || undefined}
+            onChange={id => setParentId(id ?? '')} />
         </div>
       )}
 

--- a/src/client/src/features/templates/TemplateSidebar.tsx
+++ b/src/client/src/features/templates/TemplateSidebar.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Plus, Trash2, Star, ChevronDown, ChevronUp, AlertTriangle, Copy } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
-import { Select, SelectItem } from '@/shared/ui/Select';
+import { TypePickerField } from '@/shared/ui/TypePickerField';
+import type { PickType } from '@/shared/ui/TypePicker';
 import type { Template, DocumentType } from '@/shared/api/types';
 import { useDeleteTemplate } from '@/shared/api/templates';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
@@ -136,14 +137,13 @@ export function VersionCleanupModal({ group, onClose, onDeleted }: {
 export function DocTypeSelector({ docTypes, selected, onSelect }: {
   docTypes: DocumentType[]; selected: string; onSelect: (id: string) => void;
 }) {
-  const nonAbstractDocs = docTypes.filter(dt => dt.kind === 'Document' && !dt.isAbstract);
+  const nonAbstractDocs = docTypes
+    .filter(dt => dt.kind === 'Document' && !dt.isAbstract)
+    .map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Типы документов' }));
   return (
-    <Select value={selected || undefined} onValueChange={onSelect}
-      placeholder="Выберите тип документа" aria-label="Тип документа" className="w-56">
-      {nonAbstractDocs.map((dt) => (
-        <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>
-      ))}
-    </Select>
+    <TypePickerField size="sm" className="w-56" recentKey="doc-type" title="Тип документа"
+      placeholder="Выберите тип документа" aria-label="Тип документа"
+      types={nonAbstractDocs} value={selected || undefined} onChange={id => id && onSelect(id)} />
   );
 }
 

--- a/src/client/src/shared/ui/TypePicker.tsx
+++ b/src/client/src/shared/ui/TypePicker.tsx
@@ -1,13 +1,14 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import {
-  Search, Boxes, FileText, Building2, User, MapPin, Wrench, Package, Ruler, CalendarDays,
+  Search, Boxes, FileText, Building2, User, MapPin, Wrench, Package, Ruler, CalendarDays, Ban,
   type LucideIcon,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 // Иконка семейства по эвристике (имя+код). Категории из данных не выводятся (нет тегов/единого
 // parentId-дерева), поэтому иконку подбираем по ключевым словам; неточное совпадение безвредно.
-function typeIcon(t: PickType): LucideIcon {
+// Экспортируется для `TypePickerField` — закрытый триггер показывает ту же иконку, что строки пикера.
+export function typeIcon(t: PickType): LucideIcon {
   const s = `${t.name} ${t.code}`.toLowerCase();
   if (/организ|сро|надзор|подрядчик|заказчик/.test(s)) return Building2;
   if (/персон|фио|подписант/.test(s)) return User;
@@ -30,13 +31,16 @@ export interface PickType { id: string; name: string; code: string; section: str
 
 const RECENTS_CAP = 6;
 
-export function TypePicker({ open, onOpenChange, types, onSelect, recentKey, title = 'Выберите тип' }: {
+export function TypePicker({ open, onOpenChange, types, onSelect, recentKey, title = 'Выберите тип', noneOption, onSelectNone }: {
   open: boolean;
   onOpenChange: (o: boolean) => void;
   types: PickType[];
   onSelect: (id: string) => void;
   recentKey?: string;
   title?: string;
+  /** Строка «нет значения» первой в списке (для очищаемых пикеров — напр. «Без родителя»). */
+  noneOption?: { label: string };
+  onSelectNone?: () => void;
 }) {
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
@@ -77,18 +81,29 @@ export function TypePicker({ open, onOpenChange, types, onSelect, recentKey, tit
 
   const flat = useMemo(() => sections.flatMap(g => g.items), [sections]);
 
+  // Строка «нет значения» показывается только без запроса (поиск подразумевает выбор реального типа).
+  // Занимает индекс 0; типы сдвигаются на 1 (base).
+  const noneVisible = !!noneOption && !q;
+  const base = noneVisible ? 1 : 0;
+  const total = base + flat.length;
+
   useEffect(() => { setActive(0); }, [query]);
   useEffect(() => { if (!open) setQuery(''); }, [open]);
 
   function choose(t: PickType) { pushRecent(t.id); onSelect(t.id); onOpenChange(false); }
+  function chooseNone() { onSelectNone?.(); onOpenChange(false); }
 
   function onKey(e: React.KeyboardEvent) {
-    if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, flat.length - 1)); }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, total - 1)); }
     else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, 0)); }
-    else if (e.key === 'Enter') { e.preventDefault(); const t = flat[active]; if (t) choose(t); }
+    else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (noneVisible && active === 0) { chooseNone(); return; }
+      const t = flat[active - base]; if (t) choose(t);
+    }
   }
 
-  let idx = -1; // сквозной индекс строки (совпадает с порядком flat), корректен при дублях «Недавние»
+  let idx = base - 1; // сквозной индекс строки типа (после none-строки, если она есть); ++idx даёт base
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -106,8 +121,18 @@ export function TypePicker({ open, onOpenChange, types, onSelect, recentKey, tit
             <kbd className="rounded border border-stroke px-1 text-[10px] text-fg4">Esc</kbd>
           </div>
           <ul className="overflow-y-auto p-2" role="listbox" aria-label={title}>
+            {noneVisible && (
+              <li role="option" aria-selected={active === 0}>
+                <button type="button" onMouseEnter={() => setActive(0)} onClick={chooseNone}
+                  className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                    active === 0 ? 'bg-tonal text-on-tonal' : 'text-fg1 hover:bg-black/5 dark:hover:bg-white/10'}`}>
+                  <Ban size={16} className={active === 0 ? 'text-on-tonal' : 'text-fg4'} />
+                  <span className="flex-1 truncate">{noneOption!.label}</span>
+                </button>
+              </li>
+            )}
             {flat.length === 0 ? (
-              <li className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</li>
+              !noneVisible && <li className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</li>
             ) : sections.map(g => (
               <li key={g.label}>
                 <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-fg4">{g.label}</div>

--- a/src/client/src/shared/ui/TypePickerField.tsx
+++ b/src/client/src/shared/ui/TypePickerField.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Boxes, ChevronDown, X } from 'lucide-react';
+import { TypePicker, typeIcon, type PickType } from './TypePicker';
+
+/**
+ * Триггер-поле над `TypePicker` (issue #266): закрытый вид читается как form-поле в тон нашего
+ * `Select` (значок семейства + имя выбранного типа + код по showCode + chevron), клик/Enter/Space
+ * открывают богатую модалку выбора. Единый контрол для ЛЮБОГО выбора типа (документа/поля/родителя),
+ * чтобы не плодить свои триггеры на каждом сайте. Триггер — настоящий `<button aria-haspopup>`, фокус
+ * возвращается на него по Esc (Radix Dialog). Не-типовые короткие списки (роль/scope) — обычный Select.
+ */
+export function TypePickerField({
+  types, value, onChange, recentKey, title = 'Выберите тип', placeholder = 'Выберите тип',
+  size = 'md', clearable, disabled, className = '', 'aria-label': ariaLabel,
+}: {
+  types: PickType[];
+  value: string | undefined;
+  /** id выбранного типа, либо null при выборе «нет значения» (только при `clearable`). */
+  onChange: (id: string | null) => void;
+  recentKey?: string;
+  title?: string;
+  placeholder?: string;
+  /** `sm` — компактный триггер для шапок (без кода); `md` — обычное поле формы. */
+  size?: 'sm' | 'md';
+  /** Показать строку «нет значения» в пикере + крестик-сброс на триггере. */
+  clearable?: { label: string };
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = value ? types.find(t => t.id === value) : undefined;
+  const Icon = selected ? typeIcon(selected) : Boxes;
+  const code = selected?.code.trim();
+  const showCode = size !== 'sm' && !!code && code.toLowerCase() !== selected!.name.trim().toLowerCase();
+  const h = size === 'sm' ? 'h-8' : 'h-9';
+
+  return (
+    <>
+      <button
+        type="button" disabled={disabled} onClick={() => setOpen(true)}
+        aria-haspopup="dialog" aria-label={ariaLabel} aria-expanded={open}
+        className={`group inline-flex items-center gap-2 ${h} px-3 rounded-md border border-stroke-strong ` +
+          `bg-surface text-sm text-left transition-colors focus:outline-none focus-visible:ring-2 ` +
+          `focus-visible:ring-brand data-[state=open]:ring-2 disabled:opacity-50 disabled:pointer-events-none ${className}`}
+        data-state={open ? 'open' : 'closed'}
+      >
+        <Icon size={16} className={`shrink-0 ${selected ? 'text-fg3' : 'text-fg4'}`} />
+        <span className={`flex-1 truncate ${selected ? 'text-fg1' : 'text-fg4'}`}>
+          {selected ? selected.name : placeholder}
+        </span>
+        {showCode && <span className="text-[11px] font-mono text-fg4 shrink-0">{code}</span>}
+        {clearable && selected && !disabled && (
+          <span role="button" tabIndex={-1} aria-label="Очистить"
+            onClick={e => { e.stopPropagation(); onChange(null); }}
+            className="shrink-0 text-fg4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-fg2 transition-opacity">
+            <X size={14} />
+          </span>
+        )}
+        <ChevronDown size={15} className="shrink-0 text-fg4" />
+      </button>
+
+      <TypePicker
+        open={open} onOpenChange={setOpen} title={title} recentKey={recentKey}
+        types={types} onSelect={id => onChange(id)}
+        noneOption={clearable} onSelectNone={clearable ? () => onChange(null) : undefined}
+      />
+    </>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.46.2</Version>
+    <Version>0.47.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #266.

## Идея

Любой выбор **типа** из реестра типов → через `TypePicker` (командная палитра: поиск, «Недавние», клавиатура), а не сырой `<Select>`. Не-типовые короткие списки (роль/scope/enum-значение) не трогаем. Согласовано с Дизайнером.

## Изменения

**Фаза A**
- **`shared/ui/TypePickerField`** — общий триггер-**поле** в тон `Select`: `[значок семейства] Имя [код по showCode] [chevron]`, открывает существующую модалку `TypePicker`. Пропсы: `size` (`sm` для шапок), `clearable`, `placeholder`, `disabled`. Триггер — настоящий `<button aria-haspopup="dialog">`, фокус возвращается по Esc.
- **`TypePicker`** — опциональная строка «нет значения» первой в списке (`noneOption`/`onSelectNone`) для очищаемых пикеров; экспортирован `typeIcon` (та же иконка в закрытом триггере и строках).
- **Шаблоны** (`TemplateSidebar.DocTypeSelector`) → `TypePickerField size="sm"`. Это тот же «выбор типа документа», что и «Добавить документ» в комплект (там пикер уже был) — устранён разнобой; общий `recentKey="doc-type"`.

**Фаза B**
- **Родительский тип** в `DocumentTypesPage` (форма правки + форма создания) → `TypePickerField` с `clearable` и строкой **«Без родителя»**; крестик-сброс на триггере. Eligible-фильтр (тот же kind, без себя/потомков — `getDescendantIds`) остаётся на входе, пикер про домен не знает. Убраны sentinel `NO_PARENT` и импорт `Select`.

## Проверка

`npx tsc -b` — чисто; `vitest run` — 130 тестов зелёные. Миграций нет, только фронт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)