### PR TITLE
fix(generation): обрыв цикла instance-ссылок → стаб, не сырой $ref (#330)

### DIFF
--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -211,10 +211,30 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
                 return resolved.ValueKind != JsonValueKind.Undefined ? resolved : node.Clone();
             }
 
-            // Неизвестный $ref или instance при allowInstanceRefs=false — оставляем как есть (клон).
+            // Обрыв цикла (issue #330): instance-ссылка при allowInstanceRefs=false — один документ уже
+            // развёрнут, глубже не рекурсируем (цикл A↔B). Отдаём ЧИСТЫЙ стаб (без $ref, но с
+            // displayName/instanceId): сырой ссылки не остаётся → сканер не флагает её как «не найдена»,
+            // повторный проход (двойной ResolveContextRefsAsync) не разворачивает её лишний раз, а шаблон
+            // может показать имя. Не-найденная instance-ссылка (target удалён) сюда НЕ попадает — она в
+            // ветке выше уходит в node.Clone() (остаётся $ref → корректно флагается).
+            case "instance":
+                return StripRef(node);
+
+            // Неизвестный $ref (напр. не найденная catalog/document-ссылка) — оставляем как есть (клон).
             default:
                 return node.Clone();
         }
+    }
+
+    /// <summary>Копия объекта без ключа «$ref» — стаб оборванной-по-циклу ссылки (issue #330):
+    /// перестаёт быть ссылкой (не резолвится/не флагается), но сохраняет displayName/instanceId.</summary>
+    private static JsonElement StripRef(JsonElement node)
+    {
+        var dict = new Dictionary<string, JsonElement>();
+        foreach (var p in node.EnumerateObject())
+            if (p.Name != "$ref")
+                dict[p.Name] = p.Value.Clone();
+        return JsonSerializer.SerializeToElement(dict);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -217,8 +217,36 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         var doc = E(await ResolveAsync(aId), "Док");
 
         Assert.Equal("B-значение", doc.GetProperty("Поле").GetString());
-        // Цепочка A→B→C: вложенная instance-ссылка НЕ разворачивается (защита от циклов) — остаётся $ref.
-        Assert.Equal("instance", doc.GetProperty("Вложенный").GetProperty("$ref").GetString());
+        // Цепочка A→B→C: вложенная instance-ссылка НЕ разворачивается (защита от циклов). Теперь остаётся
+        // ЧИСТЫЙ стаб без $ref (issue #330) — не флагается как висячая, id сохранён.
+        var vlozh = doc.GetProperty("Вложенный");
+        Assert.False(vlozh.TryGetProperty("$ref", out _));
+        Assert.Equal(cId.ToString(), vlozh.GetProperty("instanceId").GetString());
+    }
+
+    [Fact] // issue #330: цикл документов A↔B. A разворачивает B (один хоп), обратная B→A обрывается СТАБОМ
+           // (без $ref) — не сырая ссылка → сканер не флагает «не найдена», генерация не блокируется.
+    public async Task InstanceRef_Cycle_ResolvesToStub_NotFlagged()
+    {
+        var setId = await SetupSetAsync();
+        var type = await TypeAsync(DocumentTypeKind.Document, "DOC_CY2");
+        var aId = await DocAsync(setId, type, "{'Поле':'A'}");
+        var bId = await DocAsync(setId, type, "{'Поле':'B','Назад':{'$ref':'instance','instanceId':'" + aId + "'}}");
+        // Замыкаем: A.Ссылка → B, B.Назад → A.
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new UpdateRequisitesCommand(aId, J("{'Поле':'A','Ссылка':{'$ref':'instance','instanceId':'" + bId + "'}}")));
+
+        var ctx = await ResolveAsync(aId);
+
+        var b = E(ctx, "Ссылка");                       // A.Ссылка → B развёрнут
+        Assert.Equal("B", b.GetProperty("Поле").GetString());
+        var back = b.GetProperty("Назад");              // B.Назад → A: обрыв цикла → стаб без $ref
+        Assert.False(back.TryGetProperty("$ref", out _));
+        Assert.Equal(aId.ToString(), back.GetProperty("instanceId").GetString());
+
+        var diags = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diags);
+        Assert.DoesNotContain(diags, d => d.Path.StartsWith("Ссылка.Назад")); // стаб не флагается
     }
 
     // ── Исправленные баги ────────────────────────────────────────────────────────

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.53.14</Version>
+    <Version>0.53.15</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #330

## Симптом
Документ с кросс-ссылками (АОСР ↔ реестры: у реестра `ОсновнойДокумент` → сам АОСР) в «Проверить ссылки» давал **24 ошибки** «Ссылка на документ не разрешена — целевая запись не найдена или удалена», хотя документы существуют. Тот же сканер — гейт генерации → **генерация блокировалась**.

## Причины (обе НЕ связаны с union — union лишь вскрыл латентное; `EntityResolver` union-PR'ами не менялся)
1. Гайд от циклов `allowInstanceRefs=false` при обрыве оставлял **сырой `$ref`**, а `ScanLeftoverRefs` флагает любой `$ref` как «не найдена» (ложно для существующих целей).
2. `ResolveContextRefsAsync` вызывается **дважды** (внутри `ResolveAsync` + явно в каждом хендлере) → каждый проход +1 хоп по циклу → «один хоп» обходится, цикл разворачивается глубже и тянет ссылки развёрнутого документа (в т.ч. на удалённые орги) → 24 вместо ~4.

## Фикс
`ResolveRefObject`: instance-ссылка при `allowInstanceRefs=false` (обрыв цикла) → **чистый стаб** (`StripRef` — объект без `$ref`, с `displayName`/`instanceId`) вместо сырой ссылки. Разом:
- нет `$ref` → сканер не флагает → генерация не блокируется;
- стаб не разворачивается повторно → **двойной проход становится идемпотентным** (лишний хоп исчезает сам);
- шаблон может показать имя ссылки;
- не-найденная (удалённая) instance-ссылка по-прежнему уходит в `node.Clone()` (остаётся `$ref` → корректно флагается).

## Проверка
- Вживую на реальном документе: **24 → 0 ошибок**.
- Тесты: `InstanceRef_Depth1_Resolved_ChainStops` обновлён (теперь стаб), добавлен `InstanceRef_Cycle_ResolvesToStub_NotFlagged`. Все **451** backend зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)