### PR TITLE
Метаполе типа объекта _type в data.json (фаза 1, #342)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -91,6 +91,10 @@ public class GenerateDocumentHandler(
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 throw new ResolutionValidationException(diagnostics);
 
+            // Метаполе типа объекта (issue #342): data._type + составные по схеме. ТЕРМИНАЛЬНО — после
+            // ScanMissingRequired/union, чтобы штамп непустых объектов не сбил проверки пустоты.
+            TypeStamper.Stamp(context, instance.CompositeTypeId, allDocTypes.ToDictionary(t => t.Id));
+
             string? typeBlocksContent = null;
             string? userLibContent = null;
             if (cmd.Format == OutputFormat.Pdf)

--- a/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
+++ b/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
@@ -70,6 +70,10 @@ public class GetGenerationDebugBundleHandler(
         context.Set("params", TemplateParams.Effective(template.Parameters,
             TemplateParams.OverridesForTemplate(instance.TemplateParams, template.Id)));
 
+        // Тот же штамп _type, что и при генерации (issue #342) — debug-bundle обязан отдавать
+        // идентичную data.json, иначе отладка во внешнем Typst расходится с реальной генерацией.
+        TypeStamper.Stamp(context, instance.CompositeTypeId, allDocTypes.ToDictionary(t => t.Id));
+
         var dataJson = JsonSerializer.Serialize(context.Data, JsonOpts);
         var typeBlocks = TypstPreambleBuilder.Build(allDocTypes);
 

--- a/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
+++ b/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
@@ -88,6 +88,9 @@ public class PreviewDocumentHandler(
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 return PreviewDocumentResult.Fail("Не все ссылки разрешены — предпросмотр недоступен.", diagnostics);
 
+            // Метаполе типа объекта (issue #342) — тот же терминальный штамп, что при генерации/бандле.
+            TypeStamper.Stamp(context, instance.CompositeTypeId, allDocTypes.ToDictionary(t => t.Id));
+
             var preamble = TypstPreambleBuilder.Build(allDocTypes);
             var lib = (await userLibRepo.GetAllAsync(ct)).FirstOrDefault();
             var userLib = lib is not null && !string.IsNullOrWhiteSpace(lib.Content) ? lib.Content : null;

--- a/src/server/BHS.CRG.Application/Generation/TypeMeta.cs
+++ b/src/server/BHS.CRG.Application/Generation/TypeMeta.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Метаполе типа объекта для data.json (issue #342): <c>_type = { code, name, chain: [self … root] }</c>.
+/// <c>chain</c> ВКЛЮЧАЕТ сам тип (self-first) — по нему одной проверкой членства ловится и равенство,
+/// и потомок (основа для <c>instance-of</c>, фаза 2). <c>code == chain[0]</c> — стабильный ASCII-ключ
+/// прямого диспетча (переименуемое <c>name</c> — только для показа). Цепочка строится из графа
+/// <see cref="DocumentType.ParentId"/>. Единый источник формы для всех штамповщиков (issue #342).
+/// </summary>
+public static class TypeMeta
+{
+    /// <summary>Коды типов от конкретного к корню по ParentId. Guard от циклов/битого графа (32).</summary>
+    public static List<string> AncestorCodes(Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        var chain = new List<string>();
+        var cur = byId.GetValueOrDefault(typeId);
+        var guard = 0;
+        while (cur is not null && guard++ < 32)
+        {
+            chain.Add(cur.Code);
+            cur = cur.ParentId is { } p ? byId.GetValueOrDefault(p) : null;
+        }
+        return chain;
+    }
+
+    /// <summary>Строит JSON-объект метаполя <c>{ code, name, chain }</c> для типа. Неизвестный тип → пустые.</summary>
+    public static JsonElement BuildElement(Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        var self = byId.GetValueOrDefault(typeId);
+        return JsonSerializer.SerializeToElement(new
+        {
+            code = self?.Code ?? "",
+            name = self?.Name ?? "",
+            chain = AncestorCodes(typeId, byId),
+        });
+    }
+}

--- a/src/server/BHS.CRG.Application/Generation/TypeStamper.cs
+++ b/src/server/BHS.CRG.Application/Generation/TypeStamper.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Схема-управляемый штамп метаполя типа объекта в контекст генерации (issue #342). Проставляет
+/// <c>data._type</c> самому документу и КАЖДОМУ НЕПУСТОМУ составному объекту (inline complex/union,
+/// элементы array/doc-array, вложенные) по <b>объявленному</b> типу поля из схемы.
+///
+/// Инвариант размещения: ТЕРМИНАЛЬНЫЙ шаг — вызывается ПОСЛЕ <see cref="ResolutionScanner.ScanMissingRequired"/>
+/// и union-проверок, поэтому пустые объекты пропускаются (у пустого нет объекта → нет типа) и ни одна
+/// проверка пустоты не видит <c>_type</c> (иначе штамп в <c>{}</c> ложно = «заполнено»). Резолвер
+/// схема-агностичен — вся схема-осведомлённость локализована здесь.
+///
+/// Фаза 2: ссылки штампуются резолвером ФАКТИЧЕСКИМ типом записи (для корректного <c>instance-of</c>
+/// на подтипах); здесь уже-штампованные объекты пропускаются, домены не пересекаются.
+/// </summary>
+public static class TypeStamper
+{
+    public const string MetaKey = "_type";
+
+    /// <summary>Штампует контекст: корень документа + составные поля по эффективной схеме типа.</summary>
+    public static void Stamp(GenerationContext ctx, Guid documentTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        // Тип самого документа — мастер-диспетч data._type. Корень по пустоте не проверяется → безопасно.
+        ctx.Set(MetaKey, TypeMeta.BuildElement(documentTypeId, byId));
+
+        foreach (var f in DocumentTypeSchemaReader.EffectiveFields(documentTypeId, byId))
+            if (f.TypeId is { } tid && ctx.Data.TryGetValue(f.Key, out var v) && v is JsonElement je)
+                ctx.Set(f.Key, StampField(f.Type, tid, je, byId));
+    }
+
+    /// <summary>Штамп значения поля по кардинальности: complex/doc-ref → объект; array/doc-array → массив объектов.</summary>
+    private static JsonElement StampField(string fieldType, Guid typeId, JsonElement value, IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        if (DocumentTypeSchemaReader.IsSingleComposite(fieldType))
+            return StampObject(value, typeId, byId);
+        if (DocumentTypeSchemaReader.IsMultiValued(fieldType) && value.ValueKind == JsonValueKind.Array)
+            return JsonSerializer.SerializeToElement(
+                value.EnumerateArray().Select(it => StampObject(it, typeId, byId)).ToList());
+        return value;
+    }
+
+    /// <summary>Штамп одного составного объекта (declared typeId) + рекурсия в его составные подполя.
+    /// Не-объект / пустой / уже-штампованный (или ссылка-$ref) — оставляем как есть.</summary>
+    private static JsonElement StampObject(JsonElement obj, Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        if (obj.ValueKind != JsonValueKind.Object) return obj;
+
+        // Пустой = нет НЕ-мета свойств (нет объекта → нет типа). Уже штампованный (_type) — чужой домен
+        // (ссылка, проштампованная резолвером). $ref — неразрешённая ссылка, не данные.
+        var hasReal = false;
+        foreach (var p in obj.EnumerateObject())
+        {
+            if (p.Name == MetaKey || p.Name == "$ref") return obj;
+            if (!p.Name.StartsWith('_')) hasReal = true;
+        }
+        if (!hasReal) return obj;
+
+        var subFields = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).ToDictionary(sf => sf.Key);
+        var dict = new Dictionary<string, JsonElement>();
+        foreach (var p in obj.EnumerateObject())
+        {
+            dict[p.Name] = subFields.TryGetValue(p.Name, out var sf) && sf.TypeId is { } stid
+                && (DocumentTypeSchemaReader.IsSingleComposite(sf.Type) || DocumentTypeSchemaReader.IsMultiValued(sf.Type))
+                ? StampField(sf.Type, stid, p.Value, byId)
+                : p.Value.Clone();
+        }
+        dict[MetaKey] = TypeMeta.BuildElement(typeId, byId);
+        return JsonSerializer.SerializeToElement(dict);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Generation/TypeStamperTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/TypeStamperTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>
+/// Штамп метаполя типа объекта (issue #342): data._type + составные объекты по объявленной схеме,
+/// иерархия chain (self→root), пропуск пустых/уже-штампованных/$ref.
+/// </summary>
+public class TypeStamperTests
+{
+    private static readonly Guid DocId = Guid.Parse("d0000000-0000-0000-0000-000000000001");
+    private static readonly Guid OrgId = Guid.Parse("00000000-0000-0000-0000-0000000000a1");
+    private static readonly Guid PodrId = Guid.Parse("00000000-0000-0000-0000-0000000000a2");
+    private static readonly Guid WorkId = Guid.Parse("00000000-0000-0000-0000-0000000000b1");
+
+    private static DocumentType T(Guid id, string name, string code, Guid? parent, string fieldsJson = "[]") =>
+        DocumentType.Restore(id, name, code, DocumentTypeKind.Composite, parent,
+            JsonDocument.Parse($"{{\"fields\":{fieldsJson}}}"), JsonDocument.Parse("{}"), false,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private static IReadOnlyDictionary<Guid, DocumentType> ById(params DocumentType[] ts) => ts.ToDictionary(t => t.Id);
+
+    private static JsonElement J(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    // Схема документа: complex «Орг» (ORG) + array «Работы» (WORK) + пустой complex «Пусто» (ORG).
+    private static readonly string DocFields =
+        $"[{{\"key\":\"Орг\",\"type\":\"complex\",\"typeId\":\"{OrgId}\"}}," +
+        $"{{\"key\":\"Работы\",\"type\":\"array\",\"typeId\":\"{WorkId}\"}}," +
+        $"{{\"key\":\"Пусто\",\"type\":\"complex\",\"typeId\":\"{OrgId}\"}}]";
+
+    private static (GenerationContext ctx, IReadOnlyDictionary<Guid, DocumentType> byId) Setup()
+    {
+        var byId = ById(
+            T(DocId, "АОСР", "AOSR", null, DocFields),
+            T(OrgId, "Организация", "ORG", null),
+            T(PodrId, "Подрядчик", "PODR", OrgId),   // потомок ORG — для chain
+            T(WorkId, "Работа", "WORK", null));
+        var ctx = new GenerationContext();
+        ctx.Set("Орг", J("{\"Наименование\":\"ООО Ромашка\"}"));
+        ctx.Set("Работы", J("[{\"Название\":\"копать\"},{}]"));  // 2-й элемент пустой
+        ctx.Set("Пусто", J("{}"));                                 // пустой составной
+        ctx.Set("Номер", J("\"ЭОМ-1\""));                          // скаляр — не трогаем
+        return (ctx, byId);
+    }
+
+    private static JsonElement Get(GenerationContext ctx, string key) => (JsonElement)ctx.Data[key]!;
+
+    [Fact]
+    public void AncestorCodes_SelfFirst_ToRoot()
+    {
+        var byId = ById(T(OrgId, "Организация", "ORG", null), T(PodrId, "Подрядчик", "PODR", OrgId));
+        Assert.Equal(new[] { "PODR", "ORG" }, TypeMeta.AncestorCodes(PodrId, byId));
+        Assert.Equal(new[] { "ORG" }, TypeMeta.AncestorCodes(OrgId, byId));
+    }
+
+    [Fact]
+    public void Stamp_DocumentRoot_CodeNameChain()
+    {
+        var (ctx, byId) = Setup();
+        TypeStamper.Stamp(ctx, DocId, byId);
+        var t = Get(ctx, "_type");
+        Assert.Equal("AOSR", t.GetProperty("code").GetString());
+        Assert.Equal("АОСР", t.GetProperty("name").GetString());
+        Assert.Equal(new[] { "AOSR" }, t.GetProperty("chain").EnumerateArray().Select(e => e.GetString()).ToArray());
+    }
+
+    [Fact]
+    public void Stamp_InlineComposite_GetsDeclaredType()
+    {
+        var (ctx, byId) = Setup();
+        TypeStamper.Stamp(ctx, DocId, byId);
+        var org = Get(ctx, "Орг");
+        Assert.Equal("ORG", org.GetProperty("_type").GetProperty("code").GetString());
+        Assert.Equal("ООО Ромашка", org.GetProperty("Наименование").GetString()); // данные сохранены
+    }
+
+    [Fact]
+    public void Stamp_ArrayItems_NonEmptyOnly()
+    {
+        var (ctx, byId) = Setup();
+        TypeStamper.Stamp(ctx, DocId, byId);
+        var arr = Get(ctx, "Работы").EnumerateArray().ToList();
+        Assert.Equal("WORK", arr[0].GetProperty("_type").GetProperty("code").GetString());
+        Assert.False(arr[1].TryGetProperty("_type", out _)); // пустой элемент НЕ штампуется
+    }
+
+    [Fact]
+    public void Stamp_EmptyComposite_NotStamped()
+    {
+        var (ctx, byId) = Setup();
+        TypeStamper.Stamp(ctx, DocId, byId);
+        Assert.False(Get(ctx, "Пусто").TryGetProperty("_type", out _));
+    }
+
+    [Fact]
+    public void Stamp_Scalar_Untouched()
+    {
+        var (ctx, byId) = Setup();
+        TypeStamper.Stamp(ctx, DocId, byId);
+        Assert.Equal("ЭОМ-1", Get(ctx, "Номер").GetString());
+    }
+
+    [Fact]
+    public void Stamp_SkipsRefAndAlreadyStamped()
+    {
+        var byId = ById(T(DocId, "АОСР", "AOSR", null,
+            $"[{{\"key\":\"A\",\"type\":\"complex\",\"typeId\":\"{OrgId}\"}}," +
+            $"{{\"key\":\"B\",\"type\":\"complex\",\"typeId\":\"{OrgId}\"}}]"), T(OrgId, "Организация", "ORG", null));
+        var ctx = new GenerationContext();
+        ctx.Set("A", J("{\"$ref\":\"catalog\",\"entryId\":\"x\"}"));            // неразрешённая ссылка
+        ctx.Set("B", J("{\"Наименование\":\"Y\",\"_type\":{\"code\":\"PODR\"}}")); // уже штампован (реф, фаза 2)
+        TypeStamper.Stamp(ctx, DocId, byId);
+        Assert.True(Get(ctx, "A").TryGetProperty("$ref", out _));
+        Assert.False(Get(ctx, "A").TryGetProperty("_type", out _));            // $ref не штампуем
+        Assert.Equal("PODR", Get(ctx, "B").GetProperty("_type").GetProperty("code").GetString()); // не перезаписан
+    }
+}


### PR DESCRIPTION
Часть #342. Фаза 1 — метаполе типа. (Фаза 2 — systemlib + instance-of + штамп рефов фактическим типом — отдельно.)

В data.json документу и каждому **непустому** составному объекту добавляется:
```json
"_type": { "code": "…", "name": "…", "chain": ["конкретный", …, "корень"] }
```
`chain` self-first (включает сам тип) → одной проверкой членства ловится и равенство, и потомок (основа `instance-of`). `code == chain[0]` — стабильный ключ прямого диспетча.

## Что сделано
- **`TypeMeta.AncestorCodes`** — цепочка кодов по `ParentId` (единый источник формы для всех штамповщиков).
- **`TypeStamper`** — схема-управляемый пасс (Application): `data._type` + inline complex/union + элементы array/doc-array + вложенные, по **объявленному** типу поля. Резолвер остаётся схема-агностичным.
- **Инвариант размещения:** терминальный шаг **после** `ScanMissingRequired`/union → пустые объекты не метим (у пустого нет объекта → нет типа), семантика пустоты цела. Пропускаем `$ref` (неразрешённая ссылка) и уже-штампованные (домен рефов — резолвер, фаза 2).
- **Единая эмиссия:** штамп во всех путях data.json — генерация, превью, debug-bundle (иначе отладка во внешнем Typst расходится с генерацией — R2).

## Проверка
- `dotnet build` ✅, **459 тестов** ✅ (+`TypeStamperTests`: root/inline/массив/пустой/скаляр/`$ref`/chain; регресс missing-required цел — штамп после проверки).
- Живьём (debug-bundle АОСР): root `_type.chain = ["АОСР","Документ"]` (иерархия), inline `ОрганизацияВыполнившаяРаботу` + вложенные `.Наименование`/`.ЮридическийАдрес` проштампованы.

## Фаза 2 (отдельно, согласована с Архитектором)
`systemlib.typ` (хардкод, read-only просмотр) + `instance-of` + штамп рефов **фактическим** `CompositeTypeId` в резолвере (для корректного `instance-of` на подтипах) + компиляция через префикс-импорт с константным офсетом (R10 проверен: `#include` не наследует импорты entry-файла).

🤖 Generated with [Claude Code](https://claude.com/claude-code)