### PR TITLE
systemlib.typ + instance-of + штамп рефов фактическим типом (фаза 2, #344)

### DIFF
--- a/src/client/src/features/templates/SystemLibPanel.tsx
+++ b/src/client/src/features/templates/SystemLibPanel.tsx
@@ -1,0 +1,50 @@
+import Editor from '@monaco-editor/react';
+import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
+import { useTheme } from '@/shared/ui/ThemeProvider';
+import { useSystemTypstLib } from '@/shared/api/typstUserLib';
+import { Lock } from 'lucide-react';
+
+/**
+ * Просмотр системной Typst-библиотеки (issue #344) — ХАРДКОД, только чтение. Авто-подключается к
+ * каждому шаблону, импортировать не нужно. Содержит системные хелперы (напр. instance-of).
+ */
+export function SystemLibPanel() {
+  const { resolvedTheme } = useTheme();
+  const { data: content = '', isLoading } = useSystemTypstLib();
+
+  if (isLoading) {
+    return <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Загрузка...</div>;
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-stroke bg-surface">
+        <Lock size={13} className="text-fg4 shrink-0" />
+        <p className="text-xs text-fg3">
+          Системная библиотека — только чтение. Авто-подключается к каждому шаблону (импортировать не нужно).
+        </p>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <Editor
+          height="100%"
+          defaultLanguage="typst"
+          theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
+          value={content}
+          beforeMount={registerTypstLanguage}
+          options={{
+            readOnly: true,
+            domReadOnly: true,
+            minimap: { enabled: false },
+            fontSize: 13,
+            fontFamily: "'Cascadia Code', 'Fira Code', Consolas, monospace",
+            wordWrap: 'on',
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            tabSize: 2,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Library } from 'lucide-react';
+import { Library, Lock } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { useDocumentTitle } from '@/shared/ui/DocumentTitle';
 import { Button } from '@/shared/ui/Button';
@@ -13,6 +13,7 @@ import { useMaxTemplateVersions } from '@/features/settings/SettingsPage';
 import { buildBlankTypst } from './templateBlank';
 import { EditorPanel } from './EditorPanel';
 import { UserLibPanel } from './UserLibPanel';
+import { SystemLibPanel } from './SystemLibPanel';
 import { TemplateSidebar, DocTypeSelector, VersionCleanupModal, groupTemplates, type TemplateGroup } from './TemplateSidebar';
 // ─── New template form ────────────────────────────────────────────────────────
 
@@ -63,7 +64,7 @@ function NewTemplateForm({ documentTypeId, docType, allDocTypes, onClose, onCrea
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
-type PageMode = 'templates' | 'userlib';
+type PageMode = 'templates' | 'userlib' | 'systemlib';
 
 export function TemplatesPage() {
   const [mode, setMode] = useState<PageMode>('templates');
@@ -85,7 +86,8 @@ export function TemplatesPage() {
 
   // Заголовок вкладки: библиотека / выбранный шаблон / просматриваемый тип замещают раздел.
   useDocumentTitle(
-    mode === 'userlib' ? 'Библиотека Typst'
+    mode === 'systemlib' ? 'Системная библиотека Typst'
+    : mode === 'userlib' ? 'Библиотека Typst'
     : selectedTemplate ? `Шаблон «${selectedTemplate.name}»`
     : selectedDocType ? selectedDocType.name
     : null);
@@ -170,6 +172,17 @@ export function TemplatesPage() {
               <Library size={14} className="shrink-0" />
               Общие функции Typst
             </button>
+            <button
+              onClick={() => setMode('systemlib')}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md whitespace-nowrap transition-colors ${
+                mode === 'systemlib'
+                  ? 'bg-surface text-fg1 font-medium shadow-sm'
+                  : 'text-fg3 hover:text-fg2'
+              }`}
+            >
+              <Lock size={14} className="shrink-0" />
+              Системные функции
+            </button>
           </div>
 
           {/* Doc type selector — only in templates mode */}
@@ -180,7 +193,11 @@ export function TemplatesPage() {
       </div>
 
       {/* ── Content ── */}
-      {mode === 'userlib' ? (
+      {mode === 'systemlib' ? (
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <SystemLibPanel />
+        </div>
+      ) : mode === 'userlib' ? (
         <div className="flex-1 min-h-0 overflow-hidden">
           <UserLibPanel />
         </div>

--- a/src/client/src/shared/api/typstUserLib.ts
+++ b/src/client/src/shared/api/typstUserLib.ts
@@ -13,6 +13,18 @@ export function useTypstUserLib() {
   });
 }
 
+/** Системная Typst-библиотека (issue #344) — хардкод, только чтение. */
+export function useSystemTypstLib() {
+  return useQuery({
+    queryKey: ['typst-systemlib'],
+    queryFn: async () => {
+      const r = await apiClient.get<{ content: string }>('/templates/systemlib');
+      return r.data.content;
+    },
+    staleTime: Infinity, // константа — не протухает
+  });
+}
+
 export function useSaveTypstUserLib() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -185,7 +185,10 @@ public static class GenerationEndpoints
                 using var ms = new MemoryStream();
                 using (var zip = new System.IO.Compression.ZipArchive(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
                 {
-                    await WriteEntry(zip, "template.typ", bundle.TemplateContent);
+                    // template.typ = префикс системных импортов + шаблон (issue #344) — как компилирует
+                    // генерация, чтобы внешний `typst compile template.typ` работал (systemlib/typeblocks).
+                    await WriteEntry(zip, "template.typ", SystemTypstLib.ComposeTemplate(bundle.TemplateContent));
+                    await WriteEntry(zip, SystemTypstLib.FileName, SystemTypstLib.Content);
                     await WriteEntry(zip, "data.json", dataJson);
                     await WriteEntry(zip, "typeblocks.typ", typeBlocks);
                     await WriteEntry(zip, "userlib.typ", userLib);

--- a/src/server/BHS.CRG.Api/Endpoints/Templates/TemplateEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Templates/TemplateEndpoints.cs
@@ -1,3 +1,4 @@
+using BHS.CRG.Application.Generation;
 using BHS.CRG.Application.Templates;
 using MediatR;
 
@@ -12,6 +13,9 @@ public static class TemplateEndpoints
 
         g.MapGet("/", async (Guid documentTypeId, IMediator m)
             => Results.Ok(await m.Send(new ListTemplatesQuery(documentTypeId))));
+
+        // Системная Typst-библиотека (issue #344) — хардкод, только чтение (просмотр на странице шаблонов).
+        g.MapGet("/systemlib", () => Results.Ok(new { content = SystemTypstLib.Content }));
 
         g.MapGet("/active", async (Guid documentTypeId, IMediator m) =>
         {

--- a/src/server/BHS.CRG.Application/Generation/SystemTypstLib.cs
+++ b/src/server/BHS.CRG.Application/Generation/SystemTypstLib.cs
@@ -1,0 +1,38 @@
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Системная Typst-библиотека (issue #344) — ХАРДКОД, только чтение. Третий уровень рядом с
+/// <c>userlib.typ</c> (админ-редактируемый) и <c>typeblocks.typ</c> (автоген). Содержит системные
+/// хелперы (сейчас <c>instance-of</c>) и авто-подключается к каждому шаблону при компиляции —
+/// авторам шаблонов её импортировать не нужно. Просмотр — <c>GET /api/templates/systemlib</c> и
+/// read-only режим на странице шаблонов.
+/// </summary>
+public static class SystemTypstLib
+{
+    public const string FileName = "systemlib.typ";
+
+    /// <summary>Содержимое библиотеки. Держим здесь единым источником — эмитится в генерацию,
+    /// debug-bundle и read-only просмотр.</summary>
+    public const string Content =
+        "// systemlib.typ — системная библиотека BHS.CRG (только чтение, авто-подключается к шаблону).\n" +
+        "//\n" +
+        "// instance-of(it, code): полиморфная проверка типа объекта по метаполю _type (issue #342/#344).\n" +
+        "// true, если тип объекта РАВЕН code ЛИБО является его потомком — chain включает сам тип и всех\n" +
+        "// предков (self→root). Устойчива к объектам без _type и к не-словарям.\n" +
+        "//   #if instance-of(it, \"Организация\") [ … ]  — сработает и для потомков «Подрядчик»/«Проектировщик».\n" +
+        "#let instance-of(it, code) = type(it) == dictionary and code in it.at(\"_type\", default: (:)).at(\"chain\", default: ())\n";
+
+    /// <summary>Импорты, авто-подставляемые в НАЧАЛО шаблона при компиляции: systemlib + typeblocks.
+    /// Повторный импорт идемпотентен → старые шаблоны с ручным <c>#import "typeblocks.typ"</c> не ломаются,
+    /// новым импорты писать не нужно.</summary>
+    public static readonly string Prelude =
+        $"#import \"{FileName}\": *\n#import \"typeblocks.typ\": *\n";
+
+    /// <summary>Число строк префикса — константный офсет для сдвига номеров строк ошибок Typst обратно
+    /// на строки РЕДАКТОРА (template.typ пишется с префиксом, а автор видит шаблон без него).</summary>
+    public static readonly int PreludeLineCount = Prelude.Count(c => c == '\n');
+
+    /// <summary>Компилируемое содержимое: префикс импортов + шаблон ДОСЛОВНО (единый источник для
+    /// генерации и debug-bundle — иначе отладка расходится с генерацией).</summary>
+    public static string ComposeTemplate(string templateContent) => Prelude + templateContent;
+}

--- a/src/server/BHS.CRG.Application/Generation/TypeStamper.cs
+++ b/src/server/BHS.CRG.Application/Generation/TypeStamper.cs
@@ -14,12 +14,17 @@ namespace BHS.CRG.Application.Generation;
 /// проверка пустоты не видит <c>_type</c> (иначе штамп в <c>{}</c> ложно = «заполнено»). Резолвер
 /// схема-агностичен — вся схема-осведомлённость локализована здесь.
 ///
-/// Фаза 2: ссылки штампуются резолвером ФАКТИЧЕСКИМ типом записи (для корректного <c>instance-of</c>
-/// на подтипах); здесь уже-штампованные объекты пропускаются, домены не пересекаются.
+/// Фаза 2 (issue #344): ссылки помечаются резолвером сырым <c>_typeId</c> = ФАКТИЧЕСКИЙ
+/// <c>CompositeTypeId</c> записи (резолвер строить chain не может — он схема-агностичен и знает лишь
+/// собственный тип объекта). Здесь <c>_typeId</c> разворачивается в полный <c>_type</c> по фактическому
+/// типу (корректный <c>instance-of</c> на подтипах: поле «Организация», запись «Подрядчик»), рекурсия в
+/// подполя идёт по схеме ФАКТИЧЕСКОГО типа. Inline-объекты (без <c>_typeId</c>) — по объявленному.
 /// </summary>
 public static class TypeStamper
 {
     public const string MetaKey = "_type";
+    /// <summary>Сырой маркер фактического типа ссылки от резолвера — разворачивается здесь в <see cref="MetaKey"/>.</summary>
+    public const string TypeIdKey = "_typeId";
 
     /// <summary>Штампует контекст: корень документа + составные поля по эффективной схеме типа.</summary>
     public static void Stamp(GenerationContext ctx, Guid documentTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
@@ -43,26 +48,29 @@ public static class TypeStamper
         return value;
     }
 
-    /// <summary>Штамп одного составного объекта (declared typeId) + рекурсия в его составные подполя.
-    /// Не-объект / пустой / уже-штампованный (или ссылка-$ref) — оставляем как есть.</summary>
-    private static JsonElement StampObject(JsonElement obj, Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    /// <summary>Штамп одного составного объекта + рекурсия в его составные подполя. Тип берём из
+    /// <see cref="TypeIdKey"/> (реф — фактический тип записи), иначе из <paramref name="declaredTypeId"/>
+    /// (inline). Не-объект / пустой / уже-полностью-штампованный (_type) / ссылка-$ref — как есть.</summary>
+    private static JsonElement StampObject(JsonElement obj, Guid declaredTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
     {
         if (obj.ValueKind != JsonValueKind.Object) return obj;
 
-        // Пустой = нет НЕ-мета свойств (нет объекта → нет типа). Уже штампованный (_type) — чужой домен
-        // (ссылка, проштампованная резолвером). $ref — неразрешённая ссылка, не данные.
+        Guid? actualFromRef = null;
         var hasReal = false;
         foreach (var p in obj.EnumerateObject())
         {
-            if (p.Name == MetaKey || p.Name == "$ref") return obj;
-            if (!p.Name.StartsWith('_')) hasReal = true;
+            if (p.Name == "$ref" || p.Name == MetaKey) return obj;   // неразрешённая ссылка / уже штампован
+            if (p.Name == TypeIdKey) { if (Guid.TryParse(p.Value.GetString(), out var tid)) actualFromRef = tid; }
+            else if (!p.Name.StartsWith('_')) hasReal = true;
         }
-        if (!hasReal) return obj;
+        if (!hasReal && actualFromRef is null) return obj;           // пусто (нет объекта → нет типа)
 
+        var typeId = actualFromRef ?? declaredTypeId;                // реф → фактический; inline → объявленный
         var subFields = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).ToDictionary(sf => sf.Key);
         var dict = new Dictionary<string, JsonElement>();
         foreach (var p in obj.EnumerateObject())
         {
+            if (p.Name == TypeIdKey) continue;                       // сырой маркер не течёт в data.json
             dict[p.Name] = subFields.TryGetValue(p.Name, out var sf) && sf.TypeId is { } stid
                 && (DocumentTypeSchemaReader.IsSingleComposite(sf.Type) || DocumentTypeSchemaReader.IsMultiValued(sf.Type))
                 ? StampField(sf.Type, stid, p.Value, byId)

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -183,9 +183,13 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
                 when node.TryGetProperty("entryId", out var entryIdProp) && Guid.TryParse(entryIdProp.GetString(), out var entryId):
             {
                 var resolved = await ResolveEntryByIdAsync(entryId, scope, [], ct);
-                return resolved.ValueKind == JsonValueKind.Undefined
-                    ? node.Clone()
-                    : await ResolveNode(resolved, scope, depth + 1, allowInstanceRefs, ct);
+                if (resolved.ValueKind == JsonValueKind.Undefined) return node.Clone();
+                var recursed = await ResolveNode(resolved, scope, depth + 1, allowInstanceRefs, ct);
+                // Фактический тип записи каталога (issue #344) — для корректного instance-of на подтипах
+                // (поле «Организация», запись «Подрядчик»). Application развернёт _typeId в _type.
+                var typeId = await db.DomainObjects.Where(o => o.Id == entryId)
+                    .Select(o => (Guid?)o.CompositeTypeId).FirstOrDefaultAsync(ct);
+                return typeId is { } tid ? WithTypeId(recursed, tid) : recursed;
             }
 
             // Протягивание одного поля из реквизитов другого документа — значение как есть, без рекурсии
@@ -237,6 +241,20 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
         return JsonSerializer.SerializeToElement(dict);
     }
 
+    /// <summary>Помечает разрешённую ССЫЛКУ сырым <see cref="TypeStamper.TypeIdKey"/> = ФАКТИЧЕСКИЙ тип
+    /// записи (issue #344). Chain строит уже Application-<see cref="TypeStamper"/> (резолвер знает лишь
+    /// собственный тип объекта — агностичность к схеме полей цела). Только для инлайна ссылок (не для
+    /// профилей уровней, которые зовут тот же загрузчик, иначе сырой маркер утёк бы в data.json).</summary>
+    private static JsonElement WithTypeId(JsonElement obj, Guid typeId)
+    {
+        if (obj.ValueKind != JsonValueKind.Object) return obj;
+        var dict = new Dictionary<string, JsonElement>();
+        foreach (var p in obj.EnumerateObject())
+            if (p.Name != TypeStamper.TypeIdKey) dict[p.Name] = p.Value.Clone();
+        dict[TypeStamper.TypeIdKey] = JsonSerializer.SerializeToElement(typeId.ToString());
+        return JsonSerializer.SerializeToElement(dict);
+    }
+
     /// <summary>
     /// Загружает DocumentInstance и разворачивает его поля той же единой обработкой, но с
     /// <c>allowInstanceRefs: false</c> — вложенные instance-ссылки дальше не разворачиваются
@@ -256,6 +274,8 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
             if (v is JsonElement je)
                 dict[k] = await ResolveNode(je, scope, depth + 1, allowInstanceRefs: false, ct);
 
+        // Фактический тип развёрнутого документа-ссылки (issue #344) — Application развернёт в _type.
+        dict[TypeStamper.TypeIdKey] = JsonSerializer.SerializeToElement(obj.CompositeTypeId.ToString());
         return JsonSerializer.SerializeToElement(dict);
     }
 

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
@@ -48,9 +48,14 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
 
             await File.WriteAllTextAsync(Path.Combine(tmpDir, "data.json"), dataJson, ct);
 
+            // template.typ = префикс системных импортов + шаблон дословно (issue #344). Так systemlib
+            // и typeblocks доступны без ручного импорта; номера строк ошибок сдвигаем обратно (ниже).
             await File.WriteAllTextAsync(
                 Path.Combine(tmpDir, "template.typ"),
-                request.TemplateContent, Encoding.UTF8, ct);
+                SystemTypstLib.ComposeTemplate(request.TemplateContent), Encoding.UTF8, ct);
+
+            // systemlib.typ — системная библиотека (хардкод, issue #344). Всегда присутствует в tmpDir.
+            await File.WriteAllTextAsync(Path.Combine(tmpDir, SystemTypstLib.FileName), SystemTypstLib.Content, Encoding.UTF8, ct);
 
             // Всегда записываем typeblocks.typ — даже пустым.
             // Шаблон импортирует его напрямую: #import "typeblocks.typ": *
@@ -129,7 +134,7 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
             if (process.ExitCode != 0)
             {
                 var err = await stderrTask;
-                throw new InvalidOperationException($"Typst compilation failed (exit {process.ExitCode}):\n{err}");
+                throw new InvalidOperationException($"Typst compilation failed (exit {process.ExitCode}):\n{ShiftTemplateErrorLines(err)}");
             }
 
             var outputPath = Path.Combine(tmpDir, "output.pdf");
@@ -143,6 +148,16 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
             try { Directory.Delete(tmpDir, recursive: true); } catch { /* best effort */ }
         }
     }
+
+    // Сдвиг номеров строк ошибок Typst в template.typ обратно на строки РЕДАКТОРА (issue #344): в файл
+    // добавлен префикс импортов (SystemTypstLib.PreludeLineCount строк), а автор видит шаблон без него.
+    // Трогаем только «template.typ:N» — ошибки в systemlib/typeblocks оставляем как есть.
+    private static string ShiftTemplateErrorLines(string err) =>
+        System.Text.RegularExpressions.Regex.Replace(err, @"(template\.typ:)(\d+)(:)", m =>
+        {
+            var line = int.Parse(m.Groups[2].Value) - SystemTypstLib.PreludeLineCount;
+            return m.Groups[1].Value + (line < 1 ? 1 : line) + m.Groups[3].Value;
+        });
 
     private const long MaxAssetBytes = 100L * 1024 * 1024;
 

--- a/src/server/BHS.CRG.Tests/Generation/SystemTypstLibTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/SystemTypstLibTests.cs
@@ -1,0 +1,32 @@
+using BHS.CRG.Application.Generation;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>Системная Typst-библиотека (issue #344): авто-префикс импортов + офсет строк.</summary>
+public class SystemTypstLibTests
+{
+    [Fact]
+    public void Content_HasInstanceOf()
+    {
+        Assert.Contains("#let instance-of(", SystemTypstLib.Content);
+    }
+
+    [Fact]
+    public void ComposeTemplate_PrependsSystemlibAndTypeblocksImports_ThenTemplateVerbatim()
+    {
+        var tpl = "#set page(width: 10cm)\n= Заголовок\n";
+        var composed = SystemTypstLib.ComposeTemplate(tpl);
+        Assert.StartsWith("#import \"systemlib.typ\": *\n#import \"typeblocks.typ\": *\n", composed);
+        Assert.EndsWith(tpl, composed);                 // шаблон дословно в хвосте
+    }
+
+    [Fact]
+    public void PreludeLineCount_MatchesPrependedLines()
+    {
+        // Офсет для сдвига номеров строк ошибок = число добавленных строк префикса.
+        Assert.Equal(2, SystemTypstLib.PreludeLineCount);
+        var composed = SystemTypstLib.ComposeTemplate("X");
+        // Строка редактора N → строка composed (N + PreludeLineCount): "X" (ред. строка 1) на 3-й строке.
+        Assert.Equal("X", composed.Split('\n')[SystemTypstLib.PreludeLineCount]);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Generation/TypeStamperTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/TypeStamperTests.cs
@@ -103,6 +103,25 @@ public class TypeStamperTests
     }
 
     [Fact]
+    public void Stamp_Ref_UsesActualTypeIdFromResolver_ChainToRoot()
+    {
+        // Поле объявлено «Организация», а резолвер пометил запись фактическим типом «Подрядчик» (_typeId).
+        // Штамп берёт фактический тип: code=PODR, chain=[PODR,ORG]. Сырой _typeId в data.json не течёт.
+        var byId = ById(
+            T(DocId, "АОСР", "AOSR", null, $"[{{\"key\":\"Орг\",\"type\":\"doc-ref\",\"typeId\":\"{OrgId}\"}}]"),
+            T(OrgId, "Организация", "ORG", null),
+            T(PodrId, "Подрядчик", "PODR", OrgId));
+        var ctx = new GenerationContext();
+        ctx.Set("Орг", J($"{{\"Наименование\":\"ООО Подряд\",\"_typeId\":\"{PodrId}\"}}"));
+        TypeStamper.Stamp(ctx, DocId, byId);
+        var org = Get(ctx, "Орг");
+        Assert.Equal("PODR", org.GetProperty("_type").GetProperty("code").GetString());
+        Assert.Equal(new[] { "PODR", "ORG" }, org.GetProperty("_type").GetProperty("chain").EnumerateArray().Select(e => e.GetString()).ToArray());
+        Assert.False(org.TryGetProperty("_typeId", out _)); // сырой маркер удалён
+        Assert.Equal("ООО Подряд", org.GetProperty("Наименование").GetString());
+    }
+
+    [Fact]
     public void Stamp_SkipsRefAndAlreadyStamped()
     {
         var byId = ById(T(DocId, "АОСР", "AOSR", null,


### PR DESCRIPTION
Closes #344 · продолжение #342 (фаза 2)

Полиморфная диспетчеризация по типу объекта в Typst + системная библиотека.

## Что сделано
- **`SystemTypstLib`** — хардкод-константа с `instance-of(it, code)`: `true`, если тип объекта **равен** `code` **или** его потомок (по `chain` из `_type`). Устойчива к объектам без `_type` и к не-словарям.
- **Авто-подключение при компиляции:** система префиксит `#import "systemlib.typ": *` + `#import "typeblocks.typ": *` в начало `template.typ` — авторам импортировать не нужно; повторный импорт идемпотентен → старые шаблоны с ручным `#import typeblocks` целы. Номера строк ошибок Typst в `template.typ` сдвигаются обратно на константный офсет (редактор показывает шаблон без префикса). *(R10 проверен вживую: `#include` не наследует импорты entry-файла → используем префикс.)*
- **Штамп рефов фактическим типом:** резолвер помечает разрешённые ссылки сырым `_typeId` = фактический `CompositeTypeId` записи (2 точки: catalog + instance); `TypeStamper` разворачивает его в `_type` по **фактическому** типу с рекурсией по фактической схеме → `instance-of` корректен на подтипах (поле «Организация», запись «Подрядчик»). Только для ссылок (не для профилей уровней).
- **debug-bundle:** `+systemlib.typ` + `template.typ` с префиксом (parity с генерацией).
- **`GET /api/templates/systemlib`** + read-only режим **«Системные функции»** на странице шаблонов (Monaco, только чтение).

## Проверка
- `dotnet build` ✅, **463 backend** ✅ + **137 frontend** ✅ (`SystemTypstLibTests`, `TypeStamperTests` `_typeId`→`_type` фактический+chain).
- Живьём: `instance-of` — **6 assert'ов в Typst** (self/предок/несвязный/не-словарь/без-меты/регистр) все зелёные; systemlib-эндпоинт возвращает функцию; debug-bundle содержит `systemlib.typ` + composed `template.typ`; extracted-бандл компилируется мимо импортов (упавший `addr-full`/`.trim()` — **пред-существующий** баг типоблока: `().join()`→none, воспроизводится и без `_type`); read-only вкладка рендерит функцию.

🤖 Generated with [Claude Code](https://claude.com/claude-code)