### PR TITLE
feat(ui): причина отказа удаления в ConfirmDialog (#273)

### DIFF
--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -87,7 +87,6 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
   const [previewing, setPreviewing] = useState(false);
   const [materializing, setMaterializing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameVal, setRenameVal] = useState('');
 
@@ -149,7 +148,7 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
     { key: 'duplicate', label: 'Создать копию', icon: <Copy size={13} />, onSelect: () => duplicateMutation.mutate({ id: src.id }), disabled: duplicateMutation.isPending },
     { key: 'materialize', label: src.materializeTypeId ? 'Материализация (настроена)' : 'Материализация…', icon: <Boxes size={13} />, onSelect: () => setMaterializing(true) },
     ...(canManageExtraction && !isPdf ? [{ key: 'edit', label: 'Редактировать', icon: <Pencil size={13} />, onSelect: () => onEdit(src) }] : []),
-    ...(canManageExtraction ? [{ key: 'delete', label: 'Удалить источник', icon: <Trash2 size={13} />, danger: true, onSelect: () => { setDeleteError(null); setConfirmDelete(true); } }] : []),
+    ...(canManageExtraction ? [{ key: 'delete', label: 'Удалить источник', icon: <Trash2 size={13} />, danger: true, onSelect: () => setConfirmDelete(true) }] : []),
   ];
 
   return (
@@ -178,7 +177,6 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
               {cols.slice(0, maxColumns).join(', ')}{cols.length > maxColumns ? ` +${cols.length - maxColumns}` : ''}
             </div>
           )}
-          {deleteError && <div className="text-danger mt-1">{deleteError}</div>}
         </div>
         <div className="flex items-center gap-1 shrink-0" onClick={e => e.stopPropagation()}>
           {passiveLabel && <span className="text-fg4 italic" title="Заполняется вместе с главным источником той же тройки/пары">{passiveLabel}</span>}
@@ -232,8 +230,7 @@ function SourceRow({ src, isPdf, canManageExtraction, templates, maxColumns, onE
         title={`Удалить источник «${src.name}»?`}
         description={<p>Если источник используется в привязках документов — удаление будет отклонено.</p>}
         confirmLabel="Удалить источник"
-        onConfirm={() => deleteMutation.mutateAsync({ id: src.id }).catch((err: { response?: { data?: string } }) =>
-          setDeleteError(err?.response?.data ?? 'Не удалось удалить — возможно, источник используется в привязках.'))}
+        onConfirm={() => deleteMutation.mutateAsync({ id: src.id })}
       />
     </div>
   );

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -380,10 +380,10 @@ function SetDetail() {
         onOpenChange={o => { if (!o) setDeleteTarget(null); }}
         title={`Удалить документ «${deleteTarget ? (deleteTarget.name || docTypeMap[deleteTarget.documentTypeId]?.name || deleteTarget.documentTypeId) : ''}»?`}
         confirmLabel="Удалить документ"
-        onConfirm={() => {
+        onConfirm={async () => {
           if (!deleteTarget) return;
+          await deleteMutation.mutateAsync({ setId: set.id, instanceId: deleteTarget.id });
           if (editInstance?.id === deleteTarget.id) setEditInstance(null);
-          deleteMutation.mutate({ setId: set.id, instanceId: deleteTarget.id });
         }}
       />
 

--- a/src/client/src/features/document-sets/catalog/CatalogResource.tsx
+++ b/src/client/src/features/document-sets/catalog/CatalogResource.tsx
@@ -234,7 +234,7 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
       </Modal>
       <ConfirmDialog open={!!deleteTarget} onOpenChange={o => { if (!o) setDeleteTarget(null); }}
         title={`Удалить «${deleteTarget?.displayName ?? ''}»?`} confirmLabel="Удалить"
-        onConfirm={() => { if (deleteTarget) deleteMutation.mutate(deleteTarget.id); }} />
+        onConfirm={() => { if (deleteTarget) return deleteMutation.mutateAsync(deleteTarget.id); }} />
     </div>
   );
 }

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -265,7 +265,7 @@ export function QualityDocsPage() {
         title={`Удалить «${deleteTarget?.displayName ?? ''}»?`}
         description={<p>Связи с материалами также будут удалены.</p>}
         confirmLabel="Удалить"
-        onConfirm={() => { if (deleteTarget) del.mutate(deleteTarget.id); }}
+        onConfirm={() => { if (deleteTarget) return del.mutateAsync(deleteTarget.id); }}
       />
     </div>
   );

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -13,7 +13,6 @@ import { TypePickerField } from '@/shared/ui/TypePickerField';
 import type { PickType } from '@/shared/ui/TypePicker';
 import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
-import { apiError } from '@/shared/utils/apiError';
 import {
   useListDocumentTypes,
   useCreateDocumentType,
@@ -795,10 +794,7 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
         description={<p>Это повлияет на все документы и шаблоны, использующие этот тип. Действие необратимо.</p>}
         confirmLabel={`Удалить тип «${docType.name}»`}
         requireCheckbox="Понимаю, что это необратимо"
-        onConfirm={() => deleteMutation.mutate(docType.id, {
-          onSuccess: onDeleted,
-          onError: err => alert(apiError(err, 'Не удалось удалить тип.')),
-        })}
+        onConfirm={() => deleteMutation.mutateAsync(docType.id).then(onDeleted)}
       />
     </div>
   );

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -10,7 +10,6 @@ import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/
 import { TextField } from '@/shared/ui/TextField';
 import { DateInput } from '@/shared/ui/DateInput';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
-import { apiError } from '@/shared/utils/apiError';
 import { validateConstraint } from '@/features/document-sets/fields/PrimitiveInput';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { parseSchemaFields } from '@/shared/api/schema';
@@ -434,7 +433,7 @@ function PrimitiveTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll
         title={`Удалить тип «${type.name}»?`}
         description={<p>Поля документов, использующие этот тип, перестанут валидироваться. Действие необратимо.</p>}
         confirmLabel={`Удалить «${type.name}»`}
-        onConfirm={() => del.mutate(type.id, { onSuccess: onDeleted, onError: e => alert(apiError(e, 'Не удалось удалить тип.')) })} />
+        onConfirm={() => del.mutateAsync(type.id).then(onDeleted)} />
     </div>
   );
 }
@@ -506,7 +505,7 @@ function EnumTypeDetail({ type, allGroups, usedBy, dirty, saving, onSaveAll, onR
         title={`Удалить тип «${type.name}»?`}
         description={<p>Поля документов, использующие это перечисление, перестанут резолвить варианты. Действие необратимо.</p>}
         confirmLabel={`Удалить «${type.name}»`}
-        onConfirm={() => del.mutate(type.id, { onSuccess: onDeleted, onError: e => alert(apiError(e, 'Не удалось удалить тип.')) })} />
+        onConfirm={() => del.mutateAsync(type.id).then(onDeleted)} />
     </div>
   );
 }

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -35,11 +35,6 @@ export function UsersPage() {
     catch (e) { setRowError({ id: u.id, msg: apiError(e) }); }
   }
 
-  async function onDelete(u: AppUser) {
-    setRowError(null);
-    try { await del.mutateAsync(u.id); }
-    catch (e) { setRowError({ id: u.id, msg: apiError(e) }); }
-  }
 
   return (
     <div className="px-6 py-4 max-w-4xl">
@@ -125,7 +120,7 @@ export function UsersPage() {
         title={`Удалить пользователя «${deleteTarget?.email ?? ''}»?`}
         description={<p>Действие необратимо.</p>}
         confirmLabel="Удалить пользователя"
-        onConfirm={() => { if (deleteTarget) onDelete(deleteTarget); }}
+        onConfirm={() => { if (deleteTarget) return del.mutateAsync(deleteTarget.id); }}
       />
     </div>
   );

--- a/src/client/src/features/templates/TemplateAssetsPanel.tsx
+++ b/src/client/src/features/templates/TemplateAssetsPanel.tsx
@@ -63,7 +63,7 @@ function AssetRow({ asset }: { asset: TemplateAssetDto }) {
           </p>
         }
         confirmLabel="Удалить"
-        onConfirm={() => deleteMutation.mutate(asset.id)}
+        onConfirm={() => deleteMutation.mutateAsync(asset.id)}
       />
     </div>
   );

--- a/src/client/src/shared/ui/ConfirmDialog.tsx
+++ b/src/client/src/shared/ui/ConfirmDialog.tsx
@@ -1,6 +1,8 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useState, type ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { Button } from './Button';
+import { apiError } from '@/shared/utils/apiError';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -15,29 +17,56 @@ interface ConfirmDialogProps {
    *  подтверждения неактивна, пока чекбокс не отмечен. Использовать для операций с
    *  многоуровневым каскадом или системными последствиями (стройка/раздел/тип документа). */
   requireCheckbox?: string;
-  onConfirm: () => void;
+  /** Заголовок в состоянии отказа (после ошибки сервера, напр. 409-guard). */
+  errorTitle?: string;
+  /**
+   * Действие подтверждения. Может быть async: если промис отклоняется (напр. 409 «нельзя удалить —
+   * используется …»), диалог НЕ закрывается, а показывает причину (apiError) в теле — пользователь
+   * видит, почему кнопка «не сработала». Успех (или синхронный void без throw) — закрывает диалог.
+   * Возвращаемое значение промиса игнорируется (mutateAsync-ответ и т.п.) — важен лишь resolve/reject.
+   */
+  onConfirm: () => void | Promise<unknown>;
 }
 
 /**
  * Стилизованное подтверждение удаления — замена голому window.confirm(). Визуальный паттерн
  * вынесен из confirmClose-оверлея Modal.tsx (не сам isDirty-guard, он про другой сценарий —
- * закрытие несохранённой формы). См. память проекта feedback_delete_ui_safety —
- * найдена системная проблема (12 мест с window.confirm(), включая каскадное удаление
- * стройки без предупреждения о масштабе).
+ * закрытие несохранённой формы). См. память проекта feedback_delete_ui_safety.
+ *
+ * Показ причины отказа (issue #273): при reject `onConfirm` диалог остаётся открыт, меняет
+ * заголовок на `errorTitle` и показывает блок причины (сообщение backend как есть) вместо
+ * кнопки подтверждения — единый канал для guard-отказов удаления (409), вместо alert()/тишины.
  */
 export function ConfirmDialog({
-  open, onOpenChange, title, description, confirmLabel, cancelLabel = 'Отмена', requireCheckbox, onConfirm,
+  open, onOpenChange, title, description, confirmLabel, cancelLabel = 'Отмена',
+  requireCheckbox, errorTitle = 'Удаление невозможно', onConfirm,
 }: ConfirmDialogProps) {
   const [checked, setChecked] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!open) setChecked(false);
+    if (!open) { setChecked(false); setBusy(false); setError(null); }
   }, [open]);
 
   const canConfirm = !requireCheckbox || checked;
 
+  async function handleConfirm() {
+    setBusy(true);
+    setError(null);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch (e) {
+      // Отказ (обычно 409-guard): не закрываемся, показываем причину.
+      setError(apiError(e, 'Не удалось выполнить действие.'));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={o => { if (!busy) onOpenChange(o); }}>
       <Dialog.Portal>
         <Dialog.Overlay
           className="fixed inset-0 z-40 bg-black/40"
@@ -48,40 +77,53 @@ export function ConfirmDialog({
           style={{ boxShadow: 'var(--f-shadow28)' }}
         >
           <Dialog.Title className="text-sm font-semibold mb-2 text-fg1">
-            {title}
+            {error ? errorTitle : title}
           </Dialog.Title>
 
-          {description && (
-            <div className="text-xs mb-3 text-fg3 space-y-1">
-              {description}
+          {error ? (
+            <div className="mt-2 flex items-start gap-2.5 rounded-md bg-danger-subtle px-3 py-2.5 text-xs text-fg1">
+              <AlertTriangle size={16} className="shrink-0 mt-0.5 text-danger" />
+              <div className="max-h-40 overflow-y-auto whitespace-pre-line">{error}</div>
             </div>
+          ) : (
+            <>
+              {description && (
+                <div className="text-xs mb-3 text-fg3 space-y-1">
+                  {description}
+                </div>
+              )}
+
+              {requireCheckbox && (
+                <label className="flex items-start gap-2 mb-4 text-xs text-fg2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={e => setChecked(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  {requireCheckbox}
+                </label>
+              )}
+            </>
           )}
 
-          {requireCheckbox && (
-            <label className="flex items-start gap-2 mb-4 text-xs text-fg2 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={checked}
-                onChange={e => setChecked(e.target.checked)}
-                className="mt-0.5"
-              />
-              {requireCheckbox}
-            </label>
-          )}
-
-          {/* items-start + shrink-0 у «Отмена» и multiline+min-w-0 у подтверждения: длинная подпись
-              (в неё вшито имя объекта) переносится внутри кнопки, а не распирает узкий диалог. */}
-          <div className={`flex gap-2 justify-end items-start ${!requireCheckbox ? 'mt-4' : ''}`}>
-            <Dialog.Close asChild>
-              <Button variant="text" size="sm" className="shrink-0">{cancelLabel}</Button>
-            </Dialog.Close>
-            <Button
-              variant="filled" danger size="sm" multiline className="min-w-0"
-              disabled={!canConfirm}
-              onClick={() => { onConfirm(); onOpenChange(false); }}
-            >
-              {confirmLabel}
-            </Button>
+          <div className={`flex gap-2 justify-end items-start ${error || !requireCheckbox ? 'mt-4' : ''}`}>
+            {error ? (
+              <Button variant="tonal" size="sm" onClick={() => onOpenChange(false)}>Понятно</Button>
+            ) : (
+              <>
+                <Dialog.Close asChild>
+                  <Button variant="text" size="sm" className="shrink-0" disabled={busy}>{cancelLabel}</Button>
+                </Dialog.Close>
+                <Button
+                  variant="filled" danger size="sm" multiline className="min-w-0"
+                  disabled={!canConfirm} loading={busy}
+                  onClick={handleConfirm}
+                >
+                  {confirmLabel}
+                </Button>
+              </>
+            )}
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/src/client/src/shared/utils/apiError.ts
+++ b/src/client/src/shared/utils/apiError.ts
@@ -1,5 +1,14 @@
-/** Достаёт человекочитаемое сообщение об ошибке из ответа axios/Error (единый хелпер). */
+/** Достаёт человекочитаемое сообщение об ошибке из ответа axios/Error (единый хелпер).
+ *  Понимает обе формы тела 409/400: объект `{ error | detail }` и сырую строку
+ *  (некоторые эндпоинты отдают `Results.Conflict(ex.Message)` без обёртки). */
 export function apiError(e: unknown, fallback = 'Ошибка'): string {
-  const err = e as { response?: { data?: { error?: string; detail?: string } }; message?: string };
-  return err?.response?.data?.error || err?.response?.data?.detail || err?.message || fallback;
+  const err = e as { response?: { data?: unknown }; message?: string };
+  const data = err?.response?.data;
+  if (typeof data === 'string' && data.trim()) return data;
+  if (data && typeof data === 'object') {
+    const d = data as { error?: string; detail?: string };
+    if (d.error) return d.error;
+    if (d.detail) return d.detail;
+  }
+  return err?.message || fallback;
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.47.4</Version>
+    <Version>0.47.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #273.

## Проблема

Guard'ы (#269 и др.) отдают осмысленный **409 `{ error }`**, но причина в UI почти нигде не показывалась: удаление документа/записи/типа-инстанса/качества/пользователя/ассета — `mutate(id)` без `onError` → **молча терялась**; типы документов/полей — браузерный `alert()`; источники наборов — inline-плашка. Разнобой, toast'а нет.

Согласовано с Дизайнером: причину показываем **реактивно, внутри `ConfirmDialog`** (toast для guard-отказов не годится — транзиентный, не контекстный).

## Изменения

- **`ConfirmDialog`** — `onConfirm` может быть async. При reject промиса диалог **не закрывается**: заголовок → «Удаление невозможно», блок причины (`AlertTriangle` + `bg-danger-subtle`, сообщение backend **как есть**, скролл при длинном), кнопки → одна **«Понятно»**. Кнопка `loading` во время ожидания; overlay/Esc заблокированы, пока идёт запрос. Успех/синхронный void — закрывает как раньше.
- **«Молчаливые» удаления** переведены на **await**-мутацию (документ, запись общих данных, качество, пользователь, ассет шаблона) → причина теперь в диалоге.
- Убраны **`alert(apiError())`** у типов документов и типов полей (+ мёртвые импорты).
- **`SourcesExpander`** — inline-`setDeleteError` схлопнут в тот же механизм (единый паттерн отказа).
- **`apiError`** — устойчив к телу-строке (`Results.Conflict(ex.Message)`) и к `{ error }`.

## Два состояния диалога
- **до попытки:** «Удалить X?» + каскад/чекбокс + `[Отмена] [Удалить]`
- **после 409:** «Удаление невозможно» + блок причины + `[Понятно]`

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

## Follow-up (отдельно, не в этом PR)
- Toast-инфраструктура (успехи / не-блокирующие ошибки).
- Проактив «используется N» + дизейбл кнопки для тяжёлых случаев (тип документа/поля).

🤖 Generated with [Claude Code](https://claude.com/claude-code)