### PR TITLE
feat(documents): скопировать документ в другой комплект (#283, фаза C)

### DIFF
--- a/src/client/src/features/document-sets/CopyDocumentDialog.tsx
+++ b/src/client/src/features/document-sets/CopyDocumentDialog.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { useToast } from '@/shared/ui/Toast';
+import { usePreviewCopyDocument, useCopyDocument, type CopyWarning } from '@/shared/api/documentSets';
+import type { Construction } from '@/shared/api/types';
+
+interface TargetSet { id: string; name: string; constructionId: string }
+
+/**
+ * Поток «Скопировать документ в другой комплект» (issue #283, фаза C): пикер комплекта (в стиле
+ * TypePicker, подпись «Стройка › Раздел») → превью затронутых ссылок (dry-run) в диалоге ДО
+ * подтверждения → копирование → тост с переходом. Стратегия B «умная очистка» (backend);
+ * опция A «снимок» — фаза C2.
+ */
+export function CopyDocumentDialog({ open, onClose, setId, instance, constructions }: {
+  open: boolean;
+  onClose: () => void;
+  setId: string;
+  instance: { id: string; name: string };
+  constructions: Construction[];
+}) {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const copyMutation = useCopyDocument();
+  const [target, setTarget] = useState<TargetSet | null>(null);
+  const targetRef = useRef<TargetSet | null>(null);
+
+  useEffect(() => { if (!open) { setTarget(null); targetRef.current = null; } }, [open]);
+
+  // Плоский список комплектов для пикера (текущий исключаем — копирование только в другой).
+  const options: PickType[] = [];
+  const meta = new Map<string, TargetSet>();
+  for (const c of constructions)
+    for (const s of c.sections)
+      for (const ds of s.documentSets) {
+        if (ds.id === setId) continue;
+        options.push({ id: ds.id, name: ds.name, code: s.name, section: c.name });
+        meta.set(ds.id, { id: ds.id, name: ds.name, constructionId: c.id });
+      }
+
+  function handleSelect(id: string) {
+    const t = meta.get(id) ?? null;
+    targetRef.current = t;
+    setTarget(t);
+  }
+
+  const { data: warnings = [], isFetching } = usePreviewCopyDocument(setId, instance.id, target?.id);
+
+  async function handleCopy() {
+    if (!target) return;
+    await copyMutation.mutateAsync({ setId, instanceId: instance.id, targetSetId: target.id });
+    const t = target;
+    toast.success(`Скопировано в «${t.name}»`, {
+      action: { label: 'Перейти', onClick: () => navigate(`/document-sets/${t.constructionId}/sets/${t.id}`) },
+    });
+    onClose();
+  }
+
+  return (
+    <>
+      <TypePicker
+        open={open && target === null}
+        onOpenChange={o => { if (!o && !targetRef.current) onClose(); }}
+        title="Скопировать в комплект"
+        recentKey="copy-target-set"
+        types={options}
+        onSelect={handleSelect}
+      />
+
+      <ConfirmDialog
+        open={open && target !== null}
+        onOpenChange={o => { if (!o) { setTarget(null); targetRef.current = null; onClose(); } }}
+        title={`Скопировать «${instance.name}» в «${target?.name ?? ''}»?`}
+        description={
+          isFetching
+            ? <p className="text-fg4">Проверка ссылок…</p>
+            : <CopyWarnings warnings={warnings} />
+        }
+        confirmLabel="Скопировать"
+        onConfirm={handleCopy}
+      />
+    </>
+  );
+}
+
+/** Список предупреждений о затронутых ссылках, сгруппированный по виду; doc-ref — с именами полей. */
+function CopyWarnings({ warnings }: { warnings: CopyWarning[] }) {
+  if (warnings.length === 0)
+    return <p>Ссылки в порядке — будет создана полная копия в выбранном комплекте.</p>;
+  return (
+    <>
+      <p className="mb-1.5">При копировании в другой комплект:</p>
+      <ul className="list-disc pl-4 space-y-0.5">
+        {warnings.map(w => (
+          <li key={w.kind}>
+            {w.label}{w.count > 1 ? ` (${w.count})` : ''}
+            {w.names.length > 0 && <span className="text-fg4">: {w.names.join(', ')}</span>}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
 import {
-  Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy,
+  Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy, FolderInput,
   ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail, Database, Table2, Users,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
@@ -13,6 +13,7 @@ import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavItem, NavSection } from '@/shared/ui/ListDetailShell';
 import { useToast } from '@/shared/ui/Toast';
+import { CopyDocumentDialog } from './CopyDocumentDialog';
 import { CatalogResource } from './catalog/CatalogResource';
 import { DataSetsResource } from '@/features/datasets/DataSetsResource';
 import { SubscribersResource } from './SubscribersResource';
@@ -46,6 +47,7 @@ function SetDetail() {
   const activePanel: SetPanel = (['catalog', 'datasets', 'subscribers'].includes(panel ?? '') ? panel : 'documents') as SetPanel;
   const { data: set, isLoading } = useGetDocumentSet(setId);
   const { data: construction } = useGetConstruction(constructionId!);
+  const { data: allConstructions = [] } = useListConstructions();
   const { data: availableInstances = [] } = useGetAvailableInstances(setId);
   const { data: docTypes = [] } = useListDocumentTypes();
   const [addDocOpen, setAddDocOpen] = useState(false);
@@ -60,6 +62,7 @@ function SetDetail() {
   const deleteSet = useDeleteDocumentSet();
   const [addError, setAddError] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<DocumentInstance | null>(null);
+  const [copyInstance, setCopyInstance] = useState<DocumentInstance | null>(null);
   const [renameSetOpen, setRenameSetOpen] = useState(false);
   const [renameSetVal, setRenameSetVal] = useState('');
   const [deleteSetConfirm, setDeleteSetConfirm] = useState(false);
@@ -316,6 +319,8 @@ function SetDetail() {
                           disabled: duplicateMutation.isPending,
                           onSelect: () => duplicateMutation.mutate({ setId: set.id, instanceId: inst.id },
                             { onError: () => toast.error('Не удалось дублировать документ') }) },
+                        { key: 'copy', label: 'Скопировать в комплект', icon: <FolderInput size={14} />,
+                          onSelect: () => setCopyInstance(inst) },
                         { key: 'del', label: 'Удалить документ', icon: <Trash2 size={14} />, danger: true,
                           disabled: deleteMutation.isPending, onSelect: () => setDeleteTarget(inst) },
                       ]} />
@@ -394,6 +399,16 @@ function SetDetail() {
           if (editInstance?.id === deleteTarget.id) setEditInstance(null);
         }}
       />
+
+      {copyInstance && (
+        <CopyDocumentDialog
+          open={!!copyInstance}
+          onClose={() => setCopyInstance(null)}
+          setId={set.id}
+          instance={{ id: copyInstance.id, name: copyInstance.name || docTypeMap[copyInstance.documentTypeId]?.name || copyInstance.documentTypeId }}
+          constructions={allConstructions}
+        />
+      )}
 
       <Modal open={renameSetOpen} onOpenChange={setRenameSetOpen} title="Переименовать комплект"
         footer={

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -43,6 +43,33 @@ export function useAddDocumentToSet() {
   });
 }
 
+/** Предупреждение о воздействии копирования/переноса на ссылки (issue #283). */
+export interface CopyWarning { kind: string; label: string; count: number; names: string[] }
+
+/** Dry-run: что затронет копирование в целевой комплект — для превью в диалоге ДО подтверждения. */
+export function usePreviewCopyDocument(setId: string, instanceId: string | undefined, targetSetId: string | undefined) {
+  return useQuery({
+    queryKey: ['copy-preview', instanceId, targetSetId],
+    enabled: !!instanceId && !!targetSetId,
+    queryFn: () =>
+      apiClient
+        .post<CopyWarning[]>(`/document-sets/${setId}/documents/${instanceId}/copy/preview`, { targetSetId })
+        .then((r) => r.data),
+  });
+}
+
+export function useCopyDocument() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ setId, instanceId, targetSetId }: { setId: string; instanceId: string; targetSetId: string }) =>
+      apiClient
+        .post<{ instance: DocumentInstance; warnings: CopyWarning[] }>(
+          `/document-sets/${setId}/documents/${instanceId}/copy`, { targetSetId })
+        .then((r) => r.data),
+    onSuccess: (_d, { targetSetId }) => qc.invalidateQueries({ queryKey: ['document-sets', targetSetId] }),
+  });
+}
+
 export function useDuplicateDocumentInstance() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -106,6 +106,23 @@ public static class DocumentSetEndpoints
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
+        // issue #283 (фаза C): скопировать документ в ДРУГОЙ комплект (+ dry-run превью предупреждений).
+        g.MapPost("/{setId:guid}/documents/{id:guid}/copy/preview", async (Guid id, CopyDocumentRequest req, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new PreviewCopyDocumentQuery(id, req.TargetSetId, CopyStrategy.SmartCleanup))); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+        g.MapPost("/{setId:guid}/documents/{id:guid}/copy", async (Guid id, CopyDocumentRequest req, IMediator m) =>
+        {
+            try
+            {
+                var result = await m.Send(new CopyDocumentToSetCommand(id, req.TargetSetId, CopyStrategy.SmartCleanup));
+                return Results.Ok(new { instance = InstanceDto.From(result.Instance), warnings = result.Warnings });
+            }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
         g.MapGet("/{setId:guid}/documents/{id:guid}", async (Guid id, IMediator m) =>
         {
             var inst = await m.Send(new GetDocumentInstanceQuery(id));
@@ -227,6 +244,7 @@ public static class DocumentSetEndpoints
     record CreateSetRequest(string Name);
     record RenameRequest(string Name);
     record AddDocumentRequest(Guid DocumentTypeId);
+    record CopyDocumentRequest(Guid TargetSetId);
     record RenameDocumentInstanceRequest(string? Name);
     record SetTemplateRequest(Guid? TemplateId);
     record AssembleSetRequest(Guid[]? InstanceIds);

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -57,6 +57,27 @@ public record DeleteDocumentInstanceCommand(Guid Id) : IRequest;
 /// Дублировать документ в ТОТ ЖЕ комплект (issue #283, фаза B): клон в конец, «Копия …»,
 /// все ссылки/_baseRef сохраняются (тот же scope), свежий черновик без PDF.
 public record DuplicateDocumentInstanceCommand(Guid InstanceId) : IRequest<DomainObject>;
+
+// --- Копирование в другой комплект (issue #283, фаза C) ---
+/// Стратегия обработки исходящих ссылок при копировании/переносе в ДРУГОЙ комплект.
+public enum CopyStrategy
+{
+    /// «Умная очистка» (дефолт): flatten `_baseRef`, стрип `$ref:document/instance`, оставить `$ref:catalog`.
+    SmartCleanup,
+    // Snapshot (независимый снимок) — фаза C2, пока не реализован.
+}
+
+/// Одно предупреждение о воздействии на ссылки (сгруппировано по виду; Names — примеры полей).
+public record CopyWarning(string Kind, string Label, int Count, IReadOnlyList<string> Names);
+
+/// Результат копирования: созданный документ + предупреждения о затронутых ссылках.
+public record CopyResult(DomainObject Instance, IReadOnlyList<CopyWarning> Warnings);
+
+/// Скопировать документ в другой комплект (оригинал остаётся).
+public record CopyDocumentToSetCommand(Guid SourceId, Guid TargetSetId, CopyStrategy Strategy) : IRequest<CopyResult>;
+
+/// Dry-run: какие ссылки затронет копирование/перенос — для превью в диалоге ДО подтверждения.
+public record PreviewCopyDocumentQuery(Guid SourceId, Guid TargetSetId, CopyStrategy Strategy) : IRequest<IReadOnlyList<CopyWarning>>;
 public record UpdateRequisitesCommand(Guid InstanceId, JsonDocument Requisites) : IRequest<DomainObject>;
 public record UpdatePluginDataCommand(Guid InstanceId, JsonDocument PluginData) : IRequest<DomainObject>;
 public record GetDocumentInstanceQuery(Guid Id) : IRequest<DomainObject?>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -307,6 +307,8 @@ public class DocumentSetHandlers(
     IRequestHandler<RenameDocumentInstanceCommand, DomainObject>,
     IRequestHandler<DeleteDocumentInstanceCommand>,
     IRequestHandler<DuplicateDocumentInstanceCommand, DomainObject>,
+    IRequestHandler<CopyDocumentToSetCommand, CopyResult>,
+    IRequestHandler<PreviewCopyDocumentQuery, IReadOnlyList<CopyWarning>>,
     IRequestHandler<UpdateRequisitesCommand, DomainObject>,
     IRequestHandler<UpdatePluginDataCommand, DomainObject>,
     IRequestHandler<GetDocumentInstanceQuery, DomainObject?>,
@@ -438,6 +440,91 @@ public class DocumentSetHandlers(
         await objRepo.SaveChangesAsync(ct);
         return clone;
     }
+
+    // issue #283 (фаза C): копирование в ДРУГОЙ комплект. Оригинал остаётся (входящий guard не нужен —
+    // referrer'ы всё ещё указывают на живой оригинал; guard только для move, фаза D).
+    public async Task<CopyResult> Handle(CopyDocumentToSetCommand cmd, CancellationToken ct)
+    {
+        var (source, targetSet) = await LoadCopyEndpointsAsync(cmd.SourceId, cmd.TargetSetId, ct);
+        var (data, warnings) = await BuildCopyPlanAsync(source, targetSet, cmd.Strategy, ct);
+
+        var docs = await objRepo.GetSetDocumentsAsync(targetSet.Id, tracked: false, ct);
+        var maxOrder = docs.Count == 0 ? -1 : docs.Max(d => d.SortOrder);
+        var baseName = source.DisplayName ?? (await docTypeRepo.GetByIdAsync(source.CompositeTypeId, ct))?.Name ?? "документа";
+        var clone = DomainObject.CloneAsDocument(source, targetSet.Id, data, baseName);
+        clone.SetSortOrder(maxOrder + 1);
+
+        targetSet.TouchUpdatedAt();
+        setRepo.Update(targetSet);
+        await objRepo.AddAsync(clone, ct);
+        await objRepo.SaveChangesAsync(ct);
+        return new CopyResult(clone, warnings);
+    }
+
+    public async Task<IReadOnlyList<CopyWarning>> Handle(PreviewCopyDocumentQuery q, CancellationToken ct)
+    {
+        var (source, targetSet) = await LoadCopyEndpointsAsync(q.SourceId, q.TargetSetId, ct);
+        var (_, warnings) = await BuildCopyPlanAsync(source, targetSet, q.Strategy, ct);
+        return warnings;
+    }
+
+    private async Task<(DomainObject source, DocumentSet targetSet)> LoadCopyEndpointsAsync(Guid sourceId, Guid targetSetId, CancellationToken ct)
+    {
+        var source = await objRepo.GetByIdAsync(sourceId, ct) ?? throw new KeyNotFoundException();
+        if (!source.IsDocument) throw new InvalidOperationException("Копировать можно только документ комплекта.");
+        var targetSet = await setRepo.GetByIdAsync(targetSetId, ct) ?? throw new KeyNotFoundException("Целевой комплект не найден.");
+        return (source, targetSet);
+    }
+
+    /// Скраб исходящих ссылок (стратегия B) + сбор предупреждений. Data результата — независимый JsonDocument.
+    private async Task<(JsonDocument Data, IReadOnlyList<CopyWarning> Warnings)> BuildCopyPlanAsync(
+        DomainObject source, DocumentSet targetSet, CopyStrategy strategy, CancellationToken ct)
+    {
+        _ = strategy; // сейчас только SmartCleanup; Snapshot — фаза C2.
+        var warnings = new List<CopyWarning>();
+
+        // 1) flatten _baseRef — запекаем унаследованные значения (иначе same-set guard молча потеряет их).
+        var (flattened, didFlatten) = await FlattenBaseAsync(source.Data.RootElement, new HashSet<Guid>(), ct);
+        if (didFlatten)
+            warnings.Add(new CopyWarning("baseref", "Базовый экземпляр запечён в значения", 1, []));
+
+        // 2) стрип $ref:document/instance — same-set, в чужом комплекте = мусор.
+        var (scrubbed, strippedFields) = RefScrubber.StripInstanceRefs(flattened);
+        if (strippedFields.Count > 0)
+            warnings.Add(new CopyWarning("doc-ref", "Удалены ссылки на документы комплекта", strippedFields.Count, strippedFields));
+
+        // 3) $ref:catalog — оставляем, но проверяем разрешимость в scope целевого комплекта.
+        var section = await sectionRepo.GetByIdAsync(targetSet.SectionId, ct);
+        var unresolved = 0;
+        foreach (var catId in RefReader.CollectRefIds(scrubbed).Distinct())
+        {
+            var obj = await objRepo.GetByIdAsync(catId, ct);
+            if (obj is null || !InTargetSubtree(obj, targetSet, section?.ConstructionId)) unresolved++;
+        }
+        if (unresolved > 0)
+            warnings.Add(new CopyWarning("catalog-unresolved", "Ссылки на каталог не разрешатся в новом расположении", unresolved, []));
+
+        return (JsonDocument.Parse(scrubbed.GetRawText()), warnings);
+    }
+
+    // Рекурсивный flatten базового экземпляра: base-first merge, drop _baseRef; cycle-guard через visited.
+    private async Task<(JsonElement Data, bool Flattened)> FlattenBaseAsync(JsonElement data, HashSet<Guid> visited, CancellationToken ct)
+    {
+        if (BaseRefReader.GetBaseRefId(data) is not { } baseId || !visited.Add(baseId)) return (data, false);
+        var baseObj = await objRepo.GetByIdAsync(baseId, ct);
+        if (baseObj is null) return (data, false); // висячая база — нечего запекать
+        var (baseData, _) = await FlattenBaseAsync(baseObj.Data.RootElement, visited, ct);
+        return (BaseRefReader.MergeObjects(baseData, data), true);
+    }
+
+    private static bool InTargetSubtree(DomainObject o, DocumentSet targetSet, Guid? targetConstructionId) => o.ScopeLevel switch
+    {
+        CatalogScope.System => true,
+        CatalogScope.Construction => o.ScopeId == targetConstructionId,
+        CatalogScope.Section => o.ScopeId == targetSet.SectionId,
+        CatalogScope.Set => o.ScopeId == targetSet.Id,
+        _ => false,
+    };
 
     public async Task<DomainObject> Handle(UpdateRequisitesCommand cmd, CancellationToken ct)
     {

--- a/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
+++ b/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
@@ -29,6 +29,23 @@ public static class BaseRefReader
         if (!data.TryGetProperty("_baseRef", out var el)) return null;
         return ParseRef(el);
     }
+
+    /// <summary>
+    /// Слияние двух JSON-объектов для _baseRef-наследования: базовые поля первыми, собственные
+    /// переопределяют их на верхнем уровне; ключ «_baseRef» исключается. Чистая функция — единый
+    /// источник для резолвера генерации (<c>EntityResolver</c>) и flatten при копировании (issue #283).
+    /// </summary>
+    public static JsonElement MergeObjects(JsonElement baseData, JsonElement ownData)
+    {
+        var merged = new Dictionary<string, JsonElement>();
+        if (baseData.ValueKind == JsonValueKind.Object)
+            foreach (var p in baseData.EnumerateObject())
+                if (p.Name != "_baseRef") merged[p.Name] = p.Value.Clone();
+        if (ownData.ValueKind == JsonValueKind.Object)
+            foreach (var p in ownData.EnumerateObject())
+                if (p.Name != "_baseRef") merged[p.Name] = p.Value.Clone();
+        return JsonSerializer.SerializeToElement(merged);
+    }
 }
 
 /// <summary>
@@ -82,4 +99,52 @@ public static class DomainObjectReferences
     private static bool ReferencesObject(JsonElement data, Guid targetId)
         => BaseRefReader.GetBaseRefId(data) == targetId
            || RefReader.CollectRefIds(data).Contains(targetId);
+}
+
+/// <summary>
+/// Скраб исходящих ссылок при копировании/переносе документа в ДРУГОЙ комплект (issue #283, стратегия
+/// B «умная очистка»): убирает значения-ссылки `$ref:document/instance` — они структурно same-set и в
+/// чужом комплекте не резолвятся (дали бы сырой `{$ref}` = мусор в PDF). `$ref:catalog` НЕ трогает
+/// (валидность в новом scope проверяется отдельно, для предупреждений). Чистая функция.
+/// </summary>
+public static class RefScrubber
+{
+    /// <summary>
+    /// Очищенная копия data без doc/instance-ссылок + ключи полей верхнего уровня, чьё значение убрано.
+    /// </summary>
+    public static (JsonElement Data, IReadOnlyList<string> StrippedFields) StripInstanceRefs(JsonElement data)
+    {
+        var stripped = new List<string>();
+        var result = Strip(data, topLevel: true, stripped) ?? JsonSerializer.SerializeToElement(new Dictionary<string, JsonElement>());
+        return (result, stripped);
+    }
+
+    // Возвращает null, если узел САМ — doc/instance-ссылка (должен быть удалён вызывающим).
+    private static JsonElement? Strip(JsonElement el, bool topLevel, List<string> stripped)
+    {
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.Object:
+                if (IsInstanceRef(el)) return null;
+                var obj = new Dictionary<string, JsonElement>();
+                foreach (var p in el.EnumerateObject())
+                {
+                    var child = Strip(p.Value, topLevel: false, stripped);
+                    if (child is { } c) obj[p.Name] = c;
+                    else if (topLevel && !stripped.Contains(p.Name)) stripped.Add(p.Name);
+                }
+                return JsonSerializer.SerializeToElement(obj);
+            case JsonValueKind.Array:
+                var arr = new List<JsonElement>();
+                foreach (var item in el.EnumerateArray())
+                    if (Strip(item, topLevel: false, stripped) is { } c) arr.Add(c);
+                return JsonSerializer.SerializeToElement(arr);
+            default:
+                return el.Clone();
+        }
+    }
+
+    private static bool IsInstanceRef(JsonElement el)
+        => el.TryGetProperty("$ref", out var r) && r.ValueKind == JsonValueKind.String
+           && r.GetString() is "document" or "instance";
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -313,12 +313,7 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
     /// </summary>
     private static JsonElement MergeBaseObjects(JsonElement baseData, JsonElement ownData)
     {
-        var merged = new Dictionary<string, JsonElement>();
-        foreach (var p in baseData.EnumerateObject())
-            if (p.Name != "_baseRef") merged[p.Name] = p.Value.Clone();
-        foreach (var p in ownData.EnumerateObject())
-            if (p.Name != "_baseRef") merged[p.Name] = p.Value.Clone();
-
-        return JsonSerializer.SerializeToElement(merged);
+        // Делегируем общему BaseRefReader.MergeObjects — единое правило для резолва и flatten копии (#283).
+        return BaseRefReader.MergeObjects(baseData, ownData);
     }
 }

--- a/src/server/BHS.CRG.Tests/Integration/DocumentSetHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentSetHandlerTests.cs
@@ -157,6 +157,50 @@ public class DocumentSetHandlerTests(IntegrationTestFixture fixture) : IAsyncLif
         }
     }
 
+    // issue #283 (фаза C): копия в другой комплект — _baseRef запекается, $ref:document стрипается,
+    // предупреждения собираются; оригинал остаётся.
+    [Fact]
+    public async Task CopyDocumentToSet_FlattensBaseRef_StripsDocRef_CollectsWarnings()
+    {
+        var (_, section) = await CreateConstructionWithSectionAsync();
+        var dtId = await CreateDocTypeAsync("AOSR_COPY");
+
+        Guid targetSetId, childId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var m = Mediator(scope);
+            var srcSet = await m.Send(new CreateDocumentSetCommand(section.Id, "Источник"));
+            var target = await m.Send(new CreateDocumentSetCommand(section.Id, "Цель"));
+            targetSetId = target.Id;
+
+            var baseDoc = await m.Send(new AddDocumentToSetCommand(srcSet.Id, dtId));
+            await m.Send(new UpdateRequisitesCommand(baseDoc.Id, JsonDocument.Parse(@"{""Общее"":""X""}")));
+
+            var child = await m.Send(new AddDocumentToSetCommand(srcSet.Id, dtId));
+            childId = child.Id;
+            var childData = $@"{{""_baseRef"":""{baseDoc.Id}"",""Своё"":""Y"",""Док"":{{""$ref"":""document"",""instanceId"":""{baseDoc.Id}"",""fieldKey"":""f""}}}}";
+            await m.Send(new UpdateRequisitesCommand(child.Id, JsonDocument.Parse(childData)));
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var result = await Mediator(scope).Send(new CopyDocumentToSetCommand(childId, targetSetId, CopyStrategy.SmartCleanup));
+            Assert.Equal(targetSetId, result.Instance.ScopeId);
+            using var data = result.Instance.Data;
+            var root = data.RootElement;
+            Assert.Equal("X", root.GetProperty("Общее").GetString());   // база запечена
+            Assert.Equal("Y", root.GetProperty("Своё").GetString());     // своё сохранено
+            Assert.False(root.TryGetProperty("_baseRef", out _));         // ссылка на базу убрана
+            Assert.False(root.TryGetProperty("Док", out _));              // doc-ref стрипнут
+            Assert.Contains(result.Warnings, w => w.Kind == "baseref");
+            Assert.Contains(result.Warnings, w => w.Kind == "doc-ref");
+        }
+
+        // Оригинал на месте.
+        using (var scope = fixture.Services.CreateScope())
+            Assert.NotNull(await Mediator(scope).Send(new GetDocumentInstanceQuery(childId)));
+    }
+
     [Fact]
     public async Task UpdateRequisites_PersistsJson()
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.49.1</Version>
+    <Version>0.50.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #283 (фаза C). Стратегия ссылок — **B «умная очистка»** (выбор пользователя: B по умолчанию; A «снимок» — фаза C2).

## Backend

- **`BaseRefReader.MergeObjects`** — общий base-first merge вынесен в Application; `EntityResolver.MergeBaseObjects` теперь делегирует (единый источник для резолва и flatten).
- **`RefScrubber.StripInstanceRefs`** — чистая функция: убирает значения `$ref:document/instance` (структурно same-set, в чужом комплекте дали бы сырой `{$ref}` = мусор в PDF), возвращает имена затронутых полей.
- **`BuildCopyPlanAsync`** (стратегия B): flatten `_baseRef` (запечь унаследованные значения, cycle-guard) → стрип doc/instance-ref → валидация `$ref:catalog` в scope целевого комплекта. Всё воздействие → `CopyWarning[]`.
- **`CopyDocumentToSetCommand`** → `{ instance, warnings }`; **`PreviewCopyDocumentQuery`** — dry-run для превью ДО подтверждения (детект-половина скраба, дёшево). `POST .../copy`, `POST .../copy/preview`.

## Frontend

- **`CopyDocumentDialog`**: пикер целевого комплекта (`TypePicker`-стиль, подпись «Стройка › Раздел», текущий исключён) → превью затронутых ссылок в диалоге ДО подтверждения → копирование → **toast «Скопировано в «X» → Перейти»**.
- Действие **«Скопировать в комплект»** в kebab строки документа.

## Проверка

`tsc -b` + `vitest` (130) + backend (**427**, +1 тест copy) зелёные. Миграций нет.

## Дальше (в #283)
- Фаза D — Перенести (входящий guard #269 + `ResetToDraft` + confirm danger + переход).
- C2 (polish) — опция A «снимок» под «Дополнительно» + сворачивание длинного списка предупреждений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)