### PR TITLE
Не оставлять сырой _typeId в data.json для несхемных ключей (#346)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/TypeStamper.cs
+++ b/src/server/BHS.CRG.Application/Generation/TypeStamper.cs
@@ -5,20 +5,24 @@ using BHS.CRG.Domain.Documents;
 namespace BHS.CRG.Application.Generation;
 
 /// <summary>
-/// Схема-управляемый штамп метаполя типа объекта в контекст генерации (issue #342). Проставляет
-/// <c>data._type</c> самому документу и КАЖДОМУ НЕПУСТОМУ составному объекту (inline complex/union,
-/// элементы array/doc-array, вложенные) по <b>объявленному</b> типу поля из схемы.
+/// Штамп метаполя типа объекта в контекст генерации (issue #342). Проставляет <c>data._type</c> самому
+/// документу и КАЖДОМУ НЕПУСТОМУ составному объекту (inline complex/union, элементы array/doc-array,
+/// вложенные) по <b>объявленному</b> типу поля из схемы.
 ///
 /// Инвариант размещения: ТЕРМИНАЛЬНЫЙ шаг — вызывается ПОСЛЕ <see cref="ResolutionScanner.ScanMissingRequired"/>
 /// и union-проверок, поэтому пустые объекты пропускаются (у пустого нет объекта → нет типа) и ни одна
 /// проверка пустоты не видит <c>_type</c> (иначе штамп в <c>{}</c> ложно = «заполнено»). Резолвер
 /// схема-агностичен — вся схема-осведомлённость локализована здесь.
 ///
-/// Фаза 2 (issue #344): ссылки помечаются резолвером сырым <c>_typeId</c> = ФАКТИЧЕСКИЙ
-/// <c>CompositeTypeId</c> записи (резолвер строить chain не может — он схема-агностичен и знает лишь
-/// собственный тип объекта). Здесь <c>_typeId</c> разворачивается в полный <c>_type</c> по фактическому
-/// типу (корректный <c>instance-of</c> на подтипах: поле «Организация», запись «Подрядчик»), рекурсия в
-/// подполя идёт по схеме ФАКТИЧЕСКОГО типа. Inline-объекты (без <c>_typeId</c>) — по объявленному.
+/// Ссылки помечаются резолвером сырым <c>_typeId</c> = ФАКТИЧЕСКИЙ <c>CompositeTypeId</c> записи (issue #344;
+/// резолвер строить chain не может — знает лишь собственный тип объекта). Здесь <c>_typeId</c> разворачивается
+/// в полный <c>_type</c> по фактическому типу (корректный <c>instance-of</c> на подтипах: поле «Организация»,
+/// запись «Подрядчик»), рекурсия в подполя — по схеме ФАКТИЧЕСКОГО типа.
+///
+/// Обход идёт по ВСЕМУ дереву контекста, а не только по полям схемы (issue #346): у НЕсхемных/осиротевших
+/// ключей (напр. «НовыеРаботы» после удаления поля из типа) сырой <c>_typeId</c> тоже обязан развернуться,
+/// иначе он протекает в data.json. Вне схемы объект не штампуется объявленным типом (тип неизвестен), но
+/// <c>_typeId</c>-ссылки внутри разворачиваются, а спуск продолжается.
 /// </summary>
 public static class TypeStamper
 {
@@ -26,57 +30,68 @@ public static class TypeStamper
     /// <summary>Сырой маркер фактического типа ссылки от резолвера — разворачивается здесь в <see cref="MetaKey"/>.</summary>
     public const string TypeIdKey = "_typeId";
 
-    /// <summary>Штампует контекст: корень документа + составные поля по эффективной схеме типа.</summary>
+    /// <summary>Штампует контекст: корень документа + все верхнеуровневые ключи (схемные — по объявленному
+    /// типу; прочие — generic-обход, чтобы развернуть сырые <c>_typeId</c>-ссылки и не оставить их в выводе).</summary>
     public static void Stamp(GenerationContext ctx, Guid documentTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
     {
         // Тип самого документа — мастер-диспетч data._type. Корень по пустоте не проверяется → безопасно.
         ctx.Set(MetaKey, TypeMeta.BuildElement(documentTypeId, byId));
 
-        foreach (var f in DocumentTypeSchemaReader.EffectiveFields(documentTypeId, byId))
-            if (f.TypeId is { } tid && ctx.Data.TryGetValue(f.Key, out var v) && v is JsonElement je)
-                ctx.Set(f.Key, StampField(f.Type, tid, je, byId));
+        var schemaFields = DocumentTypeSchemaReader.EffectiveFields(documentTypeId, byId).ToDictionary(f => f.Key);
+        foreach (var key in ctx.Data.Keys.ToList())
+        {
+            if (key == MetaKey || ctx.Data[key] is not JsonElement je) continue;
+            ctx.Set(key, Process(je, CompositeTypeOf(key, schemaFields), byId));
+        }
     }
 
-    /// <summary>Штамп значения поля по кардинальности: complex/doc-ref → объект; array/doc-array → массив объектов.</summary>
-    private static JsonElement StampField(string fieldType, Guid typeId, JsonElement value, IReadOnlyDictionary<Guid, DocumentType> byId)
+    /// <summary>Объявленный composite-тип поля (для complex/doc-ref/array/doc-array), иначе null.</summary>
+    private static Guid? CompositeTypeOf(string key, IReadOnlyDictionary<string, SchemaFieldInfo> fields)
+        => fields.TryGetValue(key, out var f) && f.TypeId is { } tid
+           && (DocumentTypeSchemaReader.IsSingleComposite(f.Type) || DocumentTypeSchemaReader.IsMultiValued(f.Type))
+            ? tid : null;
+
+    /// <summary>
+    /// Единый рекурсивный проход по значению. Тип объекта = <c>_typeId</c> (реф, фактический) ⟶ иначе
+    /// <paramref name="declaredTypeId"/> (inline по схеме) ⟶ иначе неизвестен (осиротевший/несхемный).
+    /// Разворачивает <c>_typeId</c>→<c>_type</c>, штампует непустой inline-составной с известным типом,
+    /// и в любом случае спускается вглубь (чтобы ни один сырой <c>_typeId</c> не остался). Пустой объект /
+    /// уже-<c>_type</c> / <c>$ref</c> / скаляр — по сути как есть.
+    /// </summary>
+    private static JsonElement Process(JsonElement v, Guid? declaredTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
     {
-        if (DocumentTypeSchemaReader.IsSingleComposite(fieldType))
-            return StampObject(value, typeId, byId);
-        if (DocumentTypeSchemaReader.IsMultiValued(fieldType) && value.ValueKind == JsonValueKind.Array)
+        if (v.ValueKind == JsonValueKind.Array)
             return JsonSerializer.SerializeToElement(
-                value.EnumerateArray().Select(it => StampObject(it, typeId, byId)).ToList());
-        return value;
-    }
-
-    /// <summary>Штамп одного составного объекта + рекурсия в его составные подполя. Тип берём из
-    /// <see cref="TypeIdKey"/> (реф — фактический тип записи), иначе из <paramref name="declaredTypeId"/>
-    /// (inline). Не-объект / пустой / уже-полностью-штампованный (_type) / ссылка-$ref — как есть.</summary>
-    private static JsonElement StampObject(JsonElement obj, Guid declaredTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
-    {
-        if (obj.ValueKind != JsonValueKind.Object) return obj;
+                v.EnumerateArray().Select(it => Process(it, declaredTypeId, byId)).ToList());
+        if (v.ValueKind != JsonValueKind.Object) return v;
 
         Guid? actualFromRef = null;
         var hasReal = false;
-        foreach (var p in obj.EnumerateObject())
+        var hasType = false;
+        foreach (var p in v.EnumerateObject())
         {
-            if (p.Name == "$ref" || p.Name == MetaKey) return obj;   // неразрешённая ссылка / уже штампован
-            if (p.Name == TypeIdKey) { if (Guid.TryParse(p.Value.GetString(), out var tid)) actualFromRef = tid; }
+            if (p.Name == "$ref") return v;                              // неразрешённая ссылка — не данные
+            if (p.Name == MetaKey) hasType = true;
+            else if (p.Name == TypeIdKey) { if (Guid.TryParse(p.Value.GetString(), out var tid)) actualFromRef = tid; }
             else if (!p.Name.StartsWith('_')) hasReal = true;
         }
-        if (!hasReal && actualFromRef is null) return obj;           // пусто (нет объекта → нет типа)
 
-        var typeId = actualFromRef ?? declaredTypeId;                // реф → фактический; inline → объявленный
-        var subFields = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).ToDictionary(sf => sf.Key);
+        var typeId = actualFromRef ?? declaredTypeId;                    // реф → фактический; inline → объявленный
+        var subFields = typeId is { } t
+            ? DocumentTypeSchemaReader.EffectiveFields(t, byId).ToDictionary(sf => sf.Key)
+            : null;
+
         var dict = new Dictionary<string, JsonElement>();
-        foreach (var p in obj.EnumerateObject())
+        foreach (var p in v.EnumerateObject())
         {
-            if (p.Name == TypeIdKey) continue;                       // сырой маркер не течёт в data.json
-            dict[p.Name] = subFields.TryGetValue(p.Name, out var sf) && sf.TypeId is { } stid
-                && (DocumentTypeSchemaReader.IsSingleComposite(sf.Type) || DocumentTypeSchemaReader.IsMultiValued(sf.Type))
-                ? StampField(sf.Type, stid, p.Value, byId)
-                : p.Value.Clone();
+            if (p.Name == TypeIdKey) continue;                           // сырой маркер не течёт в вывод
+            if (p.Name == MetaKey) { dict[p.Name] = p.Value.Clone(); continue; } // уже штампован — сохраняем
+            var childDeclared = subFields is not null ? CompositeTypeOf(p.Name, subFields) : null;
+            dict[p.Name] = Process(p.Value, childDeclared, byId);
         }
-        dict[MetaKey] = TypeMeta.BuildElement(typeId, byId);
+        // Штампуем _type только если тип известен, объект непустой и ещё не помечен. Пустой/неизвестный — не метим.
+        if (typeId is { } tt && hasReal && !hasType)
+            dict[MetaKey] = TypeMeta.BuildElement(tt, byId);
         return JsonSerializer.SerializeToElement(dict);
     }
 }

--- a/src/server/BHS.CRG.Tests/Generation/TypeStamperTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/TypeStamperTests.cs
@@ -122,6 +122,21 @@ public class TypeStamperTests
     }
 
     [Fact]
+    public void Stamp_ConvertsTypeIdInNonSchemaKey_NoRawMarkerLeaks()
+    {
+        // Осиротевший ключ (нет в схеме документа), внутри — ссылка с сырым _typeId. Проход всё равно
+        // разворачивает _typeId→_type и НЕ оставляет сырой маркер в выводе (issue #346, утечка Фазы 2).
+        var byId = ById(T(DocId, "АОСР", "AOSR", null, "[]"), T(OrgId, "Организация", "ORG", null));
+        var ctx = new GenerationContext();
+        ctx.Set("НовыеРаботы", J($"{{\"Вложенное\":{{\"Наименование\":\"X\",\"_typeId\":\"{OrgId}\"}}}}"));
+        TypeStamper.Stamp(ctx, DocId, byId);
+        var nested = Get(ctx, "НовыеРаботы").GetProperty("Вложенное");
+        Assert.False(nested.TryGetProperty("_typeId", out _));                          // сырой маркер убран
+        Assert.Equal("ORG", nested.GetProperty("_type").GetProperty("code").GetString()); // развёрнут в _type
+        Assert.Equal("X", nested.GetProperty("Наименование").GetString());
+    }
+
+    [Fact]
     public void Stamp_SkipsRefAndAlreadyStamped()
     {
         var byId = ById(T(DocId, "АОСР", "AOSR", null,


### PR DESCRIPTION
Closes #346

Регрессия Фазы 2 (#344): `TypeStamper` обходил только поля схемы, поэтому сырой маркер резолвера `_typeId` в **осиротевших/несхемных** ключах (напр. `НовыеРаботы` после удаления поля из типа) не разворачивался в `_type` и **протекал** в data.json.

## Фикс
Единый рекурсивный проход `Process` по **всему** дереву контекста (все верхнеуровневые ключи, не только поля схемы):
- любой `_typeId` → `_type` по **фактическому** типу (id несёт тип, схема не нужна), рекурсия по его схеме;
- inline-составные **схемных** полей по-прежнему штампуются объявленным типом;
- **вне** схемы объект не штампуется (тип неизвестен), но `_typeId`-ссылки внутри разворачиваются, спуск продолжается;
- пустые / `$ref` / уже-`_type` — как есть.

## Проверка
- `dotnet build` ✅, **464 backend** ✅ (+`Stamp_ConvertsTypeIdInNonSchemaKey_NoRawMarkerLeaks`).
- Живьём (debug-bundle АОСР): **30** сырых `_typeId` под `НовыеРаботы` → **0**; `НовыеРаботы.Реестр` теперь несёт корректный `_type` (chain `РеестрРаботАОСР → … → Документ`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)