### PR TITLE
fix(ui): фокус в код-область при открытии редактора Typst-блока (#314)

### DIFF
--- a/src/client/src/features/settings/TypstRendersEditor.tsx
+++ b/src/client/src/features/settings/TypstRendersEditor.tsx
@@ -154,6 +154,9 @@ function TypstBlockDialog({ render, onSave, onClose }: {
             value={draft.block}
             onChange={val => setDraft(d => ({ ...d, block: val ?? '' }))}
             beforeMount={beforeMountTypstBlock}
+            // Фокус сразу в область кода (issue #314): Monaco монтируется асинхронно, после
+            // Radix-autofocus диалога, поэтому editor.focus() здесь выигрывает.
+            onMount={editor => editor.focus()}
             options={{
               minimap: { enabled: false },
               fontSize: 13,

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.6</Version>
+    <Version>0.53.7</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #314

## Проблема
При открытии полноэкранного редактора Typst-блока фокус уходил на первый tabbable (поле «Название варианта» / крестик), а не в область кода.

## Причина / фикс
У `<Editor>` в `TypstBlockDialog` не было `onMount`. Добавлен `onMount={editor => editor.focus()}` — Monaco монтируется асинхронно, после Radix-autofocus диалога, поэтому фокус в код-области выигрывает.

## Проверка
- Вживую (Playwright): `document.activeElement` после открытия — внутри `.monaco-editor` (native-edit-context).
- `tsc -b` чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)