### PR TITLE
Аудит своего документа в пользовательском режиме (#352)

### DIFF
--- a/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
+++ b/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react';
+import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { useToast } from '@/shared/ui/Toast';
+import { CheckCircle2, AlertTriangle, Loader2, Trash2 } from 'lucide-react';
+import { useAuditInstance, useApplyInstanceAuditFixes } from '@/shared/api/documentSets';
+import type { AuditFinding } from '@/shared/api/documentTypes';
+
+/**
+ * Аудит ОДНОГО документа в пользовательском режиме (issue #352) — юзер видит расхождения своего
+ * документа с текущей схемой и лечит их сам (без админа): удалить осиротевшее поле / очистить
+ * невалидное, либо переименовать верхнеуровневый осиротевший ключ в поле схемы. Reuse серверной
+ * машинерии типового аудита, но scope — этот инстанс.
+ */
+const CATEGORY_LABEL: Record<string, string> = {
+  'orphan-key': 'Поля, которых нет в текущей схеме',
+  'type-mismatch': 'Несовпадение вида значения с типом поля',
+};
+
+export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys, open, onClose }: {
+  setId: string; instanceId: string; docName: string; schemaFieldKeys: string[]; open: boolean; onClose: () => void;
+}) {
+  const { data: findings, isLoading, isError } = useAuditInstance(setId, instanceId, open);
+  const applyFixes = useApplyInstanceAuditFixes(setId, instanceId);
+  const toast = useToast();
+  const [confirm, setConfirm] = useState<AuditFinding | null>(null);
+  const [renameTarget, setRenameTarget] = useState<Record<string, string>>({});
+
+  const groups = useMemo(() => {
+    const byCat = new Map<string, AuditFinding[]>();
+    for (const f of findings ?? []) {
+      if (!byCat.has(f.code)) byCat.set(f.code, []);
+      byCat.get(f.code)!.push(f);
+    }
+    return [...byCat.entries()];
+  }, [findings]);
+
+  const total = findings?.length ?? 0;
+  const isTopLevel = (path: string) => !path.includes('.') && !path.includes('[');
+
+  async function apply(action: 'remove' | 'rename', path: string, targetKey?: string) {
+    try {
+      const res = await applyFixes.mutateAsync([{ action, path, targetKey }]);
+      if (res.applied > 0) toast.success('Документ исправлен');
+      else toast.info(res.outcomes[0]?.reason ?? 'Изменений не внесено');
+    } catch { toast.error('Не удалось применить исправление'); }
+  }
+
+  return (
+    <>
+      <Modal open={open} onOpenChange={o => { if (!o) onClose(); }} title={`Аудит документа «${docName}»`} wide>
+        {isLoading ? (
+          <div className="flex items-center gap-2 py-8 justify-center text-fg4 text-sm">
+            <Loader2 size={16} className="animate-spin" /> Проверка…
+          </div>
+        ) : isError ? (
+          <p className="text-sm text-danger py-6 text-center">Не удалось выполнить аудит.</p>
+        ) : total === 0 ? (
+          <div className="flex items-center gap-2 p-3 rounded-md text-sm bg-success-subtle text-success">
+            <CheckCircle2 size={15} className="shrink-0" /> Документ соответствует текущей схеме — исправлять нечего.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-xs text-fg4">
+              Данные документа расходятся с текущей схемой типа. Их можно почистить, не обращаясь к администратору.
+              Удаление необратимо (старое значение вернётся в ответе для ручного отката).
+            </p>
+            {groups.map(([code, items]) => (
+              <div key={code} className="rounded-md border border-stroke overflow-hidden">
+                <div className="flex items-center gap-2 px-3 py-2 bg-base text-xs font-medium text-fg2">
+                  <AlertTriangle size={13} className="text-warning shrink-0" />
+                  {CATEGORY_LABEL[code] ?? code}
+                  <span className="text-fg4 font-normal">· {items.length}</span>
+                </div>
+                <div className="divide-y divide-muted">
+                  {items.map(f => {
+                    const canRename = f.code === 'orphan-key' && isTopLevel(f.path);
+                    return (
+                      <div key={f.path} className="px-3 py-2.5">
+                        <div className="flex items-start gap-2">
+                          <span className="min-w-0 flex-1">
+                            <code className="text-xs text-fg2 break-all">{f.path}</code>
+                            <span className="block text-xs text-fg4">{f.message}</span>
+                          </span>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2 pt-1.5">
+                          <Button variant="text" size="sm" danger icon={<Trash2 size={13} />}
+                            disabled={applyFixes.isPending} onClick={() => setConfirm(f)}>
+                            Удалить
+                          </Button>
+                          {canRename && (
+                            <>
+                              <span className="text-fg4 text-xs">или переименовать в</span>
+                              <select value={renameTarget[f.path] ?? ''} disabled={applyFixes.isPending}
+                                onChange={e => setRenameTarget(t => ({ ...t, [f.path]: e.target.value }))}
+                                className="text-xs border border-stroke rounded px-1.5 py-1 bg-surface text-fg1">
+                                <option value="">поле схемы…</option>
+                                {schemaFieldKeys.map(k => <option key={k} value={k}>{k}</option>)}
+                              </select>
+                              <Button variant="text" size="sm" disabled={!renameTarget[f.path] || applyFixes.isPending}
+                                onClick={() => apply('rename', f.path, renameTarget[f.path])}>
+                                Переименовать
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={!!confirm}
+        onOpenChange={o => { if (!o) setConfirm(null); }}
+        title="Удалить значение из документа?"
+        description={confirm
+          ? <p>Поле <code className="font-mono">{confirm.path}</code> будет удалено из этого документа. Действие необратимо.</p>
+          : null}
+        confirmLabel="Удалить"
+        onConfirm={() => { const f = confirm; setConfirm(null); if (f) void apply('remove', f.path); }}
+      />
+    </>
+  );
+}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Loader2, FileText, Download, Eye, Pencil, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Circle, CircleDot, Mail, Database, X, Info, ChevronDown, ChevronRight } from 'lucide-react';
+import { Loader2, FileText, Download, Eye, Pencil, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Circle, CircleDot, Mail, Database, X, Info, ChevronDown, ChevronRight, Stethoscope } from 'lucide-react';
 import { Markdown } from '@/shared/ui/Markdown';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
@@ -32,6 +32,7 @@ import {
 import { ruCount } from '@/shared/utils/pluralize';
 import { DataSetsTab } from './DataSetsTab';
 import { DocumentPreviewPanel } from './DocumentPreviewPanel';
+import { InstanceAuditModal } from './InstanceAuditModal';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
 import { mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
 import { QualityLinksTab } from './QualityLinksTab';
@@ -716,7 +717,8 @@ function extractDiagnostics(err: unknown): ResolutionDiagnostic[] | null {
   return Array.isArray(data?.diagnostics) ? data!.diagnostics! : null;
 }
 
-function GenerationTab({ instance, setId }: { instance: DocumentInstance; setId: string }) {
+function GenerationTab({ instance, setId, schemaFieldKeys }: { instance: DocumentInstance; setId: string; schemaFieldKeys: string[] }) {
+  const [auditOpen, setAuditOpen] = useState(false);
   const { user } = useAuth();
   const isAdmin = user?.role === 'Admin';
   const [emailOpen, setEmailOpen] = useState(false);
@@ -852,6 +854,13 @@ function GenerationTab({ instance, setId }: { instance: DocumentInstance; setId:
           icon={<ShieldCheck size={14} />}>
           Проверить ссылки
         </Button>
+        <Button variant="outlined" onClick={() => setAuditOpen(true)}
+          title="Найти в документе поля, которых нет в текущей схеме типа, и исправить"
+          icon={<Stethoscope size={14} />}>
+          Аудит документа
+        </Button>
+        <InstanceAuditModal setId={setId} instanceId={instance.id} docName={instance.name || 'без названия'}
+          schemaFieldKeys={schemaFieldKeys} open={auditOpen} onClose={() => setAuditOpen(false)} />
         <Button variant="outlined" onClick={handleDebugBundle} disabled={debugBusy || noTemplates}
           loading={debugBusy}
           title="Скачать ZIP с template.typ, data.json, typeblocks.typ и userlib.typ для отладки во внешнем инструменте (typst compile template.typ)"
@@ -1145,7 +1154,7 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
       )}
       {tab === 'generation' && (
         <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
-          <GenerationTab instance={instance} setId={setId} />
+          <GenerationTab instance={instance} setId={setId} schemaFieldKeys={schemaFields.map(f => f.key)} />
         </div>
       )}
 

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -324,6 +324,32 @@ export async function previewDocument(instanceId: string, requisites: unknown): 
   }
 }
 
+/** Аудит одного документа (issue #352): расхождения его данных с текущей схемой. По требованию. */
+export function useAuditInstance(setId: string, instanceId: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ['instance-audit', instanceId],
+    enabled: !!instanceId && enabled,
+    staleTime: 0,
+    queryFn: () => apiClient
+      .get<import('./documentTypes').AuditFinding[]>(`/document-sets/${setId}/documents/${instanceId}/audit`)
+      .then(r => r.data),
+  });
+}
+
+/** Применение исправлений к ЭТОМУ документу (issue #352) — юзер лечит свой документ без админа. */
+export function useApplyInstanceAuditFixes(setId: string, instanceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (fixes: { action: 'remove' | 'rename'; path: string; targetKey?: string }[]) =>
+      apiClient.post<import('./documentTypes').ApplyAuditFixesResult>(
+        `/document-sets/${setId}/documents/${instanceId}/audit/apply`, { fixes }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['instance-audit', instanceId] });
+      qc.invalidateQueries({ queryKey: ['document-sets', setId] });
+    },
+  });
+}
+
 /** Проверяет разрешение ссылок экземпляра «по требованию» (warning/error). */
 export async function validateResolution(instanceId: string): Promise<ResolutionDiagnostic[]> {
   const r = await apiClient.get<ResolutionDiagnostic[]>(`/generate/validate/${instanceId}`);

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -155,6 +155,22 @@ public static class DocumentSetEndpoints
                 => Results.Ok(InstanceDto.From(await m.Send(new UpdateRequisitesCommand(
                     id, JsonDocument.Parse(body.GetRawText()))))));
 
+        // Аудит одного документа (issue #352) — пользовательский режим: юзер видит расхождения своего
+        // документа с текущей схемой и лечит их сам (те же фиксы, что у типового аудита, но по инстансу).
+        g.MapGet("/{setId:guid}/documents/{id:guid}/audit", async (Guid id, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new AuditInstanceQuery(id))); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
+        // Применение исправлений к ЭТОМУ документу. instanceId жёстко берём из маршрута (клиент не может
+        // подсунуть чужой) — фиксы несут только action/path/targetKey.
+        g.MapPost("/{setId:guid}/documents/{id:guid}/audit/apply", async (Guid id, InstanceAuditApplyRequest req, IMediator m) =>
+        {
+            var fixes = req.Fixes.Select(f => new AuditFix(id, f.Action, f.Path, f.TargetKey)).ToList();
+            return Results.Ok(await m.Send(new ApplyAuditFixesCommand(fixes)));
+        });
+
         g.MapPut("/{setId:guid}/documents/{id:guid}/plugin-data",
             async (Guid id, JsonElement body, IMediator m)
                 => Results.Ok(InstanceDto.From(await m.Send(new UpdatePluginDataCommand(
@@ -265,5 +281,7 @@ public static class DocumentSetEndpoints
     record RenameDocumentInstanceRequest(string? Name);
     record SetTemplateRequest(Guid? TemplateId);
     record AssembleSetRequest(Guid[]? InstanceIds);
+    record InstanceAuditApplyRequest(IReadOnlyList<InstanceAuditFixItem> Fixes);
+    record InstanceAuditFixItem(string Action, string Path, string? TargetKey);
     record EmailSendRequest(string[]? To, string? Subject, string? Body);
 }

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -40,6 +40,10 @@ public record DocumentTypeAuditReport(Guid TypeId, string TypeName, int Instance
 /// Path (JSON-путь в данных), Message. InstanceId/InstanceName — где найдено.
 public record AuditFinding(Guid InstanceId, string InstanceName, string Code, string Severity, string Path, string Message);
 
+/// Аудит ОДНОГО инстанса (issue #352) — пользовательский режим: юзер «лечит» свой документ без
+/// админа. Те же расхождения, что и типовой аудит, но для конкретного инстанса.
+public record AuditInstanceQuery(Guid InstanceId) : IRequest<IReadOnlyList<AuditFinding>>;
+
 /// Применение исправлений аудита (issue #350). Мутирует реквизиты инстансов по JSON-пути, атомарно
 /// (одна SaveChanges). Батч = список фиксов; фронт разворачивает «применить ко всем» в per-instance.
 public record ApplyAuditFixesCommand(IReadOnlyList<AuditFix> Fixes) : IRequest<ApplyAuditFixesResult>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -30,8 +30,19 @@ public class DocumentTypeHandlers(
     IRequestHandler<GetDocumentTypeQuery, DocumentType?>,
     IRequestHandler<GetDocumentTypeUsageQuery, DocumentTypeUsage>,
     IRequestHandler<AuditDocumentTypeQuery, DocumentTypeAuditReport>,
+    IRequestHandler<AuditInstanceQuery, IReadOnlyList<AuditFinding>>,
     IRequestHandler<ApplyAuditFixesCommand, ApplyAuditFixesResult>
 {
+    public async Task<IReadOnlyList<AuditFinding>> Handle(AuditInstanceQuery q, CancellationToken ct)
+    {
+        var inst = await objectRepo.GetByIdAsync(q.InstanceId, ct)
+            ?? throw new KeyNotFoundException($"Instance {q.InstanceId} not found");
+        var byId = (await repo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+        return Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId)
+            .Select(iss => new AuditFinding(inst.Id, inst.DisplayName, iss.Code, iss.Severity.ToString(), iss.Path, iss.Message))
+            .ToList();
+    }
+
     public async Task<ApplyAuditFixesResult> Handle(ApplyAuditFixesCommand cmd, CancellationToken ct)
     {
         var outcomes = new List<AuditFixOutcome>();


### PR DESCRIPTION
Closes #352

Пользователь может «залечить» свой документ **без администратора**: увидеть поля данных, которых нет в текущей схеме типа, и исправить их сам.

## Что сделано
- **`AuditInstanceQuery`** — аудит одного инстанса (reuse `SchemaDataAuditor`).
- **User-эндпоинты** (группа `document-sets`, **не** Admin): `GET .../documents/{id}/audit` и `POST .../documents/{id}/audit/apply`. `instanceId` **жёстко из маршрута** — клиент не может подсунуть чужой; фиксы несут только action/path/targetKey. Применение переиспользует `ApplyAuditFixesCommand` (атомарно).
- **Фронт:** кнопка «Аудит документа» на вкладке **Генерация** редактора + `InstanceAuditModal` (расхождения этого документа, действия «Удалить» / «Переименовать в поле схемы», текст «…не обращаясь к администратору»).

Полностью на машинерии типового аудита (#348/#350), scope — конкретный инстанс.

## Проверка
- `dotnet build` ✅, **477 backend** + **137 frontend** ✅.
- Живьём: `GET .../documents/{id}/audit` вернул осиротевший ключ `ДатаДокумнета`; модалка открывается из редактора (Генерация → «Аудит документа») с фиксами. Скриншот в обсуждении. Деструктивный `remove` на реальных данных не запускал.

🤖 Generated with [Claude Code](https://claude.com/claude-code)