### PR TITLE
fix(editor): пустой экран при открытии документа — цикл рендера + error boundary (#305)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/shared/ui/ThemeProvider';
+import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
 import { ToastProvider } from '@/shared/ui/Toast';
 import { AuthProvider } from '@/shared/ui/AuthProvider';
 import { ProtectedRoute, AdminRoute } from '@/shared/ui/ProtectedRoute';
@@ -33,6 +34,7 @@ export default function App() {
       <AuthProvider>
         <ToastProvider>
         <BrowserRouter>
+          <ErrorBoundary variant="page" allowReload>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
@@ -59,6 +61,7 @@ export default function App() {
               </Route>
             </Route>
           </Routes>
+          </ErrorBoundary>
         </BrowserRouter>
         </ToastProvider>
       </AuthProvider>

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -34,6 +34,7 @@ import {
 import type { Construction, DocumentInstance } from '@/shared/api/types';
 import { STATUS_LABELS, STATUS_COLORS } from './fields';
 import { InstanceEditor } from './editor';
+import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
 import { EmailSendDialog } from './EmailSendDialog';
 import { useEmailSet } from '@/shared/api/documentSets';
 import { useAuth } from '@/shared/hooks/useAuth';
@@ -383,10 +384,16 @@ function SetDetail() {
             title={liveInstance.name || docTypeMap[liveInstance.documentTypeId]?.name || 'Редактировать документ'}
             fullScreen headerless isDirty={editDirty} flushBody>
             {requestClose => (
-              <InstanceEditor key={liveInstance.id} instance={liveInstance} setId={setId} docType={docTypeMap[liveInstance.documentTypeId]}
-                allDocTypes={docTypes} otherInstances={otherInstances}
-                onClose={() => { setEditInstance(null); setEditDirty(false); }} onDirtyChange={setEditDirty}
-                requestClose={requestClose} />
+              // Граница ошибок (issue #305): краш рендера редактора изолирован в панель ошибки
+              // вместо немого пустого экрана; Esc/закрытие живут на уровне Modal (вне границы).
+              // resetKeys=[id] — смена документа сбрасывает пойманную ошибку.
+              <ErrorBoundary variant="inline" allowReload resetKeys={[liveInstance.id]}
+                title="Не удалось открыть документ">
+                <InstanceEditor key={liveInstance.id} instance={liveInstance} setId={setId} docType={docTypeMap[liveInstance.documentTypeId]}
+                  allDocTypes={docTypes} otherInstances={otherInstances}
+                  onClose={() => { setEditInstance(null); setEditDirty(false); }} onDirtyChange={setEditDirty}
+                  requestClose={requestClose} />
+              </ErrorBoundary>
             )}
           </Modal>
         );

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -71,6 +71,12 @@ function BoundStateHint({ loading, error }: { loading: boolean; error: boolean }
   return <p className="text-[11px] text-fg4 mt-0.5 italic">{text}</p>;
 }
 
+// Стабильный пустой дефолт для загружающихся списочных запросов. КРИТИЧНО (issue #305): `= []` в
+// деструктуризации создаёт НОВЫЙ массив на каждый рендер, пока `data === undefined` (загрузка). Если
+// такой список — dep useMemo, который в свою очередь dep эффекта с setState, получаем бесконечный цикл
+// «Maximum update depth exceeded» до догрузки запроса (симптом «пустой экран при открытии документа»).
+const EMPTY: never[] = [];
+
 // ─── Базовый экземпляр (issue #71) ────────────────────────────────────────────
 // Документ дочернего типа может наследоваться от базы — документа комплекта ЛИБО записи общих данных.
 // Кандидаты берутся по всей цепочке типов-предков и по скоп-близости (комплект > раздел > стройка >
@@ -128,7 +134,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   const ancestorIds = useMemo(() => ancestorTypeIds(docType, allDocTypes), [docType, allDocTypes]);
   const hasBase = ancestorIds.length > 0;
   // Общие данные всех уровней скопа комплекта (Set/Section/Construction/System) — кандидаты-записи.
-  const { data: commonData = [] } = useCommonDataForSet({ setId, enabled: hasBase });
+  const { data: commonData = EMPTY } = useCommonDataForSet({ setId, enabled: hasBase });
   const baseRef = useMemo(() => parseBaseRef(values._baseRef), [values._baseRef]);
 
   const baseCandidates = useMemo<BaseCandidate[]>(() => {

--- a/src/client/src/shared/ui/ErrorBoundary.tsx
+++ b/src/client/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,103 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle, RotateCcw, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
+
+/**
+ * React error boundary (issue #305). В приложении их не было вовсе — а в React 19 любой throw при
+ * рендере, не пойманный границей, РАЗМОНТИРУЕТ всё дерево → немой белый экран без следа в UI
+ * (симптом «пустой экран при открытии документа»). Граница ловит throw, показывает читаемую панель
+ * с текстом ошибки + сворачиваемым стеком и даёт восстановиться, не перезагружая страницу.
+ *
+ * `resetKeys` — при их изменении граница сбрасывается (напр. сменили документ/маршрут → пробуем
+ * рендер заново). `variant="inline"` — компактная панель для контента модалки (не полноэкранная).
+ */
+export class ErrorBoundary extends Component<
+  {
+    children: ReactNode;
+    /** Заголовок панели (по умолчанию — общий). */
+    title?: string;
+    /** Меняется — граница сбрасывает пойманную ошибку и пробует отрисовать детей снова. */
+    resetKeys?: unknown[];
+    /** inline — компактная панель (для модалок/секций); page — полноэкранная (корень app). */
+    variant?: 'inline' | 'page';
+    /** Показать кнопку «Перезагрузить страницу» (для корневой границы). */
+    allowReload?: boolean;
+  },
+  { error: Error | null; expanded: boolean }
+> {
+  state = { error: null as Error | null, expanded: false };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error, expanded: false };
+  }
+
+  componentDidUpdate(prev: Readonly<{ resetKeys?: unknown[] }>) {
+    // Смена resetKeys при активной ошибке → сброс (даём поддереву шанс отрисоваться на новых данных).
+    if (this.state.error && !shallowEqualArr(prev.resetKeys, this.props.resetKeys)) {
+      this.setState({ error: null, expanded: false });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Лог в консоль — чтобы стек попал в devtools даже когда панель свёрнута.
+    console.error('[ErrorBoundary] пойман сбой рендера:', error, info.componentStack);
+  }
+
+  reset = () => this.setState({ error: null, expanded: false });
+
+  render() {
+    const { error, expanded } = this.state;
+    if (!error) return this.props.children;
+
+    const { title = 'Что-то пошло не так', variant = 'inline', allowReload } = this.props;
+    const isPage = variant === 'page';
+
+    return (
+      <div className={isPage
+        ? 'min-h-screen flex items-center justify-center p-6 bg-base'
+        : 'flex-1 min-h-0 flex items-center justify-center p-6'}>
+        <div className="max-w-lg w-full rounded-xl border border-danger/30 bg-danger-subtle/40 p-5">
+          <div className="flex items-start gap-3">
+            <AlertTriangle size={20} className="text-danger shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <h2 className="text-base font-medium text-fg1">{title}</h2>
+              <p className="text-sm text-fg3 mt-1">
+                Произошла ошибка при отображении. Данные не потеряны — можно попробовать снова или
+                перезагрузить страницу.
+              </p>
+
+              <div className="flex flex-wrap items-center gap-2 mt-3">
+                <button type="button" onClick={this.reset}
+                  className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm font-medium bg-brand text-white hover:bg-brand-hover transition-colors">
+                  <RotateCcw size={14} /> Попробовать снова
+                </button>
+                {allowReload && (
+                  <button type="button" onClick={() => window.location.reload()}
+                    className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm font-medium border border-stroke text-fg2 hover:bg-base transition-colors">
+                    <RefreshCw size={14} /> Перезагрузить страницу
+                  </button>
+                )}
+              </div>
+
+              <button type="button" onClick={() => this.setState({ expanded: !expanded })}
+                className="inline-flex items-center gap-1 mt-3 text-xs text-fg4 hover:text-fg2 transition-colors">
+                {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                Подробности ошибки
+              </button>
+              {expanded && (
+                <pre className="mt-2 max-h-60 overflow-auto rounded-lg bg-black/5 dark:bg-white/5 p-3 text-[11px] leading-relaxed text-fg3 whitespace-pre-wrap break-words">
+                  {error.message}{error.stack ? `\n\n${error.stack}` : ''}
+                </pre>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function shallowEqualArr(a?: unknown[], b?: unknown[]): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((v, i) => Object.is(v, b[i]));
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.1</Version>
+    <Version>0.53.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #305

## Симптом
Иногда при открытии первого документа комплекта («Титульный лист») — **пустой белый экран**. Открыть сначала другой документ (АОСР) → Титульный открывается нормально.

## Корневая причина (пришпилена через добавленную диагностику)
**Бесконечный цикл рендера — «Maximum update depth exceeded».**

`const { data: commonData = [] } = useCommonDataForSet(...)`: пока запрос грузится (`data === undefined`), дефолт `= []` создаёт **новый пустой массив на каждый рендер**. Свежий `[]` → dep `useMemo baseCandidates` → новый массив каждый рендер → он в deps эффекта `onBaseState` (зовёт `setBaseState`) → ре-рендер → `commonData` всё ещё грузится → **цикл** до догрузки запроса. Не пойманный цикл в React 19 ронял всё дерево → немой пустой экран.

Объясняет интермиттентность и «АОСР сначала лечит»: АОСР прогревает `useCommonDataForSet(setId)` (тот же query-key) → при возврате `commonData` уже в кэше (стабильная ссылка) → `baseCandidates` стабилен → цикла нет.

## Фикс (2 части)
1. **Root cause:** стабильный модульный дефолт `EMPTY` вместо свежего `[]` в деструктуризации `commonData`. Цикл разорван.
2. **Error boundary (issue #305):** во всём фронтенде не было ни одной — поэтому цикл давал немой белый экран без следа. Добавлен переиспользуемый `ErrorBoundary` (панель с текстом ошибки + стеком, «Попробовать снова»/«Перезагрузить»); обёрнут весь app и контент редактора-модалки. Именно он и вскрыл `Maximum update depth` вместо пустого экрана.

## Проверка
- `tsc -b` — зелёный
- `vitest` (130) — зелёные

> Параллельно открыт #304 (харднинг пустого списка секций) — оба бампят версию до 0.53.2; второй по мёрджу может потребовать тривиального ребейза строки версии.

🤖 Generated with [Claude Code](https://claude.com/claude-code)