### PR TITLE
fix(union): убрать marker — ссылки резолвятся как обычно (#324)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/shared/ui/Button';
 import type {
   CatalogScope, DocumentInstance, DocumentType, FieldRef, PrimitiveTypeDef,
 } from '@/shared/api/types';
-import { isFieldRef, isInstanceRef, SCOPE_LABELS } from '@/shared/api/types';
+import { isFieldRef, SCOPE_LABELS } from '@/shared/api/types';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import {
   resolveEffectiveFields, getDefaultValues, type SchemaField,
@@ -914,12 +914,8 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
     setActiveKey(key);
   }
   // persist = один ключ активного варианта; пустой активный → {} (= «не выбрано», как обычный complex).
-  // Ссылка на документ в union — всегда НЕ-инлайнящийся marker (семантика b, issue #320): резолвер
-  // маркер не разворачивает, шаблон печатает displayName. instance-ссылку из пикера превращаем в marker.
-  function setActiveValue(v: unknown) {
-    const stored = isInstanceRef(v) ? { ...v, $ref: 'marker' as const } : v;
-    onChange(isVariantFilled(stored) ? { [activeKey]: stored } : {});
-  }
+  // Ссылочные поля в union резолвятся как обычно (issue #324) — никакой спец-обработки ссылок.
+  function setActiveValue(v: unknown) { onChange(isVariantFilled(v) ? { [activeKey]: v } : {}); }
 
   if (subFields.length === 0) return <p className="text-xs text-fg4">Union-тип без полей.</p>;
 

--- a/src/client/src/features/document-sets/fields/DocRefField.tsx
+++ b/src/client/src/features/document-sets/fields/DocRefField.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { FileText, Plus, Trash2, Unlink } from 'lucide-react';
 import type { CatalogScope, DocumentInstance, DocumentType, FieldRef } from '@/shared/api/types';
-import { isFieldRef, isInstanceRef, isMarkerRef } from '@/shared/api/types';
+import { isFieldRef, isInstanceRef } from '@/shared/api/types';
 import type { SchemaField } from '@/shared/api/schema';
 import { STATUS_COLORS, STATUS_LABELS } from './constants';
 import { InstancePickerModal } from './InstancePickerModal';
@@ -12,9 +12,7 @@ export function DocRefField({ field, allDocTypes, value, onChange, otherInstance
   setId?: string;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
-  // marker (issue #320) — ссылка-указатель (не инлайнится): отображаем как обычную instance-ссылку.
-  const marker = isMarkerRef(value);
-  const iRef = isInstanceRef(value) || isMarkerRef(value) ? value as FieldRef : null;
+  const iRef = isInstanceRef(value) ? value : null;
   const cRef = isFieldRef(value) && (value as FieldRef).$ref === 'catalog' ? value as FieldRef : null;
 
   if (iRef) {
@@ -26,11 +24,9 @@ export function DocRefField({ field, allDocTypes, value, onChange, otherInstance
         <FileText size={14} className="text-indigo-500 shrink-0" />
         <span className="flex-1 min-w-0">
           <span className="block text-sm text-indigo-700 font-medium truncate">{label}</span>
-          {marker
-            ? <span className="block text-xs text-indigo-400 truncate">указатель — в PDF печатается ссылкой, не разворачивается</span>
-            : inst?.name && dt && <span className="block text-xs text-indigo-400 truncate">{dt.name}</span>}
+          {inst?.name && dt && <span className="block text-xs text-indigo-400 truncate">{dt.name}</span>}
         </span>
-        {!marker && inst && (
+        {inst && (
           <span className={`text-xs px-1.5 py-0.5 rounded font-medium shrink-0 ${STATUS_COLORS[inst.status]}`}>
             {STATUS_LABELS[inst.status]}
           </span>

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -29,11 +29,9 @@ export interface CommonDataEntryWithScope extends CommonDataEntry {
 
 /** Ссылка на объект каталога общих данных, поле другого документа или весь DocumentInstance. */
 export interface FieldRef {
-  // 'marker' (issue #320) — ссылка-указатель на документ: НЕ разворачивается при генерации (резолвер
-  // клонирует неизвестный $ref), шаблон печатает displayName («см. «…»»). Используется union-полем.
-  readonly $ref: 'catalog' | 'document' | 'instance' | 'marker';
+  readonly $ref: 'catalog' | 'document' | 'instance';
   entryId?: string;      // catalog
-  instanceId?: string;   // document | instance | marker
+  instanceId?: string;   // document | instance
   fieldKey?: string;     // document — ключ поля в реквизитах другого документа
   displayName: string;
   scope?: CatalogScope;
@@ -42,16 +40,11 @@ export interface FieldRef {
 export function isFieldRef(val: unknown): val is FieldRef {
   return val != null && typeof val === 'object'
     && '$ref' in (val as Record<string, unknown>)
-    && ['catalog', 'document', 'instance', 'marker'].includes((val as FieldRef).$ref);
+    && ['catalog', 'document', 'instance'].includes((val as FieldRef).$ref);
 }
 
 export function isInstanceRef(val: unknown): val is FieldRef & { $ref: 'instance' } {
   return isFieldRef(val) && (val as FieldRef).$ref === 'instance';
-}
-
-/** Ссылка-указатель (не инлайнится при генерации, показывается именем) — issue #320. */
-export function isMarkerRef(val: unknown): val is FieldRef & { $ref: 'marker' } {
-  return isFieldRef(val) && (val as FieldRef).$ref === 'marker';
 }
 
 // ─── Catalog Entity ───────────────────────────────────────────────────────────

--- a/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
+++ b/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
@@ -74,10 +74,6 @@ public static class ResolutionScanner
                 if (el.TryGetProperty("$ref", out var refProp))
                 {
                     var kind = refProp.GetString();
-                    // marker (issue #320, #322) — намеренный указатель-ссылка union-варианта: резолвер его
-                    // осознанно НЕ разворачивает (шаблон печатает displayName). Это валидное значение, а
-                    // не висячая ссылка — не флагаем (иначе ложная ошибка + блок генерации).
-                    if (kind == "marker") return;
                     var target = el.TryGetProperty("entryId", out var eid) ? eid.GetString()
                         : el.TryGetProperty("instanceId", out var iid) ? iid.GetString()
                         : null;

--- a/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
@@ -41,18 +41,4 @@ public class ResolutionScannerTests
         Assert.DoesNotContain(diags, d => d.Path == "Необязательное");
         Assert.Equal(3, diags.Count);
     }
-
-    [Fact] // issue #322: marker (union-указатель) НЕ висячая ссылка — не флагаем; обычный leftover-ref — ошибка.
-    public void ScanLeftoverRefs_SkipsMarker_FlagsUnresolved()
-    {
-        var ctx = new GenerationContext();
-        ctx.Set("Указатель", Json("{\"$ref\":\"marker\",\"instanceId\":\"x\",\"displayName\":\"Реестр\"}"));
-        ctx.Set("Битая", Json("{\"$ref\":\"instance\",\"instanceId\":\"y\"}"));
-
-        var diags = new List<ResolutionDiagnostic>();
-        ResolutionScanner.ScanLeftoverRefs(ctx, diags);
-
-        Assert.DoesNotContain(diags, d => d.Path == "Указатель"); // marker — валидное значение
-        Assert.Contains(diags, d => d.Path == "Битая" && d.Severity == DiagnosticSeverity.Error);
-    }
 }

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -221,22 +221,6 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Assert.Equal("instance", doc.GetProperty("Вложенный").GetProperty("$ref").GetString());
     }
 
-    [Fact] // issue #320: marker-ссылка (union-вариант «ссылка») НЕ разворачивается — остаётся объектом
-           // с displayName, чтобы шаблон напечатал «см. «…»» вместо инлайна всего чужого документа.
-    public async Task MarkerRef_NotResolved()
-    {
-        var setId = await SetupSetAsync();
-        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_MK");
-        var otherId = await DocAsync(setId, docType, "{'Номер':'Р-1'}");
-        var docId = await DocAsync(setId, docType,
-            "{'Перечень':{'$ref':'marker','instanceId':'" + otherId + "','displayName':'Реестр работ Р-1'}}");
-
-        var v = E(await ResolveAsync(docId), "Перечень");
-
-        Assert.Equal("marker", v.GetProperty("$ref").GetString());              // не тронут
-        Assert.Equal("Реестр работ Р-1", v.GetProperty("displayName").GetString());
-    }
-
     // ── Исправленные баги ────────────────────────────────────────────────────────
 
     [Fact] // Баг A

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.11</Version>
+    <Version>0.53.12</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #324

## Уточнение
Семантика (b) «ссылка-указатель, не инлайнить, печатать «см. «…»»» оказалась не тем, что нужно. Требование: ссылочные поля в union **резолвятся** как обычный doc-ref. Механизм `marker` (Фаза 3 из #320) убран полностью.

## Изменения
- **Frontend**: `UnionFieldGroup.setActiveValue` больше не превращает instance-ссылку в marker (хранит как есть → резолвится); `FieldRef.$ref` без `'marker'`, убран `isMarkerRef`; `DocRefField` без marker-ветки.
- **Backend**: убран marker-skip из `ScanLeftoverRefs` (#322 больше не актуален); удалены marker-тесты.
- **Данные (dev)**: существующие `$ref:'marker'` мигрированы в `$ref:'instance'` (1 строка), чтобы старые значения резолвились.

## Проверка
- Вживую: validate реального документа — **0 marker-упоминаний**, ссылки резолвятся (целевой документ разворачивается). Остаточные ошибки в том документе — self-reference + удалённые записи каталога в тестовых данных, не связаны с union.
- `tsc -b` + 450 backend зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)