### PR TITLE
polish(documents): сворачивание предупреждений + не-danger кнопка копирования (#287)

### DIFF
--- a/src/client/src/features/document-sets/CopyDocumentDialog.tsx
+++ b/src/client/src/features/document-sets/CopyDocumentDialog.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useToast } from '@/shared/ui/Toast';
-import { usePreviewCopyDocument, useCopyDocument, type CopyWarning } from '@/shared/api/documentSets';
+import { usePreviewCopyDocument, useCopyDocument } from '@/shared/api/documentSets';
+import { CopyWarnings } from './CopyWarnings';
 import type { Construction } from '@/shared/api/types';
 
 interface TargetSet { id: string; name: string; constructionId: string }
@@ -74,32 +75,15 @@ export function CopyDocumentDialog({ open, onClose, setId, instance, constructio
         onOpenChange={o => { if (!o) { setTarget(null); targetRef.current = null; onClose(); } }}
         title={`Скопировать «${instance.name}» в «${target?.name ?? ''}»?`}
         description={
-          isFetching
-            ? <p className="text-fg4">Проверка ссылок…</p>
-            : <CopyWarnings warnings={warnings} />
+          isFetching ? <p className="text-fg4">Проверка ссылок…</p>
+            : warnings.length === 0
+              ? <p>Ссылки в порядке — будет создана полная копия в выбранном комплекте.</p>
+              : <><p className="mb-1.5">При копировании в другой комплект:</p><CopyWarnings warnings={warnings} /></>
         }
         confirmLabel="Скопировать"
+        confirmDanger={false}
         onConfirm={handleCopy}
       />
-    </>
-  );
-}
-
-/** Список предупреждений о затронутых ссылках, сгруппированный по виду; doc-ref — с именами полей. */
-function CopyWarnings({ warnings }: { warnings: CopyWarning[] }) {
-  if (warnings.length === 0)
-    return <p>Ссылки в порядке — будет создана полная копия в выбранном комплекте.</p>;
-  return (
-    <>
-      <p className="mb-1.5">При копировании в другой комплект:</p>
-      <ul className="list-disc pl-4 space-y-0.5">
-        {warnings.map(w => (
-          <li key={w.kind}>
-            {w.label}{w.count > 1 ? ` (${w.count})` : ''}
-            {w.names.length > 0 && <span className="text-fg4">: {w.names.join(', ')}</span>}
-          </li>
-        ))}
-      </ul>
     </>
   );
 }

--- a/src/client/src/features/document-sets/CopyWarnings.tsx
+++ b/src/client/src/features/document-sets/CopyWarnings.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import type { CopyWarning } from '@/shared/api/documentSets';
+
+/** Порог, с которого имена в предупреждении сворачиваются за «показать» (иначе диалог распухает). */
+const NAMES_INLINE_MAX = 3;
+
+/**
+ * Список предупреждений о затронутых ссылках при копировании/переносе (issue #283/#287), сгруппирован
+ * по виду. Длинный перечень имён (>3) сворачивается за «показать» — кнопка подтверждения не уезжает.
+ * Пустой список → ничего не рендерит (вызывающий сам решает, что показать).
+ */
+export function CopyWarnings({ warnings }: { warnings: CopyWarning[] }) {
+  if (warnings.length === 0) return null;
+  return (
+    <ul className="list-disc pl-4 space-y-0.5">
+      {warnings.map(w => <WarningLine key={w.kind} w={w} />)}
+    </ul>
+  );
+}
+
+function WarningLine({ w }: { w: CopyWarning }) {
+  const [open, setOpen] = useState(false);
+  const collapsed = w.names.length > NAMES_INLINE_MAX;
+  return (
+    <li>
+      {w.label}{w.count > 1 ? ` (${w.count})` : ''}
+      {w.names.length > 0 && (collapsed ? (
+        <>
+          {' '}
+          <button type="button" onClick={() => setOpen(o => !o)}
+            className="text-brand hover:text-brand-hover text-xs">
+            {open ? 'скрыть' : 'показать'}
+          </button>
+          {open && <div className="text-fg4 mt-0.5">{w.names.join(', ')}</div>}
+        </>
+      ) : (
+        <span className="text-fg4">: {w.names.join(', ')}</span>
+      ))}
+    </li>
+  );
+}

--- a/src/client/src/features/document-sets/MoveDocumentDialog.tsx
+++ b/src/client/src/features/document-sets/MoveDocumentDialog.tsx
@@ -4,6 +4,7 @@ import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useToast } from '@/shared/ui/Toast';
 import { usePreviewMoveDocument, useMoveDocument, type CopyWarning } from '@/shared/api/documentSets';
+import { CopyWarnings } from './CopyWarnings';
 import type { Construction } from '@/shared/api/types';
 
 interface TargetSet { id: string; name: string; constructionId: string }
@@ -108,16 +109,7 @@ function MoveInfo({ currentSetName, warnings }: { currentSetName: string; warnin
   return (
     <>
       <p>Документ будет удалён из комплекта «{currentSetName}». Собранный PDF обоих комплектов устареет.</p>
-      {warnings.length > 0 && (
-        <ul className="list-disc pl-4 mt-1.5 space-y-0.5">
-          {warnings.map(w => (
-            <li key={w.kind}>
-              {w.label}{w.count > 1 ? ` (${w.count})` : ''}
-              {w.names.length > 0 && <span className="text-fg4">: {w.names.join(', ')}</span>}
-            </li>
-          ))}
-        </ul>
-      )}
+      {warnings.length > 0 && <div className="mt-1.5"><CopyWarnings warnings={warnings} /></div>}
     </>
   );
 }

--- a/src/client/src/shared/ui/ConfirmDialog.tsx
+++ b/src/client/src/shared/ui/ConfirmDialog.tsx
@@ -12,6 +12,9 @@ interface ConfirmDialogProps {
   description?: ReactNode;
   /** Текст кнопки подтверждения — должен называть объект, не быть голым "Удалить". */
   confirmLabel: string;
+  /** Опасный (красный) вид кнопки подтверждения. По умолчанию true (удаление); для не-деструктивных
+   *  действий (напр. копирование) — false → обычная brand-кнопка. */
+  confirmDanger?: boolean;
   cancelLabel?: string;
   /** Текст чекбокса-барьера ("Понимаю, что это необратимо") — если задан, кнопка
    *  подтверждения неактивна, пока чекбокс не отмечен. Использовать для операций с
@@ -44,7 +47,7 @@ interface ConfirmDialogProps {
  * кнопки подтверждения — единый канал для guard-отказов удаления (409), вместо alert()/тишины.
  */
 export function ConfirmDialog({
-  open, onOpenChange, title, description, confirmLabel, cancelLabel = 'Отмена',
+  open, onOpenChange, title, description, confirmLabel, confirmDanger = true, cancelLabel = 'Отмена',
   requireCheckbox, errorTitle = 'Удаление невозможно', blocked, onConfirm,
 }: ConfirmDialogProps) {
   const [checked, setChecked] = useState(false);
@@ -124,7 +127,7 @@ export function ConfirmDialog({
                   <Button variant="text" size="sm" className="shrink-0" disabled={busy}>{cancelLabel}</Button>
                 </Dialog.Close>
                 <Button
-                  variant="filled" danger size="sm" multiline className="min-w-0"
+                  variant="filled" danger={confirmDanger} size="sm" multiline className="min-w-0"
                   disabled={!canConfirm} loading={busy}
                   onClick={handleConfirm}
                 >

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.50.1</Version>
+    <Version>0.50.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #287. Шлифовка эпика #283 (согласовано с Дизайнером).

## Изменения

- **Общий `CopyWarnings`** — длинный перечень имён в предупреждении (>3) сворачивается за «показать», чтобы кнопка подтверждения не уезжала за экран. Один компонент для диалогов копирования и переноса (убрано дублирование инлайн-списков).
- **`ConfirmDialog.confirmDanger`** (по умолчанию `true`): диалог **копирования** — `false` → обычная brand-кнопка (копирование не деструктивно). Перенос и удаление остаются danger-красными.

## Не входит

Опция A «Независимый снимок» под «Дополнительно» — это уже фича с рисковым backend-скрабом (Архитектор отметил высокую стоимость), не мелкая полировка; отдельно по запросу.

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)