### PR TITLE
fix(editor): защита от пустого экрана при пустом списке секций

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -313,6 +313,20 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   const useDrawer = items.length >= 2; // мелкие формы (<2 пунктов) — плоский fallback без drawer
   const activeIdx = Math.max(0, items.findIndex(i => i.key === activeKey));
   const activeItem = items[activeIdx] ?? items[0];
+  // Пустой экран (баг): если ВСЕ поля покрыты основой/привязками (напр. «Титульный лист» наследует
+  // всё от базы «Проект»), displayFields пуст → items пуст → activeItem undefined → renderItemBody
+  // падал. Показываем сообщение вместо краша (все хуки выше — ранний return безопасен).
+  if (!activeItem) {
+    return (
+      <div className="flex-1 min-h-0 flex items-center justify-center px-6 text-center">
+        <p className="text-sm text-fg4 max-w-md">
+          Все поля этого документа заполняются автоматически — из основы
+          {hasBase && baseRef ? ' (базового экземпляра)' : ''} или привязок к источникам данных.
+          Заполнять здесь нечего; проверить итог можно в предпросмотре или при генерации.
+        </p>
+      </div>
+    );
+  }
   const prevItem = activeIdx > 0 ? items[activeIdx - 1] : null;
   const nextItem = activeIdx >= 0 && activeIdx < items.length - 1 ? items[activeIdx + 1] : null;
   const fieldsItems = items.filter(i => i.kind === 'fields'); // для подстроки «раздел X из Y»

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.1</Version>
+    <Version>0.53.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
## Проблема
Если ВСЕ поля документа покрыты основой (`_baseRef`) или привязками к источникам, `displayFields` становится пустым → `items` пуст → `activeItem` undefined → `renderItemBody(undefined)` обращался к `item.fields`/`item.title` → падение → пустой экран.

Гвард схемы (`schemaFields.length === 0`) этот случай не ловил: схема-то есть, пустым становится именно список секций после фильтрации.

## Фикс
Ранний `return` с человекочитаемым сообщением («все поля заполняются автоматически…») вместо краша. Все хуки объявлены выше — ранний return безопасен по правилам хуков.

## Проверка
- `tsc -b` — зелёный
- `vitest` (130) — зелёные

Примечание: это харднинг класса «пустой экран». Отдельно расследуется интермиттент-репорт по «Титульному листу» — для него этот путь не срабатывает (у документа нет `_baseRef`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)