### PR TITLE
fix(quality): выбор типа документа качества через TypePickerField

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -4,6 +4,8 @@ import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { SearchInput } from '@/shared/ui/SearchInput';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { TypePickerField } from '@/shared/ui/TypePickerField';
+import type { PickType } from '@/shared/ui/TypePicker';
 import { usePreviewDataSetBindings } from '@/shared/api/datasets';
 import {
   useListQualityDocs, useListMaterialLinks, useSetMaterialLinks, useRemoveMaterialLink,
@@ -231,10 +233,11 @@ function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, materials
       {tab === 'search' && (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Select value={searchType || undefined} onValueChange={setSearchType}
-              placeholder="Тип" aria-label="Тип документа качества" className="w-52">
-              {qualityTypes.map(t => <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>)}
-            </Select>
+            <TypePickerField className="w-52" aria-label="Тип документа качества" title="Тип документа качества"
+              placeholder="Тип"
+              types={qualityTypes.map<PickType>(t => ({ id: t.id, name: t.name, code: t.code, section: 'Документы качества' }))}
+              value={searchType || undefined}
+              onChange={id => { if (id) setSearchType(id); }} />
             <div className="flex-1 flex items-center gap-2 border border-stroke-strong rounded-md px-2 transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
               <Search size={14} className="text-fg4" />
               <input value={query} onChange={e => setQuery(e.target.value)}

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo } from 'react';
 import { Loader2, ShieldCheck, Upload, Eye } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
-import { Select, SelectItem } from '@/shared/ui/Select';
+import { TypePickerField } from '@/shared/ui/TypePickerField';
+import type { PickType } from '@/shared/ui/TypePicker';
 import { TextField } from '@/shared/ui/TextField';
 import {
   useCreateQualityDoc, useUpdateQualityDoc, useSetQualityDocScan, recognizeDocument,
@@ -161,10 +162,11 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className="block text-xs font-medium text-fg2 mb-1">Тип документа</label>
-          <Select value={typeId || undefined} onValueChange={setTypeId}
-            placeholder="Выберите тип…" aria-label="Тип документа">
-            {qualityTypes.map(dt => <SelectItem key={dt.id} value={dt.id}>{dt.name}</SelectItem>)}
-          </Select>
+          <TypePickerField className="w-full" aria-label="Тип документа" title="Тип документа"
+            placeholder="Выберите тип…"
+            types={qualityTypes.map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Документы качества' }))}
+            value={typeId || undefined}
+            onChange={id => { if (id) setTypeId(id); }} />
         </div>
         <TextField label="Название в библиотеке" value={displayName}
           onChange={e => setDisplayName(e.target.value)} hint="авто из номера" />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.50.5</Version>
+    <Version>0.50.6</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Продолжение #266 / #292 — оставшиеся выборы типа из реестра.

## Что

Два `Select` с типами документов качества → **`TypePickerField`** (поиск, «Недавние», группы, клавиатура):
- **`QualityDocForm`** — тип нового документа качества.
- **`QualityLinksTab`** — фильтр поиска по типу.

Оба non-clearable (тип обязателен). `Scope`-`Select` в `QualityLinksTab` не трогали (не выбор типа).

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)