### PR TITLE
feat(guard): запрет удаления объекта — базового экземпляра (#269, фаза 1)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -137,8 +137,8 @@ public static class DocumentSetEndpoints
 
         g.MapDelete("/{setId:guid}/documents/{id:guid}", async (Guid id, IMediator m) =>
         {
-            await m.Send(new DeleteDocumentInstanceCommand(id));
-            return Results.NoContent();
+            try { await m.Send(new DeleteDocumentInstanceCommand(id)); return Results.NoContent(); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
         // ── Сборка комплекта ───────────────────────────────────────────────────

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Objects;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
@@ -372,6 +373,12 @@ public class DocumentSetHandlers(
     public async Task Handle(DeleteDocumentInstanceCommand cmd, CancellationToken ct)
     {
         var obj = await objRepo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
+        // issue #71: удаление базового экземпляра оставило бы у ссылающихся висячий "_baseRef" —
+        // при генерации базовые поля молча пропали бы (EntityResolver пропускает отсутствующую базу).
+        var referrers = await DomainObjectReferences.FindBaseRefReferrersAsync(objRepo, cmd.Id, ct);
+        if (referrers.Count > 0)
+            throw new InvalidOperationException(
+                $"Нельзя удалить документ — на него ссылаются как на базовый экземпляр: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
         objRepo.Remove(obj);
         await objRepo.SaveChangesAsync(ct);
     }
@@ -480,6 +487,12 @@ public class CommonDataHandlers(
             || (await sectionRepo.FindAsync(s => s.ProfileObjectId == cmd.Id, ct)).Count > 0
             || (await setRepo.FindAsync(s => s.ProfileObjectId == cmd.Id, ct)).Count > 0)
             throw new InvalidOperationException("Это профиль уровня — его нельзя удалить. Он редактируется на странице «Общие данные» уровня.");
+        // issue #71: запись, служащая базовым экземпляром для других объектов, — тот же guard,
+        // что и для документа: иначе у ссылающихся остаётся висячий "_baseRef".
+        var referrers = await DomainObjectReferences.FindBaseRefReferrersAsync(repo, cmd.Id, ct);
+        if (referrers.Count > 0)
+            throw new InvalidOperationException(
+                $"Нельзя удалить запись — на неё ссылаются как на базовый экземпляр: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
         repo.Remove(entry);
         await repo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
+++ b/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Objects;
+
+namespace BHS.CRG.Application.Objects;
+
+/// <summary>
+/// Разбор ссылки «_baseRef» (базовый экземпляр, issue #71): дискриминированный объект {kind,id}
+/// или голая id-строка (legacy). Единый источник правила для резолвера генерации
+/// (<c>EntityResolver</c>) и guard'ов удаления — чтобы «на что ссылается base» трактовалось одинаково.
+/// </summary>
+public static class BaseRefReader
+{
+    /// <summary>id из значения «_baseRef» ({kind,id} или голая строка), либо null.</summary>
+    public static Guid? ParseRef(JsonElement el)
+    {
+        if (el.ValueKind == JsonValueKind.String)
+            return Guid.TryParse(el.GetString(), out var g) ? g : null;
+        if (el.ValueKind == JsonValueKind.Object
+            && el.TryGetProperty("id", out var idEl) && Guid.TryParse(idEl.GetString(), out var gid))
+            return gid;
+        return null;
+    }
+
+    /// <summary>id базового объекта, на который ссылается data через «_baseRef», либо null.</summary>
+    public static Guid? GetBaseRefId(JsonElement data)
+    {
+        if (data.ValueKind != JsonValueKind.Object) return null;
+        if (!data.TryGetProperty("_baseRef", out var el)) return null;
+        return ParseRef(el);
+    }
+}
+
+/// <summary>Обратные ссылки между объектами предметной области — для guard'ов удаления.</summary>
+public static class DomainObjectReferences
+{
+    /// <summary>
+    /// Другие объекты, ссылающиеся на <paramref name="targetId"/> как на базовый экземпляр
+    /// (issue #71) — по «_baseRef» в их Data. Сканирование в памяти (предикат по JSON не
+    /// транслируется в SQL); масштаб приложения это допускает, как и прочие guard'ы удаления.
+    /// </summary>
+    public static async Task<IReadOnlyList<DomainObject>> FindBaseRefReferrersAsync(
+        IRepository<DomainObject> repo, Guid targetId, CancellationToken ct)
+    {
+        var all = await repo.GetAllAsync(ct);
+        return all.Where(o => o.Id != targetId && BaseRefReader.GetBaseRefId(o.Data.RootElement) == targetId).ToList();
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Objects;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Objects;
@@ -300,18 +301,10 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         return baseData.ValueKind == JsonValueKind.Object ? MergeBaseObjects(baseData, ownData) : ownData;
     }
 
-    /// Разбор "_baseRef": дискриминированный объект {kind,id} (issue #71) или голый id-строка (legacy).
-    /// После слияния объектов (issue #84) разновидность цели определяется её природой при резолве
-    /// (наличие фасеты), поэтому здесь нужен только id — тег kind игнорируется.
-    private static Guid? ParseBaseRef(JsonElement el)
-    {
-        if (el.ValueKind == JsonValueKind.String)
-            return Guid.TryParse(el.GetString(), out var g) ? g : null;
-        if (el.ValueKind == JsonValueKind.Object
-            && el.TryGetProperty("id", out var idEl) && Guid.TryParse(idEl.GetString(), out var gid))
-            return gid;
-        return null;
-    }
+    /// Разбор "_baseRef": делегирует общему <see cref="BaseRefReader.ParseRef"/> — единое правило
+    /// для резолвера и guard'ов удаления (issue #71). Разновидность цели определяется её природой
+    /// при резолве (наличие фасеты), поэтому здесь нужен только id — тег kind игнорируется.
+    private static Guid? ParseBaseRef(JsonElement el) => BaseRefReader.ParseRef(el);
 
     /// <summary>
     /// Слияние двух JSON-объектов для _baseRef-наследования: базовые поля первыми, собственные

--- a/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
@@ -162,6 +162,38 @@ public class CommonDataHandlerTests(IntegrationTestFixture fixture) : IAsyncLife
         Assert.Empty(list);
     }
 
+    // issue #71: запись, служащая базовым экземпляром для другого объекта, не удаляется, пока на
+    // неё ссылаются (иначе у ссылающегося остался бы висячий "_baseRef"). Дочерний (сам ни для кого
+    // не база) удаляется, после чего и база освобождается.
+    [Fact]
+    public async Task Delete_BaseInstance_BlockedWhileReferenced()
+    {
+        var typeId = await CreateCompositeTypeAsync("ORG_BASE");
+        Guid baseId, childId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var m = Mediator(scope);
+            var baseEntry = await m.Send(new CreateCommonDataEntryCommand(
+                "База", typeId, Json("{}"), CatalogScope.System, null));
+            baseId = baseEntry.Id;
+            var child = await m.Send(new CreateCommonDataEntryCommand(
+                "Дочерний", typeId, Json($@"{{""_baseRef"":""{baseId}""}}"), CatalogScope.System, null));
+            childId = child.Id;
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => Mediator(scope).Send(new DeleteCommonDataEntryCommand(baseId)));
+
+        using (var scope = fixture.Services.CreateScope())
+            await Mediator(scope).Send(new DeleteCommonDataEntryCommand(childId));
+        using (var scope = fixture.Services.CreateScope())
+            await Mediator(scope).Send(new DeleteCommonDataEntryCommand(baseId));
+
+        using (var scope = fixture.Services.CreateScope())
+            Assert.Empty(await Mediator(scope).Send(new ListCommonDataEntriesQuery()));
+    }
+
     // ── List / filter ─────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.47.1</Version>
+    <Version>0.47.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #269 (фаза 1).

## Пробел

Ни удаление документа (`DeleteDocumentInstance`), ни записи общих данных (`DeleteCommonDataEntry`) не проверяли, ссылается ли кто-то на объект через `_baseRef` (базовый экземпляр, #71). При висячей базе `EntityResolver` (`if (baseObj is null) return ownData`) **молча** пропускает наследование → дочерний объект **тихо теряет унаследованные поля** при генерации, без ошибки.

## Фикс

- **`Application/Objects/BaseRefReader`** — единый парсер `_baseRef` (`{kind,id}` или голый id-строка) + `DomainObjectReferences.FindBaseRefReferrersAsync` (кто ссылается). `EntityResolver.ParseBaseRef` теперь делегирует ему — одно правило для резолва и guard'а.
- Оба удаления `DomainObject` бросают `InvalidOperationException` с перечислением имён ссылающихся.
- Эндпоинт удаления документа теперь мапит `InvalidOperationException` → **409 Conflict** (раньше не ловил — был бы 500). Удаление общих данных уже ловило.

## Тест

`Delete_BaseInstance_BlockedWhileReferenced`: база под ссылкой не удаляется; дочерний (сам ни для кого не база) удаляется, затем и база освобождается. Плюс подтверждает, что наличие собственного `_baseRef` не мешает удалять сам объект (проверяем ссылающихся, а не «есть ли baseRef»).

## Проверка

`dotnet build` чисто, backend **420 тестов** зелёные. Миграций нет.

## Дальше (в #269)
Фаза 2 — `PrimitiveType` (по образцу `EnumType`), фаза 3 — `CatalogEntity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)