### PR TITLE
feat(guard): запрет удаления типа поля, используемого в схеме (#269, фаза 2)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Catalog/PrimitiveTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Catalog/PrimitiveTypeEndpoints.cs
@@ -29,8 +29,8 @@ public static class PrimitiveTypeEndpoints
 
         admin.MapDelete("/{id:guid}", async (Guid id, IMediator m) =>
         {
-            await m.Send(new DeletePrimitiveTypeCommand(id));
-            return Results.NoContent();
+            try { await m.Send(new DeletePrimitiveTypeCommand(id)); return Results.NoContent(); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
     }
 

--- a/src/server/BHS.CRG.Application/Catalog/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Catalog/Handlers.cs
@@ -52,7 +52,7 @@ public class CatalogHandlers(IRepository<CatalogEntity> repo) :
     }
 }
 
-public class PrimitiveTypeHandlers(IRepository<PrimitiveType> repo) :
+public class PrimitiveTypeHandlers(IRepository<PrimitiveType> repo, IRepository<DocumentType> docTypeRepo) :
     IRequestHandler<ListPrimitiveTypesQuery, IReadOnlyList<PrimitiveType>>,
     IRequestHandler<CreatePrimitiveTypeCommand, PrimitiveType>,
     IRequestHandler<UpdatePrimitiveTypeCommand, PrimitiveType>,
@@ -101,10 +101,17 @@ public class PrimitiveTypeHandlers(IRepository<PrimitiveType> repo) :
         return pt;
     }
 
+    // issue #269 (по образцу EnumType #59): удаление типа поля, используемого в схеме какого-либо типа
+    // документа, оставило бы поле с висячим typeId. Проверяем перед удалением.
     public async Task Handle(DeletePrimitiveTypeCommand cmd, CancellationToken ct)
     {
         var pt = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"PrimitiveType {cmd.Id} not found");
+        var allDocTypes = await docTypeRepo.GetAllAsync(ct);
+        var usedIn = allDocTypes.Where(t => DocumentTypeSchemaReader.ReferencesPrimitiveType(t.Schema, cmd.Id)).ToList();
+        if (usedIn.Count > 0)
+            throw new InvalidOperationException(
+                $"Нельзя удалить тип поля — используется в схеме: {string.Join(", ", usedIn.Select(t => t.Name))}.");
         repo.Remove(pt);
         await repo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
+++ b/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
@@ -97,6 +97,15 @@ public static class DocumentTypeSchemaReader
         return fields.Any(f => f.Type == "enum" && f.TypeId == enumTypeId);
     }
 
+    /// <summary>Ссылается ли схема (СОБСТВЕННЫЕ поля типа) на тип поля из реестра primitiveTypeId
+    /// через поле type="primitive" + typeId (issue #269, проверка перед удалением PrimitiveType —
+    /// по образцу <see cref="ReferencesEnumType"/>).</summary>
+    public static bool ReferencesPrimitiveType(JsonDocument schema, Guid primitiveTypeId)
+    {
+        var (fields, _, _) = ParseSchema(schema, null);
+        return fields.Any(f => f.Type == "primitive" && f.TypeId == primitiveTypeId);
+    }
+
     /// <summary>true, если childId == ancestorId либо childId — потомок ancestorId по ParentId.</summary>
     public static bool IsSameOrDescendant(Guid childId, Guid ancestorId, IReadOnlyDictionary<Guid, DocumentType> byId)
     {

--- a/src/server/BHS.CRG.Tests/Integration/PrimitiveTypeHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/PrimitiveTypeHandlerTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using BHS.CRG.Application.Catalog;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Удаление PrimitiveType (issue #269, по образцу EnumType #59): тип поля из реестра, используемый
+/// в схеме какого-либо типа документа (поле type="primitive" + typeId), удалить нельзя.
+/// </summary>
+[Collection("Integration")]
+public class PrimitiveTypeHandlerTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private IMediator Mediator(IServiceScope scope) =>
+        scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    private static JsonDocument Constraints(string json = "{}") => JsonDocument.Parse(json);
+
+    [Fact]
+    public async Task Delete_Unused_Succeeds()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var created = await Mediator(scope).Send(new CreatePrimitiveTypeCommand(
+            "Инвентарный номер", "INV1", "string", null, Constraints()));
+
+        using var scope2 = fixture.Services.CreateScope();
+        await Mediator(scope2).Send(new DeletePrimitiveTypeCommand(created.Id));
+
+        using var scope3 = fixture.Services.CreateScope();
+        var all = await Mediator(scope3).Send(new ListPrimitiveTypesQuery());
+        Assert.DoesNotContain(all, p => p.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task Delete_ReferencedInDocumentTypeSchema_ThrowsInvalidOperation()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var prim = await Mediator(scope).Send(new CreatePrimitiveTypeCommand(
+            "Инвентарный номер", "INV2", "string", null, Constraints()));
+
+        var schema = JsonDocument.Parse(
+            $$"""{"fields":[{"key":"inv","type":"primitive","typeId":"{{prim.Id}}"}]}""");
+        await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Акт", "ACT_PRIM", DocumentTypeKind.Document, null, schema));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope2).Send(new DeletePrimitiveTypeCommand(prim.Id)));
+        Assert.Contains("Акт", ex.Message);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.47.2</Version>
+    <Version>0.47.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #269 (фаза 2).

## Пробел

`DeletePrimitiveType` не проверял использование — в отличие от `EnumType` (#59). Удаление типа поля из реестра, на который ссылается поле схемы (`type="primitive"` + `typeId`), оставляло бы висячий `typeId`.

## Фикс (зеркало EnumType)

- `DocumentTypeSchemaReader.ReferencesPrimitiveType` (поле `type="primitive"` + `typeId`).
- `PrimitiveTypeHandlers` получает `IRepository<DocumentType>`; `DeletePrimitiveType` бросает `InvalidOperationException` при использовании, с перечислением типов.
- Эндпоинт удаления примитива мапит `InvalidOperationException` → **409 Conflict**.

## Тест

`PrimitiveTypeHandlerTests`: неиспользуемый удаляется; используемый в схеме → 409 с именем типа.

## Проверка

`dotnet build` чисто, тесты зелёные (примитив + enum — 8). Миграций нет.

Осталась **фаза 3** — `CatalogEntity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)