### PR TITLE
fix(generation): marker-ссылка не флагается как висячая (#322)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
+++ b/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
@@ -74,6 +74,10 @@ public static class ResolutionScanner
                 if (el.TryGetProperty("$ref", out var refProp))
                 {
                     var kind = refProp.GetString();
+                    // marker (issue #320, #322) — намеренный указатель-ссылка union-варианта: резолвер его
+                    // осознанно НЕ разворачивает (шаблон печатает displayName). Это валидное значение, а
+                    // не висячая ссылка — не флагаем (иначе ложная ошибка + блок генерации).
+                    if (kind == "marker") return;
                     var target = el.TryGetProperty("entryId", out var eid) ? eid.GetString()
                         : el.TryGetProperty("instanceId", out var iid) ? iid.GetString()
                         : null;

--- a/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
@@ -41,4 +41,18 @@ public class ResolutionScannerTests
         Assert.DoesNotContain(diags, d => d.Path == "Необязательное");
         Assert.Equal(3, diags.Count);
     }
+
+    [Fact] // issue #322: marker (union-указатель) НЕ висячая ссылка — не флагаем; обычный leftover-ref — ошибка.
+    public void ScanLeftoverRefs_SkipsMarker_FlagsUnresolved()
+    {
+        var ctx = new GenerationContext();
+        ctx.Set("Указатель", Json("{\"$ref\":\"marker\",\"instanceId\":\"x\",\"displayName\":\"Реестр\"}"));
+        ctx.Set("Битая", Json("{\"$ref\":\"instance\",\"instanceId\":\"y\"}"));
+
+        var diags = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diags);
+
+        Assert.DoesNotContain(diags, d => d.Path == "Указатель"); // marker — валидное значение
+        Assert.Contains(diags, d => d.Path == "Битая" && d.Severity == DiagnosticSeverity.Error);
+    }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.10</Version>
+    <Version>0.53.11</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #322

## Симптом
Документ с union-полем, где выбран вариант-«ссылка» (\`\$ref:'marker'\`), в «Проверить ссылки» давал 3 ошибки «Ссылка на объект типа «marker» … не разрешена». Тот же сканер — гейт генерации (\`GenerateDocumentHandler.cs:86\`), т.е. marker **блокировал генерацию PDF**.

## Причина
\`ResolutionScanner.ScanLeftoverRefs\`/\`Walk\` считал ЛЮБОЙ объект с \`\$ref\` висячей ссылкой. \`\$ref:'marker'\` (issue #320) — намеренный указатель для печати, который резолвер осознанно НЕ разворачивает; это не ошибка.

## Фикс
\`Walk\` пропускает \`kind=="marker"\`. Чинит все три пути, зовущих \`ScanLeftoverRefs\`: «Проверить ссылки», гейт генерации, живой предпросмотр.

## Проверка
- Вживую: validate реального документа с 3 маркерами → **0 ошибок** (было 3).
- Тест \`ResolutionScannerTests.ScanLeftoverRefs_SkipsMarker_FlagsUnresolved\` (marker не флагается, обычный leftover-ref — флагается). Все **452** backend зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)