### PR TITLE
feat(editor): сохранение = черновик, обязательность на генерации (#296, фаза 0)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -262,16 +262,17 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     return { total, filled, missing };
   }
 
+  // Обязательные незаполненные (не покрытые привязкой/базой) — для баннера-черновика и маркеров.
+  const missingRequired = schemaFields.filter(f => isFieldMissing(f, values[f.key]));
+
   // Сохраняет реквизиты. Возвращает true при успехе. НЕ закрывает редактор.
+  // issue #296 (вариант A): обязательность — инвариант ГЕНЕРАЦИИ, не сохранения. Save хранит черновик
+  // (в т.ч. с пустыми обязательными — их можно заполнить позже / привязать к источнику); блокирует
+  // только НЕвалидное введённое (формат/ограничения примитивов). Это разрывает дедлок «нельзя уйти
+  // на «Данные» привязать поле, потому что не сохраняется из-за этого же поля».
   async function handleSaveCore(): Promise<boolean> {
     setError('');
-    const missingRequired = schemaFields.filter(f => isFieldMissing(f, values[f.key]));
-    if (missingRequired.length > 0) {
-      setShowValidation(true);
-      setError(`Заполните обязательные поля: ${missingRequired.map(f => f.title).join(', ')}`);
-      return false;
-    }
-    // Re-validate all primitive-type fields
+    // Формат/ограничения — блокируют (нельзя хранить мусор).
     const constraintViolations: Record<string, string> = {};
     for (const f of schemaFields) {
       const def = getPrimitiveDef(f);
@@ -285,6 +286,8 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       setError('Исправьте ошибки формата в полях');
       return false;
     }
+    // Незаполненные обязательные не блокируют — но показываем маркеры (не «тихо»).
+    setShowValidation(missingRequired.length > 0);
     try {
       await mutation.mutateAsync({ setId, instanceId: instance.id, requisites: values });
       onDirty(false);
@@ -502,6 +505,19 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                 )}
               </div>
             )}
+          </div>
+        </div>
+      )}
+      {/* Баннер неполноты (issue #296, вариант A): черновик можно сохранить с пустыми обязательными —
+          но неполнота не «тихая», показываем всегда; жёсткий гейт — на генерации. */}
+      {missingRequired.length > 0 && (
+        <div className="shrink-0 px-6 pt-3">
+          <div className="flex items-start gap-2.5 rounded-lg border border-warning-border bg-warning-subtle px-3 py-2 text-xs text-warning">
+            <AlertTriangle size={15} className="shrink-0 mt-0.5" />
+            <span>
+              Черновик — не заполнено обязательных: <b>{missingRequired.length}</b>. Их можно заполнить позже или
+              привязать к источнику данных; для генерации PDF потребуются.
+            </span>
           </div>
         </div>
       )}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.51.0</Version>
+    <Version>0.52.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #296 (эпик «Линза»). Фаза 0 — разрывает дедлок, снятый с Архитектором+Дизайнером.

## Дедлок

Документ dirty, есть незаполненное **обязательное** поле, которое юзер хочет привязать к источнику (вкладка «Данные»). Уйти туда мешает dirty-guard (нужно Сохранить), а Сохранить падает на этом же поле. Круг.

## Фикс (вариант A)

**Обязательность — инвариант ГЕНЕРАЦИИ, а не сохранения.**
- `handleSaveCore`: убрана блокировка по незаполненным обязательным. Сохранение хранит черновик (в т.ч. с пустыми обязательными — их можно заполнить позже / привязать). Остаётся блок по **формату/ограничениям** (нельзя хранить невалидное).
- Подтверждено Архитектором: сервер `UpdateRequisites` required и так не проверял, save всегда `ResetToDraft` — инвариант «сохранён = полон» уже был иллюзорным.
- **Честный баннер** «Черновик — не заполнено обязательных: N» в реквизитах (неполнота не «тихая»).

Дедлок исчезает: сохранил частично → ушёл привязал → поле покрыто.

## Дальше
Фаза 0b — жёсткий гейт полноты на **генерации** (backend, чтобы «сгенерирован = полон» переехал туда, а не пропал). Фазы 1-3 — per-field привязки + убрать вкладку «Данные».

## Проверка
`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)