### PR TITLE
feat(editor): document-level «Источники данных» + фикс скалярной привязки (#296, фаза 3)

### DIFF
--- a/src/client/src/features/document-sets/editor/FieldSourceBinding.tsx
+++ b/src/client/src/features/document-sets/editor/FieldSourceBinding.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
-import * as Popover from '@radix-ui/react-popover';
-import { Database, X, Link2Off } from 'lucide-react';
+import { Database, Link2Off } from 'lucide-react';
+import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import {
   useAvailableDataSetFiles, useCreateDataSetBinding, useUpdateDataSetBinding,
@@ -15,9 +15,12 @@ type FlatSource = DataSetSource & { fileName: string };
 /**
  * Per-field привязка скалярного поля к источнику данных (issue #296, фаза 1 — «линза»). Поле — точка
  * ВХОДА; под капотом хранение остаётся источнико-центричным (#55): find-or-create единственного
- * (owner, source)-скалярного binding, правится его срез `{ключ поля: колонка}`, prune-on-empty при
- * снятии последнего среза. При выборе источника — авто-предложение покрыть остальные поля, которые он
- * заполняет (пакетность источника сохранена, дубли не плодятся).
+ * (owner, source)-скалярного binding, правится его срез `{ключ поля: колонка}`, prune-on-empty. При
+ * выборе источника — авто-предложение покрыть остальные поля, которые он заполняет.
+ *
+ * Модалка (а не Popover): редактор документа рендерится в Radix Dialog (modal), который через
+ * react-remove-scroll делает `pointer-events: none` для всего вне контента диалога — портал Popover
+ * в body оказывался инертным (клики не ловились). Вложенный Dialog (Modal) координируется корректно.
  */
 export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bindings }: {
   instanceId: string;
@@ -28,7 +31,6 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
 }) {
   const [open, setOpen] = useState(false);
 
-  // Текущий скалярный binding, покрывающий это поле (если есть).
   const currentBinding = bindings.find(b => !b.targetFieldKey && b.mapping?.[field.key]);
   const isBound = !!currentBinding;
 
@@ -38,14 +40,13 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
   const del = useDeleteDataSetBinding();
   const autoMap = useAutoMapDataSetSource();
 
-  // Скалярные источники (материализованные — для контейнерных полей, фаза 2).
   const sources: FlatSource[] = useMemo(
     () => files.flatMap(f => f.sources.filter(s => !s.materializeTypeId).map(s => ({ ...s, fileName: f.name }))),
     [files]);
 
   const [sourceId, setSourceId] = useState('');
   const [column, setColumn] = useState('');
-  const [cover, setCover] = useState<Record<string, string>>({}); // сёстры для авто-покрытия
+  const [cover, setCover] = useState<Record<string, string>>({});
   const [coverOn, setCoverOn] = useState(true);
   const [busy, setBusy] = useState(false);
 
@@ -62,7 +63,6 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
     return s;
   }, [bindings]);
 
-  // Открытие: сброс + подстановка текущего состояния.
   function onOpenChange(o: boolean) {
     setOpen(o);
     if (o) {
@@ -72,7 +72,6 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
     }
   }
 
-  // Выбор источника → авто-маппинг остальных НЕпривязанных скалярных полей (кроме этого).
   async function pickSource(id: string) {
     setSourceId(id); setColumn(''); setCover({});
     const src = sources.find(s => s.id === id);
@@ -81,7 +80,6 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
     if (siblings.length === 0) return;
     try {
       const { mapping } = await autoMap.mutateAsync({ sourceId: id, fields: siblings.map(f => ({ key: f.key, title: f.title })) });
-      // Себя, если авто-маппер предложил колонку для текущего поля — подставим по умолчанию.
       if (mapping[field.key] && !column) setColumn(mapping[field.key]);
       const others: Record<string, string> = {};
       for (const [k, c] of Object.entries(mapping)) if (k !== field.key && c) others[k] = c;
@@ -89,8 +87,7 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
     } catch { /* авто-маппинг необязателен */ }
   }
 
-  const coverTitles = Object.keys(cover)
-    .map(k => scalarFields.find(f => f.key === k)?.title ?? k);
+  const coverTitles = Object.keys(cover).map(k => scalarFields.find(f => f.key === k)?.title ?? k);
 
   async function bind() {
     if (!selectedSource || !column) return;
@@ -119,73 +116,68 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
   }
 
   return (
-    <Popover.Root open={open} onOpenChange={onOpenChange}>
-      <Popover.Trigger asChild>
-        <button type="button"
-          title={isBound ? 'Заполняется из источника данных — изменить/отвязать' : 'Привязать к источнику данных'}
-          aria-label={isBound ? 'Привязка к источнику' : 'Привязать к источнику'}
-          className={`inline-flex items-center justify-center rounded transition-colors ${
-            isBound ? 'text-brand hover:text-brand-hover' : 'text-fg4 opacity-0 group-hover:opacity-100 hover:text-fg2'}`}>
-          <Database size={13} />
-        </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content sideOffset={6} align="end"
-          className="z-50 w-80 rounded-xl border border-stroke bg-surface p-3 text-sm shadow-[var(--f-shadow16)] focus:outline-none">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-semibold text-fg2">Источник для «{field.title}»</span>
-            <Popover.Close asChild>
-              <button className="text-fg4 hover:text-fg2" aria-label="Закрыть"><X size={14} /></button>
-            </Popover.Close>
-          </div>
+    <>
+      <button type="button" onClick={() => onOpenChange(true)}
+        title={isBound ? 'Заполняется из источника данных — изменить/отвязать' : 'Привязать к источнику данных'}
+        aria-label={isBound ? 'Привязка к источнику' : 'Привязать к источнику'}
+        className={`inline-flex items-center justify-center rounded transition-colors ${
+          isBound ? 'text-brand hover:text-brand-hover' : 'text-fg4 opacity-0 group-hover:opacity-100 hover:text-fg2'}`}>
+        <Database size={13} />
+      </button>
 
-          {sources.length === 0 ? (
-            <p className="text-xs text-fg4 py-2">
-              Нет подходящих источников. Загрузите набор данных на странице «Наборы данных» или в панели уровня.
-            </p>
-          ) : (
-            <div className="space-y-2">
+      <Modal open={open} onOpenChange={onOpenChange} title={`Источник для «${field.title}»`}
+        footer={
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              {isBound && (
+                <Button variant="text" size="sm" danger onClick={unbind} disabled={busy} icon={<Link2Off size={14} />}>
+                  Отвязать
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="text" size="sm" onClick={() => setOpen(false)}>Отмена</Button>
+              <Button variant="filled" size="sm" onClick={bind} disabled={!column || busy} loading={busy}>
+                {isBound ? 'Изменить' : 'Привязать'}
+              </Button>
+            </div>
+          </div>
+        }>
+        {sources.length === 0 ? (
+          <p className="text-xs text-fg4 py-2">
+            Нет подходящих источников. Загрузите набор данных на странице «Наборы данных» или в панели уровня.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div>
+              <label className="block text-[11px] text-fg4 mb-1">Источник</label>
+              <select value={sourceId} onChange={e => pickSource(e.target.value)}
+                className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
+                <option value="">— выберите —</option>
+                {sources.map(s => <option key={s.id} value={s.id}>{s.fileName} · {s.name}</option>)}
+              </select>
+            </div>
+
+            {selectedSource && (
               <div>
-                <label className="block text-[11px] text-fg4 mb-1">Источник</label>
-                <select value={sourceId} onChange={e => pickSource(e.target.value)}
+                <label className="block text-[11px] text-fg4 mb-1">Колонка</label>
+                <select value={column} onChange={e => setColumn(e.target.value)}
                   className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
-                  <option value="">— выберите —</option>
-                  {sources.map(s => <option key={s.id} value={s.id}>{s.fileName} · {s.name}</option>)}
+                  <option value="">— не привязано —</option>
+                  {columns.map(c => <option key={c} value={c}>{c}</option>)}
                 </select>
               </div>
+            )}
 
-              {selectedSource && (
-                <div>
-                  <label className="block text-[11px] text-fg4 mb-1">Колонка</label>
-                  <select value={column} onChange={e => setColumn(e.target.value)}
-                    className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
-                    <option value="">— не привязано —</option>
-                    {columns.map(c => <option key={c} value={c}>{c}</option>)}
-                  </select>
-                </div>
-              )}
-
-              {selectedSource && coverTitles.length > 0 && (
-                <label className="flex items-start gap-2 text-xs text-fg2 cursor-pointer select-none">
-                  <input type="checkbox" checked={coverOn} onChange={e => setCoverOn(e.target.checked)} className="mt-0.5" />
-                  <span>Этот источник заполнит также: <span className="text-fg3">{coverTitles.join(', ')}</span></span>
-                </label>
-              )}
-
-              <div className="flex items-center gap-2 pt-1">
-                <Button variant="filled" size="sm" onClick={bind} disabled={!column || busy} loading={busy}>
-                  {isBound ? 'Изменить' : 'Привязать'}
-                </Button>
-                {isBound && (
-                  <Button variant="text" size="sm" danger onClick={unbind} disabled={busy} icon={<Link2Off size={13} />}>
-                    Отвязать
-                  </Button>
-                )}
-              </div>
-            </div>
-          )}
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+            {selectedSource && coverTitles.length > 0 && (
+              <label className="flex items-start gap-2 text-xs text-fg2 cursor-pointer select-none">
+                <input type="checkbox" checked={coverOn} onChange={e => setCoverOn(e.target.checked)} className="mt-0.5" />
+                <span>Этот источник заполнит также: <span className="text-fg3">{coverTitles.join(', ')}</span></span>
+              </label>
+            )}
+          </div>
+        )}
+      </Modal>
+    </>
   );
 }

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -884,7 +884,7 @@ function InstanceNameEditor({ instance, setId, docType }: {
 
 // ─── Instance editor modal ────────────────────────────────────────────────────
 
-type InstanceTab = 'requisites' | 'datasets' | 'quality' | 'generation';
+type InstanceTab = 'requisites' | 'quality' | 'generation';
 
 export function InstanceEditor({ instance, setId, docType, allDocTypes, otherInstances, onClose, onDirtyChange, requestClose }: {
   instance: DocumentInstance; setId: string; docType: DocumentType | undefined;
@@ -895,6 +895,7 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
 }) {
   const schemaFields = docType ? resolveEffectiveFields(docType, allDocTypes) : [];
   const [tab, setTab] = useState<InstanceTab>('requisites');
+  const [dataSourcesOpen, setDataSourcesOpen] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [pendingTab, setPendingTab] = useState<InstanceTab | null>(null);
   const [switching, setSwitching] = useState(false);
@@ -934,7 +935,7 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
   // с полем-ссылкой на документ качества, тэг material.qualityDocLink).
   const requiresQuality = !!docType && compositeFieldHasTag(docType, FUNCTIONAL_TAG.materialQualityDocLink, allDocTypes);
   const tabs: [InstanceTab, string][] = [
-    ['requisites', 'Реквизиты'], ['datasets', 'Данные'],
+    ['requisites', 'Реквизиты'],
     ...(requiresQuality ? [['quality', 'Документы качества'] as [InstanceTab, string]] : []),
     ['generation', 'Генерация'],
   ];
@@ -1006,6 +1007,12 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           <span className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${STATUS_COLORS[instance.status] ?? 'bg-brand-subtle text-brand'}`}>
             {STATUS_LABELS[instance.status] ?? instance.status}
           </span>
+          {/* Источники данных (issue #296, фаза 3): пакетные операции уровня документа — обзор
+              привязок, «Проверить данные», «Из шаблона». Точечная привязка — на самих полях. */}
+          <Button variant="text" size="sm" icon={<Database size={15} />} onClick={() => setDataSourcesOpen(true)}
+            className="shrink-0" title="Обзор привязок, проверка данных, шаблоны">
+            <span className="hidden sm:inline">Источники</span>
+          </Button>
           {editable && (
             <div className="flex items-center gap-2 shrink-0">
               {savedFlash && <span className="text-sm text-success hidden sm:inline">Сохранено</span>}
@@ -1036,11 +1043,17 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           onClose={onClose} onDirty={setDirty} saveRef={saveRef}
           onBaseState={setBaseState} baseControlRef={baseControlRef} />
       )}
-      {tab === 'datasets' && (
-        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
-          <DataSetsTab instance={instance} setId={setId} schemaFields={schemaFields} allDocTypes={allDocTypes} docType={docType} />
-        </div>
-      )}
+      <Modal open={dataSourcesOpen} onOpenChange={setDataSourcesOpen} title="Источники данных" wide>
+        {dataSourcesOpen && (
+          <div className="space-y-3">
+            <p className="text-xs text-fg4">
+              Точечная привязка полей — по иконке источника у каждого поля в реквизитах.
+              Здесь — обзор привязок, проверка данных и применение шаблонов на весь документ.
+            </p>
+            <DataSetsTab instance={instance} setId={setId} schemaFields={schemaFields} allDocTypes={allDocTypes} docType={docType} />
+          </div>
+        )}
+      </Modal>
       {tab === 'quality' && (
         <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
           <QualityLinksTab instance={instance} setId={setId} allDocTypes={allDocTypes} />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.52.4</Version>
+    <Version>0.53.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #296. Финал эпика «Линза» + фикс бага скалярной привязки.

## Фаза 3 — document-level «Источники данных»

- **Кнопка «Источники»** в top app bar редактора → **модалка** «Источники данных»: обзор привязок, «Проверить данные», «Из шаблона» (переиспользуем `DataSetsTab`).
- **Вкладка «Данные» удалена** из tablist. Точечная привязка — на самих полях (фазы 1/2).

## Фикс: скалярная привязка не ловила клики

Редактор рендерится в Radix Dialog (modal); `react-remove-scroll` вешает `pointer-events: none` на всё вне контента диалога. `Popover` в `FieldSourceBinding` порталился в `body` **вне** диалога → контент был инертен (клики по источнику/колонке/кнопкам не срабатывали). Перевёл на тот же `Modal`, что и `ContainerFieldBinding` (вложенный Dialog координируется корректно).

## Эпик #296 закрыт

0 черновик · 0b гейт генерации · 1 per-field скаляр · 2a контейнеры (материализация/табличный) · 2b составные (ref) · 3 document-level + убрать вкладку. **Дедлок решён по корню.**

## Проверка
`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)