### PR TITLE
fix(datasets): выбор типа материализации через TypePickerField

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -2,10 +2,8 @@ import { useState } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { dtCard, dtTable, dtTh, dtTd, dtRow } from '@/shared/ui/dataTable';
-import { Select, SelectItem } from '@/shared/ui/Select';
-
-/** Sentinel для «— не материализовать —» — Radix Select запрещает пустую строку. */
-const NO_TYPE = '__none__';
+import { TypePickerField } from '@/shared/ui/TypePickerField';
+import type { PickType } from '@/shared/ui/TypePicker';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useSetMaterialization, useMaterializePreview } from '@/shared/api/datasets';
 import { MappingEditor } from '@/features/document-sets/editor/DataSetsTab';
@@ -58,13 +56,15 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
 
         <div>
           <label className="block text-sm font-medium text-fg1 mb-1">Тип для материализации</label>
-          <Select value={typeId || NO_TYPE} aria-label="Тип для материализации"
-            onValueChange={v => { setTypeId(v === NO_TYPE ? '' : v); setMapping({}); setShowPreview(false); }}>
-            <SelectItem value={NO_TYPE}>— не материализовать —</SelectItem>
-            {allDocTypes.filter(t => !t.isAbstract).map(t => (
-              <SelectItem key={t.id} value={t.id}>{t.name} ({t.kind === 'Composite' ? 'составной' : 'документ'})</SelectItem>
-            ))}
-          </Select>
+          <TypePickerField className="w-full" aria-label="Тип для материализации" title="Тип для материализации"
+            placeholder="— не материализовать —" clearable={{ label: 'Не материализовать' }}
+            recentKey="materialize-type"
+            types={allDocTypes.filter(t => !t.isAbstract).map<PickType>(t => ({
+              id: t.id, name: t.name, code: t.code,
+              section: t.kind === 'Composite' ? 'Составные типы' : 'Типы документов',
+            }))}
+            value={typeId || undefined}
+            onChange={id => { setTypeId(id ?? ''); setMapping({}); setShowPreview(false); }} />
         </div>
 
         {selectedType && (

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.50.4</Version>
+    <Version>0.50.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Продолжение #266 («любой выбор типа из реестра → пикер»).

## Проблема

Диалог материализации источника набора данных выбирал тип из ~30 составных/документных типов обычным `Select` **без поиска** (и с длинными «(составной)»/«(документ)» подписями) — пропущенное место при развёртке #266.

## Фикс

`Select` → **`TypePickerField`** (поиск по имени/коду, «Недавние», группы «Составные типы»/«Типы документов», клавиатура), `clearable` «Не материализовать» вместо sentinel `NO_TYPE`.

## Похожие места (на решение)

Ещё два выбора типа документа качества через `Select` — `QualityLinksTab` и `QualityDocForm` — но по короткому курируемому списку (только типы с тэгом качества). Не трогал; если хочешь единообразия — переведу отдельно.

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)