### PR TITLE
fix(ui): Monaco-редакторы следуют тёмной теме (#312)

### DIFF
--- a/src/client/src/features/settings/TypstRendersEditor.tsx
+++ b/src/client/src/features/settings/TypstRendersEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type * as Monaco from 'monaco-editor';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
+import { useTheme } from '@/shared/ui/ThemeProvider';
 import { Plus, Trash2, Maximize2, Code, AlertCircle, AlertTriangle } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -98,6 +99,7 @@ function TypstBlockDialog({ render, onSave, onClose }: {
   onSave: (r: TypstRender) => void;
   onClose: () => void;
 }) {
+  const { resolvedTheme } = useTheme();
   const [draft, setDraft] = useState<TypstRender>(render);
   const isDirty = draft.name !== render.name
     || draft.fnName !== render.fnName
@@ -148,6 +150,7 @@ function TypstBlockDialog({ render, onSave, onClose }: {
           <Editor
             height="100%"
             defaultLanguage="typst"
+            theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
             value={draft.block}
             onChange={val => setDraft(d => ({ ...d, block: val ?? '' }))}
             beforeMount={beforeMountTypstBlock}

--- a/src/client/src/features/templates/EditorPanel.tsx
+++ b/src/client/src/features/templates/EditorPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useTheme } from '@/shared/ui/ThemeProvider';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { Button } from '@/shared/ui/Button';
@@ -94,6 +95,7 @@ interface EditorPanelProps {
 }
 
 export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorPanelProps) {
+  const { resolvedTheme } = useTheme();
   const [content, setContent] = useState(template.content);
   const [saving, setSaving] = useState(false);
   const [savedMsg, setSavedMsg] = useState(false);
@@ -236,6 +238,7 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
         <Editor
           height="100%"
           defaultLanguage="typst"
+          theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
           value={content}
           onChange={(val) => setContent(val ?? '')}
           beforeMount={registerTypstLanguage}

--- a/src/client/src/features/templates/UserLibPanel.tsx
+++ b/src/client/src/features/templates/UserLibPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
+import { useTheme } from '@/shared/ui/ThemeProvider';
 import { Button } from '@/shared/ui/Button';
 import { Save } from 'lucide-react';
 import { useTypstUserLib, useSaveTypstUserLib } from '@/shared/api/typstUserLib';
@@ -8,6 +9,7 @@ import { TemplateAssetsPanel } from './TemplateAssetsPanel';
 // ─── User Typst library panel ─────────────────────────────────────────────────
 
 export function UserLibPanel() {
+  const { resolvedTheme } = useTheme();
   const { data: serverContent = '', isLoading } = useTypstUserLib();
   const saveMutation = useSaveTypstUserLib();
   const [content, setContent] = useState('');
@@ -51,6 +53,7 @@ export function UserLibPanel() {
         <Editor
           height="100%"
           defaultLanguage="typst"
+          theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
           value={content}
           onChange={(val) => setContent(val ?? '')}
           beforeMount={registerTypstLanguage}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.5</Version>
+    <Version>0.53.6</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #312

## Проблема
Редакторы Monaco (шаблоны, Typst User Lib, Typst-блоки типов) оставались светлыми в тёмной теме.

## Причина
`<Editor>` создавался **без пропа `theme`**; Monaco брал дефолт `vs` (светлая) и не знает про наш `ThemeProvider` (у него своя система тем, CSS-токены не читает).

## Фикс
Проп `theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}` из `useTheme()` в трёх редакторах: `EditorPanel`, `UserLibPanel`, `TypstBlockDialog`. `@monaco-editor/react` реагирует на смену пропа → переключение темы приложения мгновенно перекрашивает редакторы.

## Проверка
- Вживую: фон Monaco в тёмной теме = `rgb(30,30,30)` (vs-dark), диалог целиком тёмный.
- `tsc -b` чистый, 130 фронт-тестов зелёные.

Follow-up (опц.): кастомная `defineTheme` под Fluent-токены (фон под surface). Пока — встроенные vs/vs-dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)