### PR TITLE
feat(templates): два режима сохранения шаблона (in-place / новая версия) + примечание к версии (#360)

### DIFF
--- a/src/client/src/features/templates/EditorPanel.tsx
+++ b/src/client/src/features/templates/EditorPanel.tsx
@@ -4,10 +4,12 @@ import { useUserLibCompletion } from '@/shared/ui/typstUserLibCompletion';
 import Editor from '@monaco-editor/react';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { Button } from '@/shared/ui/Button';
-import { BookOpen, Save, Star, CheckCircle } from 'lucide-react';
+import { Modal } from '@/shared/ui/Modal';
+import { TextField } from '@/shared/ui/TextField';
+import { BookOpen, Save, Star, CheckCircle, ChevronDown, GitBranch, History } from 'lucide-react';
 import type { Template, DocumentType } from '@/shared/api/types';
 import { resolveEffectiveFields } from '@/shared/api/schema';
-import { useUpdateTemplate, useSetTemplateDefault } from '@/shared/api/templates';
+import { useSaveTemplateContent, useCreateTemplateVersion, useSetTemplateDefault } from '@/shared/api/templates';
 import { TemplateParamsPanel } from './TemplateParamsPanel';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
 import { flattenFields } from './templateBlank';
@@ -86,6 +88,37 @@ function RequisitePicker({ docType, allDocTypes, onInsert }: {
   );
 }
 
+// ─── New-version dialog ───────────────────────────────────────────────────────
+
+function NewVersionDialog({ nextVersion, saving, onCancel, onConfirm }: {
+  nextVersion: number;
+  saving: boolean;
+  onCancel: () => void;
+  onConfirm: (comment: string) => void;
+}) {
+  const [comment, setComment] = useState('');
+  return (
+    <Modal open onOpenChange={o => { if (!o) onCancel(); }} title="Сохранить как новую версию"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="text" onClick={onCancel}>Отмена</Button>
+          <Button type="button" variant="filled" loading={saving} icon={<GitBranch size={12} />}
+            onClick={() => onConfirm(comment)}>
+            {saving ? 'Создание…' : `Создать v${nextVersion}`}
+          </Button>
+        </div>
+      }>
+      <div className="space-y-4 px-1">
+        <p className="text-sm text-fg2">
+          Будет создана <strong>версия v{nextVersion}</strong>. Текущая версия сохранится в истории.
+        </p>
+        <TextField label="Примечание к версии (необязательно)" value={comment}
+          onChange={e => setComment(e.target.value)} autoFocus />
+      </div>
+    </Modal>
+  );
+}
+
 // ─── Editor panel ─────────────────────────────────────────────────────────────
 
 interface EditorPanelProps {
@@ -102,9 +135,17 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
   const [saving, setSaving] = useState(false);
   const [savedMsg, setSavedMsg] = useState(false);
   const [error, setError] = useState('');
+  const [saveMenuOpen, setSaveMenuOpen] = useState(false);
+  const [newVersionOpen, setNewVersionOpen] = useState(false);
+  const saveMenuRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
-  const updateMutation = useUpdateTemplate();
+  const saveContentMutation = useSaveTemplateContent();
+  const newVersionMutation = useCreateTemplateVersion();
   const defaultMutation = useSetTemplateDefault();
+
+  // Есть ли несохранённые правки (dirty). После сохранения onSaved() подставляет
+  // обновлённый шаблон с тем же content → снова false.
+  const dirty = content !== template.content;
 
   // When true, the next template.id change came from our own save — skip content reset
   // so Monaco keeps its cursor position and scroll offset.
@@ -123,8 +164,14 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
     setContent(template.content);
   }, [template.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Простое сохранение (Ctrl+S) — правит текущую версию на месте. Историческую
+  // (неактивную) версию так править нельзя — её можно только форкнуть.
   async function handleSave() {
     if (savingRef.current) return; // a save is already in flight — ignore duplicate trigger
+    if (!template.isActive) {
+      setError('Историческая версия — сохраните как новую версию');
+      return;
+    }
     // Read live content from Monaco so this function is safe to call from the
     // window-level Ctrl+S handler (avoids stale-closure on `content`).
     const currentContent = editorRef.current?.getValue() ?? content;
@@ -132,7 +179,7 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
     setError('');
     setSaving(true);
     try {
-      const updated = await updateMutation.mutateAsync({ id: template.id, content: currentContent });
+      const updated = await saveContentMutation.mutateAsync({ id: template.id, content: currentContent });
       setSavedMsg(true);
       setTimeout(() => setSavedMsg(false), 2000);
       justSavedRef.current = true; // prevent useEffect from resetting cursor
@@ -145,10 +192,44 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
     }
   }
 
+  // Явное «Сохранить как новую версию» — форк новой версии, опц. с примечанием.
+  async function handleSaveAsNewVersion(comment: string) {
+    if (savingRef.current) return;
+    const currentContent = editorRef.current?.getValue() ?? content;
+    savingRef.current = true;
+    setError('');
+    setSaving(true);
+    try {
+      const updated = await newVersionMutation.mutateAsync({
+        id: template.id, content: currentContent, comment: comment.trim() || null,
+      });
+      setSavedMsg(true);
+      setTimeout(() => setSavedMsg(false), 2000);
+      justSavedRef.current = true;
+      onSaved(updated);
+      setNewVersionOpen(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Ошибка сохранения');
+    } finally {
+      setSaving(false);
+      savingRef.current = false;
+    }
+  }
+
   // Keep a stable ref so the Monaco command (registered once at mount) always
   // calls the latest handleSave without capturing a stale closure.
   const handleSaveRef = useRef(handleSave);
   useEffect(() => { handleSaveRef.current = handleSave; });
+
+  // Закрытие меню сохранения по клику вне.
+  useEffect(() => {
+    if (!saveMenuOpen) return;
+    function onClick(e: MouseEvent) {
+      if (saveMenuRef.current && !saveMenuRef.current.contains(e.target as Node)) setSaveMenuOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [saveMenuOpen]);
 
   // Prevent the browser's native Ctrl+S / Cmd+S ("Save page") using capture phase —
   // this runs before any other handler, including the browser's own shortcut.
@@ -212,9 +293,21 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
           </a>
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-fg4">v{template.version}</span>
-          {template.isActive && (
+          {/* Индикатор версии + dirty-точка */}
+          <span className="text-xs text-fg4 flex items-center gap-1" title={
+            dirty ? 'Есть несохранённые правки' : 'Сохранено'
+          }>
+            v{template.version}
+            {dirty
+              ? <span className="w-1.5 h-1.5 rounded-full bg-warning" aria-label="есть правки" />
+              : <span className="w-1.5 h-1.5 rounded-full bg-success/60" aria-label="сохранено" />}
+          </span>
+          {template.isActive ? (
             <span className="text-xs text-success flex items-center gap-1"><CheckCircle size={12} /> активный</span>
+          ) : (
+            <span className="text-xs text-fg4 flex items-center gap-1" title="Не активная версия — правится только форком в новую">
+              <History size={12} /> историческая
+            </span>
           )}
           {template.isDefault ? (
             <span className="text-xs text-yellow-600 flex items-center gap-1">
@@ -227,11 +320,43 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
             </button>
           )}
           {savedMsg && <span className="text-xs text-success">Сохранено ✓</span>}
-          {error && <span className="text-xs text-danger max-w-xs truncate">{error}</span>}
-          <Button variant="filled" size="sm" onClick={handleSave} loading={saving}
-            icon={<Save size={12} />} title="Сохранить (Ctrl+S)">
-            {saving ? 'Сохранение…' : 'Сохранить'}
-          </Button>
+          {error && <span className="text-xs text-danger max-w-xs truncate" title={error}>{error}</span>}
+
+          {/* Сплит-кнопка: слева in-place (Ctrl+S), справа каретка → меню «новая версия» */}
+          <div className="relative flex items-center" ref={saveMenuRef}>
+            {template.isActive ? (
+              <button type="button" onClick={handleSave} disabled={saving}
+                title="Сохранить в текущую версию (Ctrl+S)"
+                className="inline-flex items-center gap-1.5 h-8 pl-3 pr-2.5 text-xs font-medium rounded-l-full bg-brand text-on-brand shadow-[var(--f-shadow4)] hover:bg-brand-hover active:bg-brand-pressed disabled:opacity-40 transition-colors">
+                <Save size={12} /> {saving ? 'Сохранение…' : 'Сохранить'}
+              </button>
+            ) : (
+              // Историческую версию in-place не сохранить — левая кнопка ведёт на форк.
+              <button type="button" onClick={() => setNewVersionOpen(true)} disabled={saving}
+                title="Историческая версия — сохранить как новую"
+                className="inline-flex items-center gap-1.5 h-8 pl-3 pr-2.5 text-xs font-medium rounded-l-full bg-brand text-on-brand shadow-[var(--f-shadow4)] hover:bg-brand-hover active:bg-brand-pressed disabled:opacity-40 transition-colors">
+                <GitBranch size={12} /> Сохранить как новую
+              </button>
+            )}
+            <button type="button" onClick={() => setSaveMenuOpen(v => !v)} disabled={saving}
+              title="Ещё варианты сохранения"
+              className="inline-flex items-center h-8 px-1.5 rounded-r-full border-l border-on-brand/25 bg-brand text-on-brand shadow-[var(--f-shadow4)] hover:bg-brand-hover active:bg-brand-pressed disabled:opacity-40 transition-colors">
+              <ChevronDown size={13} />
+            </button>
+            {saveMenuOpen && (
+              <div className="absolute top-full right-0 mt-1 z-50 w-72 bg-surface border border-stroke rounded-lg shadow-lg py-1">
+                <button type="button"
+                  onClick={() => { setSaveMenuOpen(false); setNewVersionOpen(true); }}
+                  className="w-full flex items-start gap-2 px-3 py-2 text-left hover:bg-base transition-colors">
+                  <GitBranch size={14} className="text-brand shrink-0 mt-0.5" />
+                  <span>
+                    <span className="block text-sm text-fg1">Сохранить как новую версию…</span>
+                    <span className="block text-xs text-fg4">Создаст v{template.version + 1}, сохранит историю текущей</span>
+                  </span>
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -270,6 +395,15 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
           { scope: 'System', scopeId: null, label: 'системных' },
         ]}
       />
+
+      {newVersionOpen && (
+        <NewVersionDialog
+          nextVersion={template.version + 1}
+          saving={saving}
+          onCancel={() => setNewVersionOpen(false)}
+          onConfirm={handleSaveAsNewVersion}
+        />
+      )}
     </div>
   );
 }

--- a/src/client/src/features/templates/TemplateSidebar.tsx
+++ b/src/client/src/features/templates/TemplateSidebar.tsx
@@ -111,10 +111,11 @@ export function VersionCleanupModal({ group, onClose, onDeleted }: {
                   className="w-4 h-4 rounded border-stroke-strong text-danger disabled:opacity-40"
                 />
                 <span className="font-mono text-fg2 shrink-0">v{t.version}</span>
-                <span className="flex items-center gap-1.5 flex-1">
-                  {t.isActive && <span className="text-xs text-success bg-success-subtle px-1.5 py-0.5 rounded">активный</span>}
-                  {t.isDefault && <span className="text-xs text-yellow-600 bg-warning-subtle px-1.5 py-0.5 rounded">по умолч.</span>}
-                  {i === 0 && !t.isActive && <span className="text-xs text-fg4">последняя</span>}
+                <span className="flex items-center gap-1.5 flex-1 min-w-0">
+                  {t.isActive && <span className="text-xs text-success bg-success-subtle px-1.5 py-0.5 rounded shrink-0">активный</span>}
+                  {t.isDefault && <span className="text-xs text-yellow-600 bg-warning-subtle px-1.5 py-0.5 rounded shrink-0">по умолч.</span>}
+                  {i === 0 && !t.isActive && <span className="text-xs text-fg4 shrink-0">последняя</span>}
+                  {t.comment && <span className="text-xs text-fg4 truncate" title={t.comment}>{t.comment}</span>}
                 </span>
                 {protected_ && <span className="text-xs text-fg4 shrink-0">защищена</span>}
                 {!protected_ && checked && <span className="text-xs text-danger shrink-0">удалить</span>}
@@ -261,9 +262,12 @@ export function TemplateSidebar({ groups, selectedTemplate, maxVersions, documen
                           ${selectedTemplate?.id === t.id ? 'text-brand-hover' : 'text-fg2'}`}
                       >
                         <span className="text-xs font-mono shrink-0 w-6">v{t.version}</span>
-                        <span className="flex items-center gap-1 flex-1">
-                          {t.isActive && <span className="text-xs text-success">активный</span>}
-                          {t.isDefault && <span className="text-xs text-yellow-600">по умолч.</span>}
+                        <span className="flex items-center gap-1 flex-1 min-w-0">
+                          {t.isActive && <span className="text-xs text-success shrink-0">активный</span>}
+                          {t.isDefault && <span className="text-xs text-yellow-600 shrink-0">по умолч.</span>}
+                          {t.comment && (
+                            <span className="text-xs text-fg4 truncate" title={t.comment}>{t.comment}</span>
+                          )}
                         </span>
                       </button>
                       <button

--- a/src/client/src/shared/api/templates.ts
+++ b/src/client/src/shared/api/templates.ts
@@ -40,11 +40,22 @@ export function useDeleteTemplate() {
   });
 }
 
-export function useUpdateTemplate() {
+/** Простое сохранение (issue #360, Ctrl+S) — правит содержимое активной версии на месте, без новой версии. */
+export function useSaveTemplateContent() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, content }: { id: string; content: string }) =>
-      apiClient.put<Template>(`/templates/${id}`, { content }).then((r) => r.data),
+      apiClient.put<Template>(`/templates/${id}/content`, { content }).then((r) => r.data),
+    onSuccess: (t) => qc.invalidateQueries({ queryKey: ['templates', t.documentTypeId] }),
+  });
+}
+
+/** Явное «Сохранить как новую версию» (issue #360) — форк новой версии + опц. примечание. */
+export function useCreateTemplateVersion() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, content, comment }: { id: string; content: string; comment?: string | null }) =>
+      apiClient.post<Template>(`/templates/${id}/versions`, { content, comment }).then((r) => r.data),
     onSuccess: (t) => qc.invalidateQueries({ queryKey: ['templates', t.documentTypeId] }),
   });
 }

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -92,6 +92,8 @@ export interface Template {
   content: string;
   /** JSON-текст массива TemplateParam[] (jsonb-строка) или null. Парсить на клиенте. */
   parameters: string | null;
+  /** Необязательное примечание к версии (issue #360) — что за версия. */
+  comment: string | null;
   version: number;
   isActive: boolean;
   isDefault: boolean;

--- a/src/server/BHS.CRG.Api/Endpoints/Templates/TemplateEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Templates/TemplateEndpoints.cs
@@ -27,8 +27,17 @@ public static class TemplateEndpoints
             => Results.Ok(await m.Send(new CreateTemplateCommand(
                 req.DocumentTypeId, req.Name, req.Content))));
 
-        admin.MapPut("/{id:guid}", async (Guid id, UpdateTemplateRequest req, IMediator m)
-            => Results.Ok(await m.Send(new UpdateTemplateCommand(id, req.Content))));
+        // Простое сохранение (issue #360, Ctrl+S) — правит содержимое активной версии на месте.
+        // Отказ (409), если версия историческая (не активна): её можно только форкнуть.
+        admin.MapPut("/{id:guid}/content", async (Guid id, UpdateTemplateRequest req, IMediator m) =>
+        {
+            try { return Results.Ok(await m.Send(new SaveTemplateContentCommand(id, req.Content))); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+
+        // Явное «Сохранить как новую версию» (issue #360) — форк новой версии + опц. примечание.
+        admin.MapPost("/{id:guid}/versions", async (Guid id, NewVersionRequest req, IMediator m)
+            => Results.Ok(await m.Send(new UpdateTemplateCommand(id, req.Content, req.Comment))));
 
         admin.MapPost("/{id:guid}/duplicate", async (Guid id, DuplicateTemplateRequest? req, IMediator m)
             => Results.Ok(await m.Send(new DuplicateTemplateCommand(id, req?.Name))));
@@ -49,6 +58,7 @@ public static class TemplateEndpoints
 
     record CreateTemplateRequest(Guid DocumentTypeId, string Name, string Content);
     record UpdateTemplateRequest(string Content);
+    record NewVersionRequest(string Content, string? Comment);
     record DuplicateTemplateRequest(string? Name);
     record UpdateParametersRequest(string? Parameters);
 }

--- a/src/server/BHS.CRG.Application/Backup/BackupModels.cs
+++ b/src/server/BHS.CRG.Application/Backup/BackupModels.cs
@@ -25,7 +25,7 @@ public record BackupDocumentType(
 public record BackupTemplate(
     Guid Id, Guid DocumentTypeId, string Name, string Content, int Version,
     bool IsActive, bool IsDefault,
-    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt, string? Parameters = null);
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt, string? Parameters = null, string? Comment = null);
 
 public record BackupCatalogEntity(
     Guid Id, string EntityType, string DisplayName, JsonElement Data, Guid? OwnerId,

--- a/src/server/BHS.CRG.Application/Templates/Commands.cs
+++ b/src/server/BHS.CRG.Application/Templates/Commands.cs
@@ -4,7 +4,12 @@ using MediatR;
 namespace BHS.CRG.Application.Templates;
 
 public record CreateTemplateCommand(Guid DocumentTypeId, string Name, string Content) : IRequest<Template>;
-public record UpdateTemplateCommand(Guid Id, string Content) : IRequest<Template>;
+
+/// <summary>Создаёт новую версию шаблона (форк содержимого), опц. с примечанием к версии (issue #360).</summary>
+public record UpdateTemplateCommand(Guid Id, string Content, string? Comment = null) : IRequest<Template>;
+
+/// <summary>Правит содержимое текущей активной версии на месте, без создания новой (issue #360, Ctrl+S).</summary>
+public record SaveTemplateContentCommand(Guid Id, string Content) : IRequest<Template>;
 public record DuplicateTemplateCommand(Guid Id, string? NewName) : IRequest<Template>;
 public record DeleteTemplateCommand(Guid Id) : IRequest;
 public record GetActiveTemplateQuery(Guid DocumentTypeId) : IRequest<Template?>;

--- a/src/server/BHS.CRG.Application/Templates/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Templates/Handlers.cs
@@ -7,6 +7,7 @@ namespace BHS.CRG.Application.Templates;
 public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAsset> templateAssetRepo) :
     IRequestHandler<CreateTemplateCommand, Template>,
     IRequestHandler<UpdateTemplateCommand, Template>,
+    IRequestHandler<SaveTemplateContentCommand, Template>,
     IRequestHandler<DuplicateTemplateCommand, Template>,
     IRequestHandler<DeleteTemplateCommand>,
     IRequestHandler<GetActiveTemplateQuery, Template?>,
@@ -29,12 +30,24 @@ public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAs
     {
         var existing = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"Template {cmd.Id} not found");
-        var newVersion = existing.CreateNewVersion(cmd.Content);
+        var newVersion = existing.CreateNewVersion(cmd.Content, cmd.Comment);
         repo.Update(existing);
         await repo.AddAsync(newVersion, ct);
         await repo.SaveChangesAsync(ct);
         await DuplicateTemplateAssetsAsync(existing.Id, newVersion.Id, ct);
         return newVersion;
+    }
+
+    // Простое сохранение (issue #360, Ctrl+S): правит содержимое активной версии на месте, без
+    // новой версии и без дублирования ассетов (та же версия). Бросает, если версия не активна.
+    public async Task<Template> Handle(SaveTemplateContentCommand cmd, CancellationToken ct)
+    {
+        var template = await repo.GetByIdAsync(cmd.Id, ct)
+            ?? throw new KeyNotFoundException($"Template {cmd.Id} not found");
+        template.UpdateContent(cmd.Content);
+        repo.Update(template);
+        await repo.SaveChangesAsync(ct);
+        return template;
     }
 
     public async Task<Template> Handle(DuplicateTemplateCommand cmd, CancellationToken ct)

--- a/src/server/BHS.CRG.Domain/Templates/Template.cs
+++ b/src/server/BHS.CRG.Domain/Templates/Template.cs
@@ -24,6 +24,12 @@ public class Template : Entity
     /// <summary>Шаблон по умолчанию для данного типа документа.</summary>
     public bool IsDefault { get; private set; }
 
+    /// <summary>
+    /// Необязательное примечание к версии (issue #360) — что за версия, для самоописания
+    /// в истории версий и модалке очистки. Задаётся при явном «Сохранить как новую версию».
+    /// </summary>
+    public string? Comment { get; private set; }
+
     private Template() { }
 
     public static Template Create(Guid documentTypeId, string name, string content)
@@ -32,15 +38,15 @@ public class Template : Entity
     public static Template Restore(
         Guid id, Guid documentTypeId, string name, string content, int version,
         bool isActive, bool isDefault,
-        DateTimeOffset createdAt, DateTimeOffset updatedAt, string? parameters = null)
+        DateTimeOffset createdAt, DateTimeOffset updatedAt, string? parameters = null, string? comment = null)
         => new()
         {
             Id = id, DocumentTypeId = documentTypeId, Name = name, Content = content, Version = version,
             IsActive = isActive, IsDefault = isDefault,
-            Parameters = parameters, CreatedAt = createdAt, UpdatedAt = updatedAt,
+            Parameters = parameters, Comment = comment, CreatedAt = createdAt, UpdatedAt = updatedAt,
         };
 
-    public Template CreateNewVersion(string content)
+    public Template CreateNewVersion(string content, string? comment = null)
     {
         var wasDefault = IsDefault;
         IsActive = false;
@@ -55,7 +61,22 @@ public class Template : Entity
             IsActive = true,
             IsDefault = wasDefault,
             Parameters = Parameters,
+            Comment = comment,
         };
+    }
+
+    /// <summary>
+    /// Правит содержимое текущей версии на месте (issue #360, простое сохранение / Ctrl+S) —
+    /// без создания новой версии. Разрешено только для активной версии: историческую версию
+    /// нельзя переписать, её можно лишь форкнуть через <see cref="CreateNewVersion"/>.
+    /// </summary>
+    public void UpdateContent(string content)
+    {
+        if (!IsActive)
+            throw new InvalidOperationException(
+                $"Нельзя править на месте неактивную версию v{Version}: сохраните как новую версию.");
+        Content = content;
+        TouchUpdatedAt();
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -78,7 +78,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             Templates: templates.Select(t => new BackupTemplate(
                 t.Id, t.DocumentTypeId, t.Name, t.Content, t.Version,
                 t.IsActive, t.IsDefault,
-                t.CreatedAt, t.UpdatedAt, t.Parameters)).ToArray(),
+                t.CreatedAt, t.UpdatedAt, t.Parameters, t.Comment)).ToArray(),
             CatalogEntities: catalogEntities.Select(e => new BackupCatalogEntity(
                 e.Id, e.EntityType, e.DisplayName, e.Data.RootElement.Clone(), e.OwnerId,
                 e.CreatedAt, e.UpdatedAt)).ToArray(),
@@ -283,7 +283,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             var entity = Template.Restore(
                 item.Id, item.DocumentTypeId, item.Name, item.Content, item.Version,
                 item.IsActive, item.IsDefault,
-                item.CreatedAt, item.UpdatedAt, item.Parameters);
+                item.CreatedAt, item.UpdatedAt, item.Parameters, item.Comment);
             db.Entry(entity).State = existingIds.Contains(item.Id) ? EntityState.Modified : EntityState.Added;
             if (existingIds.Contains(item.Id)) stats.TemplatesUpdated++; else stats.TemplatesCreated++;
         }

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260723130841_AddTemplateComment.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260723130841_AddTemplateComment.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723130841_AddTemplateComment")]
+    partial class AddTemplateComment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260723130841_AddTemplateComment.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260723130841_AddTemplateComment.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTemplateComment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Comment",
+                table: "templates",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Comment",
+                table: "templates");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/TemplateConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/TemplateConfiguration.cs
@@ -13,6 +13,7 @@ public class TemplateConfiguration : IEntityTypeConfiguration<Template>
         b.Property(e => e.Name).HasMaxLength(256).IsRequired();
         b.Property(e => e.Content).IsRequired();
         b.Property(e => e.Parameters).HasColumnType("jsonb");
+        b.Property(e => e.Comment).HasMaxLength(1000);
         b.Property(e => e.Version).IsRequired();
         b.Property(e => e.IsActive).IsRequired();
         b.Property(e => e.IsDefault).IsRequired();

--- a/src/server/BHS.CRG.Tests/Integration/TemplateHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/TemplateHandlerTests.cs
@@ -70,6 +70,68 @@ public class TemplateHandlerTests(IntegrationTestFixture fixture) : IAsyncLifeti
         Assert.False(old.IsActive);
     }
 
+    [Fact]
+    public async Task NewVersion_WithComment_PersistsCommentOnNewVersionOnly()
+    {
+        var dtId = await CreateDocTypeAsync("DT_UC");
+
+        using var scope = fixture.Services.CreateScope();
+        var original = await Mediator(scope).Send(new CreateTemplateCommand(dtId, "Шаблон", "v1"));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var newVersion = await Mediator(scope2).Send(
+            new UpdateTemplateCommand(original.Id, "v2 content", "переход на новый штамп"));
+
+        Assert.Equal(2, newVersion.Version);
+        Assert.Equal("переход на новый штамп", newVersion.Comment);
+
+        // Примечание живёт только на новой версии, исходная без него.
+        using var scope3 = fixture.Services.CreateScope();
+        var templates = await Mediator(scope3).Send(new ListTemplatesQuery(dtId));
+        Assert.Null(templates.First(t => t.Id == original.Id).Comment);
+    }
+
+    // ── SaveContent (in-place, issue #360) ────────────────────────────────────
+
+    [Fact]
+    public async Task SaveContent_UpdatesActiveVersionInPlace_NoNewVersion()
+    {
+        var dtId = await CreateDocTypeAsync("DT_SC");
+
+        using var scope = fixture.Services.CreateScope();
+        var original = await Mediator(scope).Send(new CreateTemplateCommand(dtId, "Шаблон", "v1"));
+
+        using var scope2 = fixture.Services.CreateScope();
+        var saved = await Mediator(scope2).Send(new SaveTemplateContentCommand(original.Id, "v1 edited"));
+
+        // Тот же Id, та же версия — правка на месте.
+        Assert.Equal(original.Id, saved.Id);
+        Assert.Equal(1, saved.Version);
+        Assert.Equal("v1 edited", saved.Content);
+        Assert.True(saved.IsActive);
+
+        using var scope3 = fixture.Services.CreateScope();
+        var templates = await Mediator(scope3).Send(new ListTemplatesQuery(dtId));
+        Assert.Single(templates); // новой версии не появилось
+    }
+
+    [Fact]
+    public async Task SaveContent_OnInactiveVersion_Throws()
+    {
+        var dtId = await CreateDocTypeAsync("DT_SCI");
+
+        using var scope = fixture.Services.CreateScope();
+        var original = await Mediator(scope).Send(new CreateTemplateCommand(dtId, "Шаблон", "v1"));
+
+        // Форкаем новую версию — исходная становится исторической (неактивной).
+        using var scope2 = fixture.Services.CreateScope();
+        await Mediator(scope2).Send(new UpdateTemplateCommand(original.Id, "v2"));
+
+        using var scope3 = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Mediator(scope3).Send(new SaveTemplateContentCommand(original.Id, "hack")));
+    }
+
     // ── Delete ────────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Что
Фаза 1 плана «два сохранения + сброс в Draft + удаление версий» (согласовано с Архитектором и Дизайнером). Разделяет сохранение Typst-шаблона на два режима, закрывая «спам версий».

## Изменения
**Backend**
- `Template.UpdateContent(content)` — правка активной версии на месте (бросает `InvalidOperationException` на неактивной/исторической версии).
- `Template.Comment` (nullable) — примечание к версии: миграция `AddTemplateComment`, EF-конфиг, backup DTO + restore.
- `SaveTemplateContentCommand` → `PUT /api/templates/{id}/content` (in-place; 409 на исторической версии).
- `UpdateTemplateCommand(+Comment)` → `POST /api/templates/{id}/versions` (форк новой версии). Старый `PUT /api/templates/{id}` убран.

**Frontend (`EditorPanel`)**
- Сплит-кнопка: «💾 Сохранить» (Ctrl+S → in-place) + каретка ▾ «Сохранить как новую версию…».
- Индикатор версии с dirty-точкой (`v3 ●`/`v3 ✓`), метка «историческая» на неактивной версии (in-place заблокирован, левая кнопка ведёт на форк).
- Лёгкий диалог новой версии: след. номер + опц. «Примечание».
- Показ примечания версии в сайдбаре и модалке очистки.

## Проверка
- `dotnet build` / `tsc -b` — чисто.
- Backend-тесты: 481 (+3 новых: in-place сохранение, guard на исторической версии, примечание только на новой версии).
- Frontend-тесты: 141.
- Живой smoke: in-place правит v1 без новой версии; новая версия v2 с кириллическим примечанием; in-place на исторической v1 → 409.

## Дальше (отдельными PR)
- Фаза 2 — сброс документов в Draft при изменении шаблона.
- Фаза 3 — правила удаления версий (защита запиннутых в bulk, индивидуальное удаление → сброс на дефолт).

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
