### PR TITLE
fix(recognition): Ollama-распознавание с thinking-моделями qwen3-vl (#318)

### DIFF
--- a/src/server/BHS.CRG.Infrastructure/Recognition/OllamaRecognizerEngine.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/OllamaRecognizerEngine.cs
@@ -60,13 +60,18 @@ public class OllamaRecognizerEngine(
         // Оцениваем: промпт + ~4608 токенов на страницу; клампим в разумные пределы.
         int numCtx = Math.Clamp(2048 + images.Length * 4608, 8192, 32768);
 
+        // НЕ используем format:"json" (issue #318): у thinking-моделей (qwen3-vl) JSON-грамматика
+        // глушит основной вывод — размышления уходят в отдельное поле `thinking`, а `response`
+        // приходит ПУСТЫМ. Без format модель отдаёт чистый JSON в `response` (инструкция «только JSON»
+        // есть в промпте), а RecognitionShared.ParseValues извлекает JSON устойчиво. Non-thinking
+        // модели (qwen2.5vl) работают одинаково с format и без.
         var requestBody = new
         {
             model,
             prompt = (promptBuilder ?? RecognitionShared.BuildPrompt)(fields),
             images,
             stream = false,
-            format = "json",
+            think = false, // подсказка не размышлять (thinking-модели могут игнорировать — тогда спасает парсер)
             options = new { temperature = 0, num_ctx = numCtx },
         };
         var json = JsonSerializer.Serialize(requestBody);

--- a/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionShared.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionShared.cs
@@ -136,7 +136,10 @@ public static class RecognitionShared
     public static IReadOnlyDictionary<string, string?> ParseValues(string text, IReadOnlyList<RecognitionField> fields)
     {
         var result = new Dictionary<string, string?>();
+        // Прямой парс очищенного от markdown ответа; если не JSON целиком (напр. модель дописала прозу/
+        // размышления вокруг объекта) — извлекаем первый сбалансированный {...} и парсим его (issue #318).
         var jsonText = StripFences(text).Trim();
+        if (!LooksLikeJsonObject(jsonText)) jsonText = ExtractFirstJsonObject(text) ?? jsonText;
         try
         {
             using var doc = JsonDocument.Parse(jsonText);
@@ -170,6 +173,33 @@ public static class RecognitionShared
         var inner = s[(firstNl + 1)..];
         var lastFence = inner.LastIndexOf("```", StringComparison.Ordinal);
         return lastFence >= 0 ? inner[..lastFence] : inner;
+    }
+
+    private static bool LooksLikeJsonObject(string s) => s.StartsWith('{') && s.EndsWith('}');
+
+    /// <summary>Первый сбалансированный JSON-объект {...} в тексте (учитывает строки и экранирование) —
+    /// для ответов, где модель обернула JSON прозой/размышлениями (issue #318). null, если не найден.</summary>
+    public static string? ExtractFirstJsonObject(string text)
+    {
+        var start = text.IndexOf('{');
+        if (start < 0) return null;
+        int depth = 0;
+        bool inStr = false, esc = false;
+        for (int i = start; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (inStr)
+            {
+                if (esc) esc = false;
+                else if (c == '\\') esc = true;
+                else if (c == '"') inStr = false;
+                continue;
+            }
+            if (c == '"') inStr = true;
+            else if (c == '{') depth++;
+            else if (c == '}' && --depth == 0) return text[start..(i + 1)];
+        }
+        return null;
     }
 
     public static string Truncate(string s, int n) => s.Length <= n ? s : s[..n];

--- a/src/server/BHS.CRG.Tests/Recognition/RecognitionSharedTests.cs
+++ b/src/server/BHS.CRG.Tests/Recognition/RecognitionSharedTests.cs
@@ -1,0 +1,65 @@
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Infrastructure.Recognition;
+
+namespace BHS.CRG.Tests.Recognition;
+
+/// <summary>
+/// Устойчивый парс ответа vision-LLM (issue #318): чистый JSON, JSON обёрнутый размышлениями/прозой
+/// (thinking-модели типа qwen3-vl), markdown-fenced, пустой ответ; фильтрация по разрешённым полям.
+/// </summary>
+public class RecognitionSharedTests
+{
+    private static readonly IReadOnlyList<RecognitionField> Fields =
+    [
+        new("Наименование", "Наименование", "string"),
+        new("Номер", "Номер", "string"),
+    ];
+
+    [Fact]
+    public void ParseValues_CleanJson()
+    {
+        var r = RecognitionShared.ParseValues("{\"Наименование\":\"Кабель\",\"Номер\":\"123\"}", Fields);
+        Assert.Equal("Кабель", r["Наименование"]);
+        Assert.Equal("123", r["Номер"]);
+    }
+
+    [Fact]
+    public void ParseValues_JsonWrappedInProse_IsExtracted()
+    {
+        // thinking-модель дописала размышления вокруг JSON — извлекаем сбалансированный объект.
+        var text = "<think>Смотрю на изображение… поле Наименование = Кабель</think>\n"
+                 + "Вот результат: {\"Наименование\": \"Кабель\", \"Номер\": \"123\"} — готово.";
+        var r = RecognitionShared.ParseValues(text, Fields);
+        Assert.Equal("Кабель", r["Наименование"]);
+        Assert.Equal("123", r["Номер"]);
+    }
+
+    [Fact]
+    public void ParseValues_FencedJson()
+    {
+        var r = RecognitionShared.ParseValues("```json\n{\"Наименование\":\"Кабель\"}\n```", Fields);
+        Assert.Equal("Кабель", r["Наименование"]);
+    }
+
+    [Fact]
+    public void ParseValues_EmptyOrNonJson_ReturnsEmpty()
+    {
+        Assert.Empty(RecognitionShared.ParseValues("", Fields));
+        Assert.Empty(RecognitionShared.ParseValues("нет данных", Fields));
+    }
+
+    [Fact]
+    public void ParseValues_FiltersToAllowedFields()
+    {
+        var r = RecognitionShared.ParseValues("{\"Наименование\":\"Кабель\",\"Лишнее\":\"x\"}", Fields);
+        Assert.True(r.ContainsKey("Наименование"));
+        Assert.False(r.ContainsKey("Лишнее"));
+    }
+
+    [Fact]
+    public void ExtractFirstJsonObject_HandlesNestedAndStrings()
+    {
+        var s = "prefix {\"a\":\"}{\",\"b\":{\"c\":1}} suffix {\"ignored\":2}";
+        Assert.Equal("{\"a\":\"}{\",\"b\":{\"c\":1}}", RecognitionShared.ExtractFirstJsonObject(s));
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.8</Version>
+    <Version>0.53.9</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #318

## Проблема
С vision-моделью **qwen3-vl** распознавание документов качества возвращало пусто.

## Причина (воспроизведено на реальной Ollama + qwen3-vl:latest)
`OllamaRecognizerEngine` слал в `/api/generate` `format:"json"`. qwen3-vl — **thinking-модель**: размышления идут в отдельное поле `thinking`, а при `format:"json"` JSON-грамматика глушит основной вывод → `response` приходит **пустым** (проверено: `response=""`, 68 токенов; `think:false` не помогает). `RecognitionShared.ParseValues` требовал валидный JSON целиком → пустой результат. Без `format:"json"` та же модель отдаёт чистый JSON в `response`.

## Фикс
1. Убран `format:"json"` из запроса `OllamaRecognizerEngine` (+ `think:false` подсказкой). Non-thinking модели (qwen2.5vl) работают одинаково с/без.
2. Устойчивый `ParseValues`: извлечение первого сбалансированного `{...}` из текста, если прямой парс не прошёл (защита от утечки размышлений/прозы у ЛЮБОГО движка — Anthropic/Gemini/Ollama).

## Проверка
- Вживую: qwen3-vl без format:json прочитал тестовое изображение (сгенерированное поле документа) и вернул корректный JSON `{"Наименование":"Кабель ВВГнг 3x2.5", …}`.
- 6 новых unit-тестов `ParseValues` (чистый/обёрнутый размышлениями/fenced/пустой/фильтрация/вложенность). Все **450** backend зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)