### PR TITLE
feat(documents): дублировать документ в тот же комплект (#283, фаза B)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
 import {
-  Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical,
+  Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy,
   ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail, Database, Table2, Users,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
@@ -25,6 +25,7 @@ import {
 } from '@/shared/api/constructions';
 import {
   useGetDocumentSet, useGetAvailableInstances, useAddDocumentToSet, useDeleteDocumentInstance,
+  useDuplicateDocumentInstance,
   useReorderInstances, useAssembleSet, useDocumentSetOutput, downloadSetOutput,
   useSearchDocuments, downloadGeneratedFile, previewGeneratedFile,
 } from '@/shared/api/documentSets';
@@ -52,6 +53,7 @@ function SetDetail() {
   const [editDirty, setEditDirty] = useState(false);
   const addMutation = useAddDocumentToSet();
   const deleteMutation = useDeleteDocumentInstance();
+  const duplicateMutation = useDuplicateDocumentInstance();
   const reorderMutation = useReorderInstances();
   const assembleMutation = useAssembleSet();
   const renameSet = useRenameDocumentSet();
@@ -308,13 +310,15 @@ function SetDetail() {
                         )}
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-right">
-                      <IconButton label="Удалить документ" size="sm" danger
-                        onClick={e => { e.stopPropagation(); setDeleteTarget(inst); }}
-                        disabled={deleteMutation.isPending}
-                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
-                        <Trash2 size={14} />
-                      </IconButton>
+                    <td className="px-4 py-3 text-right" onClick={e => e.stopPropagation()}>
+                      <RowActionsMenu ariaLabel="Действия документа" actions={[
+                        { key: 'dup', label: 'Дублировать', icon: <Copy size={14} />,
+                          disabled: duplicateMutation.isPending,
+                          onSelect: () => duplicateMutation.mutate({ setId: set.id, instanceId: inst.id },
+                            { onError: () => toast.error('Не удалось дублировать документ') }) },
+                        { key: 'del', label: 'Удалить документ', icon: <Trash2 size={14} />, danger: true,
+                          disabled: deleteMutation.isPending, onSelect: () => setDeleteTarget(inst) },
+                      ]} />
                     </td>
                   </tr>
                 );

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -43,6 +43,17 @@ export function useAddDocumentToSet() {
   });
 }
 
+export function useDuplicateDocumentInstance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ setId, instanceId }: { setId: string; instanceId: string }) =>
+      apiClient
+        .post<DocumentInstance>(`/document-sets/${setId}/documents/${instanceId}/duplicate`)
+        .then((r) => r.data),
+    onSuccess: (_d, { setId }) => qc.invalidateQueries({ queryKey: ['document-sets', setId] }),
+  });
+}
+
 export function useRenameDocumentInstance() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -99,6 +99,13 @@ public static class DocumentSetEndpoints
         g.MapPost("/{setId:guid}/documents", async (Guid setId, AddDocumentRequest req, IMediator m)
             => Results.Ok(InstanceDto.From(await m.Send(new AddDocumentToSetCommand(setId, req.DocumentTypeId)))));
 
+        // issue #283 (фаза B): дублировать документ в тот же комплект.
+        g.MapPost("/{setId:guid}/documents/{id:guid}/duplicate", async (Guid id, IMediator m) =>
+        {
+            try { return Results.Ok(InstanceDto.From(await m.Send(new DuplicateDocumentInstanceCommand(id)))); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+
         g.MapGet("/{setId:guid}/documents/{id:guid}", async (Guid id, IMediator m) =>
         {
             var inst = await m.Send(new GetDocumentInstanceQuery(id));

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -54,6 +54,9 @@ public record AddDocumentToSetCommand(Guid DocumentSetId, Guid DocumentTypeId) :
 public record ReorderDocumentInstancesCommand(Guid SetId, IReadOnlyList<Guid> OrderedInstanceIds) : IRequest<DocumentSet>;
 public record RenameDocumentInstanceCommand(Guid Id, string? Name) : IRequest<DomainObject>;
 public record DeleteDocumentInstanceCommand(Guid Id) : IRequest;
+/// Дублировать документ в ТОТ ЖЕ комплект (issue #283, фаза B): клон в конец, «Копия …»,
+/// все ссылки/_baseRef сохраняются (тот же scope), свежий черновик без PDF.
+public record DuplicateDocumentInstanceCommand(Guid InstanceId) : IRequest<DomainObject>;
 public record UpdateRequisitesCommand(Guid InstanceId, JsonDocument Requisites) : IRequest<DomainObject>;
 public record UpdatePluginDataCommand(Guid InstanceId, JsonDocument PluginData) : IRequest<DomainObject>;
 public record GetDocumentInstanceQuery(Guid Id) : IRequest<DomainObject?>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -295,6 +295,7 @@ public class DocumentSetHandlers(
     IRepository<DocumentSet> setRepo,
     IRepository<Section> sectionRepo,
     IDomainObjectRepository objRepo,
+    IRepository<DocumentType> docTypeRepo,
     IBlobStorage blobStorage) :
     IRequestHandler<CreateDocumentSetCommand, DocumentSet>,
     IRequestHandler<RenameDocumentSetCommand, DocumentSet>,
@@ -305,6 +306,7 @@ public class DocumentSetHandlers(
     IRequestHandler<ReorderDocumentInstancesCommand, DocumentSet>,
     IRequestHandler<RenameDocumentInstanceCommand, DomainObject>,
     IRequestHandler<DeleteDocumentInstanceCommand>,
+    IRequestHandler<DuplicateDocumentInstanceCommand, DomainObject>,
     IRequestHandler<UpdateRequisitesCommand, DomainObject>,
     IRequestHandler<UpdatePluginDataCommand, DomainObject>,
     IRequestHandler<GetDocumentInstanceQuery, DomainObject?>,
@@ -411,6 +413,30 @@ public class DocumentSetHandlers(
                 $"Нельзя удалить документ — на него ссылаются другие объекты: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
         objRepo.Remove(obj);
         await objRepo.SaveChangesAsync(ct);
+    }
+
+    // issue #283 (фаза B): дубль в ТОТ ЖЕ комплект. Ссылки/_baseRef валидны в том же scope —
+    // сохраняем как есть (cross-set скраб — отдельные команды copy/move). Свежий черновик без PDF.
+    public async Task<DomainObject> Handle(DuplicateDocumentInstanceCommand cmd, CancellationToken ct)
+    {
+        var source = await objRepo.GetByIdAsync(cmd.InstanceId, ct) ?? throw new KeyNotFoundException();
+        if (!source.IsDocument) throw new InvalidOperationException("Дублировать можно только документ комплекта.");
+        var setId = source.ScopeId!.Value;
+
+        var docs = await objRepo.GetSetDocumentsAsync(setId, tracked: false, ct);
+        var maxOrder = docs.Count == 0 ? -1 : docs.Max(d => d.SortOrder);
+
+        // Deep-clone Data (независимый JsonDocument): _baseRef и $ref сохраняются — тот же комплект.
+        var data = JsonDocument.Parse(source.Data.RootElement.GetRawText());
+        var baseName = source.DisplayName
+            ?? (await docTypeRepo.GetByIdAsync(source.CompositeTypeId, ct))?.Name
+            ?? "документа";
+        var clone = DomainObject.CloneAsDocument(source, setId, data, $"Копия {baseName}");
+        clone.SetSortOrder(maxOrder + 1);
+
+        await objRepo.AddAsync(clone, ct);
+        await objRepo.SaveChangesAsync(ct);
+        return clone;
     }
 
     public async Task<DomainObject> Handle(UpdateRequisitesCommand cmd, CancellationToken ct)

--- a/src/server/BHS.CRG.Domain/Objects/DomainObject.cs
+++ b/src/server/BHS.CRG.Domain/Objects/DomainObject.cs
@@ -63,6 +63,25 @@ public class DomainObject : Entity
             Aliases = NormalizeAliases(aliases), CreatedAt = createdAt, UpdatedAt = updatedAt,
         };
 
+    /// <summary>
+    /// Клон как документ (issue #283, дублировать/копировать/перенести): новый объект того же типа
+    /// в целевом Set-scope с переданными (уже клонированными/обработанными вызывающим) данными.
+    /// Копирует конфиг шаблонов и алиасы; фасета свежая — Draft, без сгенерированных файлов,
+    /// PluginData пуст (это generation-кэш, при Draft невалиден). SortOrder выставляет вызывающий.
+    /// </summary>
+    public static DomainObject CloneAsDocument(DomainObject source, Guid targetSetId, JsonDocument data, string? displayName)
+    {
+        var clone = Create(source.CompositeTypeId, displayName, data, CatalogScope.Set, targetSetId, source.Aliases);
+        clone.EnsureFacet();
+        if (source.Facet is not null)
+        {
+            clone.SetTemplate(source.Facet.TemplateId);
+            clone.SetTemplateIds(source.Facet.TemplateIds);
+            clone.SetTemplateParams(source.Facet.TemplateParams);
+        }
+        return clone;
+    }
+
     /// <summary>Делает объект документом (создаёт фасету, если ещё нет). Возвращает фасету.</summary>
     public DocumentFacet EnsureFacet()
     {

--- a/src/server/BHS.CRG.Tests/Integration/DocumentSetHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentSetHandlerTests.cs
@@ -117,6 +117,46 @@ public class DocumentSetHandlerTests(IntegrationTestFixture fixture) : IAsyncLif
         Assert.Equal(dtId, inst.CompositeTypeId);
     }
 
+    // issue #283 (фаза B): дубль в тот же комплект — «Копия …», реквизиты клонированы, в конце,
+    // свежий черновик; исходный на месте.
+    [Fact]
+    public async Task DuplicateDocumentInstance_ClonesIntoSameSet()
+    {
+        var (_, section) = await CreateConstructionWithSectionAsync();
+        var dtId = await CreateDocTypeAsync("AOSR_DUP");
+
+        Guid setId, srcId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var set = await Mediator(scope).Send(new CreateDocumentSetCommand(section.Id, "Комплект"));
+            setId = set.Id;
+            var inst = await Mediator(scope).Send(new AddDocumentToSetCommand(set.Id, dtId));
+            await Mediator(scope).Send(new RenameDocumentInstanceCommand(inst.Id, "Акт-1"));
+            await Mediator(scope).Send(new UpdateRequisitesCommand(inst.Id, JsonDocument.Parse(@"{""Номер"":""7""}")));
+            srcId = inst.Id;
+        }
+
+        Guid copyId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var copy = await Mediator(scope).Send(new DuplicateDocumentInstanceCommand(srcId));
+            copyId = copy.Id;
+            Assert.NotEqual(srcId, copy.Id);
+            Assert.Equal(setId, copy.ScopeId);
+            Assert.Equal(dtId, copy.CompositeTypeId);
+            Assert.Equal("Копия Акт-1", copy.DisplayName);
+            using var data = copy.Data;
+            Assert.Equal("7", data.RootElement.GetProperty("Номер").GetString());
+        }
+
+        // Оба существуют (исходный на месте).
+        using (var scope = fixture.Services.CreateScope())
+        {
+            Assert.NotNull(await Mediator(scope).Send(new GetDocumentInstanceQuery(srcId)));
+            Assert.NotNull(await Mediator(scope).Send(new GetDocumentInstanceQuery(copyId)));
+        }
+    }
+
     [Fact]
     public async Task UpdateRequisites_PersistsJson()
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.49.0</Version>
+    <Version>0.49.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #283 (фаза B из B/C/D). Первая команда — самая простая (тот же комплект, без стратегии/пикера).

## Backend

- **`DomainObject.CloneAsDocument(source, targetSetId, data, displayName)`** — доменная фабрика клона: новый объект того же типа в Set-scope, копия конфига шаблонов + алиасов, **свежая фасета** (Draft, без сгенерированных PDF, `PluginData` пуст). `SortOrder` ставит вызывающий. Переиспользуется в C/D.
- **`DuplicateDocumentInstanceCommand`** + хендлер в `DocumentSetHandlers`: deep-clone `Data` (`GetRawText` → независимый `JsonDocument`), имя «Копия {имя\|тип}», в конец комплекта. Ссылки/`_baseRef` **сохраняются** (тот же scope → валидны). Только документ (иначе 409).
- **`POST /document-sets/{setId}/documents/{id}/duplicate`** (`InvalidOperationException` → 409).

## Frontend

- Строки документов получили **kebab** (`RowActionsMenu`): **Дублировать** + **Удалить**. Удаление переехало из hover-корзины в меню (готовим место под Скопировать/Перенести в C/D). Ошибка дубля → toast (#281).

## Проверка

`tsc -b` + `vitest` (130) + backend (**426**, +1 тест дубля) зелёные. Миграций нет.

## Дальше (в #283)
Фаза C — Скопировать в другой комплект (пикер + скраб B/A + предупреждения-превью). Фаза D — Перенести (входящий guard + ResetToDraft + confirm + переход).

🤖 Generated with [Claude Code](https://claude.com/claude-code)