### PR TITLE
feat: union-поле (список ИЛИ ссылка) — тэг + редактор + marker-ref (#320)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
-  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Link2, Pencil, Plus, RefreshCw, Trash2, Unlink, X,
+  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Info, Link2, Pencil, Plus, RefreshCw, Trash2, Unlink, X,
 } from 'lucide-react';
+import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -657,6 +658,18 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
 
+  // Union-тип (issue #320): составной тип с тэгом type.union — «заполняется ровно одно из полей».
+  // Рендерим переключатель варианта + редактор активного подполя вместо стопки всех подполей.
+  const isUnion = !!compositeType
+    && ((compositeType.schema as { tags?: string[] }).tags ?? []).includes(FUNCTIONAL_TAG.typeUnion);
+  if (isUnion) {
+    return (
+      <UnionFieldGroup field={field} allDocTypes={allDocTypes} value={value} onChange={onChange}
+        showValidation={showValidation} setId={setId} otherInstances={otherInstances}
+        scope={scope} scopeId={scopeId} docRefMode={docRefMode} nested={nested} />
+    );
+  }
+
   const picker = (
     <RefPickerModal
       open={pickerOpen} onOpenChange={setPickerOpen}
@@ -696,7 +709,6 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
   const subValues = (value != null && typeof value === 'object' && !isFieldRef(value)
     ? value : {}) as Record<string, unknown>;
   const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
-  const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
   const isEmpty = subFields.every(f => { const v = subValues[f.key]; return v == null || v === ''; });
 
   function setSubValue(key: string, val: unknown) {
@@ -719,38 +731,10 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
                 {sf.required && <span className="ml-0.5 text-danger">*</span>}
               </label>
             )}
-            {sf.type === 'complex' ? (
-              <ComplexFieldGroup field={sf} allDocTypes={allDocTypes} value={subVal}
-                onChange={v => setSubValue(sf.key, v)} showValidation={showValidation}
-                setId={setId} otherInstances={otherInstances}
-                scope={scope} scopeId={scopeId} docRefMode={docRefMode} nested />
-            ) : sf.type === 'doc-ref' ? (
-              docRefMode === 'instance' ? (
-                <DocRefField field={sf} allDocTypes={allDocTypes} value={subVal}
-                  onChange={v => setSubValue(sf.key, v ?? undefined)}
-                  otherInstances={otherInstances} setId={setId} />
-              ) : (
-                <DocRefCatalogPickerField field={sf} allDocTypes={allDocTypes} value={subVal}
-                  onChange={v => setSubValue(sf.key, v ?? undefined)}
-                  setId={setId} scope={scope ?? 'System'} scopeId={scopeId ?? null} />
-              )
-            ) : sf.type === 'doc-array' && docRefMode === 'instance' ? (
-              <DocArrayField field={sf} allDocTypes={allDocTypes} value={subVal}
-                onChange={v => setSubValue(sf.key, v)}
-                otherInstances={otherInstances} setId={setId} />
-            ) : sf.type === 'image' ? (
-              <ImageField value={subVal} onChange={v => setSubValue(sf.key, v)} />
-            ) : sf.type === 'file' ? (
-              <FileField value={subVal} onChange={v => setSubValue(sf.key, v ?? undefined)} />
-            ) : sf.type === 'array' ? (
-              <ArrayFieldEditor field={sf} allDocTypes={allDocTypes} value={subVal}
-                onChange={v => setSubValue(sf.key, v)} showValidation={showValidation}
-                setId={setId} otherInstances={otherInstances}
-                scope={scope} scopeId={scopeId} docRefMode={docRefMode} />
-            ) : (
-              <PrimitiveInput field={sf} value={subVal} label={sf.title} onChange={v => setSubValue(sf.key, v)} invalid={invalid}
-                primitiveTypeDef={primDef(sf)} />
-            )}
+            <SubfieldEditor sf={sf} value={subVal} onChange={v => setSubValue(sf.key, v)}
+              allDocTypes={allDocTypes} showValidation={showValidation} setId={setId}
+              otherInstances={otherInstances} scope={scope} scopeId={scopeId}
+              docRefMode={docRefMode} primitiveTypes={primitiveTypes} />
             {invalid && <p className="text-xs text-danger mt-1">Обязательное поле</p>}
           </div>
         );
@@ -831,4 +815,163 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
       {picker}
     </div>
   );
+}
+
+// ─── Один подполе-редактор (диспетчеризация по типу) ───────────────────────────
+// Извлечено из ComplexFieldGroup, чтобы переиспользовать для активного варианта union (issue #320).
+function SubfieldEditor({ sf, value, onChange, allDocTypes, showValidation, setId,
+  otherInstances = [], scope, scopeId, docRefMode = 'catalog', primitiveTypes }: {
+  sf: SchemaField; value: unknown; onChange: (v: unknown) => void;
+  allDocTypes: DocumentType[]; showValidation: boolean; setId?: string;
+  otherInstances?: DocumentInstance[]; scope?: CatalogScope; scopeId?: string | null;
+  docRefMode?: 'catalog' | 'instance'; primitiveTypes: PrimitiveTypeDef[];
+}) {
+  const primDef = sf.type === 'primitive' ? primitiveTypes.find(pt => pt.id === sf.typeId) : undefined;
+  const invalid = showValidation && isMissing(sf, value);
+  if (sf.type === 'complex')
+    return <ComplexFieldGroup field={sf} allDocTypes={allDocTypes} value={value} onChange={v => onChange(v)}
+      showValidation={showValidation} setId={setId} otherInstances={otherInstances}
+      scope={scope} scopeId={scopeId} docRefMode={docRefMode} nested />;
+  if (sf.type === 'doc-ref')
+    return docRefMode === 'instance'
+      ? <DocRefField field={sf} allDocTypes={allDocTypes} value={value}
+          onChange={v => onChange(v ?? undefined)} otherInstances={otherInstances} setId={setId} />
+      : <DocRefCatalogPickerField field={sf} allDocTypes={allDocTypes} value={value}
+          onChange={v => onChange(v ?? undefined)} setId={setId} scope={scope ?? 'System'} scopeId={scopeId ?? null} />;
+  if (sf.type === 'doc-array' && docRefMode === 'instance')
+    return <DocArrayField field={sf} allDocTypes={allDocTypes} value={value}
+      onChange={v => onChange(v)} otherInstances={otherInstances} setId={setId} />;
+  if (sf.type === 'image') return <ImageField value={value} onChange={v => onChange(v)} />;
+  if (sf.type === 'file') return <FileField value={value} onChange={v => onChange(v ?? undefined)} />;
+  if (sf.type === 'array')
+    return <ArrayFieldEditor field={sf} allDocTypes={allDocTypes} value={value} onChange={v => onChange(v)}
+      showValidation={showValidation} setId={setId} otherInstances={otherInstances}
+      scope={scope} scopeId={scopeId} docRefMode={docRefMode} />;
+  return <PrimitiveInput field={sf} value={value} label={sf.title} onChange={v => onChange(v)}
+    invalid={invalid} primitiveTypeDef={primDef} />;
+}
+
+// ─── Union-поле (issue #320): заполняется РОВНО ОДИН вариант (подполе union-типа) ──
+/** Вариант считается заполненным: непустой массив / FieldRef / непустой объект / непустая строка. */
+function isVariantFilled(v: unknown): boolean {
+  if (v == null) return false;
+  if (isFieldRef(v)) return true;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === 'object') return Object.keys(v as object).length > 0;
+  return String(v).trim() !== '';
+}
+
+function VariantSegmentedSwitch({ options, active, onSelect }: {
+  options: { key: string; label: string; filled: boolean }[];
+  active: string; onSelect: (key: string) => void;
+}) {
+  return (
+    <div role="radiogroup" className="inline-flex rounded-lg border border-stroke overflow-hidden text-sm">
+      {options.map((o, i) => {
+        const on = o.key === active;
+        return (
+          <button key={o.key} type="button" role="radio" aria-checked={on} onClick={() => onSelect(o.key)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${i > 0 ? 'border-l border-stroke' : ''} ${
+              on ? 'bg-brand text-white font-medium' : 'bg-surface text-fg2 hover:bg-base'}`}>
+            {o.filled && <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${on ? 'bg-white' : 'bg-brand'}`} />}
+            <span className="truncate">{o.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, setId,
+  otherInstances = [], scope, scopeId, docRefMode = 'catalog', nested = false }: {
+  field: SchemaField; allDocTypes: DocumentType[]; value: unknown;
+  onChange: (val: Record<string, unknown>) => void; showValidation: boolean;
+  setId?: string; otherInstances?: DocumentInstance[];
+  scope?: CatalogScope; scopeId?: string | null; docRefMode?: 'catalog' | 'instance'; nested?: boolean;
+}) {
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
+  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
+  const subValues = (value != null && typeof value === 'object' && !isFieldRef(value) ? value : {}) as Record<string, unknown>;
+
+  const presentKey = subFields.find(sf => isVariantFilled(subValues[sf.key]))?.key;
+  const [activeKey, setActiveKey] = useState<string>(() => presentKey ?? subFields[0]?.key ?? '');
+  // Стэш неактивных вариантов — недеструктивное переключение в течение сессии (дискриминатор C, issue #320):
+  // persist хранит ОДИН ключ, данные другого варианта живут в локальном стэше до закрытия редактора.
+  const [stash, setStash] = useState<Record<string, unknown>>({});
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // Значение пришло с заполненным ключом (загрузка/base-merge) — подхватываем активный вариант.
+  useEffect(() => { if (presentKey && presentKey !== activeKey) setActiveKey(presentKey); }, [presentKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const activeSf = subFields.find(sf => sf.key === activeKey) ?? subFields[0] ?? null;
+
+  function switchTo(key: string) {
+    if (key === activeKey) return;
+    setStash(prev => ({ ...prev, [activeKey]: subValues[activeKey] })); // припрятать текущий вариант
+    const restored = stash[key];
+    onChange(isVariantFilled(restored) ? { [key]: restored } : {}); // восстановить целевой (или пусто)
+    setActiveKey(key);
+  }
+  // persist = один ключ активного варианта; пустой активный → {} (= «не выбрано», как обычный complex).
+  function setActiveValue(v: unknown) { onChange(isVariantFilled(v) ? { [activeKey]: v } : {}); }
+
+  if (subFields.length === 0) return <p className="text-xs text-fg4">Union-тип без полей.</p>;
+
+  const options = subFields.map(sf => ({
+    key: sf.key, label: sf.title,
+    filled: isVariantFilled(subValues[sf.key]) || isVariantFilled(stash[sf.key]),
+  }));
+  const chip = (
+    <span className="text-[11px] text-fg4 flex items-center gap-1 shrink-0" title="Заполняется ровно один из вариантов">
+      <Info size={11} /> заполните одно из
+    </span>
+  );
+  const activeEditor = activeSf && (
+    <SubfieldEditor sf={activeSf} value={subValues[activeSf.key]} onChange={setActiveValue}
+      allDocTypes={allDocTypes} showValidation={showValidation} setId={setId}
+      otherInstances={otherInstances} scope={scope} scopeId={scopeId} docRefMode={docRefMode} primitiveTypes={primitiveTypes} />
+  );
+  const bar = (
+    <div className="flex items-center justify-between gap-2">
+      <VariantSegmentedSwitch options={options} active={activeKey} onSelect={switchTo} />
+      {chip}
+    </div>
+  );
+
+  // Вложенный union (глубина ≥1) — строка-сводка активного варианта + правка в модалке.
+  if (nested) {
+    return (
+      <>
+        <div className="flex items-center gap-2 border border-stroke rounded-lg px-3 py-2 bg-base">
+          <button type="button" onClick={() => setModalOpen(true)}
+            className="flex-1 min-w-0 text-left text-sm text-fg2 hover:text-fg1 truncate">
+            {unionSummary(activeSf, subValues[activeKey])}
+          </button>
+          <button type="button" onClick={() => setModalOpen(true)} title="Редактировать"
+            className="p-1 text-fg4 hover:text-fg2 transition-colors shrink-0"><Pencil size={13} /></button>
+        </div>
+        <Modal open={modalOpen} onOpenChange={setModalOpen} wide title={field.title}
+          footer={<div className="flex justify-end"><Button variant="filled" onClick={() => setModalOpen(false)}>Готово</Button></div>}>
+          <div className="px-6 py-4 space-y-3">{bar}{activeEditor}</div>
+        </Modal>
+      </>
+    );
+  }
+
+  return (
+    <div className="border border-stroke rounded-lg p-3 space-y-3">
+      {bar}
+      {activeEditor}
+    </div>
+  );
+}
+
+/** Короткая сводка активного варианта union — для свёрнутой строки во вложенном режиме. */
+function unionSummary(sf: SchemaField | null, val: unknown): string {
+  if (!sf) return '(пусто)';
+  if (!isVariantFilled(val)) return `${sf.title}: —`;
+  if (isFieldRef(val)) return `${sf.title} → ${val.displayName}`;
+  if (Array.isArray(val)) return `${sf.title} · ${val.length} стр.`;
+  return `${sf.title}: ${String(val).slice(0, 40)}`;
 }

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/shared/ui/Button';
 import type {
   CatalogScope, DocumentInstance, DocumentType, FieldRef, PrimitiveTypeDef,
 } from '@/shared/api/types';
-import { isFieldRef, SCOPE_LABELS } from '@/shared/api/types';
+import { isFieldRef, isInstanceRef, SCOPE_LABELS } from '@/shared/api/types';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import {
   resolveEffectiveFields, getDefaultValues, type SchemaField,
@@ -914,7 +914,12 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
     setActiveKey(key);
   }
   // persist = один ключ активного варианта; пустой активный → {} (= «не выбрано», как обычный complex).
-  function setActiveValue(v: unknown) { onChange(isVariantFilled(v) ? { [activeKey]: v } : {}); }
+  // Ссылка на документ в union — всегда НЕ-инлайнящийся marker (семантика b, issue #320): резолвер
+  // маркер не разворачивает, шаблон печатает displayName. instance-ссылку из пикера превращаем в marker.
+  function setActiveValue(v: unknown) {
+    const stored = isInstanceRef(v) ? { ...v, $ref: 'marker' as const } : v;
+    onChange(isVariantFilled(stored) ? { [activeKey]: stored } : {});
+  }
 
   if (subFields.length === 0) return <p className="text-xs text-fg4">Union-тип без полей.</p>;
 

--- a/src/client/src/features/document-sets/fields/DocRefField.tsx
+++ b/src/client/src/features/document-sets/fields/DocRefField.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { FileText, Plus, Trash2, Unlink } from 'lucide-react';
 import type { CatalogScope, DocumentInstance, DocumentType, FieldRef } from '@/shared/api/types';
-import { isFieldRef, isInstanceRef } from '@/shared/api/types';
+import { isFieldRef, isInstanceRef, isMarkerRef } from '@/shared/api/types';
 import type { SchemaField } from '@/shared/api/schema';
 import { STATUS_COLORS, STATUS_LABELS } from './constants';
 import { InstancePickerModal } from './InstancePickerModal';
@@ -12,7 +12,9 @@ export function DocRefField({ field, allDocTypes, value, onChange, otherInstance
   setId?: string;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
-  const iRef = isInstanceRef(value) ? value : null;
+  // marker (issue #320) — ссылка-указатель (не инлайнится): отображаем как обычную instance-ссылку.
+  const marker = isMarkerRef(value);
+  const iRef = isInstanceRef(value) || isMarkerRef(value) ? value as FieldRef : null;
   const cRef = isFieldRef(value) && (value as FieldRef).$ref === 'catalog' ? value as FieldRef : null;
 
   if (iRef) {
@@ -24,11 +26,11 @@ export function DocRefField({ field, allDocTypes, value, onChange, otherInstance
         <FileText size={14} className="text-indigo-500 shrink-0" />
         <span className="flex-1 min-w-0">
           <span className="block text-sm text-indigo-700 font-medium truncate">{label}</span>
-          {inst?.name && dt && (
-            <span className="block text-xs text-indigo-400 truncate">{dt.name}</span>
-          )}
+          {marker
+            ? <span className="block text-xs text-indigo-400 truncate">указатель — в PDF печатается ссылкой, не разворачивается</span>
+            : inst?.name && dt && <span className="block text-xs text-indigo-400 truncate">{dt.name}</span>}
         </span>
-        {inst && (
+        {!marker && inst && (
           <span className={`text-xs px-1.5 py-0.5 rounded font-medium shrink-0 ${STATUS_COLORS[inst.status]}`}>
             {STATUS_LABELS[inst.status]}
           </span>

--- a/src/client/src/shared/api/tags.ts
+++ b/src/client/src/shared/api/tags.ts
@@ -8,6 +8,7 @@ export const FUNCTIONAL_TAG = {
   docNumber: 'doc.number',
   typeQualityDocument: 'type.qualityDocument',
   typeProjectDocumentation: 'type.projectDocumentation',
+  typeUnion: 'type.union',
   materialQualityDocLink: 'material.qualityDocLink',
   identity: 'identity',
   qualityValidUntil: 'quality.validUntil',

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -29,9 +29,11 @@ export interface CommonDataEntryWithScope extends CommonDataEntry {
 
 /** Ссылка на объект каталога общих данных, поле другого документа или весь DocumentInstance. */
 export interface FieldRef {
-  readonly $ref: 'catalog' | 'document' | 'instance';
+  // 'marker' (issue #320) — ссылка-указатель на документ: НЕ разворачивается при генерации (резолвер
+  // клонирует неизвестный $ref), шаблон печатает displayName («см. «…»»). Используется union-полем.
+  readonly $ref: 'catalog' | 'document' | 'instance' | 'marker';
   entryId?: string;      // catalog
-  instanceId?: string;   // document | instance
+  instanceId?: string;   // document | instance | marker
   fieldKey?: string;     // document — ключ поля в реквизитах другого документа
   displayName: string;
   scope?: CatalogScope;
@@ -40,11 +42,16 @@ export interface FieldRef {
 export function isFieldRef(val: unknown): val is FieldRef {
   return val != null && typeof val === 'object'
     && '$ref' in (val as Record<string, unknown>)
-    && ['catalog', 'document', 'instance'].includes((val as FieldRef).$ref);
+    && ['catalog', 'document', 'instance', 'marker'].includes((val as FieldRef).$ref);
 }
 
 export function isInstanceRef(val: unknown): val is FieldRef & { $ref: 'instance' } {
   return isFieldRef(val) && (val as FieldRef).$ref === 'instance';
+}
+
+/** Ссылка-указатель (не инлайнится при генерации, показывается именем) — issue #320. */
+export function isMarkerRef(val: unknown): val is FieldRef & { $ref: 'marker' } {
+  return isFieldRef(val) && (val as FieldRef).$ref === 'marker';
 }
 
 // ─── Catalog Entity ───────────────────────────────────────────────────────────

--- a/src/server/BHS.CRG.Application/Schema/TagRegistry.cs
+++ b/src/server/BHS.CRG.Application/Schema/TagRegistry.cs
@@ -70,6 +70,9 @@ public static class TagRegistry
         new(FunctionalTag.TypeProjectDocumentation, "Проектная документация",
             "Тип документа относится к проектной документации (ГОСТ Р 21.101-2020).",
             TagScope.Type, ["Document"], Multiple: false),
+        new(FunctionalTag.TypeUnion, "Выбор одного (union)",
+            "Составной тип-«выбор»: пользователь заполняет РОВНО ОДНО из полей типа (напр. «Список» ИЛИ «Ссылка на документ»). В форме показывается переключатель варианта, а не все поля сразу.",
+            TagScope.Type, ["Composite"], Multiple: false),
 
         // ── Type: профиль уровня (issue #258) — ровно один тип на уровень (MaxBearers=1) ──
         new(FunctionalTag.ProfileConstruction, "Профиль стройки",

--- a/src/server/BHS.CRG.Domain/Schema/FunctionalTag.cs
+++ b/src/server/BHS.CRG.Domain/Schema/FunctionalTag.cs
@@ -46,6 +46,10 @@ public static class FunctionalTag
     public const string TypeQualityDocument = "type.qualityDocument";
     /// <summary>Тип документа относится к проектной документации (ГОСТ Р 21.101-2020).</summary>
     public const string TypeProjectDocumentation = "type.projectDocumentation";
+    /// <summary>Составной тип-«выбор» (union, issue #320): пользователь заполняет РОВНО ОДНО из полей
+    /// типа (напр. «список» ИЛИ «ссылка на документ»). Значение — composite с единственным заполненным
+    /// подполем; выбранный вариант определяется по заполненному ключу.</summary>
+    public const string TypeUnion = "type.union";
 
     // ── Тэги типа: профиль уровня (issue #258) ──────────────────────────────────
     // Составной тип, помеченный тэгом, — «профиль» соответствующего уровня-контейнера: его поля

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -221,6 +221,22 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Assert.Equal("instance", doc.GetProperty("Вложенный").GetProperty("$ref").GetString());
     }
 
+    [Fact] // issue #320: marker-ссылка (union-вариант «ссылка») НЕ разворачивается — остаётся объектом
+           // с displayName, чтобы шаблон напечатал «см. «…»» вместо инлайна всего чужого документа.
+    public async Task MarkerRef_NotResolved()
+    {
+        var setId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_MK");
+        var otherId = await DocAsync(setId, docType, "{'Номер':'Р-1'}");
+        var docId = await DocAsync(setId, docType,
+            "{'Перечень':{'$ref':'marker','instanceId':'" + otherId + "','displayName':'Реестр работ Р-1'}}");
+
+        var v = E(await ResolveAsync(docId), "Перечень");
+
+        Assert.Equal("marker", v.GetProperty("$ref").GetString());              // не тронут
+        Assert.Equal("Реестр работ Р-1", v.GetProperty("displayName").GetString());
+    }
+
     // ── Исправленные баги ────────────────────────────────────────────────────────
 
     [Fact] // Баг A

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.9</Version>
+    <Version>0.53.10</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #320. Дизайн согласован: Архитектор + Дизайнер + пользователь.

## Что это
Поле-«или»: значение = **массив ЛИБО ссылка на документ** (напр. «Перечень работ» inline, либо вынесен в «Реестр работ» — тогда ссылка). Реализовано БЕЗ нового `field.type`/формы значения — как **составной тип + функциональный тэг `type.union`** («заполняется ровно одно из полей типа»).

## Фаза 1 — тэг
`FunctionalTag.TypeUnion`/`TagRegistry` (Type-scope, Composite) + фронт-константа. Редактор типов показывает тэг для составных типов автоматически.

## Фаза 2 — union-редактор (UX Дизайнера)
`UnionFieldGroup` в `ComplexFieldGroup`: сегмент-переключатель варианта + редактор ТОЛЬКО активного подполя (не стопка «И»). Авто-выбор первого варианта, чип «заполните одно из», required-звёздочка на группе. Дискриминатор **C**: persist = один ключ активного варианта (пайплайн схема-агностичен), недеструктивное переключение — локальным стэшем в сессии. Извлечён `SubfieldEditor` (переиспользуется). nested-модалка со сводкой.

## Фаза 3 — marker-ref (семантика b)
Вариант-«ссылка» хранится как **не-инлайнящийся `$ref:'marker'`**: резолвер клонирует неизвестный `$ref` (без изменений), шаблон печатает `displayName` («см. «…»») вместо разворачивания всего чужого документа. `UnionFieldGroup` превращает instance-ссылку пикера в marker (в union ссылка всегда указатель). `DocRefField` показывает marker с пометкой «не разворачивается». Рендер-функция union-типа (`typstRenders`) ветвится по присутствующему ключу — авторится один раз на переиспользуемом типе.

## Проверка
- Вживую (Playwright): union-редактор рендерит сегменты, переключает варианты (массив ↔ текст ↔ marker-ссылка); marker показан с пометкой; тестовые данные подчищены.
- Тесты: `EntityResolverTests.MarkerRef_NotResolved` (маркер уцелевает), `tsc -b`, 130 фронт + 450 backend зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)