### PR TITLE
feat(guard): запрет удаления объекта с $ref-ссылкой (#269, фаза 3)

### DIFF
--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -373,12 +373,13 @@ public class DocumentSetHandlers(
     public async Task Handle(DeleteDocumentInstanceCommand cmd, CancellationToken ct)
     {
         var obj = await objRepo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
-        // issue #71: удаление базового экземпляра оставило бы у ссылающихся висячий "_baseRef" —
-        // при генерации базовые поля молча пропали бы (EntityResolver пропускает отсутствующую базу).
-        var referrers = await DomainObjectReferences.FindBaseRefReferrersAsync(objRepo, cmd.Id, ct);
+        // issue #71/#269: удаление объекта, на который ссылаются (базовый экземпляр "_baseRef" или
+        // "$ref" в значениях полей), оставило бы висячую ссылку — при генерации она молча
+        // разворачивается в ничто (EntityResolver возвращает исходный узел / пропускает базу).
+        var referrers = await DomainObjectReferences.FindReferrersAsync(objRepo, cmd.Id, ct);
         if (referrers.Count > 0)
             throw new InvalidOperationException(
-                $"Нельзя удалить документ — на него ссылаются как на базовый экземпляр: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
+                $"Нельзя удалить документ — на него ссылаются другие объекты: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
         objRepo.Remove(obj);
         await objRepo.SaveChangesAsync(ct);
     }
@@ -487,12 +488,12 @@ public class CommonDataHandlers(
             || (await sectionRepo.FindAsync(s => s.ProfileObjectId == cmd.Id, ct)).Count > 0
             || (await setRepo.FindAsync(s => s.ProfileObjectId == cmd.Id, ct)).Count > 0)
             throw new InvalidOperationException("Это профиль уровня — его нельзя удалить. Он редактируется на странице «Общие данные» уровня.");
-        // issue #71: запись, служащая базовым экземпляром для других объектов, — тот же guard,
-        // что и для документа: иначе у ссылающихся остаётся висячий "_baseRef".
-        var referrers = await DomainObjectReferences.FindBaseRefReferrersAsync(repo, cmd.Id, ct);
+        // issue #71/#269: запись, на которую ссылаются другие объекты (базовый экземпляр "_baseRef"
+        // или "$ref" в значениях полей), — тот же guard, что и для документа: иначе висячая ссылка.
+        var referrers = await DomainObjectReferences.FindReferrersAsync(repo, cmd.Id, ct);
         if (referrers.Count > 0)
             throw new InvalidOperationException(
-                $"Нельзя удалить запись — на неё ссылаются как на базовый экземпляр: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
+                $"Нельзя удалить запись — на неё ссылаются другие объекты: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
         repo.Remove(entry);
         await repo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
+++ b/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
@@ -31,18 +31,55 @@ public static class BaseRefReader
     }
 }
 
+/// <summary>
+/// Чтение ссылок «$ref» в значениях полей (issue #269): resolve-объекты
+/// {$ref:"catalog", entryId} / {$ref:"document"|"instance", instanceId}, которые EntityResolver
+/// разворачивает при генерации. Указывают на другой <c>DomainObject</c> (запись общих данных или
+/// документ). Могут лежать на любой глубине Data (вложенные объекты, массивы) — обход рекурсивный.
+/// </summary>
+public static class RefReader
+{
+    /// <summary>id всех объектов, на которые ссылается data через «$ref», рекурсивно.</summary>
+    public static IEnumerable<Guid> CollectRefIds(JsonElement el)
+    {
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.Object:
+                if (el.TryGetProperty("$ref", out var rt) && rt.ValueKind == JsonValueKind.String)
+                {
+                    // id живёт в entryId (catalog) либо instanceId (document/instance).
+                    var idProp = rt.GetString() == "catalog" ? "entryId" : "instanceId";
+                    if (el.TryGetProperty(idProp, out var idEl) && Guid.TryParse(idEl.GetString(), out var g))
+                        yield return g;
+                }
+                foreach (var p in el.EnumerateObject())
+                    foreach (var id in CollectRefIds(p.Value)) yield return id;
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in el.EnumerateArray())
+                    foreach (var id in CollectRefIds(item)) yield return id;
+                break;
+        }
+    }
+}
+
 /// <summary>Обратные ссылки между объектами предметной области — для guard'ов удаления.</summary>
 public static class DomainObjectReferences
 {
     /// <summary>
-    /// Другие объекты, ссылающиеся на <paramref name="targetId"/> как на базовый экземпляр
-    /// (issue #71) — по «_baseRef» в их Data. Сканирование в памяти (предикат по JSON не
-    /// транслируется в SQL); масштаб приложения это допускает, как и прочие guard'ы удаления.
+    /// Другие объекты, ссылающиеся на <paramref name="targetId"/>: как на базовый экземпляр
+    /// («_baseRef», issue #71) ИЛИ через «$ref» в значениях полей (issue #269 — doc-ref/@@ref).
+    /// Сканирование в памяти (предикат по JSON не транслируется в SQL); масштаб приложения это
+    /// допускает, как и прочие guard'ы удаления.
     /// </summary>
-    public static async Task<IReadOnlyList<DomainObject>> FindBaseRefReferrersAsync(
+    public static async Task<IReadOnlyList<DomainObject>> FindReferrersAsync(
         IRepository<DomainObject> repo, Guid targetId, CancellationToken ct)
     {
         var all = await repo.GetAllAsync(ct);
-        return all.Where(o => o.Id != targetId && BaseRefReader.GetBaseRefId(o.Data.RootElement) == targetId).ToList();
+        return all.Where(o => o.Id != targetId && ReferencesObject(o.Data.RootElement, targetId)).ToList();
     }
+
+    private static bool ReferencesObject(JsonElement data, Guid targetId)
+        => BaseRefReader.GetBaseRefId(data) == targetId
+           || RefReader.CollectRefIds(data).Contains(targetId);
 }

--- a/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/CommonDataHandlerTests.cs
@@ -194,6 +194,38 @@ public class CommonDataHandlerTests(IntegrationTestFixture fixture) : IAsyncLife
             Assert.Empty(await Mediator(scope).Send(new ListCommonDataEntriesQuery()));
     }
 
+    // issue #269: запись, на которую ссылаются через "$ref" в значении поля другого объекта
+    // (doc-ref/@@ref, разворачивается EntityResolver), не удаляется, пока жива ссылка. Ссылка
+    // вложена в поле — проверяем рекурсивный обход Data.
+    [Fact]
+    public async Task Delete_BlockedWhenReferencedByFieldRef()
+    {
+        var typeId = await CreateCompositeTypeAsync("ORG_REF");
+        Guid targetId, holderId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var m = Mediator(scope);
+            var target = await m.Send(new CreateCommonDataEntryCommand(
+                "Цель", typeId, Json("{}"), CatalogScope.System, null));
+            targetId = target.Id;
+            var holder = await m.Send(new CreateCommonDataEntryCommand(
+                "Владелец ссылки", typeId,
+                Json($@"{{""org"":{{""$ref"":""catalog"",""entryId"":""{targetId}""}}}}"),
+                CatalogScope.System, null));
+            holderId = holder.Id;
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => Mediator(scope).Send(new DeleteCommonDataEntryCommand(targetId)));
+
+        // Удаляем ссылающегося — цель освобождается.
+        using (var scope = fixture.Services.CreateScope())
+            await Mediator(scope).Send(new DeleteCommonDataEntryCommand(holderId));
+        using (var scope = fixture.Services.CreateScope())
+            await Mediator(scope).Send(new DeleteCommonDataEntryCommand(targetId));
+    }
+
     // ── List / filter ─────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.47.3</Version>
+    <Version>0.47.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #269 (фазы 1–3).

## Пробел

`_baseRef`-guard (фаза 1) не покрывал ссылки между объектами через **`$ref`** в значениях полей:
- `{$ref:"catalog", entryId}` — `@@ref`-привязка на запись общих данных;
- `{$ref:"document"|"instance", instanceId}` — doc-ref на другой документ.

При удалении цели `EntityResolver` разворачивает висячую ссылку в исходный узел (или пропускает) → сырой объект-ссылка утёк бы в документ.

## Про исходную «фазу 3» (CatalogEntity)

**Отменена.** `CatalogEntity` — легаси: на неё не ссылается ни резолвер (`$ref:catalog` резолвится в `DomainObject`, не `CatalogEntity`), ни фронтенд (`/api/catalog` не вызывается). Guard был бы мёртвым кодом. Вместо этого закрыт реальный `$ref`-пробел (согласовано, вариант A).

## Фикс

- **`RefReader.CollectRefIds`** — рекурсивный сбор id из `$ref` (вложенные объекты + массивы); id в `entryId` (catalog) / `instanceId` (document/instance).
- **`DomainObjectReferences.FindReferrersAsync`** — объединяет `_baseRef` и `$ref`; оба удаления `DomainObject` используют его (сообщение «на объект ссылаются другие объекты: …»).

## Тест

`Delete_BlockedWhenReferencedByFieldRef`: запись под вложенной `$ref`-ссылкой не удаляется; после удаления ссылающегося — освобождается. (Плюс прежний `_baseRef`-тест по-прежнему зелёный через объединённый guard.)

## Проверка

`dotnet build` чисто, backend **423 теста** зелёные. Миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)