### PR TITLE
feat(typst): проактивная проверка сборки Typst-блоков (#309, фаза 2)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   Plus, ChevronRight, Trash2, Copy, Folder, FileText, Boxes, EyeOff, Check,
-  Braces, RotateCcw, Code, Database, Cpu, HelpCircle,
+  Braces, RotateCcw, Code, Database, Cpu, HelpCircle, RefreshCw,
 } from 'lucide-react';
 import { Switch } from '@/shared/ui/Switch';
 import { Markdown } from '@/shared/ui/Markdown';
@@ -37,6 +37,7 @@ import {
   type TypstRender,
 } from '@/shared/api/schema';
 import { TypstRendersEditor } from './TypstRendersEditor';
+import { useTypstBlocksCheck, TypstBlocksPanel, blocksCheckProblemsByFn } from './TypstBlocksCheck';
 import { schemaToJson, validateFields, TYPE_LABELS, toCamelKey } from './schemaConstants';
 import { useTagRegistry, typeTags as typeTagDefs, FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { GroupedFieldsEditor } from './GroupedFieldsEditor';
@@ -424,9 +425,10 @@ function CreateForm({
 
 // ─── Schema editor (inline) ────────────────────────────────────────────────────
 
-function SchemaEditor({ docType, allDocTypes }: {
+function SchemaEditor({ docType, allDocTypes, onSelectType }: {
   docType: DocumentType;
   allDocTypes: DocumentType[];
+  onSelectType: (id: string) => void;
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const { data: enumTypes = [] } = useListEnumTypes();
@@ -438,6 +440,7 @@ function SchemaEditor({ docType, allDocTypes }: {
     () => schemaDef.fieldOverrides ?? {},
   );
   const [typstRenders, setTypstRenders] = useState<TypstRender[]>(() => schemaDef.typstRenders ?? []);
+  const blocksCheck = useTypstBlocksCheck(docType.id, onSelectType);
   const [docTypeTags, setDocTypeTags] = useState<string[]>(() => schemaDef.tags ?? []);
   const [ungroupedOrder, setUngroupedOrder] = useState<string[]>(() => schemaDef.ungroupedOrder ?? []);
   const [help, setHelp] = useState<string>(() => schemaDef.help ?? '');
@@ -512,6 +515,8 @@ function SchemaEditor({ docType, allDocTypes }: {
     try {
       await mutation.mutateAsync({ id: docType.id, schema: schemaToJson(fields, excludedFields, fieldOverrides, groups, typstRenders, docTypeTags, ungroupedOrder, help) });
       setDirty(false);
+      // Проверка сборки блоков после сохранения (issue #309, фаза 2) — не блокирует save.
+      if (typstRenders.length > 0) void blocksCheck.run(typstRenders);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Ошибка сохранения');
       throw err;
@@ -668,10 +673,22 @@ function SchemaEditor({ docType, allDocTypes }: {
         <SectionCard icon={<Code size={15} />} title="Typst-блоки (варианты отображения)"
           count={typstRenders.length} countClass="text-purple-600"
           open={showTypstRenders} onToggle={() => setShowTypstRenders(v => !v)}>
-          <div className="pt-2">
+          <div className="pt-2 space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-fg4">Функции отображения для Typst-шаблонов.</p>
+              <Button variant="text" size="sm" icon={<RefreshCw size={13} className={blocksCheck.checking ? 'animate-spin' : ''} />}
+                disabled={blocksCheck.checking} onClick={() => void blocksCheck.run(typstRenders)}>
+                Проверить блоки
+              </Button>
+            </div>
+            {blocksCheck.problems && (
+              <TypstBlocksPanel problems={blocksCheck.problems} currentTypeId={docType.id} onSelectType={onSelectType} />
+            )}
             <TypstRendersEditor
               renders={typstRenders}
               onChange={r => { setTypstRenders(r); setDirty(true); }}
+              onBlockCommitted={r => void blocksCheck.run(r)}
+              problemsByFn={blocksCheckProblemsByFn(blocksCheck.problems, docType.id)}
               fields={effectiveFields}
               allDocTypes={allDocTypes}
             />
@@ -699,9 +716,10 @@ function findReferencingTypes(id: string, allDocTypes: DocumentType[]): Document
 }
 
 /** Правая панель list-detail (issue #197 Фаза A): шапка типа (метрики+действия) + редактор как есть. */
-function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving, onSaveAll, onRevert, onDuplicate }: {
+function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving, onSaveAll, onRevert, onDuplicate, onSelectType }: {
   docType: DocumentType; allDocTypes: DocumentType[]; allGroups: string[]; onDeleted: () => void;
   dirty: boolean; saving: boolean; onSaveAll: () => Promise<void>; onRevert: () => void; onDuplicate: () => void;
+  onSelectType: (id: string) => void;
 }) {
   const deleteMutation = useDeleteDocumentType();
   const { data: usage } = useDocumentTypeUsage(docType.id);
@@ -798,7 +816,7 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
         <div className="mx-auto max-w-4xl">
           <PropertiesEditor docType={docType} allDocTypes={allDocTypes} />
-          <SchemaEditor docType={docType} allDocTypes={allDocTypes} />
+          <SchemaEditor docType={docType} allDocTypes={allDocTypes} onSelectType={onSelectType} />
         </div>
       </div>
       {templatesOpen && (
@@ -901,7 +919,7 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
             <TypeDetail key={selected.id} docType={selected} allDocTypes={allDocTypes}
               allGroups={allGroups} onDeleted={() => setSelectedId(null)}
               dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll}
-              onDuplicate={() => duplicateType(selected)} />
+              onDuplicate={() => duplicateType(selected)} onSelectType={requestSelect} />
           ) : (
             <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Ничего не найдено</div>
           )} />

--- a/src/client/src/features/settings/TypstBlocksCheck.tsx
+++ b/src/client/src/features/settings/TypstBlocksCheck.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { CheckCircle2, AlertCircle, AlertTriangle, ArrowRight } from 'lucide-react';
+import { useToast } from '@/shared/ui/Toast';
+import { useValidateTypstBlocks, type TypstBlockProblem } from '@/shared/api/documentTypes';
+import type { TypstRender } from '@/shared/api/schema';
+
+/**
+ * Проверка сборки Typst-блоков (issue #309, фаза 2). Глобальна и межтипова: результат живёт в двух
+ * зонах — блоки ТЕКУЩЕГО типа показываем инлайн-панелью здесь, а проблему в ДРУГОМ типе (цикл/чужая
+ * ссылка) — тостом-указателем «Перейти» (инвариант тостов: тост для off-screen результата).
+ */
+const CODE_LABEL: Record<string, string> = {
+  cycle: 'взаимные ссылки',
+  'duplicate-fn': 'дубликат имени',
+  syntax: 'синтаксис',
+  'checker-unavailable': 'проверка недоступна',
+};
+
+export function useTypstBlocksCheck(typeId: string, onSelectType: (id: string) => void) {
+  const validate = useValidateTypstBlocks();
+  const toast = useToast();
+  const [problems, setProblems] = useState<TypstBlockProblem[] | null>(null);
+
+  async function run(renders: TypstRender[]) {
+    try {
+      const res = await validate.mutateAsync({ typeId, renders });
+      setProblems(res);
+      // Off-screen проблема (в другом типе) → тост-указатель с навигацией.
+      const other = res.find(p => p.severity === 'error' && p.typeId && p.typeId !== typeId);
+      if (other?.typeId) {
+        toast.error(`Блок «${other.fnName ?? '—'}» в типе «${other.typeName ?? '—'}» больше не собирается`, {
+          action: { label: 'Перейти', onClick: () => onSelectType(other.typeId!) },
+        });
+      }
+    } catch {
+      toast.error('Не удалось проверить блоки');
+    }
+  }
+
+  return { problems, checking: validate.isPending, run, reset: () => setProblems(null) };
+}
+
+/** Карта fnName → худшая severity для блоков ТЕКУЩЕГО типа — для бейджей на карточках. */
+export function blocksCheckProblemsByFn(problems: TypstBlockProblem[] | null, typeId: string): Record<string, 'error' | 'warning'> {
+  const m: Record<string, 'error' | 'warning'> = {};
+  for (const p of problems ?? []) {
+    if (!p.fnName || (p.typeId && p.typeId !== typeId)) continue;
+    if (p.severity === 'error' || m[p.fnName] !== 'error') m[p.fnName] = p.severity;
+  }
+  return m;
+}
+
+export function TypstBlocksPanel({ problems, currentTypeId, onSelectType }: {
+  problems: TypstBlockProblem[];
+  currentTypeId: string;
+  onSelectType: (id: string) => void;
+}) {
+  if (problems.length === 0)
+    return (
+      <div className="flex items-center gap-2 p-2.5 rounded-md text-sm bg-success-subtle text-success">
+        <CheckCircle2 size={15} className="shrink-0" /> Все Typst-блоки собираются
+      </div>
+    );
+
+  const here = problems.filter(p => !p.typeId || p.typeId === currentTypeId);
+  const other = problems.filter(p => p.typeId && p.typeId !== currentTypeId);
+  const errors = problems.filter(p => p.severity === 'error').length;
+  const warns = problems.length - errors;
+
+  return (
+    <div className="rounded-md border border-stroke overflow-hidden text-xs">
+      <div className="px-3 py-2 font-medium bg-base text-fg2">
+        Проблемы сборки блоков: {errors} ошиб.{warns ? `, ${warns} предупр.` : ''}
+      </div>
+      {here.length > 0 && <Group title="В этом типе" items={here} />}
+      {other.length > 0 && <Group title="В других типах" items={other} onSelectType={onSelectType} />}
+    </div>
+  );
+}
+
+function Group({ title, items, onSelectType }: {
+  title: string; items: TypstBlockProblem[]; onSelectType?: (id: string) => void;
+}) {
+  return (
+    <div>
+      <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-fg4">{title}</div>
+      <div className="divide-y divide-muted">
+        {items.map((p, i) => (
+          <div key={i} className="flex items-start gap-2 px-3 py-2">
+            {p.severity === 'error'
+              ? <AlertCircle size={14} className="text-danger shrink-0 mt-0.5" />
+              : <AlertTriangle size={14} className="text-warning shrink-0 mt-0.5" />}
+            <div className="min-w-0 flex-1">
+              {p.fnName && (
+                <div className="text-fg3">
+                  <code className="text-fg2">{p.fnName}</code>
+                  {p.line != null ? ` · строка ${p.line}` : ''} · {CODE_LABEL[p.code] ?? p.code}
+                </div>
+              )}
+              <p className={p.severity === 'error' ? 'text-danger' : 'text-fg2'}>{p.message}</p>
+              {onSelectType && p.typeId && (
+                <button type="button" onClick={() => onSelectType(p.typeId!)}
+                  className="inline-flex items-center gap-1 mt-1 text-brand hover:text-brand-hover">
+                  Перейти к «{p.typeName ?? 'типу'}» <ArrowRight size={12} />
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/features/settings/TypstRendersEditor.tsx
+++ b/src/client/src/features/settings/TypstRendersEditor.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type * as Monaco from 'monaco-editor';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
-import { Plus, Trash2, Maximize2, Code } from 'lucide-react';
+import { Plus, Trash2, Maximize2, Code, AlertCircle, AlertTriangle } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import type { DocumentType } from '@/shared/api/types';
@@ -181,11 +181,15 @@ function TypstBlockDialog({ render, onSave, onClose }: {
 
 // ─── Typst renders editor ─────────────────────────────────────────────────────
 
-export function TypstRendersEditor({ renders, onChange, fields, allDocTypes }: {
+export function TypstRendersEditor({ renders, onChange, fields, allDocTypes, onBlockCommitted, problemsByFn }: {
   renders: TypstRender[];
   onChange: (r: TypstRender[]) => void;
   fields: SchemaField[];
   allDocTypes: DocumentType[];
+  /** Вызывается при коммите одного блока («Применить» в диалоге) — триггер проверки сборки (#309). */
+  onBlockCommitted?: (renders: TypstRender[]) => void;
+  /** fnName → severity: бейдж на карточке блока с проблемой сборки. */
+  problemsByFn?: Record<string, 'error' | 'warning'>;
 }) {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -240,6 +244,14 @@ export function TypstRendersEditor({ renders, onChange, fields, allDocTypes }: {
               className="w-full flex items-center gap-2 px-3 py-2 rounded-md border border-stroke bg-surface hover:bg-muted/50 transition-colors text-left">
               <Code size={14} className="text-fg4 shrink-0" />
               <span className="text-sm text-fg2 flex-1">Редактировать Typst-код</span>
+              {problemsByFn?.[r.fnName.trim()] === 'error' && (
+                <span className="inline-flex items-center gap-1 text-xs text-danger shrink-0" title="Ошибка сборки блока">
+                  <AlertCircle size={13} /> не собирается
+                </span>
+              )}
+              {problemsByFn?.[r.fnName.trim()] === 'warning' && (
+                <AlertTriangle size={13} className="text-warning shrink-0" />
+              )}
               <span className="text-xs text-fg4 shrink-0">{lines > 0 ? `${lines} стр.` : 'пусто'}</span>
               <Maximize2 size={13} className="text-fg4 shrink-0" />
             </button>
@@ -261,7 +273,11 @@ export function TypstRendersEditor({ renders, onChange, fields, allDocTypes }: {
       {editingIndex !== null && renders[editingIndex] && (
         <TypstBlockDialog
           render={renders[editingIndex]}
-          onSave={r => update(editingIndex, r)}
+          onSave={r => {
+            const next = renders.map((rr, idx) => idx === editingIndex ? { ...rr, ...r } : rr);
+            onChange(next);
+            onBlockCommitted?.(next); // «Применить» — дискретный триггер проверки сборки (#309)
+          }}
           onClose={() => setEditingIndex(null)}
         />
       )}

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -1,6 +1,27 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from './client';
 import type { DocumentType, DocumentTypeKind } from './types';
+import type { TypstRender } from './schema';
+
+/** Проблема сборки Typst-блоков (issue #309, фаза 2). Глобальна: `typeId` — где живёт блок. */
+export interface TypstBlockProblem {
+  severity: 'error' | 'warning';
+  code: 'cycle' | 'duplicate-fn' | 'syntax' | 'checker-unavailable';
+  message: string;
+  typeId: string | null;
+  typeName: string | null;
+  variantName: string | null;
+  fnName: string | null;
+  line: number | null;
+}
+
+/** Проверка сборки всех Typst-блоков с draft-overlay текущего типа (тело = его черновик renders). */
+export function useValidateTypstBlocks() {
+  return useMutation({
+    mutationFn: ({ typeId, renders }: { typeId: string; renders: TypstRender[] }) =>
+      apiClient.post<TypstBlockProblem[]>(`/document-types/${typeId}/validate-typst-blocks`, renders).then(r => r.data),
+  });
+}
 
 export function useListDocumentTypes(kind?: DocumentTypeKind) {
   return useQuery({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Generation;
 using BHS.CRG.Domain.Documents;
 using MediatR;
 
@@ -55,6 +56,12 @@ public static class DocumentTypeEndpoints
             try { return Results.Ok(await m.Send(new UpdateDocumentTypeSchemaCommand(id, JsonDocument.Parse(req.Schema)))); }
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
+
+        // Проверка сборки Typst-блоков (issue #309, фаза 2): глобально по всем типам, с draft-overlay
+        // редактируемого типа (тело = его несохранённый массив typstRenders). Ловит циклы/дубликаты
+        // (граф) + синтаксис (Typst CLI). Не мутирует — только диагностика.
+        admin.MapPost("/{id:guid}/validate-typst-blocks", async (Guid id, JsonElement? draftRenders, IMediator m)
+            => Results.Ok(await m.Send(new ValidateTypstBlocksQuery(id, draftRenders))));
 
         admin.MapPut("/{id:guid}/abstract", async (Guid id, SetAbstractRequest req, IMediator m)
             => Results.Ok(await m.Send(new SetDocumentTypeAbstractCommand(id, req.IsAbstract))));

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -242,6 +242,7 @@ builder.Services.AddHttpClient<IFileUrlFetcher, HttpFileUrlFetcher>()
     .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(60));
 builder.Services.AddSingleton<TypstGenerator>();
 builder.Services.AddSingleton<IDocumentGeneratorFactory, DocumentGeneratorFactory>();
+builder.Services.AddSingleton<ITypstSyntaxChecker, TypstSyntaxChecker>();
 
 // ── DataSets ──────────────────────────────────────────────────────────────────
 builder.Services.AddSingleton<IDataSetParser, CsvDataSetParser>();

--- a/src/server/BHS.CRG.Application/Generation/ITypstSyntaxChecker.cs
+++ b/src/server/BHS.CRG.Application/Generation/ITypstSyntaxChecker.cs
@@ -1,0 +1,16 @@
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>Одна синтаксическая ошибка Typst с координатами внутри typeblocks.typ.</summary>
+public record TypstSyntaxError(int Line, int Column, string Message);
+
+/// <summary>
+/// Синтакс-проверка собранного typeblocks.typ через Typst CLI (issue #309, фаза 2). Компилирует
+/// harness, который лишь ИМПОРТИРУЕТ typeblocks.typ — тела функций (замыкания) НЕ вызываются, поэтому
+/// ленивые семантические ошибки (unknown variable, доступ к полю) НЕ всплывают, а ловятся именно
+/// синтаксические (битые скобки/токены из редактора). Реализация делит запуск процесса с генератором
+/// (Application не шеллит напрямую). Бросает при невозможности запустить CLI — обрабатывает вызывающий.
+/// </summary>
+public interface ITypstSyntaxChecker
+{
+    Task<IReadOnlyList<TypstSyntaxError>> CheckAsync(string typeBlocksContent, CancellationToken ct);
+}

--- a/src/server/BHS.CRG.Application/Generation/TypstPreambleBuilder.cs
+++ b/src/server/BHS.CRG.Application/Generation/TypstPreambleBuilder.cs
@@ -43,19 +43,27 @@ public static class TypstPreambleBuilder
     /// <summary>Адаптер: схема типа → плоские записи блоков (с провенансом). Пустые/битые — пропускаются.</summary>
     public static IEnumerable<TypstBlockRecord> ExtractRenders(DocumentType type)
     {
-        if (!type.Schema.RootElement.TryGetProperty("typstRenders", out var renders)
-            || renders.ValueKind != JsonValueKind.Array)
-            yield break;
+        if (type.Schema.RootElement.TryGetProperty("typstRenders", out var renders))
+            foreach (var r in ExtractRenders(renders, type.Id, type.Name, type.Code))
+                yield return r;
+    }
 
-        foreach (var render in renders.EnumerateArray())
+    /// <summary>Адаптер поверх сырого массива typstRenders (для draft-overlay проверки, issue #309 фаза 2):
+    /// тот же JSON-shape, что в схеме, но приходит НЕсохранённым черновиком из UI.</summary>
+    public static IEnumerable<TypstBlockRecord> ExtractRenders(JsonElement rendersArray, Guid typeId, string typeName, string code)
+    {
+        if (rendersArray.ValueKind != JsonValueKind.Array) yield break;
+
+        foreach (var render in rendersArray.EnumerateArray())
         {
+            if (render.ValueKind != JsonValueKind.Object) continue;
             var fnName = render.TryGetProperty("fnName", out var fn) ? fn.GetString() : null;
             var block = render.TryGetProperty("block", out var bl) ? bl.GetString() : null;
             if (string.IsNullOrWhiteSpace(fnName) || string.IsNullOrWhiteSpace(block)) continue;
             var variant = render.TryGetProperty("name", out var nm) ? nm.GetString() ?? "" : "";
             var fnTrim = fnName.Trim();
-            yield return new TypstBlockRecord(fnTrim, block, Provenance(type.Name, type.Code, variant, fnTrim),
-                type.Id, type.Name, variant);
+            yield return new TypstBlockRecord(fnTrim, block, Provenance(typeName, code, variant, fnTrim),
+                typeId, typeName, variant);
         }
     }
 

--- a/src/server/BHS.CRG.Application/Generation/ValidateTypstBlocks.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateTypstBlocks.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>Одна проблема сборки Typst-блоков, привязанная к конкретному блоку (тип + вариант).</summary>
+public record TypstBlockProblem(
+    string Severity,        // "error" | "warning"
+    string Code,            // "cycle" | "duplicate-fn" | "syntax" | "checker-unavailable"
+    string Message,
+    Guid? TypeId,
+    string? TypeName,
+    string? VariantName,
+    string? FnName,
+    int? Line);             // строка внутри блока (для синтакса), 1-based; иначе null
+
+/// <summary>
+/// Проверяет, соберётся ли typeblocks.typ ВСЕХ типов (issue #309, фаза 2). Глобальна (typeblocks
+/// общий), с draft-overlay: черновик редактируемого типа (<paramref name="DraftRenders"/>) подмешивается
+/// поверх персистентных блоков остальных — граф «как если бы сохранили» (иначе проверка на «Применить»
+/// до «Сохранить» видела бы старую версию). Ловит: циклы взаимных ссылок и дубликаты имён (граф) +
+/// синтаксические ошибки (Typst CLI). «Ссылка на несуществующую функцию» здесь НЕ ловится (наш universe
+/// имён неполон — userlib/builtins) — это ошибка времени генерации.
+/// </summary>
+public record ValidateTypstBlocksQuery(Guid? OverlayTypeId, JsonElement? DraftRenders)
+    : IRequest<IReadOnlyList<TypstBlockProblem>>;
+
+public class ValidateTypstBlocksHandler(
+    IRepository<DocumentType> docTypeRepo,
+    ITypstSyntaxChecker checker
+) : IRequestHandler<ValidateTypstBlocksQuery, IReadOnlyList<TypstBlockProblem>>
+{
+    public async Task<IReadOnlyList<TypstBlockProblem>> Handle(ValidateTypstBlocksQuery q, CancellationToken ct)
+    {
+        var types = await docTypeRepo.GetAllAsync(ct);
+
+        // Собираем записи: для overlay-типа с присланным черновиком — из черновика (толерантно), иначе
+        // из персистентной схемы. Единый вход → одно ядро сборки/сортировки/диагностик, что и генерация.
+        var records = new List<TypstBlockRecord>();
+        foreach (var t in types)
+        {
+            if (q.OverlayTypeId is { } oid && t.Id == oid && q.DraftRenders is { } draft)
+                records.AddRange(TypstPreambleBuilder.ExtractRenders(draft, t.Id, t.Name, t.Code));
+            else
+                records.AddRange(TypstPreambleBuilder.ExtractRenders(t));
+        }
+
+        var built = TypstPreambleBuilder.BuildDetailed(records);
+        var byFn = records
+            .GroupBy(r => r.FnName)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var problems = new List<TypstBlockProblem>();
+
+        // Диагностики графа (цикл, дубликат) → привязываем к первой участвующей функции.
+        foreach (var d in built.Diagnostics)
+        {
+            var rec = d.FnNames.Count > 0 && byFn.TryGetValue(d.FnNames[0], out var r) ? r : null;
+            problems.Add(new TypstBlockProblem(
+                d.Severity == TypstBlockDiagnosticSeverity.Error ? "error" : "warning",
+                d.Code, d.Message, rec?.TypeId, rec?.TypeName, rec?.VariantName, rec?.FnName, null));
+        }
+
+        // Синтаксис: компилируем отсортированный typeblocks.typ, ошибки маппим по line-map на блок.
+        try
+        {
+            foreach (var e in await checker.CheckAsync(built.Content, ct))
+            {
+                var span = built.Spans.FirstOrDefault(s => e.Line >= s.StartLine && e.Line <= s.EndLine);
+                var rec = span is not null && byFn.TryGetValue(span.FnName, out var r) ? r : null;
+                problems.Add(new TypstBlockProblem(
+                    "error", "syntax", e.Message,
+                    rec?.TypeId, rec?.TypeName, rec?.VariantName, span?.FnName,
+                    span is null ? null : e.Line - span.StartLine + 1));
+            }
+        }
+        catch (Exception ex)
+        {
+            // CLI недоступен/сбой — не роняем проверку, помечаем предупреждением (граф-диагностики уже собраны).
+            problems.Add(new TypstBlockProblem("warning", "checker-unavailable",
+                $"Проверка синтаксиса недоступна: {ex.Message}", null, null, null, null, null));
+        }
+
+        return problems;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstSyntaxChecker.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstSyntaxChecker.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using BHS.CRG.Application.Generation;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Синтакс-проверка typeblocks.typ через Typst CLI (issue #309, фаза 2). Пишет typeblocks.typ + harness
+/// `check.typ`, который лишь ИМПОРТИРУЕТ его (`#import: *`) — тела-замыкания не вызываются, ленивые
+/// семантические ошибки не всплывают; ловятся синтаксические (парсер обходит весь файл). `--diagnostic-format
+/// short` даёт разбираемые строки `typeblocks.typ:line:col: error: …`, маппящиеся по line-map на блок.
+/// Тот же CLI (env TYPST_PATH) и паттерн запуска процесса, что у TypstGenerator.
+/// </summary>
+public class TypstSyntaxChecker : ITypstSyntaxChecker
+{
+    private static readonly string TypstPath =
+        Environment.GetEnvironmentVariable("TYPST_PATH") ?? "typst";
+
+    // Короткий формат диагностики: путь:строка:колонка: severity: сообщение.
+    private static readonly Regex ShortDiag =
+        new(@"typeblocks\.typ:(\d+):(\d+):\s*(error|warning):\s*(.*)", RegexOptions.Compiled);
+
+    public async Task<IReadOnlyList<TypstSyntaxError>> CheckAsync(string typeBlocksContent, CancellationToken ct)
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "typst-check-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(tmp, "typeblocks.typ"),
+                string.IsNullOrEmpty(typeBlocksContent) ? "// empty" : typeBlocksContent, Encoding.UTF8, ct);
+
+            // Harness: импорт форсит ПАРС typeblocks.typ; тела ленивы (не вызваны) → без ложных ошибок
+            // данных. Немного текста — чтобы документ имел страницу и Typst не ругался на пустой вывод.
+            await File.WriteAllTextAsync(Path.Combine(tmp, "check.typ"),
+                "#import \"typeblocks.typ\": *\n" + "x\n", Encoding.UTF8, ct);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = TypstPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tmp,
+            };
+            foreach (var a in new[] { "compile", "check.typ", "out.pdf", "--diagnostic-format", "short", "--root", tmp })
+                psi.ArgumentList.Add(a);
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Не удалось запустить Typst CLI");
+
+            var stderrTask = process.StandardError.ReadToEndAsync(ct);
+            await process.WaitForExitAsync(ct);
+            var stderr = await stderrTask;
+
+            var errors = new List<TypstSyntaxError>();
+            foreach (Match m in ShortDiag.Matches(stderr))
+                if (m.Groups[3].Value == "error")
+                    errors.Add(new TypstSyntaxError(
+                        int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value), m.Groups[4].Value.Trim()));
+            return errors;
+        }
+        finally
+        {
+            try { Directory.Delete(tmp, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/src/server/BHS.CRG.Tests/Generation/ValidateTypstBlocksHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ValidateTypstBlocksHandlerTests.cs
@@ -1,0 +1,105 @@
+using System.Linq.Expressions;
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>
+/// Проверка сборки Typst-блоков (issue #309, фаза 2): draft-overlay меняет граф, диагностики графа и
+/// синтаксиса маппятся на конкретный блок (тип+вариант), недоступность CLI не роняет проверку.
+/// </summary>
+public class ValidateTypstBlocksHandlerTests
+{
+    private sealed class FakeTypeRepo(IReadOnlyList<DocumentType> types) : IRepository<DocumentType>
+    {
+        public Task<IReadOnlyList<DocumentType>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(types);
+        public Task<DocumentType?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IReadOnlyList<DocumentType>> FindAsync(Expression<Func<DocumentType, bool>> p, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task AddAsync(DocumentType e, CancellationToken ct = default) => throw new NotImplementedException();
+        public void Update(DocumentType e) => throw new NotImplementedException();
+        public void Remove(DocumentType e) => throw new NotImplementedException();
+        public Task SaveChangesAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeChecker(Func<string, IReadOnlyList<TypstSyntaxError>> f) : ITypstSyntaxChecker
+    {
+        public Task<IReadOnlyList<TypstSyntaxError>> CheckAsync(string content, CancellationToken ct) => Task.FromResult(f(content));
+    }
+
+    private static readonly Func<string, IReadOnlyList<TypstSyntaxError>> NoSyntaxErrors = _ => Array.Empty<TypstSyntaxError>();
+
+    private static string RendersJson((string variant, string fn, string block)[] rs) =>
+        string.Join(",", rs.Select(r =>
+            $"{{\"name\":{JsonSerializer.Serialize(r.variant)},\"fnName\":{JsonSerializer.Serialize(r.fn)},\"block\":{JsonSerializer.Serialize(r.block)}}}"));
+
+    private static DocumentType Type(string name, string code, params (string variant, string fn, string block)[] rs) =>
+        DocumentType.Create(name, code, DocumentTypeKind.Composite, null,
+            JsonDocument.Parse($"{{\"typstRenders\":[{RendersJson(rs)}]}}"));
+
+    private static JsonElement Draft(params (string variant, string fn, string block)[] rs) =>
+        JsonDocument.Parse($"[{RendersJson(rs)}]").RootElement.Clone();
+
+    private static ValidateTypstBlocksHandler Handler(IReadOnlyList<DocumentType> types,
+        Func<string, IReadOnlyList<TypstSyntaxError>>? checker = null) =>
+        new(new FakeTypeRepo(types), new FakeChecker(checker ?? NoSyntaxErrors));
+
+    [Fact]
+    public async Task DraftOverlay_ChangesGraph_IntroducesCycle()
+    {
+        // Персист: addr-contacts вызывает addr-full — упорядочиваемо, цикла нет.
+        var addr = Type("Адрес", "ADDR", ("Полный", "addr-full", "{ it.x }"));
+        var contacts = Type("Контакты", "CONT", ("Строка", "addr-contacts", "{ addr-full(it) }"));
+        var handler = Handler(new[] { addr, contacts });
+
+        var clean = await handler.Handle(new ValidateTypstBlocksQuery(null, null), default);
+        Assert.DoesNotContain(clean, p => p.Code == "cycle");
+
+        // Черновик делает addr-full вызывающим addr-contacts → взаимный цикл.
+        var draft = Draft(("Полный", "addr-full", "{ addr-contacts(it) }"));
+        var withCycle = await handler.Handle(new ValidateTypstBlocksQuery(addr.Id, draft), default);
+        Assert.Contains(withCycle, p => p.Code == "cycle");
+    }
+
+    [Fact]
+    public async Task SyntaxError_IsMappedToBlock_ByLineMap()
+    {
+        var addr = Type("Адрес", "ADDR", ("Полный", "addr-full", "{ it.x }"));
+        // Комментарий = строка 1, #let addr-full = строка 2 → ошибка на строке 2 маппится на addr-full.
+        var handler = Handler(new[] { addr }, _ => new[] { new TypstSyntaxError(2, 1, "unexpected token") });
+
+        var res = await handler.Handle(new ValidateTypstBlocksQuery(null, null), default);
+        var syntax = Assert.Single(res, p => p.Code == "syntax");
+        Assert.Equal("addr-full", syntax.FnName);
+        Assert.Equal("Адрес", syntax.TypeName);
+        Assert.Equal(1, syntax.Line);
+    }
+
+    [Fact]
+    public async Task DuplicateFnName_AcrossTypes_IsReported()
+    {
+        var a = Type("A", "A", ("v", "dup", "{ it.x }"));
+        var b = Type("B", "B", ("v", "dup", "{ it.y }"));
+        var res = await Handler(new[] { a, b }).Handle(new ValidateTypstBlocksQuery(null, null), default);
+        Assert.Contains(res, p => p.Code == "duplicate-fn");
+    }
+
+    [Fact]
+    public async Task CheckerUnavailable_DoesNotThrow_ReportsWarning()
+    {
+        var t = Type("A", "A", ("v", "f", "{ it.x }"));
+        var handler = Handler(new[] { t }, _ => throw new InvalidOperationException("no cli"));
+        var res = await handler.Handle(new ValidateTypstBlocksQuery(null, null), default);
+        Assert.Contains(res, p => p.Code == "checker-unavailable" && p.Severity == "warning");
+    }
+
+    [Fact]
+    public async Task Clean_Blocks_ProduceNoProblems()
+    {
+        var addr = Type("Адрес", "ADDR", ("Полный", "addr-full", "{ addr-contacts(it) }"));
+        var contacts = Type("Контакты", "CONT", ("Строка", "addr-contacts", "{ it.x }"));
+        var res = await Handler(new[] { addr, contacts }).Handle(new ValidateTypstBlocksQuery(null, null), default);
+        Assert.Empty(res);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.4</Version>
+    <Version>0.53.5</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #309 (фаза 2; фаза 1 — топосорт+провенанс — уже в master, #310).

## Что это
Проактивная **глобальная межтиповая** проверка «соберётся ли `typeblocks.typ` всех типов» после правки блока — с **draft-overlay** редактируемого типа (граф «как если бы сохранили», иначе проверка на «Применить» до «Сохранить» видела бы старую версию).

Ловит **циклы** взаимных ссылок, **дубликаты** имён (граф) и **синтаксис** (Typst CLI). «Ссылка на несуществующую функцию» здесь НЕ ловится (universe имён неполон — userlib/builtins) — остаётся ошибкой времени генерации.

## Backend
- `ITypstSyntaxChecker` + `TypstSyntaxChecker` (Infra): компилирует отсортированный `typeblocks.typ` через Typst CLI harness'ом, который лишь **импортирует** его — тела-замыкания не вызываются (ленивы), поэтому ложных ошибок данных нет, ловятся синтаксические. `--diagnostic-format short` → `file:line:col` маппится по **line-map** (из фазы 1) обратно на блок (тип+вариант).
- `ValidateTypstBlocksQuery` (MediatR) + `POST /api/document-types/{id}/validate-typst-blocks` (Admin). Недоступность CLI не роняет проверку (warning). `ExtractRenders` overload поверх draft-массива.
- 6 тестов handler (overlay меняет граф; синтаксис маппится по line-map; дубликат; недоступность CLI; чистый кейс). **Все 444 backend зелёные.**

## Frontend (дизайн Дизайнера — «две зоны»)
- `useTypstBlocksCheck` + `TypstBlocksPanel`: инлайн-панель в секции «Typst-блоки» с группами **«В этом типе»** / **«В других типах»**; бейдж «не собирается» на карточке блока; **тост-указатель** для проблемы в ДРУГОМ типе → «Перейти» (навигация в list-detail).
- Триггеры (дискретные, не по keystroke): «⟳ Проверить блоки», «Применить» в диалоге блока, после «Сохранить». **Не блокирует сохранение** (#296) — гейт на генерации.

## Проверка
- Вживую (реальный Typst 0.15.1): POST с циклом+синтаксисом → корректные диагностики, кириллица UTF-8 корректна, маппинг синтаксиса на строку блока верный.
- `tsc -b` чистый, 130 фронт + 444 backend тестов зелёные.

## Отложено (follow-up)
Точки-здоровья типов в левом рейле (карта здоровья всей системы) — нужен подъём состояния в корень страницы; панель + тост уже покрывают межтиповую видимость.

🤖 Generated with [Claude Code](https://claude.com/claude-code)