### PR TITLE
fix(types): предупреждать о несохранённых правках типа при переходе по разделам (#307)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/shared/ui/ThemeProvider';
 import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
+import { NavigationGuardProvider } from '@/shared/ui/NavigationGuard';
 import { ToastProvider } from '@/shared/ui/Toast';
 import { AuthProvider } from '@/shared/ui/AuthProvider';
 import { ProtectedRoute, AdminRoute } from '@/shared/ui/ProtectedRoute';
@@ -35,6 +36,7 @@ export default function App() {
         <ToastProvider>
         <BrowserRouter>
           <ErrorBoundary variant="page" allowReload>
+          <NavigationGuardProvider>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
@@ -61,6 +63,7 @@ export default function App() {
               </Route>
             </Route>
           </Routes>
+          </NavigationGuardProvider>
           </ErrorBoundary>
         </BrowserRouter>
         </ToastProvider>

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -45,6 +45,7 @@ import {
   TypeEditorProvider, useRegisterEditor, useTypeEditorRegistry, LeaveGuardDialog, SectionCard,
 } from './typeEditorShell';
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
+import { useLeaveGuard } from '@/shared/ui/NavigationGuard';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { useToast } from '@/shared/ui/Toast';
 import { uniqueCode } from './PrimitiveTypesPage';
@@ -839,6 +840,11 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
   });
   const requestSelect = (id: string) => { if (id !== selectedId) request(id); };
 
+  // Гард ухода со страницы по маршруту (issue #307): сайдбар-навигация перехватывается, показываем
+  // тот же диалог. `routeLeave` хранит отложенный переход (proceed).
+  const [routeLeave, setRouteLeave] = useState<(() => void) | null>(null);
+  useLeaveGuard(anyDirty, (proceed) => setRouteLeave(() => proceed));
+
   const filtered = allDocTypes
     .filter(dt => dt.kind === kind)
     .sort((a, b) => a.name.localeCompare(b.name, 'ru'));
@@ -902,6 +908,16 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
       </TypeEditorProvider>
 
       <LeaveGuardDialog {...dialogProps} />
+
+      {/* Гард ухода по маршруту (сайдбар/перезагрузка), issue #307 */}
+      <LeaveGuardDialog
+        open={routeLeave !== null} saving={saving}
+        onCancel={() => setRouteLeave(null)}
+        onDiscard={() => { const p = routeLeave; setRouteLeave(null); p?.(); }}
+        onSave={async () => {
+          try { await saveAll(); const p = routeLeave; setRouteLeave(null); p?.(); }
+          catch { setRouteLeave(null); /* ошибка показана в форме */ }
+        }} />
 
       <Modal open={createOpen} onOpenChange={setCreateOpen}
         title={kind === 'Document' ? 'Новый тип документа' : 'Новый составной тип'}

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -7,6 +7,7 @@ import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
+import { useLeaveGuard } from '@/shared/ui/NavigationGuard';
 import { TextField } from '@/shared/ui/TextField';
 import { DateInput } from '@/shared/ui/DateInput';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -614,6 +615,10 @@ export function PrimitiveTypesPage() {
   const requestSelect = (id: string) => { if (id !== selectedId) request({ mode, id }); };
   const requestMode = (m: Mode) => { if (m !== mode) request({ mode: m, id: null }); };
 
+  // Гард ухода со страницы по маршруту (issue #307): тот же диалог при сайдбар-навигации/перезагрузке.
+  const [routeLeave, setRouteLeave] = useState<(() => void) | null>(null);
+  useLeaveGuard(anyDirty, (proceed) => setRouteLeave(() => proceed));
+
   const selectedPrim = mode === 'primitive' ? (sortedPrim.find(t => t.id === selectedId) ?? sortedPrim[0]) : undefined;
   const selectedEnum = mode === 'enum' ? (sortedEnum.find(t => t.id === selectedId) ?? sortedEnum[0]) : undefined;
   const addLabel = mode === 'primitive' ? 'Добавить тип' : 'Добавить перечисление';
@@ -657,6 +662,16 @@ export function PrimitiveTypesPage() {
       </TypeEditorProvider>
 
       <LeaveGuardDialog {...dialogProps} />
+
+      {/* Гард ухода по маршруту (сайдбар/перезагрузка), issue #307 */}
+      <LeaveGuardDialog
+        open={routeLeave !== null} saving={saving}
+        onCancel={() => setRouteLeave(null)}
+        onDiscard={() => { const p = routeLeave; setRouteLeave(null); p?.(); }}
+        onSave={async () => {
+          try { await saveAll(); const p = routeLeave; setRouteLeave(null); p?.(); }
+          catch { setRouteLeave(null); /* ошибка показана в форме */ }
+        }} />
 
       <Modal open={createOpen} onOpenChange={setCreateOpen}
         title={mode === 'primitive' ? 'Новый тип поля' : 'Новый тип перечисления'}>

--- a/src/client/src/shared/ui/AppShell.tsx
+++ b/src/client/src/shared/ui/AppShell.tsx
@@ -11,6 +11,7 @@ import { Avatar } from '@/shared/ui/Avatar';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { ShortcutsHelp } from '@/shared/ui/ShortcutsHelp';
 import { workNav, settingsNav, type NavItem } from '@/shared/ui/navConfig';
+import { useGuardedNavClick } from '@/shared/ui/NavigationGuard';
 import { LogOut, Sun, Moon, Monitor, KeyRound, Check, ChevronsUpDown, MailWarning, X } from 'lucide-react';
 
 const themeOptions: { value: Theme; icon: typeof Sun; label: string }[] = [
@@ -50,6 +51,7 @@ function NavSection({
   label: string;
   items: NavItem[];
 }) {
+  const guardedClick = useGuardedNavClick();
   return (
     <div>
       <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-widest select-none text-fg4">
@@ -60,6 +62,7 @@ function NavSection({
           <NavLink
             key={to}
             to={to}
+            onClick={guardedClick(to)}
             className={({ isActive }) =>
               `group flex items-center gap-3 px-3 py-2.5 rounded-full text-sm font-medium select-none transition-colors ` +
               `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand ${
@@ -92,6 +95,7 @@ export function AppShell() {
   const [pwOpen, setPwOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  const guardedProfileClick = useGuardedNavClick();
 
   // Глобальные шорткаты (issue #107): Ctrl/⌘+K — палитра, «?» — справка (не в полях ввода).
   useEffect(() => {
@@ -139,7 +143,7 @@ export function AppShell() {
 
           <div className="space-y-0.5">
             {/* Блок пользователя — пилюля с аватаром */}
-            <NavLink to="/profile"
+            <NavLink to="/profile" onClick={guardedProfileClick('/profile')}
               className={({ isActive }) => `flex items-center gap-3 h-14 px-4 rounded-[28px] transition-colors ` +
                 `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
                 (isActive ? 'bg-tonal' : 'hover:bg-black/5 dark:hover:bg-white/10')}>

--- a/src/client/src/shared/ui/NavigationGuard.tsx
+++ b/src/client/src/shared/ui/NavigationGuard.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useRef, useEffect, type ReactNode, type MouseEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/** Обработчик ухода: показывает подтверждение и вызывает `proceed()`, если пользователь решил уйти. */
+type LeaveHandler = (proceed: () => void) => void;
+
+interface NavGuard {
+  /** Активная страница регистрирует свой обработчик ухода (или снимает — null). */
+  register: (h: LeaveHandler | null) => void;
+  /** Навигация вызывает перед переходом: есть обработчик → вызывает его (диалог) и возвращает true
+   *  (переход заблокирован, решение за обработчиком); иначе false (уходить сразу). */
+  attempt: (proceed: () => void) => boolean;
+}
+
+const Ctx = createContext<NavGuard | null>(null);
+
+/**
+ * Router-agnostic гард навигации при несохранённых правках (issue #307). `<BrowserRouter>` (не
+ * data-router) не поддерживает `useBlocker`, поэтому переходы перехватываются в самих ссылках
+ * навигации (AppShell) через `attempt`, а страница-владелец показывает подтверждение. Один обработчик
+ * за раз — под `<Outlet/>` смонтирована лишь одна страница.
+ */
+export function NavigationGuardProvider({ children }: { children: ReactNode }) {
+  const handlerRef = useRef<LeaveHandler | null>(null);
+  const value = useRef<NavGuard>({
+    register: (h) => { handlerRef.current = h; },
+    attempt: (proceed) => {
+      if (handlerRef.current) { handlerRef.current(proceed); return true; }
+      return false;
+    },
+  }).current;
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useNavigationGuard() { return useContext(Ctx); }
+
+/**
+ * onClick-обработчик для ссылок навигации (NavLink/Link): при активном гарде отменяет мгновенный
+ * переход и отдаёт решение странице-владельцу; иначе — обычная навигация. Modifier-клики (Ctrl/⌘/Shift
+ * — открыть в новой вкладке) и не-левый клик не перехватываются.
+ */
+export function useGuardedNavClick() {
+  const guard = useNavigationGuard();
+  const navigate = useNavigate();
+  return (to: string) => (e: MouseEvent) => {
+    if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+    if (guard && guard.attempt(() => navigate(to))) e.preventDefault();
+  };
+}
+
+/**
+ * Регистрирует гард ухода со страницы, пока `active` (есть несохранённые правки). `onLeave(proceed)`
+ * должен показать подтверждение и вызвать `proceed()` при выборе «уйти»/«сохранить». Дополнительно —
+ * `beforeunload` на перезагрузку/закрытие вкладки. Перехват in-app переходов — в ссылках AppShell.
+ */
+export function useLeaveGuard(active: boolean, onLeave: LeaveHandler) {
+  const guard = useNavigationGuard();
+  const cbRef = useRef(onLeave);
+  cbRef.current = onLeave;
+  useEffect(() => {
+    if (!guard) return;
+    guard.register(active ? (proceed) => cbRef.current(proceed) : null);
+    return () => guard.register(null);
+  }, [guard, active]);
+  useEffect(() => {
+    if (!active) return;
+    const h = (e: BeforeUnloadEvent) => { e.preventDefault(); e.returnValue = ''; };
+    window.addEventListener('beforeunload', h);
+    return () => window.removeEventListener('beforeunload', h);
+  }, [active]);
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.2</Version>
+    <Version>0.53.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #307

## Симптом
В редакторе типов (Типы документов / Составные типы / Типы полей) правишь тип (напр. Typst-блок), не сохраняешь и кликаешь другой раздел в сайдбаре → переход молча, правки теряются, предупреждения нет.

## Диагностика (воспроизведено вживую, Playwright)
- Правка Typst-блока корректно ставит `dirty` (бейдж «есть изменения») ✓
- Смена **типа** в списке при dirty → гард «Несохранённые изменения» **срабатывает** ✓
- Переход в **другой раздел по сайдбару** при dirty → url меняется молча, гарда **нет** ✗

`useDirtyGuard` перехватывал только выбор элемента внутри страницы; route-навигация (NavLink) — ничем. `react-router-dom@7` с `<BrowserRouter>` (не data-router) не поддерживает `useBlocker`.

## Фикс
Router-agnostic `NavigationGuard` (`shared/ui/NavigationGuard.tsx`):
- Провайдер + `useGuardedNavClick` перехватывает клики по ссылкам навигации в AppShell (modifier-клики «в новой вкладке» пропускаются).
- Активная страница с несохранёнными правками регистрирует обработчик ухода (`useLeaveGuard(anyDirty, …)`) → клик по разделу отменяет мгновенный переход и показывает тот же `LeaveGuardDialog` (Сохранить / Не сохранять / Отмена).
- `beforeunload` на перезагрузку/закрытие вкладки.
- Применено к `DocumentTypesPage` и `PrimitiveTypesPage`.

Известное ограничение: браузерные «назад/вперёд» не перехватываются (нужен data-router); основной путь (сайдбар/перезагрузка) закрыт.

## Проверка
- Playwright: dirty → клик сайдбара → гард показан, переход заблокирован; «Не сохранять» уводит ✓
- `tsc -b` + `vitest` (130) зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)