### PR TITLE
Стабильный ключ поля/кода — авто-генерация только у новой сущности (фаза 1, #355)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   Plus, ChevronRight, Trash2, Copy, Folder, FileText, Boxes, EyeOff, Check,
@@ -40,7 +40,7 @@ import {
 } from '@/shared/api/schema';
 import { TypstRendersEditor } from './TypstRendersEditor';
 import { useTypstBlocksCheck, TypstBlocksPanel, blocksCheckProblemsByFn } from './TypstBlocksCheck';
-import { schemaToJson, validateFields, TYPE_LABELS, toCamelKey } from './schemaConstants';
+import { schemaToJson, validateFields, TYPE_LABELS, nextAutoKey } from './schemaConstants';
 import { useTagRegistry, typeTags as typeTagDefs, FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { GroupedFieldsEditor } from './GroupedFieldsEditor';
 import { JsonPreview, FieldBuilder, DefaultValueCell, type FieldRegistries } from './FieldBuilder';
@@ -222,12 +222,11 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
 
   const dirty = name !== docType.name || code !== docType.code || parentId !== (docType.parentId ?? '');
 
-  // См. FieldBuilder.updateTitle — тот же принцип: код перегенерируется, пока совпадает
-  // с авто-значением текущего названия (или пуст); ручная правка кода отключает автогенерацию.
+  // Код типа стабилен после создания (issue #355): у существующего типа переименование НЕ меняет код
+  // (иначе ломаются ссылки/резолв, #59). Авто-код — только у нового (без id).
   function handleNameChange(v: string) {
-    const isCodeAuto = !code.trim() || code === toCamelKey(name);
+    setCode(nextAutoKey(code, name, v, !docType.id));
     setName(v);
-    if (isCodeAuto) setCode(toCamelKey(v));
   }
 
   // Сохранение параметров: бросает при ошибке — чтобы общий «Сохранить»/гард прервались (issue #197).
@@ -306,9 +305,8 @@ function CreateForm({
   const mutation = useCreateDocumentType();
 
   function handleNameChange(v: string) {
-    const isCodeAuto = !code.trim() || code === toCamelKey(name);
+    setCode(nextAutoKey(code, name, v, true)); // форма создания — тип всегда новый
     setName(v);
-    if (isCodeAuto) setCode(toCamelKey(v));
   }
 
   const sameKindTypes = allDocTypes.filter(dt => dt.kind === kind);
@@ -436,6 +434,9 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
   const { data: enumTypes = [] } = useListEnumTypes();
   const schemaDef = docType.schema as unknown as SchemaDefinition;
   const [fields, setFields] = useState<SchemaField[]>(() => parseSchemaFields(docType.schema));
+  // Ключи полей из СОХРАНЁННОЙ схемы (issue #355): их ключи заморожены (переименование не меняет ключ).
+  // Новое поле (ключа нет в наборе) — ключ авто-следует за именем. Пересчитывается при сохранении/сбросе.
+  const persistedKeys = useMemo(() => new Set(parseSchemaFields(docType.schema).map(f => f.key)), [docType.schema]);
   const [groups, setGroups] = useState<FieldGroup[]>(() => normalizeGroupMembership(schemaDef.groups ?? []));
   const [excludedFields, setExcludedFields] = useState<string[]>(() => schemaDef.excludedFields ?? []);
   const [fieldOverrides, setFieldOverrides] = useState<Record<string, { required?: boolean; defaultValue?: unknown }>>(
@@ -588,6 +589,7 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
               onUngroupedOrderChange={o => { setUngroupedOrder(o); setDirty(true); }}
               parentEffectiveFields={activeInheritedFields}
               disabledKeys={inheritedKeys}
+              persistedKeys={persistedKeys}
               reg={reg}
             />}
       </div>

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { useCreateEnumType, buildEnumTypeDto } from '@/shared/api/enumTypes';
 import type { EnumOptionDef, EnumTypeDef } from '@/shared/api/types';
-import { toCamelKey } from './schemaConstants';
+import { nextAutoKey } from './schemaConstants';
 
 // Реестр перечислений (issue #59) переведён в list-detail (issue #210) — редактор живёт в
 // PrimitiveTypesPage (EnumTypeDetail). Здесь остаются переиспользуемые куски: редактор вариантов
@@ -86,9 +86,8 @@ export function EnumForm({ onSaved, onCancel }: { onSaved: () => void; onCancel:
   const create = useCreateEnumType();
 
   function handleNameChange(v: string) {
-    const isCodeAuto = !code.trim() || code === toCamelKey(name);
+    setCode(nextAutoKey(code, name, v, true)); // форма создания — enum-тип всегда новый (issue #355)
     setName(v);
-    if (isCodeAuto) setCode(toCamelKey(v));
   }
 
   async function handleSave() {

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -1,11 +1,12 @@
 import { useId, useMemo, useState } from 'react';
-import { Plus, Trash2, ArrowUp, ArrowDown, Cpu, GripVertical, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Trash2, ArrowUp, ArrowDown, Cpu, GripVertical, ChevronDown, ChevronUp, Lock, Link2 } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Button } from '@/shared/ui/Button';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
 import type { DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import type { SchemaField, FieldGroup } from '@/shared/api/schema';
-import { TYPE_LABELS, toCamelKey } from './schemaConstants';
+import { TYPE_LABELS, toCamelKey, nextAutoKey } from './schemaConstants';
 import { useTagRegistry, fieldTags, type TagDefinition } from '@/shared/api/tags';
 // ─── JSON preview ──────────────────────────────────────────────────────────────
 
@@ -105,6 +106,8 @@ interface FieldCardProps {
   field: SchemaField;
   reg: FieldRegistries;
   keyConflict: boolean;
+  /** Поле ещё НЕ сохранено (issue #355): ключ авто-следует за именем. У сохранённого — заморожен. */
+  isNew: boolean;
   open: boolean;
   onToggleOpen: () => void;
   onChange: (patch: Partial<SchemaField>) => void;
@@ -125,12 +128,21 @@ interface FieldCardProps {
  *  редактор (все ветки типов/опций/тэгов). Индекс-независима — переиспользуется в плоском и
  *  группированном представлении (issue #197 Фаза C). */
 export function FieldCard({
-  field, reg, keyConflict, open, onToggleOpen, onChange, onRemove,
+  field, reg, keyConflict, isNew, open, onToggleOpen, onChange, onRemove,
   onMoveUp, onMoveDown, isFirst, isLast, dragging, onDragStart, onDragEnd, onDragOver, onDrop,
 }: FieldCardProps) {
   const { primitiveTypes, enumTypes, tagRegistry } = reg;
   const tags = field.tags ?? [];
   const [pickerOpen, setPickerOpen] = useState(false);
+  // Стабильность ключа (issue #355): у сохранённого поля ключ заморожен (read-only + замок), меняется
+  // только явной разблокировкой с предупреждением о дрейфе данных. originalKey фиксируем на монтировании
+  // (для сохранённого = персистентный ключ) — по нему показываем warning, пока ключ изменён.
+  const [keyUnlocked, setKeyUnlocked] = useState(false);
+  const [confirmUnlock, setConfirmUnlock] = useState(false);
+  const [originalKey] = useState(field.key);
+  const keyLocked = !isNew && !keyUnlocked;
+  const keyChanged = !isNew && field.key !== originalKey;
+  const keyAutoNew = isNew && !!field.title.trim() && field.key === toCamelKey(field.title);
   const pickTypes = useMemo(() => buildFieldTypeOptions(reg),
     [reg.compositeTypes, reg.primitiveTypes, reg.enumTypes, reg.allDocTypes]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -151,10 +163,11 @@ export function FieldCard({
   // Легаси enum-поле (issue #59): options инлайн, typeId не выбран.
   const isLegacyEnum = field.type === 'enum' && !field.typeId && (field.options?.length ?? 0) > 0;
   const enumTypeDef = field.type === 'enum' ? enumTypes.find(et => et.id === field.typeId) : undefined;
-  // Ключ «автоматический», пока совпадает с toCamelKey(title) — тогда перегенерируем при вводе названия.
+  // Ключ следует за именем только у НОВОГО поля, пока не тронут вручную (issue #355). У сохранённого —
+  // заморожен: переименование НЕ меняет ключ (иначе данные документов осиротеют).
   const updateTitle = (title: string) => {
-    const isKeyAuto = !field.key.trim() || field.key === toCamelKey(field.title);
-    onChange({ title, ...(isKeyAuto ? { key: toCamelKey(title) } : {}) });
+    const key = nextAutoKey(field.key, field.title, title, isNew);
+    onChange({ title, ...(key !== field.key ? { key } : {}) });
   };
 
   return (
@@ -194,22 +207,32 @@ export function FieldCard({
           placeholder="Название"
           className="border border-stroke-strong rounded-md px-3 py-1.5 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand bg-surface"
         />
-        {/* Key */}
+        {/* Key — стабильный идентификатор хранения (issue #355) */}
         <div className="relative">
           <input
             value={field.key}
             onChange={e => onChange({ key: e.target.value })}
+            readOnly={keyLocked}
             placeholder="КлючПоля"
             spellCheck={false}
-            className={`w-full border rounded-md px-3 py-1.5 text-sm font-mono focus:outline-none focus-visible:ring-2 ${
-              keyConflict
-                ? 'border-danger focus-visible:ring-danger'
-                : 'border-stroke-strong focus-visible:ring-brand'
-            } bg-surface`}
+            title={keyLocked ? 'Идентификатор хранения — заморожен. Нажмите замок, чтобы изменить.' : undefined}
+            className={`w-full border rounded-md pl-3 pr-7 py-1.5 text-sm font-mono focus:outline-none focus-visible:ring-2 ${
+              keyConflict ? 'border-danger focus-visible:ring-danger' : 'border-stroke-strong focus-visible:ring-brand'
+            } ${keyLocked ? 'bg-muted/60 text-fg3 cursor-default' : 'bg-surface'}`}
           />
-          {keyConflict && (
+          {keyConflict ? (
             <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-danger">!</span>
-          )}
+          ) : keyLocked ? (
+            <button type="button" onClick={() => setConfirmUnlock(true)}
+              title="Изменить ключ (осторожно: осиротит данные документов)"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 text-fg4 hover:text-fg2">
+              <Lock size={13} />
+            </button>
+          ) : keyAutoNew ? (
+            <span title="Ключ авто-генерируется из названия" className="absolute right-2 top-1/2 -translate-y-1/2 text-fg4 pointer-events-none">
+              <Link2 size={13} />
+            </span>
+          ) : null}
         </div>
         {/* Type — открывает searchable TypePicker (issue #197) */}
         <button type="button" onClick={() => setPickerOpen(true)} title="Выбрать тип поля"
@@ -243,6 +266,25 @@ export function FieldCard({
           </button>
         </div>
       </div>
+      {/* Предупреждение о дрейфе данных при изменённом ключе существующего поля (issue #355). */}
+      {keyChanged && (
+        <p className="text-xs text-danger flex items-start gap-1.5">
+          <Lock size={12} className="shrink-0 mt-0.5" />
+          <span>Ключ изменён с «<span className="font-mono">{originalKey}</span>» — данные существующих
+            документов останутся под старым ключом (осиротеют). Перенос старый→новый — через «Аудит»
+            (переименование осиротевшего ключа в поле схемы).</span>
+        </p>
+      )}
+      <ConfirmDialog
+        open={confirmUnlock}
+        onOpenChange={setConfirmUnlock}
+        title="Изменить ключ поля?"
+        description={<p>Ключ — идентификатор хранения. После смены данные всех существующих документов
+          этого типа осиротеют по старому ключу «<span className="font-mono">{originalKey}</span>».
+          Перенести их на новый ключ можно через «Аудит» (переименование осиротевшего ключа). Продолжить?</p>}
+        confirmLabel="Изменить ключ"
+        onConfirm={() => { setConfirmUnlock(false); setKeyUnlocked(true); }}
+      />
       {/* Default value editor */}
       {field.type !== 'complex' && field.type !== 'array' && field.type !== 'primitive'
         && field.type !== 'doc-ref' && field.type !== 'doc-array' && (
@@ -378,13 +420,16 @@ interface FieldBuilderProps {
   fields: SchemaField[];
   onChange: (fields: SchemaField[]) => void;
   disabledKeys?: Set<string>;
+  /** Ключи полей из СОХРАНЁННОЙ схемы (issue #355): их ключи заморожены. Пусто (по умолч.) = все поля
+   *  новые (форма создания типа) → ключ авто-следует за именем. */
+  persistedKeys?: Set<string>;
   compositeTypes: DocumentType[];
   primitiveTypes: PrimitiveTypeDef[];
   enumTypes: EnumTypeDef[];
   allDocTypes: DocumentType[];
 }
 
-export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, primitiveTypes, enumTypes, allDocTypes }: FieldBuilderProps) {
+export function FieldBuilder({ fields, onChange, disabledKeys, persistedKeys, compositeTypes, primitiveTypes, enumTypes, allDocTypes }: FieldBuilderProps) {
   const uid = useId();
   const { data: tagRegistry } = useTagRegistry();
   const reg: FieldRegistries = { compositeTypes, primitiveTypes, enumTypes, allDocTypes, tagRegistry };
@@ -410,6 +455,7 @@ export function FieldBuilder({ fields, onChange, disabledKeys, compositeTypes, p
           field={field}
           reg={reg}
           keyConflict={!!field.key && !!disabledKeys?.has(field.key.trim())}
+          isNew={!persistedKeys?.has(field.key.trim())}
           open={openIndex === i}
           onToggleOpen={() => setOpenIndex(o => o === i ? null : i)}
           onChange={patch => onChange(fields.map((f, idx) => idx === i ? { ...f, ...patch } : f))}

--- a/src/client/src/features/settings/GroupedFieldsEditor.tsx
+++ b/src/client/src/features/settings/GroupedFieldsEditor.tsx
@@ -13,7 +13,7 @@ import { FieldCard, fieldTypeSummary, type FieldRegistries } from './FieldBuilde
  * группы (в конец) / «Без группы» (разгруппировать). Порядок групп — стрелками на шапке группы.
  */
 export function GroupedFieldsEditor({
-  fields, onFieldsChange, groups, onGroupsChange, ungroupedOrder = [], onUngroupedOrderChange, parentEffectiveFields, disabledKeys, reg,
+  fields, onFieldsChange, groups, onGroupsChange, ungroupedOrder = [], onUngroupedOrderChange, parentEffectiveFields, disabledKeys, persistedKeys, reg,
 }: {
   fields: SchemaField[];
   onFieldsChange: (f: SchemaField[]) => void;
@@ -24,6 +24,8 @@ export function GroupedFieldsEditor({
   onUngroupedOrderChange?: (o: string[]) => void;
   parentEffectiveFields: SchemaField[];
   disabledKeys?: Set<string>;
+  /** Ключи полей из СОХРАНЁННОЙ схемы (issue #355) — их ключи заморожены. */
+  persistedKeys?: Set<string>;
   reg: FieldRegistries;
 }) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -183,6 +185,7 @@ export function GroupedFieldsEditor({
           field={own}
           reg={reg}
           keyConflict={!!own.key && !!disabledKeys?.has(own.key.trim())}
+          isNew={!persistedKeys?.has(own.key.trim())}
           open={openIndex === idx}
           onToggleOpen={() => setOpenIndex(o => o === idx ? null : idx)}
           onChange={patch => patchOwn(own, patch)}

--- a/src/client/src/features/settings/schemaConstants.test.ts
+++ b/src/client/src/features/settings/schemaConstants.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { toCamelKey } from './schemaConstants';
+import { toCamelKey, nextAutoKey } from './schemaConstants';
+
+describe('nextAutoKey (issue #355)', () => {
+  it('новое поле: пустой ключ следует за именем', () => {
+    expect(nextAutoKey('', '', 'Номер', true)).toBe('Номер');
+  });
+  it('новое поле: ключ достраивается по мере ввода имени (пока совпадает с камелизацией старого)', () => {
+    expect(nextAutoKey('Номер', 'Номер', 'Номер документа', true)).toBe('НомерДокумента');
+  });
+  it('новое поле с РУЧНО заданным ключом: не трогаем при переименовании', () => {
+    expect(nextAutoKey('myKey', 'Номер', 'Номер документа', true)).toBe('myKey');
+  });
+  it('СОХРАНЁННОЕ поле: ключ заморожен, переименование его не меняет', () => {
+    expect(nextAutoKey('Номер', 'Номер', 'Новое имя', false)).toBe('Номер');
+  });
+});
 
 describe('toCamelKey', () => {
   it('склеивает слова, каждое с заглавной буквы', () => {

--- a/src/client/src/features/settings/schemaConstants.ts
+++ b/src/client/src/features/settings/schemaConstants.ts
@@ -31,6 +31,18 @@ export function toCamelKey(title: string): string {
     .join('');
 }
 
+/**
+ * Ключ/код при переименовании сущности (issue #355). Авто-генерация — свойство НОВОЙ (ещё не
+ * сохранённой) сущности: ключ следует за именем только пока `isNew` И ключ не тронут вручную (всё ещё
+ * совпадает с камелизацией ТЕКУЩЕГО имени `currentTitle`). Тогда возвращаем ключ из НОВОГО имени
+ * `newTitle`. Иначе — у сохранённой сущности или после ручной правки ключа — ключ ЗАМОРОЖЕН (как есть),
+ * чтобы переименование не осиротило данные.
+ */
+export function nextAutoKey(currentKey: string, currentTitle: string, newTitle: string, isNew: boolean): string {
+  const isAuto = isNew && (!currentKey.trim() || currentKey === toCamelKey(currentTitle));
+  return isAuto ? toCamelKey(newTitle) : currentKey;
+}
+
 // ─── Validation ───────────────────────────────────────────────────────────────
 
 export function validateFields(fields: SchemaField[]): string | null {


### PR DESCRIPTION
Closes #355 · согласовано с Архитектором + Дизайнером

Авто-генерация ключа из user-friendly имени — свойство **новой** (ещё не сохранённой) сущности. У **существующего** поля/типа переименование имени **больше не меняет ключ** автоматически (иначе данные всех документов осиротеют по старому ключу — тот же дрейф, что ловит аудит #348/#350/#352).

## Что сделано
- **`nextAutoKey(currentKey, currentTitle, newTitle, isNew)`** (schemaConstants) — единый хелпер: ключ следует за именем только пока `isNew` И не тронут вручную, иначе **заморожен**. Заменяет хрупкую эвристику `key === toCamelKey(title)`.
- **`FieldBuilder`/`FieldCard`**: проп `isNew`; ключ существующего поля **read-only + замок** («идентификатор хранения»); ✎-разблокировка через **ConfirmDialog** (предупреждение: данные осиротеют, перенос — через «Аудит»); inline-warning пока ключ ≠ исходного; глиф-цепочка «авто из названия» у нового поля. `isNew` считает родитель по **снапшоту персистентных ключей** сохранённой схемы.
- **Код типа документа / enum-типа**: тот же `nextAutoKey` (`isNew = !id`) — переименование существующего типа не меняет код (ломало бы ссылки/резолв #59). Полный lock-UX для типа/enum — follow-up.

## Проверка
- `tsc -b` ✅, **141 frontend** ✅ (+тесты `nextAutoKey`: новое/ручное/сохранённое). Только фронтенд (бэкенд не менялся).
- Живьём: переименование существующего поля АОСР «Застройщик или заказчик» → ключ заморожен `ЗастройщикИлиЗаказчик` (read-only + замок), не перегенерировался. Скриншот в обсуждении.

## Фаза 2 (follow-up, согласована)
Авто-предложение миграции старый→новый ключ прямо на сохранении (композиция схема-rename × audit-rename #350/#352), чтобы не ходить в «Аудит» руками.

🤖 Generated with [Claude Code](https://claude.com/claude-code)