### PR TITLE
fix(ui): длинное значение Select обрезать многоточием

### DIFF
--- a/src/client/src/shared/ui/Select.tsx
+++ b/src/client/src/shared/ui/Select.tsx
@@ -38,7 +38,9 @@ export function Select({
   return (
     <RS.Root value={value} onValueChange={onValueChange} disabled={disabled} required={required} name={name}>
       <RS.Trigger className={`${TRIGGER} ${className}`} aria-label={aria['aria-label']}>
-        <RS.Value placeholder={placeholder} />
+        {/* min-w-0 + truncate: длинное выбранное значение обрезается многоточием, а не переносится
+            на вторую строку, распирая триггер фиксированной высоты. */}
+        <span className="min-w-0 flex-1 truncate text-left"><RS.Value placeholder={placeholder} /></span>
         <RS.Icon className="text-fg4 shrink-0"><ChevronDown size={15} /></RS.Icon>
       </RS.Trigger>
       <RS.Portal>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.50.3</Version>
+    <Version>0.50.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Симптом

Длинная выбранная опция (напр. «Основная надпись (ГОСТ Р 21.101-2020) — реестр по страницам» в диалоге «Распознать PDF (профиль)») переносилась на вторую строку и **распирала триггер** `Select` фиксированной высоты `h-9` — chevron сжимался, вёрстка ломалась. См. скриншот.

## Фикс

Значение обёрнуто в `span.min-w-0.flex-1.truncate` → одна строка с многоточием; `chevron` остаётся `shrink-0`. Общая правка для всех `Select` в приложении.

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)