### PR TITLE
feat(editor): per-field привязка контейнерных полей «линза» (#296, фаза 2a)

### DIFF
--- a/src/client/src/features/document-sets/editor/ContainerFieldBinding.tsx
+++ b/src/client/src/features/document-sets/editor/ContainerFieldBinding.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react';
+import { Database, Link2Off } from 'lucide-react';
+import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
+import { MappingEditor } from './DataSetsTab';
+import {
+  useAvailableDataSetFiles, useCreateDataSetBinding, useUpdateDataSetBinding, useDeleteDataSetBinding,
+} from '@/shared/api/datasets';
+import type { DataSetBinding, DataSetSource, DocumentType } from '@/shared/api/types';
+import type { SchemaField } from '@/shared/api/schema';
+
+type FlatSource = DataSetSource & { fileName: string };
+
+/** Совместимость по наследованию: childId == ancestorId либо потомок ancestorId по parentId. */
+function isSameOrDescendant(childId: string, ancestorId: string, allDocTypes: DocumentType[]): boolean {
+  let cur: string | null = childId;
+  let guard = 0;
+  while (cur && guard++ < 32) {
+    if (cur === ancestorId) return true;
+    cur = allDocTypes.find(t => t.id === cur)?.parentId ?? null;
+  }
+  return false;
+}
+
+/**
+ * Per-field привязка КОНТЕЙНЕРНОГО поля (array/doc-array/complex/doc-ref) к источнику (issue #296,
+ * фаза 2a — «линза»). Модалка (тяжесть аффорданса = тяжести привязки): материализованный источник
+ * совместимого типа → типизированный указатель (без маппинга); array/doc-array + обычный источник →
+ * табличный маппинг элемента (переиспользуем MappingEditor). Привязка — своя, targetFieldKey=это поле.
+ * Ref-маппинг составных/doc-ref по каталогу (scalar-slice) — фаза 2b.
+ */
+export function ContainerFieldBinding({ instanceId, setId, field, allDocTypes, bindings }: {
+  instanceId: string;
+  setId: string;
+  field: SchemaField;
+  allDocTypes: DocumentType[];
+  bindings: DataSetBinding[];
+}) {
+  const [open, setOpen] = useState(false);
+  const existing = bindings.find(b => b.targetFieldKey === field.key);
+  const isBound = !!existing;
+
+  const { data: files = [] } = useAvailableDataSetFiles(setId);
+  const create = useCreateDataSetBinding();
+  const update = useUpdateDataSetBinding();
+  const del = useDeleteDataSetBinding();
+
+  const isTabular = field.type === 'array' || field.type === 'doc-array';
+
+  // Совместимые источники: материализованные того же типа (указатель) + обычные (только для табличных).
+  const sources: FlatSource[] = useMemo(() => {
+    const flat = files.flatMap(f => f.sources.map(s => ({ ...s, fileName: f.name })));
+    return flat.filter(s => {
+      if (s.materializeTypeId) return !!field.typeId && isSameOrDescendant(s.materializeTypeId, field.typeId, allDocTypes);
+      return isTabular; // обычный источник подходит только табличному полю
+    });
+  }, [files, field.typeId, isTabular, allDocTypes]);
+
+  const [sourceId, setSourceId] = useState('');
+  const [mapping, setMapping] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+
+  const selectedSource = sources.find(s => s.id === sourceId);
+  const isMaterialized = !!selectedSource?.materializeTypeId;
+
+  function onOpenChange(o: boolean) {
+    setOpen(o);
+    if (o) {
+      setSourceId(existing?.sourceId ?? '');
+      setMapping(existing?.mapping ?? {});
+    }
+  }
+
+  async function save() {
+    if (!selectedSource) return;
+    setBusy(true);
+    try {
+      const map = isMaterialized ? {} : mapping;
+      if (existing && existing.sourceId === selectedSource.id) {
+        await update.mutateAsync({ id: existing.id, ownerId: instanceId, targetFieldKey: field.key, mapping: map });
+      } else {
+        if (existing) await del.mutateAsync({ id: existing.id, ownerId: instanceId });
+        await create.mutateAsync({ ownerId: instanceId, sourceId: selectedSource.id, targetFieldKey: field.key, mapping: map });
+      }
+      setOpen(false);
+    } finally { setBusy(false); }
+  }
+
+  async function unbind() {
+    if (!existing) return;
+    setBusy(true);
+    try { await del.mutateAsync({ id: existing.id, ownerId: instanceId }); setOpen(false); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <>
+      <button type="button" onClick={() => onOpenChange(true)}
+        title={isBound ? 'Заполняется из источника — изменить/отвязать' : 'Привязать к источнику данных'}
+        aria-label={isBound ? 'Привязка к источнику' : 'Привязать к источнику'}
+        className={`inline-flex items-center justify-center rounded transition-colors ${
+          isBound ? 'text-brand hover:text-brand-hover' : 'text-fg4 opacity-0 group-hover:opacity-100 hover:text-fg2'}`}>
+        <Database size={13} />
+      </button>
+
+      <Modal open={open} onOpenChange={onOpenChange} title={`Привязка «${field.title}» к источнику`} wide
+        footer={
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              {isBound && (
+                <Button variant="text" size="sm" danger onClick={unbind} disabled={busy} icon={<Link2Off size={14} />}>
+                  Отвязать
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="text" size="sm" onClick={() => setOpen(false)}>Отмена</Button>
+              <Button variant="filled" size="sm" onClick={save} disabled={!selectedSource || busy} loading={busy}>
+                {isBound ? 'Изменить' : 'Привязать'}
+              </Button>
+            </div>
+          </div>
+        }>
+        <div className="space-y-4 min-w-[520px]">
+          {sources.length === 0 ? (
+            <p className="text-xs text-fg4 py-2">
+              Нет подходящих источников для этого поля. {isTabular
+                ? 'Загрузите набор данных на странице «Наборы данных» или в панели уровня.'
+                : `Нужен источник, материализованный в тип «${allDocTypes.find(t => t.id === field.typeId)?.name ?? 'этого поля'}» (настраивается на источнике).`}
+            </p>
+          ) : (
+            <>
+              <div>
+                <label className="block text-xs font-medium text-fg3 mb-1">Источник данных</label>
+                <select value={sourceId} onChange={e => { setSourceId(e.target.value); setMapping({}); }}
+                  className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
+                  <option value="">— выберите источник —</option>
+                  {sources.map(s => (
+                    <option key={s.id} value={s.id}>
+                      {s.fileName} · {s.name}{s.materializeTypeId ? ` (материализация → ${allDocTypes.find(t => t.id === s.materializeTypeId)?.name ?? 'тип'})` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {selectedSource && (isMaterialized ? (
+                <div className="rounded-lg border border-brand/40 bg-brand/5 p-3 text-xs text-fg3">
+                  Источник материализуется в тип <b>{allDocTypes.find(t => t.id === selectedSource.materializeTypeId)?.name ?? '—'}</b> —
+                  маппинг задан на источнике, поле заполнится напрямую.
+                </div>
+              ) : (
+                <div className="rounded-lg border border-stroke p-3">
+                  <MappingEditor source={selectedSource} schemaFields={[]} tabularFields={[field]}
+                    allDocTypes={allDocTypes} mapping={mapping} targetFieldKey={field.key}
+                    onChange={m => setMapping(m)} hideModeSelector />
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -22,6 +22,7 @@ import {
   getDefaultValues, isScalarField, type SchemaField,
 } from '@/shared/api/schema';
 import { FieldSourceBinding } from './FieldSourceBinding';
+import { ContainerFieldBinding } from './ContainerFieldBinding';
 import {
   STATUS_LABELS, STATUS_COLORS,
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
@@ -55,22 +56,9 @@ function SourceBoundDocField() {
     <div className="flex items-center gap-2 border border-brand/40 rounded-lg px-3 py-2 bg-brand/5">
       <Database size={14} className="text-brand shrink-0" />
       <span className="text-xs text-fg3">
-        Заполняется из привязанного источника данных — правьте связку на вкладке «Данные».
+        Заполняется из привязанного источника данных — правьте связку по иконке источника у поля.
       </span>
     </div>
-  );
-}
-
-/// Компактный индикатор для скалярного поля, заполняемого привязкой (issue #55): иконка в строке
-/// лейбла (тот же слот, что занимает тип-хинт) вместо полноразмерной плашки — иначе при «один
-/// биндинг → много полей» форма превращается в стену одинаковых боксов.
-function SourceBoundBadge({ onGoToDataTab }: { onGoToDataTab: () => void }) {
-  return (
-    <button type="button" onClick={onGoToDataTab}
-      title="Заполняется из привязанного источника данных — открыть вкладку «Данные»"
-      className="ml-1 inline-flex align-middle text-brand hover:text-brand-hover">
-      <Database size={11} />
-    </button>
   );
 }
 
@@ -88,11 +76,11 @@ function BoundStateHint({ loading, error }: { loading: boolean; error: boolean }
 // Кандидаты берутся по всей цепочке типов-предков и по скоп-близости (комплект > раздел > стройка >
 // система), внутри уровня — по близости наследования. Ссылка хранится как _baseRef {kind,id}.
 
-function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef, onGoToDataTab, onBaseState, baseControlRef }: {
+function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, otherInstances, onDirty, saveRef, onBaseState, baseControlRef }: {
   instance: DocumentInstance; setId: string; schemaFields: SchemaField[];
   allDocTypes: DocumentType[]; docType: DocumentType | undefined;
   otherInstances: DocumentInstance[]; onClose: () => void;
-  onDirty: (dirty: boolean) => void; saveRef: SaveRef; onGoToDataTab: () => void;
+  onDirty: (dirty: boolean) => void; saveRef: SaveRef;
   /** Синк состояния «Основы» вверх — для chip в шапке (issue #223). */
   onBaseState: (s: { hasBase: boolean; selected: BaseCandidate | undefined; missing: boolean; candidates: BaseCandidate[]; coveredCount: number }) => void;
   /** Канал управления «Основой» из шапки (доступен, пока смонтирована вкладка реквизитов). */
@@ -348,20 +336,28 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
           const wide = isWide(field);
 
           if (wide) {
+            const isContainer = field.type === 'complex' || field.type === 'array' || field.type === 'doc-ref' || field.type === 'doc-array';
             return (
-              <div key={field.key} className="col-span-2">
+              <div key={field.key} className="col-span-2 relative group">
+                {/* Per-field привязка контейнерного поля «линза» (issue #296, фаза 2a) — модалка в углу. */}
+                {isContainer && (
+                  <div className="absolute top-0.5 right-0.5 z-10">
+                    <ContainerFieldBinding instanceId={instance.id} setId={setId} field={field}
+                      allDocTypes={allDocTypes} bindings={dsBindings} />
+                  </div>
+                )}
                 {field.type !== 'boolean' && field.type !== 'complex' && field.type !== 'array' && (
-                  <label className="block text-xs font-medium text-fg2 mb-1">
+                  <label className="block text-xs font-medium text-fg2 mb-1 pr-5">
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
                     {!field.required && <span className="ml-1 text-[10px] text-fg4 font-normal">опц.</span>}
-                    {bound && <SourceBoundBadge onGoToDataTab={onGoToDataTab} />}
                   </label>
                 )}
                 {field.type === 'complex' ? (
+                  bound ? <SourceBoundDocField /> : (
                   <div>
                     <div className="flex items-center justify-between mb-1">
-                      <label className="block text-xs font-medium text-fg2">
+                      <label className="block text-xs font-medium text-fg2 pr-5">
                         {field.title}
                         {field.required && <span className="ml-0.5 text-danger">*</span>}
                       </label>
@@ -370,10 +366,13 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                       onChange={v => setValue(field.key, v)} showValidation={showValidation}
                       setId={setId} otherInstances={otherInstances} docRefMode="instance" />
                   </div>
+                  )
                 ) : field.type === 'array' ? (
+                  bound ? <SourceBoundDocField /> : (
                   <ArrayFieldEditor field={field} allDocTypes={allDocTypes} value={raw}
                     onChange={v => setValue(field.key, v)} showValidation={showValidation}
                     setId={setId} otherInstances={otherInstances} docRefMode="instance" />
+                  )
                 ) : field.type === 'doc-ref' ? (
                   sourceBoundFields.has(field.key) ? <SourceBoundDocField /> : (
                     <DocRefField field={field} allDocTypes={allDocTypes} value={raw}
@@ -1035,7 +1034,6 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
         <RequisitesTab instance={instance} setId={setId} schemaFields={schemaFields}
           allDocTypes={allDocTypes} docType={docType} otherInstances={otherInstances}
           onClose={onClose} onDirty={setDirty} saveRef={saveRef}
-          onGoToDataTab={() => requestTab('datasets')}
           onBaseState={setBaseState} baseControlRef={baseControlRef} />
       )}
       {tab === 'datasets' && (

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.52.2</Version>
+    <Version>0.52.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #296 (эпик «Линза»). Фаза 2a — привязка контейнерных полей прямо в реквизитах.

## Изменения

- **`ContainerFieldBinding`** — модалка на поле array/doc-array/complex/doc-ref (тяжесть аффорданса = тяжести привязки):
  - **материализованный источник** совместимого типа → типизированный указатель (без маппинга);
  - **array/doc-array + обычный источник** → табличный маппинг элемента (переиспользуем `MappingEditor` в табличном режиме).
  - Привязка своя (`targetFieldKey=поле`); отвязка удаляет её. Источники отфильтрованы по совместимости типа; пустой список — онбординг с подсказкой.
- **`RequisitesTab`**: иконка привязки в углу контейнерного поля (bound — brand; unbound — по hover). `complex`/`array` теперь показывают bound-состояние (как `doc-ref`/`doc-array`). Удалён устаревший `SourceBoundBadge` и проп `onGoToDataTab`; текст `SourceBoundDocField` больше не ссылается на вкладку «Данные».

## Осталось
Фаза 2b — ref-маппинг составных/`doc-ref` по каталогу (scalar-slice, по имени/идентификатору). Фаза 3 — document-level поверхность + убрать вкладку «Данные».

## Проверка
`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)