### PR TITLE
feat(editor): per-field скалярная привязка к источнику «линза» (#296, фаза 1)

### DIFF
--- a/src/client/src/features/document-sets/editor/FieldSourceBinding.tsx
+++ b/src/client/src/features/document-sets/editor/FieldSourceBinding.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { Database, X, Link2Off } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import {
+  useAvailableDataSetFiles, useCreateDataSetBinding, useUpdateDataSetBinding,
+  useDeleteDataSetBinding, useAutoMapDataSetSource,
+} from '@/shared/api/datasets';
+import { parseSourceColumnNames } from '@/shared/api/datasetHelpers';
+import type { DataSetBinding, DataSetSource } from '@/shared/api/types';
+import type { SchemaField } from '@/shared/api/schema';
+
+type FlatSource = DataSetSource & { fileName: string };
+
+/**
+ * Per-field привязка скалярного поля к источнику данных (issue #296, фаза 1 — «линза»). Поле — точка
+ * ВХОДА; под капотом хранение остаётся источнико-центричным (#55): find-or-create единственного
+ * (owner, source)-скалярного binding, правится его срез `{ключ поля: колонка}`, prune-on-empty при
+ * снятии последнего среза. При выборе источника — авто-предложение покрыть остальные поля, которые он
+ * заполняет (пакетность источника сохранена, дубли не плодятся).
+ */
+export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bindings }: {
+  instanceId: string;
+  setId: string;
+  field: SchemaField;
+  scalarFields: SchemaField[];
+  bindings: DataSetBinding[];
+}) {
+  const [open, setOpen] = useState(false);
+
+  // Текущий скалярный binding, покрывающий это поле (если есть).
+  const currentBinding = bindings.find(b => !b.targetFieldKey && b.mapping?.[field.key]);
+  const isBound = !!currentBinding;
+
+  const { data: files = [] } = useAvailableDataSetFiles(setId);
+  const create = useCreateDataSetBinding();
+  const update = useUpdateDataSetBinding();
+  const del = useDeleteDataSetBinding();
+  const autoMap = useAutoMapDataSetSource();
+
+  // Скалярные источники (материализованные — для контейнерных полей, фаза 2).
+  const sources: FlatSource[] = useMemo(
+    () => files.flatMap(f => f.sources.filter(s => !s.materializeTypeId).map(s => ({ ...s, fileName: f.name }))),
+    [files]);
+
+  const [sourceId, setSourceId] = useState('');
+  const [column, setColumn] = useState('');
+  const [cover, setCover] = useState<Record<string, string>>({}); // сёстры для авто-покрытия
+  const [coverOn, setCoverOn] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const selectedSource = sources.find(s => s.id === sourceId);
+  const columns = useMemo(() => {
+    if (!selectedSource) return [];
+    const computed = (selectedSource.computedColumns ?? []).map(c => c.alias).filter(Boolean);
+    return [...new Set([...parseSourceColumnNames(selectedSource.cachedSchema), ...computed])];
+  }, [selectedSource]);
+
+  const boundKeys = useMemo(() => {
+    const s = new Set<string>();
+    for (const b of bindings) if (!b.targetFieldKey) for (const k of Object.keys(b.mapping ?? {})) s.add(k);
+    return s;
+  }, [bindings]);
+
+  // Открытие: сброс + подстановка текущего состояния.
+  function onOpenChange(o: boolean) {
+    setOpen(o);
+    if (o) {
+      setSourceId(currentBinding?.sourceId ?? '');
+      setColumn(currentBinding?.mapping?.[field.key] ?? '');
+      setCover({}); setCoverOn(true);
+    }
+  }
+
+  // Выбор источника → авто-маппинг остальных НЕпривязанных скалярных полей (кроме этого).
+  async function pickSource(id: string) {
+    setSourceId(id); setColumn(''); setCover({});
+    const src = sources.find(s => s.id === id);
+    if (!src) return;
+    const siblings = scalarFields.filter(f => f.key !== field.key && !boundKeys.has(f.key));
+    if (siblings.length === 0) return;
+    try {
+      const { mapping } = await autoMap.mutateAsync({ sourceId: id, fields: siblings.map(f => ({ key: f.key, title: f.title })) });
+      // Себя, если авто-маппер предложил колонку для текущего поля — подставим по умолчанию.
+      if (mapping[field.key] && !column) setColumn(mapping[field.key]);
+      const others: Record<string, string> = {};
+      for (const [k, c] of Object.entries(mapping)) if (k !== field.key && c) others[k] = c;
+      setCover(others);
+    } catch { /* авто-маппинг необязателен */ }
+  }
+
+  const coverTitles = Object.keys(cover)
+    .map(k => scalarFields.find(f => f.key === k)?.title ?? k);
+
+  async function bind() {
+    if (!selectedSource || !column) return;
+    setBusy(true);
+    try {
+      const existing = bindings.find(b => !b.targetFieldKey && b.sourceId === selectedSource.id);
+      const mapping: Record<string, string> = { ...(existing?.mapping ?? {}) };
+      mapping[field.key] = column;
+      if (coverOn) for (const [k, c] of Object.entries(cover)) mapping[k] = c;
+      if (existing) await update.mutateAsync({ id: existing.id, ownerId: instanceId, targetFieldKey: null, mapping });
+      else await create.mutateAsync({ ownerId: instanceId, sourceId: selectedSource.id, targetFieldKey: null, mapping });
+      setOpen(false);
+    } finally { setBusy(false); }
+  }
+
+  async function unbind() {
+    if (!currentBinding) return;
+    setBusy(true);
+    try {
+      const mapping = { ...currentBinding.mapping };
+      delete mapping[field.key];
+      if (Object.keys(mapping).length === 0) await del.mutateAsync({ id: currentBinding.id, ownerId: instanceId });
+      else await update.mutateAsync({ id: currentBinding.id, ownerId: instanceId, targetFieldKey: null, mapping });
+      setOpen(false);
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger asChild>
+        <button type="button"
+          title={isBound ? 'Заполняется из источника данных — изменить/отвязать' : 'Привязать к источнику данных'}
+          aria-label={isBound ? 'Привязка к источнику' : 'Привязать к источнику'}
+          className={`inline-flex items-center justify-center rounded transition-colors ${
+            isBound ? 'text-brand hover:text-brand-hover' : 'text-fg4 opacity-0 group-hover:opacity-100 hover:text-fg2'}`}>
+          <Database size={13} />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content sideOffset={6} align="end"
+          className="z-50 w-80 rounded-xl border border-stroke bg-surface p-3 text-sm shadow-[var(--f-shadow16)] focus:outline-none">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-semibold text-fg2">Источник для «{field.title}»</span>
+            <Popover.Close asChild>
+              <button className="text-fg4 hover:text-fg2" aria-label="Закрыть"><X size={14} /></button>
+            </Popover.Close>
+          </div>
+
+          {sources.length === 0 ? (
+            <p className="text-xs text-fg4 py-2">
+              Нет подходящих источников. Загрузите набор данных на странице «Наборы данных» или в панели уровня.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              <div>
+                <label className="block text-[11px] text-fg4 mb-1">Источник</label>
+                <select value={sourceId} onChange={e => pickSource(e.target.value)}
+                  className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
+                  <option value="">— выберите —</option>
+                  {sources.map(s => <option key={s.id} value={s.id}>{s.fileName} · {s.name}</option>)}
+                </select>
+              </div>
+
+              {selectedSource && (
+                <div>
+                  <label className="block text-[11px] text-fg4 mb-1">Колонка</label>
+                  <select value={column} onChange={e => setColumn(e.target.value)}
+                    className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
+                    <option value="">— не привязано —</option>
+                    {columns.map(c => <option key={c} value={c}>{c}</option>)}
+                  </select>
+                </div>
+              )}
+
+              {selectedSource && coverTitles.length > 0 && (
+                <label className="flex items-start gap-2 text-xs text-fg2 cursor-pointer select-none">
+                  <input type="checkbox" checked={coverOn} onChange={e => setCoverOn(e.target.checked)} className="mt-0.5" />
+                  <span>Этот источник заполнит также: <span className="text-fg3">{coverTitles.join(', ')}</span></span>
+                </label>
+              )}
+
+              <div className="flex items-center gap-2 pt-1">
+                <Button variant="filled" size="sm" onClick={bind} disabled={!column || busy} loading={busy}>
+                  {isBound ? 'Изменить' : 'Привязать'}
+                </Button>
+                {isBound && (
+                  <Button variant="text" size="sm" danger onClick={unbind} disabled={busy} icon={<Link2Off size={13} />}>
+                    Отвязать
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -19,8 +19,9 @@ import { SCOPE_LABELS, isFieldRef } from '@/shared/api/types';
 import { useCommonDataForSet } from '@/shared/api/commonData';
 import {
   groupEffectiveFields, resolveEffectiveFields, compositeFieldHasTag, parseSchemaFields,
-  getDefaultValues, type SchemaField,
+  getDefaultValues, isScalarField, type SchemaField,
 } from '@/shared/api/schema';
+import { FieldSourceBinding } from './FieldSourceBinding';
 import {
   STATUS_LABELS, STATUS_COLORS,
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
@@ -130,6 +131,9 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
     }
     return s;
   }, [dsBindings]);
+  // Скалярные поля — для per-field привязки «линза» (issue #296, фаза 1): выбор источника на поле +
+  // авто-предложение покрыть остальные скалярные поля этого источника.
+  const scalarSchemaFields = useMemo(() => schemaFields.filter(f => isScalarField(f) && f.type !== 'file'), [schemaFields]);
   // Базовый экземпляр (issue #71): документ дочернего типа наследуется от базы — документа комплекта
   // ЛИБО записи общих данных (по цепочке типов-предков и скоп-близости). При связке наследуются её
   // данные (мердж при генерации), вручную заполняются только собственные поля. Ссылка — `_baseRef` {kind,id}.
@@ -405,14 +409,18 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
           // Простые поля (string/number/date/enum/boolean/primitive). Редактируемые — MD3 floating-label
           // (G1); привязанные к источнику (read-only, с бейджем) — оставляем label-сверху.
           return (
-            <div key={field.key} className="col-span-1 min-w-0">
+            <div key={field.key} className="col-span-1 min-w-0 relative group">
+              {/* Per-field привязка «линза» (issue #296, фаза 1): иконка в углу — привязать/изменить/отвязать. */}
+              <div className="absolute top-0.5 right-0.5 z-10">
+                <FieldSourceBinding instanceId={instance.id} setId={setId} field={field}
+                  scalarFields={scalarSchemaFields} bindings={dsBindings} />
+              </div>
               {bound ? (
                 <>
-                  <label className="block text-xs font-medium text-fg2 mb-1">
+                  <label className="block text-xs font-medium text-fg2 mb-1 pr-5">
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
                     {primitiveDef && <span className="ml-1 text-[10px] text-fg4 font-normal">· {primitiveDef.name}</span>}
-                    <SourceBoundBadge onGoToDataTab={onGoToDataTab} />
                   </label>
                   <PrimitiveInput field={field} value={displayValue}
                     onChange={v => setValue(field.key, v, primitiveDef)}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.52.1</Version>
+    <Version>0.52.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #296 (эпик «Линза»). Фаза 1 — привязка скалярного поля к источнику прямо в реквизитах.

## Идея (проработано с Архитектором+Дизайнером)

**Поле = линза на привязку.** UI становится field-centric, но хранение остаётся источнико-центричным (#55 в силе): под капотом — find-or-create единственного `(owner, source)`-скалярного binding, правится его срез `{ключ поля: колонка}`, prune-on-empty при снятии последнего среза. **Фронт-only** поверх существующей CRUD привязок.

## Изменения

- **`FieldSourceBinding`** — поповер на скалярном поле (иконка `Database` в углу ячейки): выбор источника + колонки. При выборе источника — авто-маппинг остальных **непривязанных** скалярных полей → «Этот источник заполнит также: …» (чекбокс). Так пакетность источника сохранена, а дубли одного источника на 5 полей не плодятся. Отвязка убирает срез поля и прунит пустой binding.
- **`RequisitesTab`**: иконка привязки в углу скалярного поля (bound — brand всегда видна; unbound — faint по hover). `SourceBoundBadge` убран из скалярного лейбла.
- Материализованные источники в списке скаляра не показываются (они для контейнерных полей — фаза 2).

Вкладка «Данные» пока сосуществует (уберём в фазе 3) — миграция инкрементальная.

## Проверка

`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)