### PR TITLE
Миграция данных при переименовании ключа поля (фаза 2, #357)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   Plus, ChevronRight, Trash2, Copy, Folder, FileText, Boxes, EyeOff, Check,
@@ -20,6 +20,7 @@ import {
   useCreateDocumentType,
   useUpdateDocumentType,
   useUpdateDocumentTypeSchema,
+  useMigrateFieldKey,
   useDeleteDocumentType,
   useDocumentTypeUsage,
   useSetDocumentTypeAbstract,
@@ -457,6 +458,12 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
   const [error, setError] = useState('');
   const [dirty, setDirty] = useState(false);
   const mutation = useUpdateDocumentTypeSchema();
+  // Миграция ключа (issue #357): накапливаем переименования ключей сохранённых полей (origKey→newKey),
+  // после успешного сохранения схемы предлагаем перенести данные документов старый→новый.
+  const renamesRef = useRef<Map<string, string>>(new Map());
+  const migrateKey = useMigrateFieldKey(docType.id);
+  const schemaToast = useToast();
+  const [pendingMigration, setPendingMigration] = useState<{ from: string; to: string }[] | null>(null);
 
   const compositeTypes = allDocTypes.filter(dt => dt.kind === 'Composite');
   const parentType = docType.parentId ? allDocTypes.find(dt => dt.id === docType.parentId) ?? null : null;
@@ -520,6 +527,12 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
       setDirty(false);
       // Проверка сборки блоков после сохранения (issue #309, фаза 2) — не блокирует save.
       if (typstRenders.length > 0) void blocksCheck.run(typstRenders);
+      // issue #357: у сохранённого поля сменился ключ (persistedKeys — старые ключи в этом замыкании) →
+      // предложить перенос данных документов старый→новый. Схема уже сохранена (ключ переехал в ней).
+      const renames = [...renamesRef.current]
+        .filter(([from, to]) => from !== to && persistedKeys.has(from) && fields.some(f => f.key.trim() === to));
+      renamesRef.current.clear();
+      if (renames.length) setPendingMigration(renames.map(([from, to]) => ({ from, to })));
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Ошибка сохранения');
       throw err;
@@ -590,6 +603,7 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
               parentEffectiveFields={activeInheritedFields}
               disabledKeys={inheritedKeys}
               persistedKeys={persistedKeys}
+              onKeyRename={(from, to) => renamesRef.current.set(from, to)}
               reg={reg}
             />}
       </div>
@@ -701,6 +715,33 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
       )}
 
       {!showJson && error && <p className="text-xs text-danger pt-1">{error}</p>}
+
+      {/* Предложение миграции данных при переименовании ключа сохранённого поля (issue #357). */}
+      <ConfirmDialog
+        open={!!pendingMigration}
+        onOpenChange={o => { if (!o) setPendingMigration(null); }}
+        title="Перенести данные документов на новый ключ?"
+        description={pendingMigration && (
+          <div className="space-y-1">
+            <p>Ключ(и) поля изменены. Перенести значения существующих документов этого типа со старого ключа на новый?</p>
+            <ul className="text-xs font-mono text-fg3">
+              {pendingMigration.map(r => <li key={r.from}>{r.from} → {r.to}</li>)}
+            </ul>
+            <p className="text-xs text-fg4">Без переноса старые значения останутся под прежним ключом (осиротеют) — их потом покажет «Аудит».</p>
+          </div>
+        )}
+        confirmLabel="Перенести данные"
+        onConfirm={async () => {
+          const renames = pendingMigration ?? [];
+          setPendingMigration(null);
+          let total = 0;
+          for (const r of renames) {
+            try { total += (await migrateKey.mutateAsync({ oldKey: r.from, newKey: r.to })).migrated; }
+            catch { schemaToast.error(`Не удалось перенести «${r.from}»`); }
+          }
+          schemaToast.success(`Перенесено документов: ${total}`);
+        }}
+      />
     </div>
   );
 }

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -108,6 +108,8 @@ interface FieldCardProps {
   keyConflict: boolean;
   /** Поле ещё НЕ сохранено (issue #355): ключ авто-следует за именем. У сохранённого — заморожен. */
   isNew: boolean;
+  /** Смена ключа СОХРАНЁННОГО поля (issue #357) — для предложения миграции данных на сохранении схемы. */
+  onKeyRename?: (from: string, to: string) => void;
   open: boolean;
   onToggleOpen: () => void;
   onChange: (patch: Partial<SchemaField>) => void;
@@ -128,7 +130,7 @@ interface FieldCardProps {
  *  редактор (все ветки типов/опций/тэгов). Индекс-независима — переиспользуется в плоском и
  *  группированном представлении (issue #197 Фаза C). */
 export function FieldCard({
-  field, reg, keyConflict, isNew, open, onToggleOpen, onChange, onRemove,
+  field, reg, keyConflict, isNew, onKeyRename, open, onToggleOpen, onChange, onRemove,
   onMoveUp, onMoveDown, isFirst, isLast, dragging, onDragStart, onDragEnd, onDragOver, onDrop,
 }: FieldCardProps) {
   const { primitiveTypes, enumTypes, tagRegistry } = reg;
@@ -211,7 +213,7 @@ export function FieldCard({
         <div className="relative">
           <input
             value={field.key}
-            onChange={e => onChange({ key: e.target.value })}
+            onChange={e => { onChange({ key: e.target.value }); if (!isNew) onKeyRename?.(originalKey, e.target.value); }}
             readOnly={keyLocked}
             placeholder="КлючПоля"
             spellCheck={false}

--- a/src/client/src/features/settings/GroupedFieldsEditor.tsx
+++ b/src/client/src/features/settings/GroupedFieldsEditor.tsx
@@ -13,7 +13,7 @@ import { FieldCard, fieldTypeSummary, type FieldRegistries } from './FieldBuilde
  * группы (в конец) / «Без группы» (разгруппировать). Порядок групп — стрелками на шапке группы.
  */
 export function GroupedFieldsEditor({
-  fields, onFieldsChange, groups, onGroupsChange, ungroupedOrder = [], onUngroupedOrderChange, parentEffectiveFields, disabledKeys, persistedKeys, reg,
+  fields, onFieldsChange, groups, onGroupsChange, ungroupedOrder = [], onUngroupedOrderChange, parentEffectiveFields, disabledKeys, persistedKeys, onKeyRename, reg,
 }: {
   fields: SchemaField[];
   onFieldsChange: (f: SchemaField[]) => void;
@@ -26,6 +26,8 @@ export function GroupedFieldsEditor({
   disabledKeys?: Set<string>;
   /** Ключи полей из СОХРАНЁННОЙ схемы (issue #355) — их ключи заморожены. */
   persistedKeys?: Set<string>;
+  /** Смена ключа сохранённого поля (issue #357) — для миграции данных на сохранении. */
+  onKeyRename?: (from: string, to: string) => void;
   reg: FieldRegistries;
 }) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -186,6 +188,7 @@ export function GroupedFieldsEditor({
           reg={reg}
           keyConflict={!!own.key && !!disabledKeys?.has(own.key.trim())}
           isNew={!persistedKeys?.has(own.key.trim())}
+          onKeyRename={onKeyRename}
           open={openIndex === idx}
           onToggleOpen={() => setOpenIndex(o => o === idx ? null : idx)}
           onChange={patch => patchOwn(own, patch)}

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -127,6 +127,19 @@ export function useApplyAuditFixes(typeId: string | undefined) {
   });
 }
 
+/** Миграция ключа поля в данных инстансов при переименовании ключа в схеме (issue #357). */
+export function useMigrateFieldKey(typeId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ oldKey, newKey }: { oldKey: string; newKey: string }) =>
+      apiClient.post<{ migrated: number }>(`/document-types/${typeId}/migrate-field-key`, { oldKey, newKey }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['document-type-audit', typeId] });
+      qc.invalidateQueries({ queryKey: ['document-sets'] });
+    },
+  });
+}
+
 export function useDeleteDocumentType() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -83,6 +83,10 @@ public static class DocumentTypeEndpoints
         admin.MapPost("/{id:guid}/audit/apply", async (Guid id, ApplyAuditFixesRequest req, IMediator m)
             => Results.Ok(await m.Send(new ApplyAuditFixesCommand(req.Fixes))));
 
+        // Миграция ключа поля в данных инстансов при переименовании ключа в схеме (issue #357).
+        admin.MapPost("/{id:guid}/migrate-field-key", async (Guid id, MigrateFieldKeyRequest req, IMediator m)
+            => Results.Ok(new { migrated = await m.Send(new MigrateFieldKeyCommand(id, req.OldKey, req.NewKey)) }));
+
         // Использование типа (issue #275) — проактивный показ «чем занят тип» до попытки удаления.
         admin.MapGet("/{id:guid}/usage", async (Guid id, IMediator m) =>
         {
@@ -104,4 +108,5 @@ public static class DocumentTypeEndpoints
     record SetAllowsProxyRequest(bool AllowsProxy);
     record SetGroupRequest(string? Group);
     record ApplyAuditFixesRequest(IReadOnlyList<AuditFix> Fixes);
+    record MigrateFieldKeyRequest(string OldKey, string NewKey);
 }

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -44,6 +44,11 @@ public record AuditFinding(Guid InstanceId, string InstanceName, string Code, st
 /// админа. Те же расхождения, что и типовой аудит, но для конкретного инстанса.
 public record AuditInstanceQuery(Guid InstanceId) : IRequest<IReadOnlyList<AuditFinding>>;
 
+/// Миграция ключа поля в данных всех инстансов типа (и подтипов) при переименовании ключа в схеме
+/// (issue #357): переносит значение старый→новый ключ (только в пустую цель), атомарно. Возвращает
+/// число перенесённых инстансов. Композиция «rename в схеме × rename в данных» (переиспользует JsonPathEditor).
+public record MigrateFieldKeyCommand(Guid TypeId, string OldKey, string NewKey) : IRequest<int>;
+
 /// Применение исправлений аудита (issue #350). Мутирует реквизиты инстансов по JSON-пути, атомарно
 /// (одна SaveChanges). Батч = список фиксов; фронт разворачивает «применить ко всем» в per-instance.
 public record ApplyAuditFixesCommand(IReadOnlyList<AuditFix> Fixes) : IRequest<ApplyAuditFixesResult>;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -31,8 +31,35 @@ public class DocumentTypeHandlers(
     IRequestHandler<GetDocumentTypeUsageQuery, DocumentTypeUsage>,
     IRequestHandler<AuditDocumentTypeQuery, DocumentTypeAuditReport>,
     IRequestHandler<AuditInstanceQuery, IReadOnlyList<AuditFinding>>,
+    IRequestHandler<MigrateFieldKeyCommand, int>,
     IRequestHandler<ApplyAuditFixesCommand, ApplyAuditFixesResult>
 {
+    public async Task<int> Handle(MigrateFieldKeyCommand cmd, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(cmd.OldKey) || string.IsNullOrWhiteSpace(cmd.NewKey) || cmd.OldKey == cmd.NewKey)
+            return 0;
+        var all = await repo.GetAllAsync(ct);
+        var byId = all.ToDictionary(t => t.Id);
+        var typeIds = all.Where(t => Schema.DocumentTypeSchemaReader.IsSameOrDescendant(t.Id, cmd.TypeId, byId))
+            .Select(t => t.Id).ToList();
+        var instances = (await objectRepo.FindAsync(o => typeIds.Contains(o.CompositeTypeId), ct)).ToList();
+
+        var migrated = 0;
+        foreach (var inst in instances)
+        {
+            var root = System.Text.Json.Nodes.JsonNode.Parse(inst.Data.RootElement.GetRawText()) as System.Text.Json.Nodes.JsonObject;
+            if (root is null) continue;
+            if (Schema.JsonPathEditor.Rename(root, cmd.OldKey, cmd.NewKey, out _, out _))
+            {
+                inst.SetData(System.Text.Json.JsonDocument.Parse(root.ToJsonString()));
+                objectRepo.Update(inst);
+                migrated++;
+            }
+        }
+        if (migrated > 0) await objectRepo.SaveChangesAsync(ct); // атомарно
+        return migrated;
+    }
+
     public async Task<IReadOnlyList<AuditFinding>> Handle(AuditInstanceQuery q, CancellationToken ct)
     {
         var inst = await objectRepo.GetByIdAsync(q.InstanceId, ct)


### PR DESCRIPTION
Closes #357 · продолжение #355 · согласовано с Архитектором

Если админ **явно** сменил ключ сохранённого поля, после сохранения схемы предлагаем **перенести данные** документов старый→новый ключ (композиция «rename в схеме × rename в данных»), чтобы не оставлять орфан.

## Что сделано
- **`MigrateFieldKeyCommand`** + endpoint `POST /document-types/{id}/migrate-field-key` (Admin): переносит значение старый→новый ключ во **всех** инстансах типа и подтипов (`JsonPathEditor.Rename` — только в пустую цель), **атомарно** (один `SaveChanges`), возвращает число перенесённых.
- **Фронт:** `FieldCard` сообщает смену ключа сохранённого поля (`onKeyRename`) → `SchemaEditor` копит `origKey→newKey`; после успешного сохранения схемы, если ключ(и) сменились, **ConfirmDialog** «Перенести данные?» → миграция + тост с итогом. Без переноса — орфан, который покажет «Аудит».

## Проверка
- `dotnet build` ✅, **477+ backend** + **141 frontend** ✅.
- Живьём (throwaway-тип, **полный цикл**): создал тип с полем + документ с данными → сменил ключ → `migrate-field-key` → данные переехали `OldKey357`→`NewKey357` (`requisites: {"NewKey357":"HELLO"}`), `migrated=1`; за собой прибрано. Безопасный no-match → `migrated:0` без мутации. Деструктив на реальных данных не запускал.

🤖 Generated with [Claude Code](https://claude.com/claude-code)