### PR TITLE
fix(typst): топосортировка typeblocks.typ + провенанс (#309, фаза 1)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/TypstPreambleBuilder.cs
+++ b/src/server/BHS.CRG.Application/Generation/TypstPreambleBuilder.cs
@@ -1,32 +1,238 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Application.Generation;
 
+/// <summary>Плоская запись одного Typst-блока (вариант отображения типа) с провенансом.</summary>
+public sealed record TypstBlockRecord(string FnName, string Block, string Provenance, Guid TypeId, string TypeName, string VariantName);
+
+public enum TypstBlockDiagnosticSeverity { Warning, Error }
+
+/// <summary>Диагностика сборки typeblocks.typ (цикл ссылок, дубликат имени функции).</summary>
+public sealed record TypstBlockDiagnostic(
+    TypstBlockDiagnosticSeverity Severity, string Code, string Message, IReadOnlyList<string> FnNames);
+
+/// <summary>Карта строк: где в итоговом typeblocks.typ лежит блок (для маппинга ошибок Typst назад на тип/вариант).</summary>
+public sealed record TypstBlockSpan(string FnName, string Provenance, Guid TypeId, int StartLine, int EndLine);
+
+public sealed record TypstPreambleResult(
+    string Content, IReadOnlyList<TypstBlockSpan> Spans, IReadOnlyList<TypstBlockDiagnostic> Diagnostics);
+
 /// <summary>
-/// Собирает typeblocks.typ — функции рендеринга составных типов,
-/// объявленные в схемах типов документов (свойство "typstRenders").
-/// Используется и при генерации, и при выгрузке отладочного пакета,
-/// чтобы оба пути давали идентичный typeblocks.typ.
+/// Собирает typeblocks.typ — функции рендеринга составных типов (схема, свойство "typstRenders").
+///
+/// Порядок КРИТИЧЕН (issue #309): в Typst замыкание захватывает лексическую область НА МЕСТЕ
+/// определения, поэтому если блок A вызывает функцию B, `#let B` обязан стоять ВЫШЕ, иначе
+/// `unknown variable`. Блоки топологически сортируются по зависимостям (Kahn, тай-брейк по исходному
+/// индексу → стабильно и обратно совместимо); межтиповые циклы неразрешимы во flat-`#let` и
+/// выдаются диагностикой (best-effort порядок, без pre-throw — Typst ленив и сам финальный арбитр).
+///
+/// Адаптер (<see cref="ExtractRenders"/>: тип → плоские записи) отделён от чистого ядра
+/// (<see cref="BuildDetailed"/>: граф+сорт+эмиссия). Генерация и debug-бандл зовут одно ядро —
+/// единый источник правды порядка/номеров строк. Фаза 2 (проверка блоков) переиспользует ядро с
+/// draft-overlay.
 /// </summary>
 public static class TypstPreambleBuilder
 {
+    /// <summary>Обратно совместимая точка: типы → готовый текст typeblocks.typ (генерация, debug-бандл).</summary>
     public static string Build(IEnumerable<DocumentType> compositeTypes)
+        => BuildDetailed(compositeTypes.SelectMany(ExtractRenders)).Content;
+
+    /// <summary>Адаптер: схема типа → плоские записи блоков (с провенансом). Пустые/битые — пропускаются.</summary>
+    public static IEnumerable<TypstBlockRecord> ExtractRenders(DocumentType type)
     {
-        var sb = new StringBuilder();
-        foreach (var ct in compositeTypes)
+        if (!type.Schema.RootElement.TryGetProperty("typstRenders", out var renders)
+            || renders.ValueKind != JsonValueKind.Array)
+            yield break;
+
+        foreach (var render in renders.EnumerateArray())
         {
-            if (!ct.Schema.RootElement.TryGetProperty("typstRenders", out var renders)) continue;
-            if (renders.ValueKind != JsonValueKind.Array) continue;
-            foreach (var render in renders.EnumerateArray())
+            var fnName = render.TryGetProperty("fnName", out var fn) ? fn.GetString() : null;
+            var block = render.TryGetProperty("block", out var bl) ? bl.GetString() : null;
+            if (string.IsNullOrWhiteSpace(fnName) || string.IsNullOrWhiteSpace(block)) continue;
+            var variant = render.TryGetProperty("name", out var nm) ? nm.GetString() ?? "" : "";
+            var fnTrim = fnName.Trim();
+            yield return new TypstBlockRecord(fnTrim, block, Provenance(type.Name, type.Code, variant, fnTrim),
+                type.Id, type.Name, variant);
+        }
+    }
+
+    /// <summary>Провенанс-строка над блоком (одна строка — без переводов строк, чтобы не сбить line-map).</summary>
+    private static string Provenance(string typeName, string code, string variant, string fnName)
+    {
+        static string San(string? s) => (s ?? "").Replace('\r', ' ').Replace('\n', ' ').Trim();
+        return $"[type: {San(typeName)} ({San(code)})] variant: {San(variant)} -> {fnName}";
+    }
+
+    /// <summary>Чистое ядро: граф зависимостей → топосорт → эмиссия с провенансом + line-map + диагностики.</summary>
+    public static TypstPreambleResult BuildDetailed(IEnumerable<TypstBlockRecord> records)
+    {
+        var list = records.ToList();
+        var diagnostics = new List<TypstBlockDiagnostic>();
+        var n = list.Count;
+
+        // Дубликаты fnName между типами: typeblocks глобален → одноимённые функции делают граф
+        // неоднозначным и в самом Typst перекрывают друг друга (последняя побеждает).
+        foreach (var g in list.GroupBy(r => r.FnName).Where(g => g.Count() > 1))
+            diagnostics.Add(new(TypstBlockDiagnosticSeverity.Error, "duplicate-fn",
+                $"Имя функции «{g.Key}» задано более чем в одном варианте: {string.Join("; ", g.Select(r => r.Provenance))}",
+                new[] { g.Key }));
+
+        var known = new HashSet<string>(list.Select(r => r.FnName));
+        var nameToIndices = new Dictionary<string, List<int>>();
+        for (int i = 0; i < n; i++)
+        {
+            if (!nameToIndices.TryGetValue(list[i].FnName, out var l)) { l = new(); nameToIndices[list[i].FnName] = l; }
+            l.Add(i);
+        }
+
+        // deps[i] = индексы блоков, которые блок i вызывает (они должны идти ВЫШЕ i).
+        var deps = new List<HashSet<int>>(n);
+        for (int i = 0; i < n; i++)
+        {
+            var set = new HashSet<int>();
+            foreach (var refName in FindReferencedFnNames(list[i].Block, known, list[i].FnName))
+                if (nameToIndices.TryGetValue(refName, out var targets))
+                    foreach (var t in targets) if (t != i) set.Add(t);
+            deps.Add(set);
+        }
+
+        // Kahn с тай-брейком по исходному индексу: зависимости раньше зависимых, независимые — в
+        // исходном порядке (двигается только реально неверно упорядоченное → обратная совместимость).
+        var dependents = new List<List<int>>();
+        for (int i = 0; i < n; i++) dependents.Add(new());
+        for (int i = 0; i < n; i++) foreach (var d in deps[i]) dependents[d].Add(i);
+
+        var remaining = deps.Select(d => d.Count).ToArray();
+        var emitted = new bool[n];
+        var ready = new SortedSet<int>();
+        for (int i = 0; i < n; i++) if (remaining[i] == 0) ready.Add(i);
+
+        var order = new List<int>(n);
+        while (ready.Count > 0)
+        {
+            var i = ready.Min; ready.Remove(i);
+            order.Add(i); emitted[i] = true;
+            foreach (var dep in dependents[i])
+                if (!emitted[dep] && --remaining[dep] == 0) ready.Add(dep);
+        }
+
+        // Оставшиеся — в циклах (или ниже по течению цикла). Best-effort: добавляем в исходном порядке.
+        if (order.Count < n)
+        {
+            foreach (var cycle in FindCycles(deps, emitted))
+                diagnostics.Add(new(TypstBlockDiagnosticSeverity.Error, "cycle",
+                    $"Взаимные ссылки между блоками — Typst не может их упорядочить: "
+                    + string.Join(" → ", cycle.Select(i => list[i].FnName)) + " → " + list[cycle[0]].FnName,
+                    cycle.Select(i => list[i].FnName).ToList()));
+            for (int i = 0; i < n; i++) if (!emitted[i]) { order.Add(i); emitted[i] = true; }
+        }
+
+        // Эмиссия + line-map. Явный '\n' (не Environment.NewLine) — чтобы номера строк совпадали
+        // с тем, что видит Typst, кросс-платформенно.
+        var sb = new StringBuilder();
+        var spans = new List<TypstBlockSpan>(n);
+        int line = 1;
+        foreach (var idx in order)
+        {
+            var r = list[idx];
+            sb.Append("// ").Append(r.Provenance).Append('\n');
+            line++;
+            var def = $"#let {r.FnName}(it) = {r.Block}";
+            int defLines = 1 + def.Count(c => c == '\n');
+            spans.Add(new(r.FnName, r.Provenance, r.TypeId, line, line + defLines - 1));
+            sb.Append(def).Append('\n');
+            line += defLines;
+        }
+        return new(sb.ToString(), spans, diagnostics);
+    }
+
+    /// <summary>Ссылки блока на ДРУГИЕ известные функции: скан вызова `name(` по границе идентификатора,
+    /// с очисткой комментариев/строк (чтобы упоминание в комментарии не давало ложное ребро/цикл).</summary>
+    private static IEnumerable<string> FindReferencedFnNames(string block, HashSet<string> known, string self)
+    {
+        var cleaned = StripCommentsAndStrings(block);
+        foreach (var name in known)
+        {
+            if (name == self) continue; // саморекурсию Typst допускает — не ребро
+            if (Regex.IsMatch(cleaned, $@"(?<![\w\-]){Regex.Escape(name)}\s*\("))
+                yield return name;
+        }
+    }
+
+    /// <summary>Одно-проходная очистка Typst line/block-комментариев и строк "…" (переводы строк
+    /// сохраняются). Не полный парсинг — достаточно, чтобы убрать ложные упоминания имён функций.</summary>
+    private static string StripCommentsAndStrings(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c == '/' && i + 1 < s.Length && s[i + 1] == '/')
             {
-                var fnName = render.TryGetProperty("fnName", out var fn) ? fn.GetString() : null;
-                var block = render.TryGetProperty("block", out var bl) ? bl.GetString() : null;
-                if (string.IsNullOrWhiteSpace(fnName) || string.IsNullOrWhiteSpace(block)) continue;
-                sb.AppendLine($"#let {fnName}(it) = {block}");
+                while (i < s.Length && s[i] != '\n') i++;
+                if (i < s.Length) sb.Append('\n');
+                continue;
             }
+            if (c == '/' && i + 1 < s.Length && s[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < s.Length && !(s[i] == '*' && s[i + 1] == '/')) { if (s[i] == '\n') sb.Append('\n'); i++; }
+                i++; // встанем на '/', внешний i++ пройдёт дальше
+                continue;
+            }
+            if (c == '"')
+            {
+                i++;
+                while (i < s.Length && s[i] != '"')
+                {
+                    if (s[i] == '\\' && i + 1 < s.Length) { i++; }
+                    else if (s[i] == '\n') sb.Append('\n');
+                    i++;
+                }
+                continue;
+            }
+            sb.Append(c);
         }
         return sb.ToString();
+    }
+
+    /// <summary>Нетривиальные SCC (циклы) среди ещё не отсортированных узлов — Tarjan. Саморефы исключены,
+    /// поэтому SCC размера &gt;1 = реальный цикл взаимных ссылок.</summary>
+    private static List<List<int>> FindCycles(List<HashSet<int>> deps, bool[] emitted)
+    {
+        int n = deps.Count;
+        var index = new int[n];
+        var low = new int[n];
+        var onStack = new bool[n];
+        Array.Fill(index, -1);
+        var stack = new Stack<int>();
+        int counter = 0;
+        var result = new List<List<int>>();
+
+        void Strong(int v)
+        {
+            index[v] = low[v] = counter++;
+            stack.Push(v); onStack[v] = true;
+            foreach (var w in deps[v])
+            {
+                if (emitted[w]) continue; // уже упорядоченные — вне циклов
+                if (index[w] == -1) { Strong(w); low[v] = Math.Min(low[v], low[w]); }
+                else if (onStack[w]) low[v] = Math.Min(low[v], index[w]);
+            }
+            if (low[v] == index[v])
+            {
+                var comp = new List<int>();
+                int w;
+                do { w = stack.Pop(); onStack[w] = false; comp.Add(w); } while (w != v);
+                if (comp.Count > 1) { comp.Reverse(); result.Add(comp); }
+            }
+        }
+
+        for (int v = 0; v < n; v++)
+            if (!emitted[v] && index[v] == -1) Strong(v);
+        return result;
     }
 }

--- a/src/server/BHS.CRG.Tests/Generation/TypstPreambleBuilderTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/TypstPreambleBuilderTests.cs
@@ -1,0 +1,95 @@
+using BHS.CRG.Application.Generation;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>
+/// Топосорт и диагностики сборки typeblocks.typ (issue #309): порядок определений по зависимостям
+/// (замыкание Typst захватывает область на месте определения), стабильность, циклы, дубликаты,
+/// провенанс и line-map.
+/// </summary>
+public class TypstPreambleBuilderTests
+{
+    private static TypstBlockRecord R(string fn, string block) =>
+        new(fn, block, $"prov:{fn}", Guid.NewGuid(), "T", fn);
+
+    private static int Idx(string content, string fn) => content.IndexOf($"#let {fn}(", StringComparison.Ordinal);
+
+    [Fact]
+    public void Dependency_IsEmittedBeforeDependent()
+    {
+        // a вызывает b → #let b обязан идти выше #let a, хотя a передан первым.
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("a", "{ b(it) }"), R("b", "{ it.x }") });
+        Assert.True(Idx(res.Content, "b") < Idx(res.Content, "a"));
+        Assert.Empty(res.Diagnostics);
+    }
+
+    [Fact]
+    public void IndependentBlocks_KeepOriginalOrder()
+    {
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("first", "{ it.x }"), R("second", "{ it.y }") });
+        Assert.True(Idx(res.Content, "first") < Idx(res.Content, "second"));
+        Assert.Empty(res.Diagnostics);
+    }
+
+    [Fact]
+    public void SelfRecursion_IsNotACycle()
+    {
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("f", "{ if it.n > 0 { f(it) } }") });
+        Assert.Empty(res.Diagnostics);
+    }
+
+    [Fact]
+    public void MutualReference_ReportsCycle_ButStillEmitsBoth()
+    {
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("a", "{ b(it) }"), R("b", "{ a(it) }") });
+        Assert.Contains(res.Diagnostics, d => d.Code == "cycle" && d.Severity == TypstBlockDiagnosticSeverity.Error);
+        Assert.True(Idx(res.Content, "a") >= 0 && Idx(res.Content, "b") >= 0);
+    }
+
+    [Fact]
+    public void DuplicateFnName_IsReported()
+    {
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("dup", "{ it.x }"), R("dup", "{ it.y }") });
+        Assert.Contains(res.Diagnostics, d => d.Code == "duplicate-fn");
+    }
+
+    [Fact]
+    public void ReferenceInsideComment_DoesNotCreateEdge()
+    {
+        // Упоминание b() только в комментарии не должно двигать порядок (нет реальной зависимости).
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("a", "{ // uses b(it)\n it.x }"), R("b", "{ it.y }") });
+        Assert.True(Idx(res.Content, "a") < Idx(res.Content, "b"));
+        Assert.Empty(res.Diagnostics);
+    }
+
+    [Fact]
+    public void Emits_ProvenanceComment_AndLineMap()
+    {
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("f", "{ it.x }") });
+        Assert.Contains("// prov:f", res.Content);
+        var span = Assert.Single(res.Spans);
+        Assert.Equal("f", span.FnName);
+        var lines = res.Content.Split('\n');
+        Assert.StartsWith("#let f(", lines[span.StartLine - 1]);
+    }
+
+    [Fact]
+    public void LineMap_TracksMultiLineBlocks()
+    {
+        // Комментарий = строка 1; `#let f(it) = {\n it.x \n}` (2 перевода строки) = строки 2..4.
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("f", "{\n it.x \n}") });
+        var span = Assert.Single(res.Spans);
+        Assert.Equal(2, span.StartLine);
+        Assert.Equal(4, span.EndLine);
+    }
+
+    [Fact]
+    public void Chain_OrdersTransitively()
+    {
+        // c→b→a: итог должен идти a, b, c (каждая зависимость выше зависимого), хотя дан обратный порядок.
+        var res = TypstPreambleBuilder.BuildDetailed(new[] { R("c", "{ b(it) }"), R("b", "{ a(it) }"), R("a", "{ it.x }") });
+        Assert.True(Idx(res.Content, "a") < Idx(res.Content, "b"));
+        Assert.True(Idx(res.Content, "b") < Idx(res.Content, "c"));
+        Assert.Empty(res.Diagnostics);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.3</Version>
+    <Version>0.53.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Часть #309 (фаза 1 — исправляет исходную боль; фаза 2 «проактивная проверка блоков» — отдельным PR).

## Проблема
Typst-блоки типов склеиваются в один `typeblocks.typ` строками `#let fnName(it) = block` в произвольном (БД) порядке. В Typst замыкание захватывает лексическую область НА МЕСТЕ ОПРЕДЕЛЕНИЯ — если блок A вызывает функцию B, `#let B` обязан идти выше, иначе `unknown variable`. При межтиповых ссылках порядок ломал компиляцию.

## Решение (Вариант A, согласовано с Архитектором и Дизайнером)
`TypstPreambleBuilder` разбит на адаптер + чистое ядро:
- **`ExtractRenders(type)` → плоские записи** (с провенансом).
- **`BuildDetailed(records)` → `{ Content, Spans(line-map), Diagnostics }`**:
  - топосорт **Kahn** с тай-брейком по исходному индексу → стабильно и **обратно совместимо** (двигается только реально неверно упорядоченное, регрессий по существующим шаблонам нет); саморефы исключены (Typst допускает рекурсию);
  - рёбра — скан вызовов известных `fnName` с одно-проходной очисткой комментариев/строк (чтобы упоминание в комментарии не давало ложное ребро/цикл);
  - **циклы** (Tarjan) и **дубликаты `fnName`** → диагностики, best-effort порядок **без pre-throw** в генерации (Typst ленив; финальный арбитр — он);
  - **провенанс-комментарий** над каждым блоком `// [type: Имя (code)] variant: … -> fn` + **line-map** для маппинга ошибок Typst (задел под фазу 2).

`Build(types) → string` сохранён → генерация и debug-бандл не тронуты, оба получают отсортированный контент из одного ядра.

## Проверка
- 9 новых unit-тестов ядра (порядок, стабильность, саморекурсия, цикл, дубликат, провенанс/line-map, транзитивная цепочка, ложное ребро в комментарии)
- Все **439** backend-тестов зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)