### PR TITLE
fix(ui): Esc на подтверждении закрытия = продолжить редактирование (#328)

### DIFF
--- a/src/client/src/shared/ui/Modal.tsx
+++ b/src/client/src/shared/ui/Modal.tsx
@@ -53,6 +53,13 @@ export function Modal({ open, onOpenChange, title, children, wide, extraWide, fu
             }`}
           style={fullScreen ? undefined : { boxShadow: 'var(--f-shadow28)' }}
           onEscapeKeyDown={e => {
+            // Esc при показанном подтверждении = «Продолжить редактирование» (закрыть подтверждение,
+            // остаться в редакторе), а не закрыть/no-op.
+            if (confirmClose) {
+              e.preventDefault();
+              setConfirmClose(false);
+              return;
+            }
             if (isDirty) {
               e.preventDefault();
               setConfirmClose(true);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.13</Version>
+    <Version>0.53.14</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #328

## Проблема
Когда после Esc показано подтверждение «Закрыть без сохранения?», повторный Esc был no-op. Ожидаемо: Esc на подтверждении = «Продолжить редактирование».

## Фикс
В общем `Modal` `onEscapeKeyDown`: если показано `confirmClose` — снять его (вернуться в редактор), а не показывать повторно. Действует для всех диалогов с `isDirty`-guard (Typst-блок, редактор документа, редактор шаблона и т.д.).

## Проверка
- Вживую (Playwright): грязный блок → Esc (подтверждение) → Esc (редактор остаётся открыт, подтверждение исчезает).
- `tsc -b` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)