### PR TITLE
feat(ui): toast-инфраструктура транзиентных уведомлений (#281)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/shared/ui/ThemeProvider';
+import { ToastProvider } from '@/shared/ui/Toast';
 import { AuthProvider } from '@/shared/ui/AuthProvider';
 import { ProtectedRoute, AdminRoute } from '@/shared/ui/ProtectedRoute';
 import { AppShell } from '@/shared/ui/AppShell';
@@ -30,6 +31,7 @@ export default function App() {
     <ThemeProvider>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
+        <ToastProvider>
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
@@ -58,6 +60,7 @@ export default function App() {
             </Route>
           </Routes>
         </BrowserRouter>
+        </ToastProvider>
       </AuthProvider>
     </QueryClientProvider>
     </ThemeProvider>

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavItem, NavSection } from '@/shared/ui/ListDetailShell';
+import { useToast } from '@/shared/ui/Toast';
 import { CatalogResource } from './catalog/CatalogResource';
 import { DataSetsResource } from '@/features/datasets/DataSetsResource';
 import { SubscribersResource } from './SubscribersResource';
@@ -73,6 +74,7 @@ function SetDetail() {
   const { user: me } = useAuth();
   const isAdmin = me?.role === 'Admin';
   const emailSet = useEmailSet();
+  const toast = useToast();
 
   useEffect(() => {
     if (watching && output && output.generatedAt !== watchStartRef.current) {
@@ -114,7 +116,8 @@ function SetDetail() {
     const j = index + dir;
     if (j < 0 || j >= ids.length) return;
     [ids[index], ids[j]] = [ids[j], ids[index]];
-    reorderMutation.mutate({ setId: set!.id, orderedIds: ids });
+    reorderMutation.mutate({ setId: set!.id, orderedIds: ids },
+      { onError: () => toast.error('Не удалось изменить порядок документов') });
   }
 
   // Переставить документ из позиции from в позицию вставки pos (перед instances[pos]; pos=N — в конец).
@@ -124,7 +127,8 @@ function SetDetail() {
     const [moved] = ids.splice(from, 1);
     const insertAt = pos > from ? pos - 1 : pos; // учёт сдвига после удаления
     ids.splice(insertAt, 0, moved);
-    reorderMutation.mutate({ setId: set!.id, orderedIds: ids });
+    reorderMutation.mutate({ setId: set!.id, orderedIds: ids },
+      { onError: () => toast.error('Не удалось изменить порядок документов') });
   }
   function endDrag() { setDragIndex(null); setDropPos(null); }
   // Позиция вставки по половине строки под курсором (верх → перед, низ → после) — полный диапазон, вкл. конец.

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -46,6 +46,7 @@ import {
 } from './typeEditorShell';
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
+import { useToast } from '@/shared/ui/Toast';
 import { uniqueCode } from './PrimitiveTypesPage';
 
 /** Единственное членство (issue #197 Фаза C): каждый ключ поля остаётся только в первой группе,
@@ -703,6 +704,7 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
 }) {
   const deleteMutation = useDeleteDocumentType();
   const { data: usage } = useDocumentTypeUsage(docType.id);
+  const toast = useToast();
   const groupMutation = useSetDocumentTypeGroup();
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -779,7 +781,8 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
         actions={
           <>
             <GroupPicker groups={allGroups} value={docType.group}
-              onChange={group => groupMutation.mutate({ id: docType.id, group })} />
+              onChange={group => groupMutation.mutate({ id: docType.id, group },
+                { onError: () => toast.error('Не удалось изменить группу типа') })} />
             <RowActionsMenu ariaLabel="Действия типа" actions={[
               { key: 'dup', label: 'Дублировать', icon: <Copy size={14} />, onSelect: onDuplicate },
               ...(docType.kind === 'Document'

--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -202,3 +202,9 @@ body {
     background-color: var(--f-bg1);
   }
 }
+
+/* Появление тоста (issue #281) — лёгкий slide-up + fade. */
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: none; }
+}

--- a/src/client/src/shared/ui/Toast.tsx
+++ b/src/client/src/shared/ui/Toast.tsx
@@ -1,0 +1,106 @@
+import * as RT from '@radix-ui/react-toast';
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
+import { CheckCircle2, AlertTriangle, Info, X, type LucideIcon } from 'lucide-react';
+
+/**
+ * Эфемерные уведомления (issue #281) поверх `@radix-ui/react-toast` — swipe-dismiss, пауза на
+ * hover/focus, `aria-live`, очередь и таймеры даёт Radix. НЕ для guard-отказов удаления (те в
+ * диалоге, #273) и не дублирует контекстные места (flash у кнопки, колокольчик фон-задач).
+ * Инвариант: тост — для результата, не видимого на текущем экране, или не-блокирующего сетевого
+ * сбоя без своего места.
+ */
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface ToastOptions {
+  message: string;
+  variant?: ToastVariant;
+  /** Мс до авто-скрытия. По умолчанию: success/info 4с, error 8с. */
+  duration?: number;
+  /** Опциональное одиночное действие (текст-кнопка справа) — напр. «Перейти». */
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastItem extends ToastOptions { id: number }
+
+interface ToastApi {
+  toast: (o: ToastOptions) => void;
+  success: (message: string, o?: Omit<ToastOptions, 'message' | 'variant'>) => void;
+  error: (message: string, o?: Omit<ToastOptions, 'message' | 'variant'>) => void;
+  info: (message: string, o?: Omit<ToastOptions, 'message' | 'variant'>) => void;
+}
+
+const ToastCtx = createContext<ToastApi | null>(null);
+
+const MAX_VISIBLE = 3;
+const DEFAULT_DURATION: Record<ToastVariant, number> = { success: 4000, info: 4000, error: 8000 };
+
+const VARIANT_ICON: Record<ToastVariant, LucideIcon> = { success: CheckCircle2, error: AlertTriangle, info: Info };
+const VARIANT_ICON_COLOR: Record<ToastVariant, string> = {
+  success: 'text-success', error: 'text-danger', info: 'text-fg3',
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([]);
+  const idRef = useRef(0);
+
+  const push = useCallback((o: ToastOptions) => {
+    setItems(prev => [...prev, { ...o, id: ++idRef.current }].slice(-MAX_VISIBLE));
+  }, []);
+  const remove = useCallback((id: number) => setItems(prev => prev.filter(t => t.id !== id)), []);
+
+  const api = useMemo<ToastApi>(() => ({
+    toast: push,
+    success: (message, o) => push({ ...o, message, variant: 'success' }),
+    error: (message, o) => push({ ...o, message, variant: 'error' }),
+    info: (message, o) => push({ ...o, message, variant: 'info' }),
+  }), [push]);
+
+  return (
+    <ToastCtx.Provider value={api}>
+      <RT.Provider swipeDirection="right">
+        {children}
+        {items.map(t => <ToastCard key={t.id} item={t} onRemove={() => remove(t.id)} />)}
+        <RT.Viewport className="fixed bottom-4 right-4 z-[100] flex w-[380px] max-w-[calc(100vw-2rem)] flex-col gap-2 outline-none" />
+      </RT.Provider>
+    </ToastCtx.Provider>
+  );
+}
+
+/** Доступ к тостам. Должен вызываться под `ToastProvider` (смонтирован в App). */
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastCtx);
+  if (!ctx) throw new Error('useToast должен использоваться внутри ToastProvider');
+  return ctx;
+}
+
+function ToastCard({ item, onRemove }: { item: ToastItem; onRemove: () => void }) {
+  const variant = item.variant ?? 'info';
+  const Icon = VARIANT_ICON[variant];
+  const bg = variant === 'error' ? 'bg-danger-subtle' : 'bg-surface';
+  return (
+    <RT.Root
+      duration={item.duration ?? DEFAULT_DURATION[variant]}
+      // error — foreground (assertive/role=alert); успех/инфо — background (polite/role=status).
+      type={variant === 'error' ? 'foreground' : 'background'}
+      onOpenChange={open => { if (!open) onRemove(); }}
+      className={`flex items-start gap-2.5 rounded-lg border border-stroke ${bg} px-3.5 py-3 shadow-[var(--f-shadow16)]
+        data-[state=open]:[animation:toast-in_150ms_ease-out]
+        data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)]
+        data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-transform
+        data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)]`}
+    >
+      <Icon size={18} className={`mt-0.5 shrink-0 ${VARIANT_ICON_COLOR[variant]}`} />
+      <RT.Description className="flex-1 min-w-0 text-sm text-fg1">{item.message}</RT.Description>
+      {item.action && (
+        <RT.Action altText={item.action.label} asChild onClick={() => item.action!.onClick()}>
+          <button type="button" className="shrink-0 text-sm font-medium text-brand hover:text-brand-hover transition-colors">
+            {item.action.label}
+          </button>
+        </RT.Action>
+      )}
+      <RT.Close aria-label="Закрыть" className="shrink-0 text-fg4 hover:text-fg2 transition-colors">
+        <X size={15} />
+      </RT.Close>
+    </RT.Root>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.48.2</Version>
+    <Version>0.49.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #281. Согласовано с Дизайнером.

## Что

Общего примитива эфемерных уведомлений в приложении не было. Заведён `ToastProvider` + `useToast()` на `@radix-ui/react-toast` (уже была в deps — swipe-dismiss, пауза на hover/focus, `aria-live`, очередь и таймеры из коробки).

**НЕ для guard-отказов удаления** (те в диалоге, #273). Инвариант: тост — для результата, не видимого на текущем экране, или не-блокирующего сетевого сбоя без своего места; где есть контекстное место (flash у кнопки, ошибка в диалоге, колокольчик фон-задач) — не дублирует.

## Примитив

- `useToast()` → `success/error/info({ message, action?, duration? })`.
- Позиция снизу-справа (верх-право занят колокольчиком + пилюлей задач).
- Варианты: success (`CheckCircle2`/`text-success`), error (`AlertTriangle`/`bg-danger-subtle` — «весит» больше), info. Крестик всегда; авто success/info ~4с, error ~8с; пауза на hover/focus.
- Стек max 3 (новые снизу), опциональное одиночное действие-ссылка.
- A11y: error → `foreground` (assertive/alert), success/info → `background` (polite/status).
- Смонтирован в `App` вокруг роутера; keyframe `toast-in` в `index.css`.

## Подключения (2 ранее «молчащих» места)

- Сбой изменения **порядка документов** (`DocumentSetsPage`, DnD/↑↓ — был `mutate` без `onError`).
- Сбой смены **группы типа** (`DocumentTypesPage`).

Тосты успеха копирования/переноса документа подключатся при реализации B/C/D (отложено).

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)