### PR TITLE
fix(ui): длинная подпись кнопки в ConfirmDialog не распирает диалог

### DIFF
--- a/src/client/src/shared/ui/Button.tsx
+++ b/src/client/src/shared/ui/Button.tsx
@@ -11,7 +11,7 @@ export type ButtonVariant = 'filled' | 'tonal' | 'outlined' | 'text';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 const BASE =
-  'inline-flex items-center justify-center gap-2 rounded-full font-medium whitespace-nowrap select-none ' +
+  'inline-flex items-center justify-center gap-2 rounded-full font-medium select-none ' +
   'transition-[background-color,box-shadow,filter,color,border-color] duration-150 ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 ' +
   'focus-visible:ring-offset-base disabled:opacity-40 disabled:pointer-events-none';
@@ -26,6 +26,18 @@ const TEXT_SIZE: Record<ButtonSize, string> = {
   sm: 'h-8 px-2 text-xs',
   md: 'h-9 px-3 text-sm',
   lg: 'h-10 px-4 text-sm',
+};
+// multiline: фикс. высота → min-h (растёт при переносе). Литеральные строки — иначе Tailwind
+// не сгенерирует классы (динамический .replace() не сканируется при сборке).
+const MULTILINE_SIZE: Record<ButtonSize, string> = {
+  sm: 'min-h-8 px-3 text-xs',
+  md: 'min-h-9 px-4 text-sm',
+  lg: 'min-h-10 px-6 text-sm',
+};
+const MULTILINE_TEXT_SIZE: Record<ButtonSize, string> = {
+  sm: 'min-h-8 px-2 text-xs',
+  md: 'min-h-9 px-3 text-sm',
+  lg: 'min-h-10 px-4 text-sm',
 };
 
 function variantClass(variant: ButtonVariant, danger: boolean): string {
@@ -56,20 +68,26 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: ReactNode;
   trailingIcon?: ReactNode;
   fullWidth?: boolean;
+  /** Разрешить перенос длинной подписи на несколько строк (высота растёт, фикс. h → min-h).
+   *  По умолчанию кнопки однострочные (whitespace-nowrap). */
+  multiline?: boolean;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   { variant = 'text', size = 'md', danger = false, loading = false,
-    icon, trailingIcon, fullWidth, className = '', type, disabled, children, ...rest },
+    icon, trailingIcon, fullWidth, multiline = false, className = '', type, disabled, children, ...rest },
   ref,
 ) {
-  const sizes = variant === 'text' ? TEXT_SIZE : SIZE;
+  // Однострочные по умолчанию; multiline меняет фикс. высоту на min-h + вертикальный отступ и разрешает перенос.
+  const sizeCls = multiline
+    ? `${(variant === 'text' ? MULTILINE_TEXT_SIZE : MULTILINE_SIZE)[size]} py-1.5 whitespace-normal`
+    : `${(variant === 'text' ? TEXT_SIZE : SIZE)[size]} whitespace-nowrap`;
   return (
     <button
       ref={ref}
       type={type ?? 'button'}
       disabled={disabled || loading}
-      className={`${BASE} ${sizes[size]} ${variantClass(variant, danger)} ${fullWidth ? 'w-full' : ''} ${className}`}
+      className={`${BASE} ${sizeCls} ${variantClass(variant, danger)} ${fullWidth ? 'w-full' : ''} ${className}`}
       {...rest}
     >
       {loading ? <Loader2 size={16} className="animate-spin shrink-0" /> : icon}

--- a/src/client/src/shared/ui/ConfirmDialog.tsx
+++ b/src/client/src/shared/ui/ConfirmDialog.tsx
@@ -69,12 +69,14 @@ export function ConfirmDialog({
             </label>
           )}
 
-          <div className={`flex gap-2 justify-end ${!requireCheckbox ? 'mt-4' : ''}`}>
+          {/* items-start + shrink-0 у «Отмена» и multiline+min-w-0 у подтверждения: длинная подпись
+              (в неё вшито имя объекта) переносится внутри кнопки, а не распирает узкий диалог. */}
+          <div className={`flex gap-2 justify-end items-start ${!requireCheckbox ? 'mt-4' : ''}`}>
             <Dialog.Close asChild>
-              <Button variant="text" size="sm">{cancelLabel}</Button>
+              <Button variant="text" size="sm" className="shrink-0">{cancelLabel}</Button>
             </Dialog.Close>
             <Button
-              variant="filled" danger size="sm"
+              variant="filled" danger size="sm" multiline className="min-w-0"
               disabled={!canConfirm}
               onClick={() => { onConfirm(); onOpenChange(false); }}
             >

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.47.0</Version>
+    <Version>0.47.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Симптом

При удалении типа с длинным именем (напр. «Организация технического надзора») кнопка подтверждения — в её подпись вшито имя объекта — не переносилась (`whitespace-nowrap` + фиксированная `h-8`) и вылезала за края узкого `max-w-sm`-диалога, выталкивая «Отмена» наружу. См. скриншот в обсуждении.

## Фикс

- **`Button`** — новый проп `multiline`: фикс. высота → `min-h` (растёт при переносе), вертикальный отступ, `whitespace-normal`. Размеры заданы литеральными картами (динамический `.replace()` Tailwind не сканирует при сборке — класс не сгенерировался бы).
- **`ConfirmDialog`** — кнопка подтверждения `multiline` + `min-w-0`, «Отмена» `shrink-0`, ряд `items-start`. Длинная подпись переносится внутри кнопки, диалог не распирается. Короткие подписи выглядят как раньше (`min-h-8` ≈ прежняя `h-8`).

## Проверка

`tsc -b` + `vitest` (130) зелёные. Затрагивает все `ConfirmDialog` (удаления по всему приложению) и добавляет опциональный проп в общий `Button` — поведение по умолчанию не меняется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)