### PR TITLE
fix(editor): метка уровня в пикере источника (различать одноимённые)

### DIFF
--- a/src/client/src/features/document-sets/editor/ContainerFieldBinding.tsx
+++ b/src/client/src/features/document-sets/editor/ContainerFieldBinding.tsx
@@ -6,10 +6,11 @@ import { MappingEditor } from './DataSetsTab';
 import {
   useAvailableDataSetFiles, useCreateDataSetBinding, useUpdateDataSetBinding, useDeleteDataSetBinding,
 } from '@/shared/api/datasets';
-import type { DataSetBinding, DataSetSource, DocumentType } from '@/shared/api/types';
+import type { DataSetBinding, DataSetSource, DocumentType, CatalogScope } from '@/shared/api/types';
+import { SCOPE_LABELS } from '@/shared/api/types';
 import type { SchemaField } from '@/shared/api/schema';
 
-type FlatSource = DataSetSource & { fileName: string };
+type FlatSource = DataSetSource & { fileName: string; fileScope: CatalogScope };
 
 /** Совместимость по наследованию: childId == ancestorId либо потомок ancestorId по parentId. */
 function isSameOrDescendant(childId: string, ancestorId: string, allDocTypes: DocumentType[]): boolean {
@@ -52,7 +53,7 @@ export function ContainerFieldBinding({ instanceId, setId, field, allDocTypes, b
   const del = useDeleteDataSetBinding();
 
   const sources: FlatSource[] = useMemo(() => {
-    const flat = files.flatMap(f => f.sources.map(s => ({ ...s, fileName: f.name })));
+    const flat = files.flatMap(f => f.sources.map(s => ({ ...s, fileName: f.name, fileScope: f.scope })));
     return flat.filter(s => {
       if (s.materializeTypeId) return !!field.typeId && isSameOrDescendant(s.materializeTypeId, field.typeId, allDocTypes);
       return isTabular || isComplexRef; // обычный источник — табличному или составному (ref) полю
@@ -168,7 +169,7 @@ export function ContainerFieldBinding({ instanceId, setId, field, allDocTypes, b
                   <option value="">— выберите источник —</option>
                   {sources.map(s => (
                     <option key={s.id} value={s.id}>
-                      {s.fileName} · {s.name}{s.materializeTypeId ? ` (материализация → ${allDocTypes.find(t => t.id === s.materializeTypeId)?.name ?? 'тип'})` : ''}
+                      [{SCOPE_LABELS[s.fileScope]}] {s.fileName} · {s.name}{s.materializeTypeId ? ` (материализация → ${allDocTypes.find(t => t.id === s.materializeTypeId)?.name ?? 'тип'})` : ''}
                     </option>
                   ))}
                 </select>

--- a/src/client/src/features/document-sets/editor/FieldSourceBinding.tsx
+++ b/src/client/src/features/document-sets/editor/FieldSourceBinding.tsx
@@ -7,10 +7,11 @@ import {
   useDeleteDataSetBinding, useAutoMapDataSetSource,
 } from '@/shared/api/datasets';
 import { parseSourceColumnNames } from '@/shared/api/datasetHelpers';
-import type { DataSetBinding, DataSetSource } from '@/shared/api/types';
+import type { DataSetBinding, DataSetSource, CatalogScope } from '@/shared/api/types';
+import { SCOPE_LABELS } from '@/shared/api/types';
 import type { SchemaField } from '@/shared/api/schema';
 
-type FlatSource = DataSetSource & { fileName: string };
+type FlatSource = DataSetSource & { fileName: string; fileScope: CatalogScope };
 
 /**
  * Per-field привязка скалярного поля к источнику данных (issue #296, фаза 1 — «линза»). Поле — точка
@@ -41,7 +42,7 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
   const autoMap = useAutoMapDataSetSource();
 
   const sources: FlatSource[] = useMemo(
-    () => files.flatMap(f => f.sources.filter(s => !s.materializeTypeId).map(s => ({ ...s, fileName: f.name }))),
+    () => files.flatMap(f => f.sources.filter(s => !s.materializeTypeId).map(s => ({ ...s, fileName: f.name, fileScope: f.scope }))),
     [files]);
 
   const [sourceId, setSourceId] = useState('');
@@ -154,7 +155,7 @@ export function FieldSourceBinding({ instanceId, setId, field, scalarFields, bin
               <select value={sourceId} onChange={e => pickSource(e.target.value)}
                 className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
                 <option value="">— выберите —</option>
-                {sources.map(s => <option key={s.id} value={s.id}>{s.fileName} · {s.name}</option>)}
+                {sources.map(s => <option key={s.id} value={s.id}>[{SCOPE_LABELS[s.fileScope]}] {s.fileName} · {s.name}</option>)}
               </select>
             </div>
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.0</Version>
+    <Version>0.53.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Диагноз

«Дублирующиеся» источники в диалоге привязки — на самом деле **два разных источника** с одинаковым именем. Проверил БД: файл «250701-ЭОМ-ЕЦДМ, ДНС-Сити_ИД» загружен дважды — один на уровне **Комплекта**, другой на **Разделе**; в каждом свой источник «Схемы» (разные id). Бэкенд возвращает оба (правильно — они на разных уровнях), но пикеры per-field привязки не показывали scope → записи выглядели идентично.

## Фикс

`FieldSourceBinding` / `ContainerFieldBinding`: в опции источника добавлена метка уровня — `[Комплект/Раздел/Стройка/Система] {файл} · {источник}` (как было в прежней вкладке «Данные» через `SCOPE_LABELS`). Теперь одноимённые источники с разных уровней различимы.

## Проверка
`tsc -b` + `vitest` (130) зелёные. Только фронтенд, миграций нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)