### PR TITLE
feat(datasets): live-предпросмотр материализации по текущему маппингу (#294)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -25,7 +25,8 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
 
   const selectedType = allDocTypes.find(t => t.id === typeId);
   const effectiveFields = selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : [];
-  const preview = useMaterializePreview(source.id, showPreview && !!source.materializeTypeId);
+  // Live-превью по ТЕКУЩИМ (несохранённым) типу+маппингу (issue #294): обновляется на каждую правку.
+  const preview = useMaterializePreview(source.id, typeId || undefined, mapping, showPreview && !!typeId);
 
   function handleSave() {
     save.mutate(
@@ -64,7 +65,7 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
               section: t.kind === 'Composite' ? 'Составные типы' : 'Типы документов',
             }))}
             value={typeId || undefined}
-            onChange={id => { setTypeId(id ?? ''); setMapping({}); setShowPreview(false); }} />
+            onChange={id => { setTypeId(id ?? ''); setMapping({}); }} />
         </div>
 
         {selectedType && (
@@ -86,7 +87,7 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
           )
         )}
 
-        {source.materializeTypeId && (
+        {typeId && (
           <div>
             <button type="button" onClick={() => setShowPreview(v => !v)}
               className="text-xs text-brand hover:text-brand-hover">
@@ -122,9 +123,6 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
               </div>
             )}
           </div>
-        )}
-        {!source.materializeTypeId && typeId && (
-          <p className="text-[11px] text-fg4">Сохраните материализацию, чтобы увидеть предпросмотр.</p>
         )}
       </div>
     </Modal>

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { apiClient } from './client';
 import { filenameFromContentDisposition } from './attachments';
 import type {
@@ -128,12 +128,20 @@ export interface MaterializePreview {
   error: string | null;
 }
 
-/** Предпросмотр материализации источника (строки → объекты формы типа). enabled — управляет запросом. */
-export function useMaterializePreview(sourceId: string | undefined, enabled: boolean) {
+/** Live-предпросмотр материализации по ТЕКУЩИМ (несохранённым) типу+маппингу (issue #294).
+ *  Ключ включает typeId+mapping → перезапрос при их изменении; keepPreviousData — без мигания. */
+export function useMaterializePreview(
+  sourceId: string | undefined, typeId: string | undefined,
+  mapping: Record<string, string>, enabled: boolean,
+) {
   return useQuery<MaterializePreview>({
-    queryKey: ['datasets', 'materialize-preview', sourceId],
-    queryFn: () => apiClient.get(`/datasets/sources/${sourceId}/materialization/preview`).then(r => r.data),
+    queryKey: ['datasets', 'materialize-preview', sourceId, typeId ?? '', JSON.stringify(mapping)],
+    queryFn: () =>
+      apiClient
+        .post(`/datasets/sources/${sourceId}/materialization/preview`, { typeId: typeId || null, mapping })
+        .then(r => r.data),
     enabled: !!sourceId && enabled,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -175,10 +175,11 @@ public static class DataSetEndpoints
         });
 
         // Предпросмотр материализации: строки источника → объекты формы типа (без резолва каталога).
-        g.MapGet("/sources/{sourceId:guid}/materialization/preview", async (
-            Guid sourceId, int? maxRows, IDataSetService svc, CancellationToken ct) =>
+        // Live-превью материализации (issue #294): принимает текущие (несохранённые) typeId+mapping из диалога.
+        g.MapPost("/sources/{sourceId:guid}/materialization/preview", async (
+            Guid sourceId, MaterializePreviewRequest req, IDataSetService svc, CancellationToken ct) =>
         {
-            var result = await svc.MaterializePreviewAsync(sourceId, maxRows ?? 50, ct);
+            var result = await svc.MaterializePreviewAsync(sourceId, req.MaxRows ?? 50, req.TypeId, req.Mapping, ct);
             return result is null ? Results.NotFound() : Results.Ok(result);
         });
 
@@ -382,6 +383,7 @@ public static class DataSetEndpoints
     private record SourceRequest(string Name, string SheetOrPath, ColumnExprDto[]? ColumnExpressions);
     private record RenameSourceRequest(string Name);
     private record MaterializationRequest(Guid? TypeId, Dictionary<string, string>? Mapping);
+    private record MaterializePreviewRequest(Guid? TypeId, Dictionary<string, string>? Mapping, int? MaxRows);
     private record ProcessingRequest(object? RowFilter, object? ComputedColumns, object? SortSpec);
     private record ProcessingTemplateRequest(
         string Name, string? SheetOrPath, ColumnExprDto[]? ColumnExpressions,

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -29,8 +29,9 @@ public interface IDataSetService
     Task<DataSetSourceDto> CreateSourceAsync(Guid fileId, CreateSourceInput input, CancellationToken ct);
     /// <summary>Настроить/снять материализацию источника в тип (issue #19). typeId=null снимает.</summary>
     Task<DataSetSourceDto?> SetMaterializationAsync(Guid sourceId, Guid? typeId, Dictionary<string, string>? mapping, CancellationToken ct);
-    /// <summary>Предпросмотр материализации источника (строки → объекты формы типа).</summary>
-    Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, CancellationToken ct);
+    /// <summary>Предпросмотр материализации источника (строки → объекты формы типа). typeId/mapping —
+    /// переданные (для live-превью несохранённой настройки, issue #294); null → сохранённые на источнике.</summary>
+    Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, Guid? typeId, Dictionary<string, string>? mapping, CancellationToken ct);
     Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct);
     /// <summary>Лёгкое переименование источника (issue #43) — только имя, без extraction/кэша; для любого
     /// источника, включая PDF-проекции.</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -47,8 +47,8 @@ public class DataSetService(
         sources.CreateSourceAsync(fileId, input, ct);
     public Task<DataSetSourceDto?> SetMaterializationAsync(Guid sourceId, Guid? typeId, Dictionary<string, string>? mapping, CancellationToken ct) =>
         sources.SetMaterializationAsync(sourceId, typeId, mapping, ct);
-    public Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, CancellationToken ct) =>
-        sources.MaterializePreviewAsync(sourceId, maxRows, ct);
+    public Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, Guid? typeId, Dictionary<string, string>? mapping, CancellationToken ct) =>
+        sources.MaterializePreviewAsync(sourceId, maxRows, typeId, mapping, ct);
     public Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct) =>
         sources.UpdateSourceAsync(sourceId, input, ct);
     public Task<DataSetSourceDto?> RenameSourceAsync(Guid sourceId, string name, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -201,23 +201,27 @@ public class DataSetSourceService(
     /// MaterializeMapping. Ссылочный (@@ref) показывается маркером, файловый (@@file) — объектом-вложением
     /// (тот же рендер, что у превью привязки — см. DataSetDtoMapper.PreviewCell). Без резолва каталога.
     /// </summary>
-    public async Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, CancellationToken ct)
+    public async Task<MaterializePreviewDto?> MaterializePreviewAsync(
+        Guid sourceId, int maxRows, Guid? typeId, Dictionary<string, string>? mapping, CancellationToken ct)
     {
         var source = await db.DataSetSources.Include(s => s.File).AsNoTracking().FirstOrDefaultAsync(s => s.Id == sourceId, ct);
         if (source == null) return null;
-        if (source.MaterializeTypeId is null)
+        // typeId/mapping переданы диалогом (live-превью несохранённой настройки, issue #294) — иначе
+        // сохранённые на источнике. typeId служит лишь маркером «есть что материализовать».
+        var effTypeId = typeId ?? source.MaterializeTypeId;
+        if (effTypeId is null)
             return new MaterializePreviewDto(null, 0, [], "Материализация не настроена");
+        var effMapping = mapping ?? JsonSerializer.Deserialize<Dictionary<string, string>>(source.MaterializeMapping ?? "{}") ?? new();
 
         try
         {
             var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
-            var mapping = JsonSerializer.Deserialize<Dictionary<string, string>>(source.MaterializeMapping ?? "{}") ?? new();
             var take = maxRows <= 0 ? 50 : maxRows;
 
             var mapped = rows.Take(take).Select(row =>
             {
                 var obj = new Dictionary<string, object?>();
-                foreach (var (fieldKey, mapVal) in mapping)
+                foreach (var (fieldKey, mapVal) in effMapping)
                 {
                     var v = DataSetDtoMapper.PreviewCell(mapVal, row);
                     if (v is not null) obj[fieldKey] = v;
@@ -225,11 +229,11 @@ public class DataSetSourceService(
                 return obj;
             }).ToList();
 
-            return new MaterializePreviewDto(source.MaterializeTypeId, rows.Count, mapped, null);
+            return new MaterializePreviewDto(effTypeId, rows.Count, mapped, null);
         }
         catch (Exception ex)
         {
-            return new MaterializePreviewDto(source.MaterializeTypeId, 0, [], ex.Message);
+            return new MaterializePreviewDto(effTypeId, 0, [], ex.Message);
         }
     }
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.50.6</Version>
+    <Version>0.51.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #294.

## Проблема

Предпросмотр в диалоге материализации строился по **сохранённому** типу+маппингу (отсюда подпись «Сохраните материализацию, чтобы увидеть предпросмотр»). Настраиваешь маппинг — предпросмотр не отражает, пока не сохранишь.

## Фикс

- **Backend**: `MaterializePreviewAsync(sourceId, maxRows, typeId, mapping, ct)` — принимает текущие `typeId`+`mapping` (null → сохранённые на источнике; обратная совместимость). Эндпоинт `GET` → **`POST`** с телом `{ typeId, mapping, maxRows }`.
- **Frontend**: `useMaterializePreview` — POST с текущими `typeId`+`mapping`; queryKey включает их → **перезапрос при каждой правке**; `keepPreviousData` — без мигания «Загрузка…». Предпросмотр доступен по **текущему** типу (не только сохранённому); убрана подпись «Сохраните…».

Теперь при открытом предпросмотре колонки/значения обновляются по мере привязки полей.

## Проверка

`tsc -b` + `vitest` (130) + backend (**429**) зелёные. Миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)