### PR TITLE
Стандартные импорты — только при создании шаблона (#353)

### DIFF
--- a/src/client/src/features/templates/templateBlank.ts
+++ b/src/client/src/features/templates/templateBlank.ts
@@ -39,7 +39,10 @@ export function buildBlankTypst(name: string, docType: DocumentType, allDocTypes
   // First scalar field to use in the title example
   const firstField = scalarFields[0]?.path ?? 'Наименование';
 
-  return `// ════════════════════════════════════════════════════════════════════
+  return `#import "systemlib.typ": *
+#import "typeblocks.typ": *
+
+// ════════════════════════════════════════════════════════════════════
 // Шаблон : ${name}
 // Тип    : ${docType.name} (${docType.code})
 // Движок : Typst 0.15  https://typst.app/docs

--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -185,9 +185,9 @@ public static class GenerationEndpoints
                 using var ms = new MemoryStream();
                 using (var zip = new System.IO.Compression.ZipArchive(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
                 {
-                    // template.typ = префикс системных импортов + шаблон (issue #344) — как компилирует
-                    // генерация, чтобы внешний `typst compile template.typ` работал (systemlib/typeblocks).
-                    await WriteEntry(zip, "template.typ", SystemTypstLib.ComposeTemplate(bundle.TemplateContent));
+                    // template.typ — дословно (issue #353), как компилирует генерация. Стандартные импорты
+                    // уже в самом шаблоне; systemlib.typ кладём рядом, чтобы `#import "systemlib.typ"` резолвился.
+                    await WriteEntry(zip, "template.typ", bundle.TemplateContent);
                     await WriteEntry(zip, SystemTypstLib.FileName, SystemTypstLib.Content);
                     await WriteEntry(zip, "data.json", dataJson);
                     await WriteEntry(zip, "typeblocks.typ", typeBlocks);

--- a/src/server/BHS.CRG.Application/Generation/SystemTypstLib.cs
+++ b/src/server/BHS.CRG.Application/Generation/SystemTypstLib.cs
@@ -22,17 +22,14 @@ public static class SystemTypstLib
         "//   #if instance-of(it, \"Организация\") [ … ]  — сработает и для потомков «Подрядчик»/«Проектировщик».\n" +
         "#let instance-of(it, code) = type(it) == dictionary and code in it.at(\"_type\", default: (:)).at(\"chain\", default: ())\n";
 
-    /// <summary>Импорты, авто-подставляемые в НАЧАЛО шаблона при компиляции: systemlib + typeblocks.
-    /// Повторный импорт идемпотентен → старые шаблоны с ручным <c>#import "typeblocks.typ"</c> не ломаются,
-    /// новым импорты писать не нужно.</summary>
+    /// <summary>Стандартные импорты, которые вставляются в НАЧАЛО шаблона ТОЛЬКО ПРИ СОЗДАНИИ шаблона
+    /// (issue #353): systemlib + typeblocks. Компиляция/превью/debug-bundle шаблон НЕ трогают — он
+    /// компилируется дословно, поэтому импорты обязаны жить в самом содержимом шаблона.</summary>
     public static readonly string Prelude =
         $"#import \"{FileName}\": *\n#import \"typeblocks.typ\": *\n";
 
-    /// <summary>Число строк префикса — константный офсет для сдвига номеров строк ошибок Typst обратно
-    /// на строки РЕДАКТОРА (template.typ пишется с префиксом, а автор видит шаблон без него).</summary>
-    public static readonly int PreludeLineCount = Prelude.Count(c => c == '\n');
-
-    /// <summary>Компилируемое содержимое: префикс импортов + шаблон ДОСЛОВНО (единый источник для
-    /// генерации и debug-bundle — иначе отладка расходится с генерацией).</summary>
-    public static string ComposeTemplate(string templateContent) => Prelude + templateContent;
+    /// <summary>Добавляет стандартные импорты в начало содержимого нового шаблона — идемпотентно
+    /// (если systemlib уже импортирован, не дублируем).</summary>
+    public static string EnsureImports(string content)
+        => content.Contains($"\"{FileName}\"") ? content : Prelude + (content ?? "");
 }

--- a/src/server/BHS.CRG.Application/Templates/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Templates/Handlers.cs
@@ -16,7 +16,10 @@ public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAs
 {
     public async Task<Template> Handle(CreateTemplateCommand cmd, CancellationToken ct)
     {
-        var template = Template.Create(cmd.DocumentTypeId, cmd.Name, cmd.Content);
+        // Стандартные импорты (systemlib + typeblocks) вставляем ТОЛЬКО при создании шаблона (issue #353):
+        // дальше шаблон компилируется дословно, поэтому импорты обязаны жить в его содержимом.
+        var content = Generation.SystemTypstLib.EnsureImports(cmd.Content);
+        var template = Template.Create(cmd.DocumentTypeId, cmd.Name, content);
         await repo.AddAsync(template, ct);
         await repo.SaveChangesAsync(ct);
         return template;

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
@@ -48,13 +48,14 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
 
             await File.WriteAllTextAsync(Path.Combine(tmpDir, "data.json"), dataJson, ct);
 
-            // template.typ = префикс системных импортов + шаблон дословно (issue #344). Так systemlib
-            // и typeblocks доступны без ручного импорта; номера строк ошибок сдвигаем обратно (ниже).
+            // template.typ пишется ДОСЛОВНО (issue #353): стандартные импорты живут в самом шаблоне
+            // (добавляются при его создании), компиляция их не подставляет → номера строк ошибок = строки редактора.
             await File.WriteAllTextAsync(
                 Path.Combine(tmpDir, "template.typ"),
-                SystemTypstLib.ComposeTemplate(request.TemplateContent), Encoding.UTF8, ct);
+                request.TemplateContent, Encoding.UTF8, ct);
 
-            // systemlib.typ — системная библиотека (хардкод, issue #344). Всегда присутствует в tmpDir.
+            // systemlib.typ — системная библиотека (хардкод, issue #344). Всегда присутствует в tmpDir,
+            // чтобы `#import "systemlib.typ"` в шаблоне резолвился.
             await File.WriteAllTextAsync(Path.Combine(tmpDir, SystemTypstLib.FileName), SystemTypstLib.Content, Encoding.UTF8, ct);
 
             // Всегда записываем typeblocks.typ — даже пустым.
@@ -134,7 +135,7 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
             if (process.ExitCode != 0)
             {
                 var err = await stderrTask;
-                throw new InvalidOperationException($"Typst compilation failed (exit {process.ExitCode}):\n{ShiftTemplateErrorLines(err)}");
+                throw new InvalidOperationException($"Typst compilation failed (exit {process.ExitCode}):\n{err}");
             }
 
             var outputPath = Path.Combine(tmpDir, "output.pdf");
@@ -148,16 +149,6 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
             try { Directory.Delete(tmpDir, recursive: true); } catch { /* best effort */ }
         }
     }
-
-    // Сдвиг номеров строк ошибок Typst в template.typ обратно на строки РЕДАКТОРА (issue #344): в файл
-    // добавлен префикс импортов (SystemTypstLib.PreludeLineCount строк), а автор видит шаблон без него.
-    // Трогаем только «template.typ:N» — ошибки в systemlib/typeblocks оставляем как есть.
-    private static string ShiftTemplateErrorLines(string err) =>
-        System.Text.RegularExpressions.Regex.Replace(err, @"(template\.typ:)(\d+)(:)", m =>
-        {
-            var line = int.Parse(m.Groups[2].Value) - SystemTypstLib.PreludeLineCount;
-            return m.Groups[1].Value + (line < 1 ? 1 : line) + m.Groups[3].Value;
-        });
 
     private const long MaxAssetBytes = 100L * 1024 * 1024;
 

--- a/src/server/BHS.CRG.Tests/Generation/SystemTypstLibTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/SystemTypstLibTests.cs
@@ -2,7 +2,7 @@ using BHS.CRG.Application.Generation;
 
 namespace BHS.CRG.Tests.Generation;
 
-/// <summary>Системная Typst-библиотека (issue #344): авто-префикс импортов + офсет строк.</summary>
+/// <summary>Системная Typst-библиотека (issue #344/#353): содержимое + стандартные импорты при создании.</summary>
 public class SystemTypstLibTests
 {
     [Fact]
@@ -12,21 +12,24 @@ public class SystemTypstLibTests
     }
 
     [Fact]
-    public void ComposeTemplate_PrependsSystemlibAndTypeblocksImports_ThenTemplateVerbatim()
+    public void EnsureImports_PrependsSystemlibAndTypeblocks()
     {
-        var tpl = "#set page(width: 10cm)\n= Заголовок\n";
-        var composed = SystemTypstLib.ComposeTemplate(tpl);
-        Assert.StartsWith("#import \"systemlib.typ\": *\n#import \"typeblocks.typ\": *\n", composed);
-        Assert.EndsWith(tpl, composed);                 // шаблон дословно в хвосте
+        var content = "= Заголовок\n";
+        var result = SystemTypstLib.EnsureImports(content);
+        Assert.StartsWith("#import \"systemlib.typ\": *\n#import \"typeblocks.typ\": *\n", result);
+        Assert.EndsWith(content, result);
     }
 
     [Fact]
-    public void PreludeLineCount_MatchesPrependedLines()
+    public void EnsureImports_Idempotent_WhenSystemlibAlreadyImported()
     {
-        // Офсет для сдвига номеров строк ошибок = число добавленных строк префикса.
-        Assert.Equal(2, SystemTypstLib.PreludeLineCount);
-        var composed = SystemTypstLib.ComposeTemplate("X");
-        // Строка редактора N → строка composed (N + PreludeLineCount): "X" (ред. строка 1) на 3-й строке.
-        Assert.Equal("X", composed.Split('\n')[SystemTypstLib.PreludeLineCount]);
+        var content = "#import \"systemlib.typ\": *\n#import \"typeblocks.typ\": *\n= Тело\n";
+        Assert.Equal(content, SystemTypstLib.EnsureImports(content)); // не дублируем
+    }
+
+    [Fact]
+    public void EnsureImports_EmptyContent_GetsImports()
+    {
+        Assert.Contains("#import \"systemlib.typ\": *", SystemTypstLib.EnsureImports(""));
     }
 }


### PR DESCRIPTION
Closes #353

Стандартные импорты (`systemlib` + `typeblocks`) добавляются в шаблон **только при его создании**. Компиляция / превью / debug-bundle шаблон **не трогают** — он компилируется **дословно**. Это откат авто-префикса из Фазы 2 (#344).

## Что изменилось
- **`SystemTypstLib`**: `ComposeTemplate`/`PreludeLineCount` убраны; добавлен `EnsureImports(content)` — префикс `systemlib`+`typeblocks` при создании, **идемпотентно** (если systemlib уже импортирован — не дублируем).
- **`TypstGenerator`**: `template.typ` пишется дословно; сдвиг строк ошибок (`ShiftTemplateErrorLines`) убран — офсет больше не нужен, номера строк = строки редактора. `systemlib.typ` по-прежнему кладётся в tmpDir, чтобы `#import "systemlib.typ"` резолвился.
- **debug-bundle**: `template.typ` дословно.
- **`CreateTemplateCommand`**: `EnsureImports` к содержимому нового шаблона (покрывает и API-создание).
- **Фронт `buildBlankTypst`**: два импорта в начале заготовки (чистое размещение).

## Проверка
- `dotnet build` ✅, **478 backend** + **137 frontend** ✅ (`SystemTypstLibTests` переписаны под `EnsureImports`).
- Живьём: создание шаблона (content без импортов) → импорты добавлены, тело сохранено; debug-bundle `template.typ` дословный (без авто-префикса, без дублей); существующий АОСР-шаблон компилируется (импорты в его содержимом).

🤖 Generated with [Claude Code](https://claude.com/claude-code)