### PR TITLE
feat(generation): гейт полноты обязательных на генерации (#296, фаза 0b)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -84,6 +84,10 @@ public class GenerateDocumentHandler(
             // Проверка разрешения ссылок перед генерацией: оставшиеся $ref — ошибки,
             // при их наличии прерываем генерацию с диагностикой.
             ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
+            // Полнота обязательных (issue #296, фаза 0b): проверяем ПОСЛЕ полного резолва (реквизиты +
+            // привязки + база + дефолты) — обязательность = инвариант генерации, а не сохранения.
+            ResolutionScanner.ScanMissingRequired(context,
+                DocumentTypeSchemaReader.EffectiveFields(instance.CompositeTypeId, allDocTypes.ToDictionary(t => t.Id)), diagnostics);
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 throw new ResolutionValidationException(diagnostics);
 

--- a/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
+++ b/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BHS.CRG.Application.Schema;
 
 namespace BHS.CRG.Application.Generation;
 
@@ -29,6 +30,40 @@ public static class ResolutionScanner
         foreach (var (key, value) in ctx.Data)
             if (value is JsonElement el)
                 Walk(key, el, diagnostics);
+    }
+
+    /// <summary>
+    /// Обязательные поля, оставшиеся пустыми ПОСЛЕ полного резолва (реквизиты + привязки + база +
+    /// дефолты) — ошибки генерации (issue #296, фаза 0b). Обязательность = инвариант генерации, а не
+    /// сохранения: черновик хранится неполным (можно заполнить позже/привязать), но выпустить PDF с
+    /// пустым обязательным нельзя.
+    /// </summary>
+    public static void ScanMissingRequired(
+        GenerationContext ctx, IReadOnlyList<SchemaFieldInfo> effectiveFields, List<ResolutionDiagnostic> diagnostics)
+    {
+        foreach (var f in effectiveFields)
+        {
+            if (!f.Required) continue;
+            ctx.Data.TryGetValue(f.Key, out var v);
+            if (IsEmpty(v))
+                diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Error, f.Key,
+                    $"Обязательное поле «{f.Title ?? f.Key}» не заполнено."));
+        }
+    }
+
+    private static bool IsEmpty(object? v)
+    {
+        if (v is null) return true;
+        if (v is JsonElement el)
+            return el.ValueKind switch
+            {
+                JsonValueKind.Null or JsonValueKind.Undefined => true,
+                JsonValueKind.String => string.IsNullOrWhiteSpace(el.GetString()),
+                JsonValueKind.Array => el.GetArrayLength() == 0,
+                JsonValueKind.Object => !el.EnumerateObject().Any(),
+                _ => false, // number / true / false — заполнено
+            };
+        return false; // резолвнутые не-JSON значения считаем заполненными
     }
 
     private static void Walk(string path, JsonElement el, List<ResolutionDiagnostic> diagnostics)

--- a/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
@@ -1,4 +1,6 @@
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
 using BHS.CRG.Domain.Objects;
 using MediatR;
 
@@ -13,6 +15,7 @@ public record ValidateInstanceResolutionQuery(Guid InstanceId) : IRequest<IReadO
 
 public class ValidateInstanceResolutionHandler(
     IRepository<DomainObject> instanceRepo,
+    IRepository<DocumentType> docTypeRepo,
     IEntityResolver entityResolver,
     IDataSetResolver dataSetResolver
 ) : IRequestHandler<ValidateInstanceResolutionQuery, IReadOnlyList<ResolutionDiagnostic>>
@@ -30,6 +33,9 @@ public class ValidateInstanceResolutionHandler(
         await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
         await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
         ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
+        // Полнота обязательных (issue #296, фаза 0b) — та же проверка, что при генерации.
+        var byId = (await docTypeRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+        ResolutionScanner.ScanMissingRequired(context, DocumentTypeSchemaReader.EffectiveFields(instance.CompositeTypeId, byId), diagnostics);
         return diagnostics;
     }
 }

--- a/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
+++ b/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
@@ -16,7 +16,7 @@ public record EnumOptionInfo(string Code, string Label);
 /// (легаси: код==имя) либо резолвлены из EnumType по `typeId`. Null — не enum-поле, либо enumTypesById
 /// не передан вызывающим кодом.</param>
 public record SchemaFieldInfo(string Key, string Type, Guid? TypeId, string? Title = null,
-    JsonElement? DefaultValue = null, IReadOnlyList<EnumOptionInfo>? Options = null);
+    JsonElement? DefaultValue = null, IReadOnlyList<EnumOptionInfo>? Options = null, bool Required = false);
 
 /// <summary>Скалярное ли поле (пригодное для табличного распознавания/материализации из плоских колонок).</summary>
 public static class SchemaFieldKinds
@@ -154,7 +154,8 @@ public static class DocumentTypeSchemaReader
                 // 1:1) — если пусто, резолвим typeId через EnumType (толерантное сосуществование
                 // обоих представлений, без принудительной миграции).
                 IReadOnlyList<EnumOptionInfo>? options = type == "enum" ? ParseEnumOptions(f, typeId, enumTypesById) : null;
-                fields.Add(new SchemaFieldInfo(key, type, typeId, title, defaultValue, options));
+                var required = f.TryGetProperty("required", out var rq) && rq.ValueKind == JsonValueKind.True;
+                fields.Add(new SchemaFieldInfo(key, type, typeId, title, defaultValue, options, required));
             }
 
         if (root.TryGetProperty("excludedFields", out var ex) && ex.ValueKind == JsonValueKind.Array)

--- a/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Schema;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>
+/// Гейт полноты обязательных при генерации (issue #296, фаза 0b): пустые/отсутствующие обязательные
+/// поля после резолва → ошибки; заполненные и необязательные — нет.
+/// </summary>
+public class ResolutionScannerTests
+{
+    private static JsonElement Json(string s) => JsonDocument.Parse(s).RootElement.Clone();
+
+    [Fact]
+    public void ScanMissingRequired_FlagsEmptyAndMissing_NotFilledNotOptional()
+    {
+        var ctx = new GenerationContext();
+        ctx.Set("Заполнено", Json("\"значение\""));
+        ctx.Set("Пусто", Json("\"  \""));           // пустая строка (пробелы)
+        ctx.Set("ПустойМассив", Json("[]"));         // пустой массив
+        // «Отсутствует» — не в контексте вовсе
+
+        var fields = new List<SchemaFieldInfo>
+        {
+            new("Заполнено", "string", null, "Заполнено", Required: true),
+            new("Пусто", "string", null, "Пусто", Required: true),
+            new("ПустойМассив", "array", null, "Массив", Required: true),
+            new("Отсутствует", "string", null, "Отсутствует", Required: true),
+            new("Необязательное", "string", null, "Необязательное", Required: false),
+        };
+
+        var diags = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanMissingRequired(ctx, fields, diags);
+
+        Assert.All(diags, d => Assert.Equal(DiagnosticSeverity.Error, d.Severity));
+        Assert.Contains(diags, d => d.Path == "Пусто");
+        Assert.Contains(diags, d => d.Path == "ПустойМассив");
+        Assert.Contains(diags, d => d.Path == "Отсутствует");
+        Assert.DoesNotContain(diags, d => d.Path == "Заполнено");
+        Assert.DoesNotContain(diags, d => d.Path == "Необязательное");
+        Assert.Equal(3, diags.Count);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.52.0</Version>
+    <Version>0.52.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #296. Дополняет фазу 0: раз сохранение больше не требует обязательных (черновик), инвариант «сгенерирован = полон» **переезжает на генерацию**, а не пропадает.

## Изменения (backend)

- **`SchemaFieldInfo.Required`** + парсинг `required` в `DocumentTypeSchemaReader`.
- **`ResolutionScanner.ScanMissingRequired`**: после полного резолва (реквизиты + привязки + база + дефолты) пустые/отсутствующие обязательные → `Error`-диагностика. Пусто = null/пустая строка/пустой массив/пустой объект.
- Подключено в **`GenerateDocumentHandler`** (прерывает генерацию — как leftover-`$ref`) и **`ValidateInstanceResolution`** (кнопка «Проверить» тоже показывает список).
- Фронт уже рендерит диагностику генерации/проверки — правки не нужны.
- Юнит-тест `ScanMissingRequired`.

Теперь: сохранить неполный черновик — можно; сгенерировать неполный PDF — нельзя (точный список незаполненного).

## Проверка

`dotnet build` + **430** тестов (+1) зелёные. Только backend, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)