### PR TITLE
feat(types): проактивное «используется N» для типов документов (#275)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -19,6 +19,7 @@ import {
   useUpdateDocumentType,
   useUpdateDocumentTypeSchema,
   useDeleteDocumentType,
+  useDocumentTypeUsage,
   useSetDocumentTypeAbstract,
   useSetDocumentTypeAllowsProxy,
   useSetDocumentTypeGroup,
@@ -701,6 +702,7 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
   dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDuplicate: () => void;
 }) {
   const deleteMutation = useDeleteDocumentType();
+  const { data: usage } = useDocumentTypeUsage(docType.id);
   const groupMutation = useSetDocumentTypeGroup();
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -708,13 +710,24 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
   const effectiveFields = resolveEffectiveFields(docType, allDocTypes);
   const ownFieldCount = parseSchemaFields(docType.schema).length;
   const parentType = docType.parentId ? allDocTypes.find(dt => dt.id === docType.parentId) : null;
-  const hasChildren = allDocTypes.some(dt => dt.parentId === docType.id);
-  // Типы, ссылающиеся на этот тип полем complex/array/doc-ref/doc-array (актуально для составных —
-  // удаление сломало бы ссылки). issue #197 Фаза C — полировка Composite.
+  // Типы, ссылающиеся на этот тип полем complex/array/doc-ref/doc-array (для бейджа «используется: N»).
   const referencedBy = findReferencingTypes(docType.id, allDocTypes);
-  const deleteBlock = hasChildren ? 'Нельзя удалить: есть дочерние типы'
-    : referencedBy.length > 0 ? `Нельзя удалить: используется другими типами (${referencedBy.length})`
-    : null;
+  // Проактивное использование (issue #275): полный набор причин с backend (объекты/шаблоны/качество/
+  // привязки/материализация/наследники/подтип). При наличии — диалог удаления открывается сразу в
+  // состоянии «нельзя» со списком причин; реактивный 409 остаётся страховкой от гонок.
+  const usageReasons = usage?.reasons ?? [];
+  const deleteBlockedNode = usageReasons.length > 0 ? (
+    <div>
+      <p className="mb-1.5 font-medium">Тип используется — сначала снимите зависимости:</p>
+      <ul className="list-disc pl-4 space-y-0.5">
+        {usageReasons.map(r => (
+          <li key={r.kind}>
+            {r.label}{r.names.length > 0 ? `: ${r.names.join(', ')}` : r.count > 0 ? `: ${r.count}` : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  ) : undefined;
   const compositeTypes = allDocTypes.filter(dt => dt.kind === 'Composite');
   const requiredCount = effectiveFields.filter(f => f.required).length;
   const complexFields = effectiveFields.filter(f => f.type === 'complex');
@@ -772,8 +785,8 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
               ...(docType.kind === 'Document'
                 ? [{ key: 'tpl', label: 'Шаблоны данных', icon: <Database size={14} />, onSelect: () => setTemplatesOpen(true) }]
                 : []),
-              { key: 'del', label: deleteBlock ?? 'Удалить тип', danger: true, disabled: deleteMutation.isPending || !!deleteBlock,
-                icon: <Trash2 size={14} />, onSelect: () => { if (!deleteBlock) setDeleteConfirmOpen(true); } },
+              { key: 'del', label: 'Удалить тип', danger: true, disabled: deleteMutation.isPending,
+                icon: <Trash2 size={14} />, onSelect: () => setDeleteConfirmOpen(true) },
             ]} />
           </>
         } />
@@ -794,6 +807,7 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
         description={<p>Это повлияет на все документы и шаблоны, использующие этот тип. Действие необратимо.</p>}
         confirmLabel={`Удалить тип «${docType.name}»`}
         requireCheckbox="Понимаю, что это необратимо"
+        blocked={deleteBlockedNode}
         onConfirm={() => deleteMutation.mutateAsync(docType.id).then(onDeleted)}
       />
     </div>

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -63,6 +63,19 @@ export function useSetDocumentTypeGroup() {
   });
 }
 
+export interface DocumentTypeUsageReason { kind: string; label: string; count: number; names: string[] }
+export interface DocumentTypeUsage { reasons: DocumentTypeUsageReason[]; inUse: boolean }
+
+/** Использование типа документа (issue #275) — проактивно, почему тип нельзя удалить.
+ *  Тот же набор проверок, что и guard удаления; `id` пуст → запрос отключён. */
+export function useDocumentTypeUsage(id: string | undefined) {
+  return useQuery({
+    queryKey: ['document-type-usage', id],
+    enabled: !!id,
+    queryFn: () => apiClient.get<DocumentTypeUsage>(`/document-types/${id}/usage`).then(r => r.data),
+  });
+}
+
 export function useDeleteDocumentType() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/client/src/shared/ui/ConfirmDialog.tsx
+++ b/src/client/src/shared/ui/ConfirmDialog.tsx
@@ -20,6 +20,12 @@ interface ConfirmDialogProps {
   /** Заголовок в состоянии отказа (после ошибки сервера, напр. 409-guard). */
   errorTitle?: string;
   /**
+   * Проактивная блокировка (issue #275): если задано — диалог сразу открывается в состоянии
+   * «нельзя» (тот же вид, что и реактивная ошибка): заголовок `errorTitle`, этот контент вместо
+   * подтверждения, кнопка только «Понятно». Реактивный 409 остаётся страховкой от гонок.
+   */
+  blocked?: ReactNode;
+  /**
    * Действие подтверждения. Может быть async: если промис отклоняется (напр. 409 «нельзя удалить —
    * используется …»), диалог НЕ закрывается, а показывает причину (apiError) в теле — пользователь
    * видит, почему кнопка «не сработала». Успех (или синхронный void без throw) — закрывает диалог.
@@ -39,7 +45,7 @@ interface ConfirmDialogProps {
  */
 export function ConfirmDialog({
   open, onOpenChange, title, description, confirmLabel, cancelLabel = 'Отмена',
-  requireCheckbox, errorTitle = 'Удаление невозможно', onConfirm,
+  requireCheckbox, errorTitle = 'Удаление невозможно', blocked, onConfirm,
 }: ConfirmDialogProps) {
   const [checked, setChecked] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -50,6 +56,8 @@ export function ConfirmDialog({
   }, [open]);
 
   const canConfirm = !requireCheckbox || checked;
+  // Состояние «нельзя»: проактивная блокировка (blocked) ИЛИ реактивная ошибка после попытки (error).
+  const blockedView = error != null || blocked != null;
 
   async function handleConfirm() {
     setBusy(true);
@@ -77,13 +85,13 @@ export function ConfirmDialog({
           style={{ boxShadow: 'var(--f-shadow28)' }}
         >
           <Dialog.Title className="text-sm font-semibold mb-2 text-fg1">
-            {error ? errorTitle : title}
+            {blockedView ? errorTitle : title}
           </Dialog.Title>
 
-          {error ? (
+          {blockedView ? (
             <div className="mt-2 flex items-start gap-2.5 rounded-md bg-danger-subtle px-3 py-2.5 text-xs text-fg1">
               <AlertTriangle size={16} className="shrink-0 mt-0.5 text-danger" />
-              <div className="max-h-40 overflow-y-auto whitespace-pre-line">{error}</div>
+              <div className="max-h-40 overflow-y-auto whitespace-pre-line min-w-0">{error ?? blocked}</div>
             </div>
           ) : (
             <>
@@ -107,8 +115,8 @@ export function ConfirmDialog({
             </>
           )}
 
-          <div className={`flex gap-2 justify-end items-start ${error || !requireCheckbox ? 'mt-4' : ''}`}>
-            {error ? (
+          <div className={`flex gap-2 justify-end items-start ${blockedView || !requireCheckbox ? 'mt-4' : ''}`}>
+            {blockedView ? (
               <Button variant="tonal" size="sm" onClick={() => onOpenChange(false)}>Понятно</Button>
             ) : (
               <>

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -65,6 +65,13 @@ public static class DocumentTypeEndpoints
         admin.MapPut("/{id:guid}/group", async (Guid id, SetGroupRequest req, IMediator m)
             => Results.Ok(await m.Send(new SetDocumentTypeGroupCommand(id, req.Group))));
 
+        // Использование типа (issue #275) — проактивный показ «чем занят тип» до попытки удаления.
+        admin.MapGet("/{id:guid}/usage", async (Guid id, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new GetDocumentTypeUsageQuery(id))); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
         admin.MapDelete("/{id:guid}", async (Guid id, IMediator m) =>
         {
             try { await m.Send(new DeleteDocumentTypeCommand(id)); return Results.NoContent(); }

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -17,6 +17,19 @@ public record DeleteDocumentTypeCommand(Guid Id) : IRequest;
 public record ListDocumentTypesQuery(DocumentTypeKind? Kind = null) : IRequest<IReadOnlyList<DocumentType>>;
 public record GetDocumentTypeQuery(Guid Id) : IRequest<DocumentType?>;
 
+/// Использование типа документа (issue #275) — чем занят тип, из-за чего его нельзя удалить.
+/// Показывается проактивно (до попытки удаления); те же проверки, что и guard удаления.
+public record GetDocumentTypeUsageQuery(Guid Id) : IRequest<DocumentTypeUsage>;
+
+public record DocumentTypeUsage(IReadOnlyList<DocumentTypeUsageReason> Reasons)
+{
+    public bool InUse => Reasons.Count > 0;
+}
+
+/// Одна причина занятости: Kind — машинный вид, Label — человекочитаемо, Count — сколько (0 для
+/// булева признака вроде «профиль уровня»), Names — примеры имён (для видов, где они уместны).
+public record DocumentTypeUsageReason(string Kind, string Label, int Count, IReadOnlyList<string> Names);
+
 // --- Construction ---
 public record CreateConstructionCommand(string Name, Guid UserId) : IRequest<Construction>;
 public record RenameConstructionCommand(Guid Id, string Name) : IRequest<Construction>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -27,7 +27,8 @@ public class DocumentTypeHandlers(
     IRequestHandler<SetDocumentTypeGroupCommand, DocumentType>,
     IRequestHandler<DeleteDocumentTypeCommand>,
     IRequestHandler<ListDocumentTypesQuery, IReadOnlyList<DocumentType>>,
-    IRequestHandler<GetDocumentTypeQuery, DocumentType?>
+    IRequestHandler<GetDocumentTypeQuery, DocumentType?>,
+    IRequestHandler<GetDocumentTypeUsageQuery, DocumentTypeUsage>
 {
     public async Task<DocumentType> Handle(CreateDocumentTypeCommand cmd, CancellationToken ct)
     {
@@ -141,46 +142,74 @@ public class DocumentTypeHandlers(
         return dt;
     }
 
-    // issue #57: удаление типа не проверяло использование. Ниже — прикладные проверки (по образцу
-    // ParentId-проверки и DataSetSourceService.DeleteSourceAsync). После слияния (issue #84) документы
-    // и записи общих данных — единый DomainObject.CompositeTypeId, поэтому проверка объектов одна.
+    // issue #57: удаление типа не проверяло использование. Проверки вынесены в ComputeUsageAsync —
+    // общий источник для guard'а удаления И проактивного показа (issue #275), чтобы не разъехались.
     public async Task Handle(DeleteDocumentTypeCommand cmd, CancellationToken ct)
     {
         var dt = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
         var all = await repo.GetAllAsync(ct);
-        if (all.Any(x => x.ParentId == cmd.Id))
-            throw new InvalidOperationException("Нельзя удалить тип, от которого наследуются другие типы.");
-
-        // issue #258: тип, назначенный профилем уровня (несёт тэг profile-*), удалять нельзя — снять тэг.
-        if (SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileConstruction)
-            || SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileSection)
-            || SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileSet))
-            throw new InvalidOperationException("Нельзя удалить тип — он назначен профилем уровня. Снимите тэг «Профиль …» перед удалением.");
-
-        if ((await objectRepo.FindAsync(o => o.CompositeTypeId == cmd.Id, ct)).Count > 0)
-            throw new InvalidOperationException("Нельзя удалить тип — по нему уже созданы объекты (документы или записи общих данных).");
-
-        if ((await templateRepo.FindAsync(t => t.DocumentTypeId == cmd.Id, ct)).Count > 0)
-            throw new InvalidOperationException("Нельзя удалить тип — для него есть шаблоны.");
-
-        if ((await qualityDocRepo.FindAsync(q => q.DocumentTypeId == cmd.Id, ct)).Count > 0)
-            throw new InvalidOperationException("Нельзя удалить тип — есть документы качества этого типа.");
-
-        if ((await dataSetService.ListTemplatesAsync(cmd.Id, ct)).Count > 0)
-            throw new InvalidOperationException("Нельзя удалить тип — для него есть шаблоны привязки наборов данных.");
-
-        if (await dataSetService.AnySourceMaterializedAsTypeAsync(cmd.Id, ct))
-            throw new InvalidOperationException("Нельзя удалить тип — на него материализован источник набора данных.");
-
-        // Тип может использоваться как составной подтип внутри схемы ДРУГОГО типа (complex/array/
-        // doc-ref/doc-array поле с typeId == cmd.Id) — сам себя (собственную схему) не проверяем.
-        var usedInSchemas = all.Where(t => t.Id != cmd.Id && DocumentTypeSchemaReader.ReferencesType(t.Schema, cmd.Id)).ToList();
-        if (usedInSchemas.Count > 0)
+        var usage = await ComputeUsageAsync(dt, all, ct);
+        if (usage.InUse)
             throw new InvalidOperationException(
-                $"Нельзя удалить тип — используется как составной подтип в схеме: {string.Join(", ", usedInSchemas.Select(t => t.Name))}.");
+                "Нельзя удалить тип — используется. " + string.Join("; ", usage.Reasons.Select(FormatReason)) + ".");
 
         repo.Remove(dt);
         await repo.SaveChangesAsync(ct);
+    }
+
+    public async Task<DocumentTypeUsage> Handle(GetDocumentTypeUsageQuery q, CancellationToken ct)
+    {
+        var dt = await repo.GetByIdAsync(q.Id, ct) ?? throw new KeyNotFoundException();
+        return await ComputeUsageAsync(dt, await repo.GetAllAsync(ct), ct);
+    }
+
+    private static string FormatReason(DocumentTypeUsageReason r) =>
+        r.Names.Count > 0 ? $"{r.Label}: {string.Join(", ", r.Names)}"
+        : r.Count > 0 ? $"{r.Label}: {r.Count}"
+        : r.Label;
+
+    // Все причины, из-за которых тип нельзя удалить (issue #57 + #258 + #269). После слияния (issue #84)
+    // документы и записи общих данных — единый DomainObject.CompositeTypeId, поэтому проверка объектов одна.
+    private async Task<DocumentTypeUsage> ComputeUsageAsync(DocumentType dt, IReadOnlyList<DocumentType> all, CancellationToken ct)
+    {
+        var reasons = new List<DocumentTypeUsageReason>();
+
+        var children = all.Where(x => x.ParentId == dt.Id).ToList();
+        if (children.Count > 0)
+            reasons.Add(new("children", "Наследуются типы", children.Count, children.Select(c => c.Name).ToList()));
+
+        // issue #258: тип-профиль уровня (несёт тэг profile-*) — снять тэг перед удалением.
+        if (SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileConstruction)
+            || SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileSection)
+            || SchemaTags.SchemaHasTypeTag(dt.Schema, FunctionalTag.ProfileSet))
+            reasons.Add(new("profile", "Назначен профилем уровня (снимите тэг «Профиль …»)", 0, []));
+
+        var objects = await objectRepo.FindAsync(o => o.CompositeTypeId == dt.Id, ct);
+        if (objects.Count > 0)
+            reasons.Add(new("objects", "Созданы объекты (документы или записи общих данных)", objects.Count, []));
+
+        var templates = await templateRepo.FindAsync(t => t.DocumentTypeId == dt.Id, ct);
+        if (templates.Count > 0)
+            reasons.Add(new("templates", "Шаблоны", templates.Count, []));
+
+        var qdocs = await qualityDocRepo.FindAsync(qd => qd.DocumentTypeId == dt.Id, ct);
+        if (qdocs.Count > 0)
+            reasons.Add(new("quality", "Документы качества", qdocs.Count, []));
+
+        var bindingTemplates = await dataSetService.ListTemplatesAsync(dt.Id, ct);
+        if (bindingTemplates.Count > 0)
+            reasons.Add(new("binding-templates", "Шаблоны привязки наборов данных", bindingTemplates.Count, []));
+
+        if (await dataSetService.AnySourceMaterializedAsTypeAsync(dt.Id, ct))
+            reasons.Add(new("materialized", "Материализован источник набора данных", 0, []));
+
+        // Тип может использоваться как составной подтип в схеме ДРУГОГО типа (complex/array/doc-ref/
+        // doc-array поле с typeId == dt.Id) — сам себя (собственную схему) не проверяем.
+        var usedInSchemas = all.Where(t => t.Id != dt.Id && DocumentTypeSchemaReader.ReferencesType(t.Schema, dt.Id)).ToList();
+        if (usedInSchemas.Count > 0)
+            reasons.Add(new("subtype", "Используется как составной подтип в схеме", usedInSchemas.Count, usedInSchemas.Select(t => t.Name).ToList()));
+
+        return new DocumentTypeUsage(reasons);
     }
 
     public async Task<IReadOnlyList<DocumentType>> Handle(ListDocumentTypesQuery q, CancellationToken ct)

--- a/src/server/BHS.CRG.Tests/Integration/DocumentTypeHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentTypeHandlerTests.cs
@@ -177,6 +177,37 @@ public class DocumentTypeHandlerTests(IntegrationTestFixture fixture) : IAsyncLi
         Assert.Null(await Mediator(scope3).Send(new GetDocumentTypeQuery(dt.Id)));
     }
 
+    // issue #275: проактивный usage-запрос — тот же источник проверок, что и guard удаления.
+    [Fact]
+    public async Task Usage_Unused_IsEmpty()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Свободный", "USAGE0", DocumentTypeKind.Document, null, EmptySchema()));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var usage = await Mediator(scope2).Send(new GetDocumentTypeUsageQuery(dt.Id));
+        Assert.False(usage.InUse);
+        Assert.Empty(usage.Reasons);
+    }
+
+    [Fact]
+    public async Task Usage_WithChildren_ReportsReason()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var parent = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Родитель", "USAGE_P", DocumentTypeKind.Document, null, EmptySchema()));
+        await Mediator(scope).Send(
+            new CreateDocumentTypeCommand("Дочерний", "USAGE_C", DocumentTypeKind.Document, parent.Id, EmptySchema()));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var usage = await Mediator(scope2).Send(new GetDocumentTypeUsageQuery(parent.Id));
+        Assert.True(usage.InUse);
+        var reason = Assert.Single(usage.Reasons, r => r.Kind == "children");
+        Assert.Equal(1, reason.Count);
+        Assert.Contains("Дочерний", reason.Names);
+    }
+
     [Fact]
     public async Task Delete_WithDocumentInstance_ThrowsInvalidOperation()
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.47.5</Version>
+    <Version>0.48.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #275. Follow-up к #273 (согласовано с Дизайнером).

## Идея

Для тяжёлого случая — удаление **типа документа** — показывать использование **проактивно**, до попытки, а не только реактивным 409.

## Backend

- **`GET /api/document-types/{id}/usage`** → `{ reasons: [{ kind, label, count, names }], inUse }`.
- Все 8 проверок (наследники / профиль уровня / объекты / шаблоны / документы качества / шаблоны привязок / материализация / составной подтип) вынесены в общий **`ComputeUsageAsync`** — guard удаления и usage используют **один источник** (не разъедутся). Сообщение guard'а теперь перечисляет **все** причины сразу (раньше — первую сработавшую).

## Frontend

- **`ConfirmDialog`** — новый проп `blocked`: проактивное состояние «нельзя» (тот же вид, что и реактивная ошибка): заголовок «Удаление невозможно», список причин, кнопка только «Понятно».
- **`DocumentTypesPage`** — диалог удаления при `inUse` открывается **сразу заблокированным** со списком причин; приблизительная клиентская эвристика (только наследники+ссылки из схемы) заменена на полный backend-usage. Реактивный 409 остаётся страховкой от гонок.

## Проверка

`tsc -b` + `vitest` (130) + backend (**425**, +2 usage) зелёные. Миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)