### PR TITLE
feat(documents): перенести документ в другой комплект (#283, фаза D)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
 import {
-  Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy, FolderInput,
+  Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy, FolderInput, FolderOutput,
   ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail, Database, Table2, Users,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
@@ -14,6 +14,7 @@ import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavItem, NavSection } from '@/shared/ui/ListDetailShell';
 import { useToast } from '@/shared/ui/Toast';
 import { CopyDocumentDialog } from './CopyDocumentDialog';
+import { MoveDocumentDialog } from './MoveDocumentDialog';
 import { CatalogResource } from './catalog/CatalogResource';
 import { DataSetsResource } from '@/features/datasets/DataSetsResource';
 import { SubscribersResource } from './SubscribersResource';
@@ -63,6 +64,7 @@ function SetDetail() {
   const [addError, setAddError] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<DocumentInstance | null>(null);
   const [copyInstance, setCopyInstance] = useState<DocumentInstance | null>(null);
+  const [moveInstance, setMoveInstance] = useState<DocumentInstance | null>(null);
   const [renameSetOpen, setRenameSetOpen] = useState(false);
   const [renameSetVal, setRenameSetVal] = useState('');
   const [deleteSetConfirm, setDeleteSetConfirm] = useState(false);
@@ -321,6 +323,8 @@ function SetDetail() {
                             { onError: () => toast.error('Не удалось дублировать документ') }) },
                         { key: 'copy', label: 'Скопировать в комплект', icon: <FolderInput size={14} />,
                           onSelect: () => setCopyInstance(inst) },
+                        { key: 'move', label: 'Перенести в комплект', icon: <FolderOutput size={14} />,
+                          onSelect: () => setMoveInstance(inst) },
                         { key: 'del', label: 'Удалить документ', icon: <Trash2 size={14} />, danger: true,
                           disabled: deleteMutation.isPending, onSelect: () => setDeleteTarget(inst) },
                       ]} />
@@ -406,6 +410,17 @@ function SetDetail() {
           onClose={() => setCopyInstance(null)}
           setId={set.id}
           instance={{ id: copyInstance.id, name: copyInstance.name || docTypeMap[copyInstance.documentTypeId]?.name || copyInstance.documentTypeId }}
+          constructions={allConstructions}
+        />
+      )}
+
+      {moveInstance && (
+        <MoveDocumentDialog
+          open={!!moveInstance}
+          onClose={() => setMoveInstance(null)}
+          setId={set.id}
+          currentSetName={set.name}
+          instance={{ id: moveInstance.id, name: moveInstance.name || docTypeMap[moveInstance.documentTypeId]?.name || moveInstance.documentTypeId }}
           constructions={allConstructions}
         />
       )}

--- a/src/client/src/features/document-sets/MoveDocumentDialog.tsx
+++ b/src/client/src/features/document-sets/MoveDocumentDialog.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { useToast } from '@/shared/ui/Toast';
+import { usePreviewMoveDocument, useMoveDocument, type CopyWarning } from '@/shared/api/documentSets';
+import type { Construction } from '@/shared/api/types';
+
+interface TargetSet { id: string; name: string; constructionId: string }
+
+/**
+ * Поток «Перенести документ в другой комплект» (issue #283, фаза D): пикер комплекта → превью
+ * (затронутые ссылки + блокировка по входящим ссылкам) → перенос → переход в целевой комплект.
+ * Строже копирования: документ уходит из текущего; блокируется, если на него ссылаются (guard #269).
+ */
+export function MoveDocumentDialog({ open, onClose, setId, currentSetName, instance, constructions }: {
+  open: boolean;
+  onClose: () => void;
+  setId: string;
+  currentSetName: string;
+  instance: { id: string; name: string };
+  constructions: Construction[];
+}) {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const moveMutation = useMoveDocument();
+  const [target, setTarget] = useState<TargetSet | null>(null);
+  const targetRef = useRef<TargetSet | null>(null);
+
+  useEffect(() => { if (!open) { setTarget(null); targetRef.current = null; } }, [open]);
+
+  const options: PickType[] = [];
+  const meta = new Map<string, TargetSet>();
+  for (const c of constructions)
+    for (const s of c.sections)
+      for (const ds of s.documentSets) {
+        if (ds.id === setId) continue;
+        options.push({ id: ds.id, name: ds.name, code: s.name, section: c.name });
+        meta.set(ds.id, { id: ds.id, name: ds.name, constructionId: c.id });
+      }
+
+  function handleSelect(id: string) {
+    const t = meta.get(id) ?? null;
+    targetRef.current = t;
+    setTarget(t);
+  }
+
+  const { data: preview, isFetching } = usePreviewMoveDocument(setId, instance.id, target?.id);
+  const blockedBy = preview?.blockedBy ?? [];
+  const warnings = preview?.warnings ?? [];
+  const isBlocked = !isFetching && blockedBy.length > 0;
+
+  async function handleMove() {
+    if (!target) return;
+    await moveMutation.mutateAsync({ setId, instanceId: instance.id, targetSetId: target.id });
+    const t = target;
+    onClose();
+    navigate(`/document-sets/${t.constructionId}/sets/${t.id}`);
+    toast.success(`Перенесено в «${t.name}»`);
+  }
+
+  return (
+    <>
+      <TypePicker
+        open={open && target === null}
+        onOpenChange={o => { if (!o && !targetRef.current) onClose(); }}
+        title="Перенести в комплект"
+        recentKey="copy-target-set"
+        types={options}
+        onSelect={handleSelect}
+      />
+
+      <ConfirmDialog
+        open={open && target !== null}
+        onOpenChange={o => { if (!o) { setTarget(null); targetRef.current = null; onClose(); } }}
+        title={`Перенести «${instance.name}» в «${target?.name ?? ''}»?`}
+        errorTitle="Перенос невозможен"
+        blocked={isBlocked
+          ? <BlockedByRefs currentSetName={currentSetName} names={blockedBy} />
+          : undefined}
+        description={
+          isFetching
+            ? <p className="text-fg4">Проверка ссылок…</p>
+            : <MoveInfo currentSetName={currentSetName} warnings={warnings} />
+        }
+        requireCheckbox={!isBlocked && warnings.length > 0
+          ? 'Понимаю: связи, специфичные для комплекта, могут не перенестись'
+          : undefined}
+        confirmLabel="Перенести"
+        onConfirm={handleMove}
+      />
+    </>
+  );
+}
+
+function BlockedByRefs({ currentSetName, names }: { currentSetName: string; names: string[] }) {
+  return (
+    <div>
+      <p className="mb-1.5 font-medium">На документ ссылаются в комплекте «{currentSetName}» — сначала снимите ссылки:</p>
+      <ul className="list-disc pl-4 space-y-0.5">
+        {names.map(n => <li key={n}>{n}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+function MoveInfo({ currentSetName, warnings }: { currentSetName: string; warnings: CopyWarning[] }) {
+  return (
+    <>
+      <p>Документ будет удалён из комплекта «{currentSetName}». Собранный PDF обоих комплектов устареет.</p>
+      {warnings.length > 0 && (
+        <ul className="list-disc pl-4 mt-1.5 space-y-0.5">
+          {warnings.map(w => (
+            <li key={w.kind}>
+              {w.label}{w.count > 1 ? ` (${w.count})` : ''}
+              {w.names.length > 0 && <span className="text-fg4">: {w.names.join(', ')}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -70,6 +70,35 @@ export function useCopyDocument() {
   });
 }
 
+/** Превью переноса: затронутые ссылки + имена объектов, из-за которых перенос заблокирован (#283). */
+export interface MovePreview { warnings: CopyWarning[]; blockedBy: string[] }
+
+export function usePreviewMoveDocument(setId: string, instanceId: string | undefined, targetSetId: string | undefined) {
+  return useQuery({
+    queryKey: ['move-preview', instanceId, targetSetId],
+    enabled: !!instanceId && !!targetSetId,
+    queryFn: () =>
+      apiClient
+        .post<MovePreview>(`/document-sets/${setId}/documents/${instanceId}/move/preview`, { targetSetId })
+        .then((r) => r.data),
+  });
+}
+
+export function useMoveDocument() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ setId, instanceId, targetSetId }: { setId: string; instanceId: string; targetSetId: string }) =>
+      apiClient
+        .post<{ instance: DocumentInstance; warnings: CopyWarning[] }>(
+          `/document-sets/${setId}/documents/${instanceId}/move`, { targetSetId })
+        .then((r) => r.data),
+    onSuccess: (_d, { setId, targetSetId }) => {
+      qc.invalidateQueries({ queryKey: ['document-sets', setId] });
+      qc.invalidateQueries({ queryKey: ['document-sets', targetSetId] });
+    },
+  });
+}
+
 export function useDuplicateDocumentInstance() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -123,6 +123,23 @@ public static class DocumentSetEndpoints
             catch (KeyNotFoundException) { return Results.NotFound(); }
         });
 
+        // issue #283 (фаза D): перенести документ в ДРУГОЙ комплект (+ dry-run превью: warnings + чем заблокирован).
+        g.MapPost("/{setId:guid}/documents/{id:guid}/move/preview", async (Guid id, CopyDocumentRequest req, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new PreviewMoveDocumentQuery(id, req.TargetSetId, CopyStrategy.SmartCleanup))); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+        g.MapPost("/{setId:guid}/documents/{id:guid}/move", async (Guid id, CopyDocumentRequest req, IMediator m) =>
+        {
+            try
+            {
+                var result = await m.Send(new MoveDocumentToSetCommand(id, req.TargetSetId, CopyStrategy.SmartCleanup));
+                return Results.Ok(new { instance = InstanceDto.From(result.Instance), warnings = result.Warnings });
+            }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
         g.MapGet("/{setId:guid}/documents/{id:guid}", async (Guid id, IMediator m) =>
         {
             var inst = await m.Send(new GetDocumentInstanceQuery(id));

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -78,6 +78,16 @@ public record CopyDocumentToSetCommand(Guid SourceId, Guid TargetSetId, CopyStra
 
 /// Dry-run: какие ссылки затронет копирование/перенос — для превью в диалоге ДО подтверждения.
 public record PreviewCopyDocumentQuery(Guid SourceId, Guid TargetSetId, CopyStrategy Strategy) : IRequest<IReadOnlyList<CopyWarning>>;
+
+// --- Перенос в другой комплект (issue #283, фаза D) ---
+/// Перенести документ в другой комплект (уходит из текущего). Блокируется, если на него ссылаются
+/// (входящий guard, как удаление #269); при переносе — тот же скраб исходящих ссылок, что и copy;
+/// сгенерированные PDF сбрасываются (контекст резолва сменился).
+public record MoveDocumentToSetCommand(Guid SourceId, Guid TargetSetId, CopyStrategy Strategy) : IRequest<CopyResult>;
+
+/// Превью переноса: затронутые ссылки (как copy) + имена объектов, из-за которых перенос заблокирован.
+public record MovePreview(IReadOnlyList<CopyWarning> Warnings, IReadOnlyList<string> BlockedBy);
+public record PreviewMoveDocumentQuery(Guid SourceId, Guid TargetSetId, CopyStrategy Strategy) : IRequest<MovePreview>;
 public record UpdateRequisitesCommand(Guid InstanceId, JsonDocument Requisites) : IRequest<DomainObject>;
 public record UpdatePluginDataCommand(Guid InstanceId, JsonDocument PluginData) : IRequest<DomainObject>;
 public record GetDocumentInstanceQuery(Guid Id) : IRequest<DomainObject?>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -309,6 +309,8 @@ public class DocumentSetHandlers(
     IRequestHandler<DuplicateDocumentInstanceCommand, DomainObject>,
     IRequestHandler<CopyDocumentToSetCommand, CopyResult>,
     IRequestHandler<PreviewCopyDocumentQuery, IReadOnlyList<CopyWarning>>,
+    IRequestHandler<MoveDocumentToSetCommand, CopyResult>,
+    IRequestHandler<PreviewMoveDocumentQuery, MovePreview>,
     IRequestHandler<UpdateRequisitesCommand, DomainObject>,
     IRequestHandler<UpdatePluginDataCommand, DomainObject>,
     IRequestHandler<GetDocumentInstanceQuery, DomainObject?>,
@@ -466,6 +468,46 @@ public class DocumentSetHandlers(
         var (source, targetSet) = await LoadCopyEndpointsAsync(q.SourceId, q.TargetSetId, ct);
         var (_, warnings) = await BuildCopyPlanAsync(source, targetSet, q.Strategy, ct);
         return warnings;
+    }
+
+    // issue #283 (фаза D): перенос в другой комплект. Входящий guard (как удаление #269): если на
+    // документ ссылаются — блокируем (в исходном комплекте ссылка повиснет). Тот же скраб исходящих,
+    // что и copy; PDF сбрасываются (контекст резолва сменился).
+    public async Task<CopyResult> Handle(MoveDocumentToSetCommand cmd, CancellationToken ct)
+    {
+        var (source, targetSet) = await LoadCopyEndpointsAsync(cmd.SourceId, cmd.TargetSetId, ct);
+        var srcSetId = source.ScopeId!.Value;
+        if (srcSetId == targetSet.Id) throw new InvalidOperationException("Документ уже в этом комплекте.");
+
+        var referrers = await DomainObjectReferences.FindReferrersAsync(objRepo, source.Id, ct);
+        if (referrers.Count > 0)
+            throw new InvalidOperationException(
+                $"Нельзя перенести документ — на него ссылаются другие объекты: {string.Join(", ", referrers.Select(r => r.DisplayName ?? "без имени"))}.");
+
+        var (data, warnings) = await BuildCopyPlanAsync(source, targetSet, cmd.Strategy, ct);
+        var docs = await objRepo.GetSetDocumentsAsync(targetSet.Id, tracked: false, ct);
+        var maxOrder = docs.Count == 0 ? -1 : docs.Max(d => d.SortOrder);
+
+        var blobs = source.ResetToDraft(); // собранный вывод обоих комплектов устаревает
+        source.SetData(data);
+        source.MoveToSet(targetSet.Id);
+        source.SetSortOrder(maxOrder + 1);
+
+        targetSet.TouchUpdatedAt();
+        setRepo.Update(targetSet);
+        if (await setRepo.GetByIdAsync(srcSetId, ct) is { } srcSet) { srcSet.TouchUpdatedAt(); setRepo.Update(srcSet); }
+        objRepo.Update(source);
+        await objRepo.SaveChangesAsync(ct);
+        foreach (var path in blobs) await blobStorage.DeleteAsync(path, ct);
+        return new CopyResult(source, warnings);
+    }
+
+    public async Task<MovePreview> Handle(PreviewMoveDocumentQuery q, CancellationToken ct)
+    {
+        var (source, targetSet) = await LoadCopyEndpointsAsync(q.SourceId, q.TargetSetId, ct);
+        var referrers = await DomainObjectReferences.FindReferrersAsync(objRepo, source.Id, ct);
+        var (_, warnings) = await BuildCopyPlanAsync(source, targetSet, q.Strategy, ct);
+        return new MovePreview(warnings, referrers.Select(r => r.DisplayName ?? "без имени").ToList());
     }
 
     private async Task<(DomainObject source, DocumentSet targetSet)> LoadCopyEndpointsAsync(Guid sourceId, Guid targetSetId, CancellationToken ct)

--- a/src/server/BHS.CRG.Domain/Objects/DomainObject.cs
+++ b/src/server/BHS.CRG.Domain/Objects/DomainObject.cs
@@ -101,6 +101,9 @@ public class DomainObject : Entity
     public void Rename(string? displayName) { DisplayName = Norm(displayName); TouchUpdatedAt(); }
     public void SetData(JsonDocument data) { Data = data; TouchUpdatedAt(); }
 
+    /// <summary>Перенос документа в другой комплект (issue #283, фаза D): смена носителя Set-scope.</summary>
+    public void MoveToSet(Guid targetSetId) { ScopeLevel = CatalogScope.Set; ScopeId = targetSetId; TouchUpdatedAt(); }
+
     // ── Документные изменения (через фасету; TouchUpdatedAt на объекте) ──────────
     private DocumentFacet Doc => Facet ?? throw new InvalidOperationException("Объект не является документом (нет фасеты).");
 

--- a/src/server/BHS.CRG.Tests/Integration/DocumentSetHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentSetHandlerTests.cs
@@ -201,6 +201,64 @@ public class DocumentSetHandlerTests(IntegrationTestFixture fixture) : IAsyncLif
             Assert.NotNull(await Mediator(scope).Send(new GetDocumentInstanceQuery(childId)));
     }
 
+    // issue #283 (фаза D): перенос — документ меняет комплект (тот же Id), реквизиты переносятся.
+    [Fact]
+    public async Task MoveDocumentToSet_ChangesSet()
+    {
+        var (_, section) = await CreateConstructionWithSectionAsync();
+        var dtId = await CreateDocTypeAsync("AOSR_MOVE");
+
+        Guid targetSetId, docId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var m = Mediator(scope);
+            var srcSet = await m.Send(new CreateDocumentSetCommand(section.Id, "Источник"));
+            var target = await m.Send(new CreateDocumentSetCommand(section.Id, "Цель"));
+            targetSetId = target.Id;
+            var doc = await m.Send(new AddDocumentToSetCommand(srcSet.Id, dtId));
+            docId = doc.Id;
+            await m.Send(new UpdateRequisitesCommand(doc.Id, JsonDocument.Parse(@"{""Номер"":""9""}")));
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var result = await Mediator(scope).Send(new MoveDocumentToSetCommand(docId, targetSetId, CopyStrategy.SmartCleanup));
+            Assert.Equal(docId, result.Instance.Id);       // тот же документ
+            Assert.Equal(targetSetId, result.Instance.ScopeId);
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var moved = await Mediator(scope).Send(new GetDocumentInstanceQuery(docId));
+            Assert.Equal(targetSetId, moved!.ScopeId);
+        }
+    }
+
+    // Перенос блокируется, если на документ ссылаются (входящий guard, как удаление #269).
+    [Fact]
+    public async Task MoveDocumentToSet_BlockedWhenReferenced()
+    {
+        var (_, section) = await CreateConstructionWithSectionAsync();
+        var dtId = await CreateDocTypeAsync("AOSR_MOVEB");
+
+        Guid targetSetId, baseId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var m = Mediator(scope);
+            var srcSet = await m.Send(new CreateDocumentSetCommand(section.Id, "Источник"));
+            var target = await m.Send(new CreateDocumentSetCommand(section.Id, "Цель"));
+            targetSetId = target.Id;
+            var baseDoc = await m.Send(new AddDocumentToSetCommand(srcSet.Id, dtId));
+            baseId = baseDoc.Id;
+            var child = await m.Send(new AddDocumentToSetCommand(srcSet.Id, dtId));
+            await m.Send(new UpdateRequisitesCommand(child.Id, JsonDocument.Parse($@"{{""_baseRef"":""{baseId}""}}")));
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => Mediator(scope).Send(new MoveDocumentToSetCommand(baseId, targetSetId, CopyStrategy.SmartCleanup)));
+    }
+
     [Fact]
     public async Task UpdateRequisites_PersistsJson()
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.50.0</Version>
+    <Version>0.50.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #283 (фаза D). Закрывает эпик B/C/D.

## Backend

- **`DomainObject.MoveToSet(targetSetId)`** — смена носителя Set-scope (тот же документ).
- **`MoveDocumentToSetCommand`**: **входящий guard** (как удаление #269 — блок при referrer'ах: иначе в исходном комплекте ссылка повиснет) + тот же скраб исходящих ссылок, что copy (`BuildCopyPlanAsync`) + **`ResetToDraft`** (PDF обоих комплектов устаревают) + `SortOrder` в конец целевого. Тот же `Id`.
- **`PreviewMoveDocumentQuery`** → `{ warnings, blockedBy }` (dry-run: затронутые ссылки + чем заблокирован). `POST .../move`, `POST .../move/preview`.

## Frontend

- **`MoveDocumentDialog`**: пикер комплекта → превью. При входящих ссылках — **блокирующее состояние** (список ссылающихся, «Понятно», перенос недоступен). Иначе строгий тон «Документ будет удалён из «X», PDF устареет» + **чекбокс-барьер** при затронутых ссылках → перенос → **переход в целевой комплект** + toast.
- Действие **«Перенести в комплект»** в kebab строки документа (теперь: Дублировать · Скопировать · Перенести · Удалить).

## Проверка

`tsc -b` + `vitest` (130) + backend (**429**, +2 теста move) зелёные. Миграций нет.

## Эпик #283
Фазы B (#284), C (#285), D (этот) — готовы. Опция A «снимок» + сворачивание длинного списка предупреждений — необязательный C2-polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)