### PR TITLE
feat(typst): автокомплит функций из userlib.typ (#326)

### DIFF
--- a/src/client/src/features/settings/TypstRendersEditor.tsx
+++ b/src/client/src/features/settings/TypstRendersEditor.tsx
@@ -3,6 +3,7 @@ import type * as Monaco from 'monaco-editor';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { useTheme } from '@/shared/ui/ThemeProvider';
+import { useUserLibCompletion } from '@/shared/ui/typstUserLibCompletion';
 import { Plus, Trash2, Maximize2, Code, AlertCircle, AlertTriangle } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -100,6 +101,7 @@ function TypstBlockDialog({ render, onSave, onClose }: {
   onClose: () => void;
 }) {
   const { resolvedTheme } = useTheme();
+  useUserLibCompletion();
   const [draft, setDraft] = useState<TypstRender>(render);
   const isDirty = draft.name !== render.name
     || draft.fnName !== render.fnName

--- a/src/client/src/features/templates/EditorPanel.tsx
+++ b/src/client/src/features/templates/EditorPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTheme } from '@/shared/ui/ThemeProvider';
+import { useUserLibCompletion } from '@/shared/ui/typstUserLibCompletion';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { Button } from '@/shared/ui/Button';
@@ -96,6 +97,7 @@ interface EditorPanelProps {
 
 export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorPanelProps) {
   const { resolvedTheme } = useTheme();
+  useUserLibCompletion();
   const [content, setContent] = useState(template.content);
   const [saving, setSaving] = useState(false);
   const [savedMsg, setSavedMsg] = useState(false);

--- a/src/client/src/features/templates/UserLibPanel.tsx
+++ b/src/client/src/features/templates/UserLibPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { useTheme } from '@/shared/ui/ThemeProvider';
+import { useUserLibCompletion } from '@/shared/ui/typstUserLibCompletion';
 import { Button } from '@/shared/ui/Button';
 import { Save } from 'lucide-react';
 import { useTypstUserLib, useSaveTypstUserLib } from '@/shared/api/typstUserLib';
@@ -10,6 +11,7 @@ import { TemplateAssetsPanel } from './TemplateAssetsPanel';
 
 export function UserLibPanel() {
   const { resolvedTheme } = useTheme();
+  useUserLibCompletion();
   const { data: serverContent = '', isLoading } = useTypstUserLib();
   const saveMutation = useSaveTypstUserLib();
   const [content, setContent] = useState('');

--- a/src/client/src/shared/ui/typstLanguage.ts
+++ b/src/client/src/shared/ui/typstLanguage.ts
@@ -1,4 +1,5 @@
 import type * as Monaco from 'monaco-editor';
+import { registerUserLibCompletion } from './typstUserLibCompletion';
 
 let registered = false;
 
@@ -101,4 +102,7 @@ export function registerTypstLanguage(monaco: typeof Monaco) {
       { open: '_', close: '_' },
     ],
   });
+
+  // Автокомплит функций из userlib.typ (issue #326) — единая точка для всех Typst-редакторов.
+  registerUserLibCompletion(monaco);
 }

--- a/src/client/src/shared/ui/typstUserLibCompletion.ts
+++ b/src/client/src/shared/ui/typstUserLibCompletion.ts
@@ -1,0 +1,79 @@
+import type * as Monaco from 'monaco-editor';
+import { useEffect } from 'react';
+import { useTypstUserLib } from '@/shared/api/typstUserLib';
+
+/**
+ * Автокомплит функций/значений из общей библиотеки Typst (`userlib.typ`) в Monaco-редакторах
+ * (шаблоны, Typst-блоки типов, сам userlib). Зеркалит паттерн `it.`-провайдера: модульный список
+ * обновляется хуком из загруженного userlib, провайдер регистрируется один раз и читает его лениво.
+ */
+interface UserLibDef { name: string; params: string; isFunction: boolean; }
+
+let _defs: UserLibDef[] = [];
+let _registered = false;
+
+/** Парсит `#let name(params) = …` (функция) и `#let name = …` (значение) из содержимого userlib.typ. */
+export function setUserLibDefs(content: string): void {
+  const defs: UserLibDef[] = [];
+  const seen = new Set<string>();
+  // Имя — Typst-идентификатор (буквы/цифры/_/-), опциональные (params) → функция.
+  const re = /#let\s+([\p{L}_][\p{L}\p{N}_-]*)\s*(\(([^)]*)\))?/gu;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    if (seen.has(m[1])) continue;
+    seen.add(m[1]);
+    defs.push({ name: m[1], params: m[3] ?? '', isFunction: m[2] != null });
+  }
+  _defs = defs;
+}
+
+/** Регистрирует провайдер автокомплита userlib для языка typst (один раз глобально). */
+export function registerUserLibCompletion(monaco: typeof Monaco): void {
+  if (_registered) return;
+  _registered = true;
+  monaco.languages.registerCompletionItemProvider('typst', {
+    triggerCharacters: ['#'],
+    provideCompletionItems(model, position) {
+      if (_defs.length === 0) return { suggestions: [] };
+      const line = model.getValueInRange({
+        startLineNumber: position.lineNumber, startColumn: 1,
+        endLineNumber: position.lineNumber, endColumn: position.column,
+      });
+      // Хвостовой идентификатор (с дефисами) — префикс для фильтра; либо только что напечатан «#».
+      const idMatch = line.match(/([\p{L}_][\p{L}\p{N}_-]*)$/u);
+      const prefix = idMatch ? idMatch[1] : '';
+      const afterHash = /#$/.test(line);
+      if (prefix.length === 0 && !afterHash) return { suggestions: [] };
+
+      const range = {
+        startLineNumber: position.lineNumber, endLineNumber: position.lineNumber,
+        startColumn: position.column - prefix.length, endColumn: position.column,
+      };
+      const matches = prefix
+        ? _defs.filter(d => d.name.toLowerCase().startsWith(prefix.toLowerCase()))
+        : _defs;
+
+      return {
+        suggestions: matches.map(d => ({
+          label: d.isFunction ? `${d.name}(${d.params})` : d.name,
+          kind: d.isFunction
+            ? monaco.languages.CompletionItemKind.Function
+            : monaco.languages.CompletionItemKind.Variable,
+          insertText: d.isFunction ? `${d.name}($0)` : d.name,
+          insertTextRules: d.isFunction
+            ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+            : undefined,
+          range,
+          detail: 'userlib.typ',
+          documentation: d.isFunction ? `#let ${d.name}(${d.params}) = …` : `#let ${d.name} = …`,
+        })),
+      };
+    },
+  });
+}
+
+/** Хук: подтягивает userlib.typ и обновляет список автокомплита. Вызывать в компонентах-хостах Typst-редакторов. */
+export function useUserLibCompletion(): void {
+  const { data } = useTypstUserLib();
+  useEffect(() => { setUserLibDefs(data ?? ''); }, [data]);
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.12</Version>
+    <Version>0.53.13</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #326

## Что
Monaco-редакторы Typst (шаблоны, Typst-блоки типов, сам userlib) теперь предлагают функции/значения из общей библиотеки `userlib.typ` — по аналогии с существующим `it.`-автокомплитом.

## Как
- `shared/ui/typstUserLibCompletion.ts`: парсит `#let name(params)` / `#let name = …` из содержимого userlib, регистрирует Monaco completion-провайдер. Учитывает **дефисы** в Typst-идентификаторах (`capitalize-first`, `parse-iso-date`, `place-facsimile`), помечает источник «userlib.typ», функции вставляет сниппетом `name($0)`. Триггер `#` + фильтр по префиксу.
- Регистрация — в `registerTypstLanguage` (единая точка для всех Typst-редакторов).
- `useUserLibCompletion()` подтягивает userlib (React Query) и обновляет список; вызван в `EditorPanel`, `UserLibPanel`, `TypstBlockDialog`.

## Проверка
- Вживую (Playwright): «capital» → `capitalize-first(s)` [userlib.typ]; «parse» → `parse-iso-date`.
- `tsc -b` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)