### PR TITLE
Заголовок вкладки браузера = текущее положение в приложении (#336)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/shared/ui/ThemeProvider';
 import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
 import { NavigationGuardProvider } from '@/shared/ui/NavigationGuard';
+import { DocumentTitleManager } from '@/shared/ui/DocumentTitle';
 import { ToastProvider } from '@/shared/ui/Toast';
 import { AuthProvider } from '@/shared/ui/AuthProvider';
 import { ProtectedRoute, AdminRoute } from '@/shared/ui/ProtectedRoute';
@@ -37,6 +38,7 @@ export default function App() {
         <BrowserRouter>
           <ErrorBoundary variant="page" allowReload>
           <NavigationGuardProvider>
+          <DocumentTitleManager>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
@@ -63,6 +65,7 @@ export default function App() {
               </Route>
             </Route>
           </Routes>
+          </DocumentTitleManager>
           </NavigationGuardProvider>
           </ErrorBoundary>
         </BrowserRouter>

--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -13,6 +13,7 @@ import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavItem, NavSection } from '@/shared/ui/ListDetailShell';
 import { useToast } from '@/shared/ui/Toast';
+import { useDocumentTitle } from '@/shared/ui/DocumentTitle';
 import { CopyDocumentDialog } from './CopyDocumentDialog';
 import { MoveDocumentDialog } from './MoveDocumentDialog';
 import { CatalogResource } from './catalog/CatalogResource';
@@ -102,6 +103,12 @@ function SetDetail() {
       setSearchParams(prev => { prev.delete('doc'); return prev; }, { replace: true });
     }
   }, [docParam, set, setSearchParams]);
+
+  // Заголовок вкладки: открытый документ замещает имя комплекта («Документ — «Комплект»»).
+  const openDocName = editInstance
+    ? (editInstance.name || docTypes.find(t => t.id === editInstance.documentTypeId)?.name || 'Документ')
+    : null;
+  useDocumentTitle(set ? (openDocName ? `${openDocName} — «${set.name}»` : `Комплект «${set.name}»`) : null);
 
   if (isLoading) return <div className="p-6 text-sm text-fg4">Загрузка...</div>;
   if (!set) return <div className="p-6 text-sm text-danger">Комплект не найден</div>;
@@ -492,6 +499,11 @@ function SectionDetail() {
   const renameSection = useRenameSection();
   const deleteSection = useDeleteSection();
 
+  useDocumentTitle((() => {
+    const s = construction?.sections.find(s => s.id === sectionId);
+    return s ? `Раздел «${s.name}»` : null;
+  })());
+
   if (isLoading) return <div className="p-6 text-sm text-fg4">Загрузка...</div>;
   if (!construction) return <div className="p-6 text-sm text-danger">Стройка не найдена</div>;
   const section = construction.sections.find(s => s.id === sectionId);
@@ -661,6 +673,8 @@ function ConstructionDetail() {
       navigate(`/document-sets/${constructionId}/sections/${s.id}`);
     } catch (err: unknown) { setSectionError(err instanceof Error ? err.message : 'Ошибка'); }
   }
+
+  useDocumentTitle(construction ? `Стройка «${construction.name}»` : null);
 
   if (isLoading) return <div className="p-6 text-sm text-fg4">Загрузка...</div>;
   if (!construction) return <div className="p-6 text-sm text-danger">Стройка не найдена</div>;

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -5,6 +5,7 @@ import {
   Braces, RotateCcw, Code, Database, Cpu, HelpCircle, RefreshCw,
 } from 'lucide-react';
 import { Switch } from '@/shared/ui/Switch';
+import { useDocumentTitle } from '@/shared/ui/DocumentTitle';
 import { Markdown } from '@/shared/ui/Markdown';
 import { BindingTemplatesDialog } from './BindingTemplatesDialog';
 import { Modal } from '@/shared/ui/Modal';
@@ -862,6 +863,12 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
   // тот же диалог. `routeLeave` хранит отложенный переход (proceed).
   const [routeLeave, setRouteLeave] = useState<(() => void) | null>(null);
   useLeaveGuard(anyDirty, (proceed) => setRouteLeave(() => proceed));
+
+  // Заголовок вкладки: выбранный тип замещает раздел.
+  const selectedType = allDocTypes.find(dt => dt.id === selectedId);
+  useDocumentTitle(selectedType
+    ? `${kind === 'Composite' ? 'Составной тип' : 'Тип'} «${selectedType.name}»`
+    : null);
 
   const filtered = allDocTypes
     .filter(dt => dt.kind === kind)

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Library } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
+import { useDocumentTitle } from '@/shared/ui/DocumentTitle';
 import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
@@ -81,6 +82,13 @@ export function TemplatesPage() {
 
   const selectedDocType = docTypes.find(dt => dt.id === selectedTypeId) ?? null;
   const groups = groupTemplates(templates);
+
+  // Заголовок вкладки: библиотека / выбранный шаблон / просматриваемый тип замещают раздел.
+  useDocumentTitle(
+    mode === 'userlib' ? 'Библиотека Typst'
+    : selectedTemplate ? `Шаблон «${selectedTemplate.name}»`
+    : selectedDocType ? selectedDocType.name
+    : null);
 
   useEffect(() => { setSelectedTemplate(null); }, [selectedTypeId]);
 

--- a/src/client/src/shared/ui/DocumentTitle.tsx
+++ b/src/client/src/shared/ui/DocumentTitle.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Заголовок вкладки браузера = текущее положение в приложении (раздел, а при открытой сущности —
+ * её имя). Один писатель `document.title`: `DocumentTitleManager` считает РАЗДЕЛ по маршруту, а
+ * экран с открытой сущностью проталкивает ДЕТАЛЬ через `useDocumentTitle(...)` — деталь замещает
+ * раздел. Формат: `{деталь ?? раздел} · BHS.CRG`.
+ *
+ * Деталь — одно значение (LAST writer wins). Маршруты взаимоисключающи (одновременно смонтирован
+ * ровно один detail-экран), поэтому конфликта нет; вложенную сущность (документ поверх комплекта)
+ * компонует сам родитель (SetDetail даёт «Документ — Комплект»), а не второй писатель.
+ */
+const APP_NAME = 'BHS.CRG';
+
+const SECTION_TITLES: Record<string, string> = {
+  'document-sets': 'Комплекты',
+  'common-data': 'Общие данные',
+  'datasets': 'Наборы данных',
+  'quality-docs': 'Документы качества',
+  'templates': 'Шаблоны',
+  'document-types': 'Типы документов',
+  'composite-types': 'Составные типы',
+  'field-types': 'Типы полей',
+  'users': 'Пользователи',
+  'settings': 'Настройки',
+  'profile': 'Профиль',
+  'login': 'Вход',
+};
+
+function sectionFor(pathname: string): string | null {
+  const seg = pathname.split('/').filter(Boolean)[0];
+  if (!seg) return SECTION_TITLES['document-sets']; // корень → редирект на комплекты
+  return SECTION_TITLES[seg] ?? null;
+}
+
+const DetailCtx = createContext<(detail: string | null) => void>(() => {});
+
+export function DocumentTitleManager({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const [detail, setDetail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const base = detail ?? sectionFor(location.pathname);
+    document.title = base ? `${base} · ${APP_NAME}` : APP_NAME;
+  }, [location.pathname, detail]);
+
+  return <DetailCtx.Provider value={setDetail}>{children}</DetailCtx.Provider>;
+}
+
+/**
+ * Экран с открытой сущностью задаёт деталь заголовка (имя сущности). `null`/`undefined` — детали нет
+ * (показываем раздел). Деталь снимается при размонтировании экрана. Вызывать безусловно (до ранних
+ * return-ов), передавая null пока данные грузятся.
+ */
+export function useDocumentTitle(detail: string | null | undefined): void {
+  const setDetail = useContext(DetailCtx);
+  useEffect(() => {
+    setDetail(detail ?? null);
+    return () => setDetail(null);
+  }, [setDetail, detail]);
+}


### PR DESCRIPTION
Closes #336

`document.title` теперь показывает, где ты находишься — раздел, а при открытой сущности её имя. Удобно при нескольких вкладках приложения.

## Механизм
- `DocumentTitleManager` (внутри роутера) — единственный писатель `document.title`: считает **раздел** по верхнему сегменту маршрута.
- `useDocumentTitle(detail)` — экран с открытой сущностью проталкивает **деталь** (имя), которая замещает раздел; снимается при размонтировании. Один писатель ⇒ без гонок; маршруты взаимоисключающи ⇒ без конфликтов; вложенность (документ поверх комплекта) компонует сам родитель.
- Формат: `{деталь ?? раздел} · BHS.CRG`.

## Покрытие
- **Разделы** (все): Комплекты, Общие данные, Наборы данных, Документы качества, Шаблоны, Типы документов, Составные типы, Типы полей, Пользователи, Настройки, Профиль, Вход.
- **Детали**: стройка → раздел → комплект → открытый документ; типы/составные типы; шаблоны/библиотека Typst.
- Наборы данных / общие данные / докум. качества — пока на уровне раздела (деталь — лёгкий follow-up при желании).

## Проверка (live)
- Разделы: `Комплекты · BHS.CRG`, `Наборы данных · BHS.CRG`, `Типы полей · BHS.CRG`, …
- Детали: `Стройка «ДНС ЕЦДМ» · BHS.CRG`, `Раздел «ОВиК» · BHS.CRG`, `Комплект «…» · BHS.CRG`
- `tsc -b` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)