### PR TITLE
feat(templates): сброс документов в Draft при изменении шаблона (фаза 2, #362)

### DIFF
--- a/src/client/src/features/templates/EditorPanel.tsx
+++ b/src/client/src/features/templates/EditorPanel.tsx
@@ -6,6 +6,8 @@ import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { Button } from '@/shared/ui/Button';
 import { Modal } from '@/shared/ui/Modal';
 import { TextField } from '@/shared/ui/TextField';
+import { useToast } from '@/shared/ui/Toast';
+import { ruCount } from '@/shared/utils/pluralize';
 import { BookOpen, Save, Star, CheckCircle, ChevronDown, GitBranch, History } from 'lucide-react';
 import type { Template, DocumentType } from '@/shared/api/types';
 import { resolveEffectiveFields } from '@/shared/api/schema';
@@ -142,6 +144,13 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
   const saveContentMutation = useSaveTemplateContent();
   const newVersionMutation = useCreateTemplateVersion();
   const defaultMutation = useSetTemplateDefault();
+  const toast = useToast();
+
+  // Неблокирующее предупреждение: сколько документов ушло в черновик из-за устаревшего PDF (issue #362).
+  function notifyReset(count: number) {
+    if (count > 0)
+      toast.info(`${ruCount(count, 'документ', 'документа', 'документов')} переведено в черновик — PDF устарел`);
+  }
 
   // Есть ли несохранённые правки (dirty). После сохранения onSaved() подставляет
   // обновлённый шаблон с тем же content → снова false.
@@ -179,11 +188,12 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
     setError('');
     setSaving(true);
     try {
-      const updated = await saveContentMutation.mutateAsync({ id: template.id, content: currentContent });
+      const res = await saveContentMutation.mutateAsync({ id: template.id, content: currentContent });
       setSavedMsg(true);
       setTimeout(() => setSavedMsg(false), 2000);
       justSavedRef.current = true; // prevent useEffect from resetting cursor
-      onSaved(updated);
+      onSaved(res.template);
+      notifyReset(res.resetDocuments);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Ошибка сохранения');
     } finally {
@@ -200,13 +210,14 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
     setError('');
     setSaving(true);
     try {
-      const updated = await newVersionMutation.mutateAsync({
+      const res = await newVersionMutation.mutateAsync({
         id: template.id, content: currentContent, comment: comment.trim() || null,
       });
       setSavedMsg(true);
       setTimeout(() => setSavedMsg(false), 2000);
       justSavedRef.current = true;
-      onSaved(updated);
+      onSaved(res.template);
+      notifyReset(res.resetDocuments);
       setNewVersionOpen(false);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Ошибка сохранения');
@@ -258,8 +269,9 @@ export function EditorPanel({ template, docType, allDocTypes, onSaved }: EditorP
   }
 
   async function handleSetDefault() {
-    const updated = await defaultMutation.mutateAsync({ id: template.id, documentTypeId: template.documentTypeId });
-    onSaved(updated);
+    const res = await defaultMutation.mutateAsync({ id: template.id, documentTypeId: template.documentTypeId });
+    onSaved(res.template);
+    notifyReset(res.resetDocuments);
   }
 
   function insertAtCursor(snippet: string) {

--- a/src/client/src/shared/api/templates.ts
+++ b/src/client/src/shared/api/templates.ts
@@ -40,13 +40,20 @@ export function useDeleteTemplate() {
   });
 }
 
+/** Результат мутации шаблона, влияющей на вывод (issue #362): шаблон + число документов,
+ *  сброшенных в Draft из-за устаревшего PDF. */
+export interface TemplateMutationResult {
+  template: Template;
+  resetDocuments: number;
+}
+
 /** Простое сохранение (issue #360, Ctrl+S) — правит содержимое активной версии на месте, без новой версии. */
 export function useSaveTemplateContent() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, content }: { id: string; content: string }) =>
-      apiClient.put<Template>(`/templates/${id}/content`, { content }).then((r) => r.data),
-    onSuccess: (t) => qc.invalidateQueries({ queryKey: ['templates', t.documentTypeId] }),
+      apiClient.put<TemplateMutationResult>(`/templates/${id}/content`, { content }).then((r) => r.data),
+    onSuccess: (res) => qc.invalidateQueries({ queryKey: ['templates', res.template.documentTypeId] }),
   });
 }
 
@@ -55,8 +62,8 @@ export function useCreateTemplateVersion() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, content, comment }: { id: string; content: string; comment?: string | null }) =>
-      apiClient.post<Template>(`/templates/${id}/versions`, { content, comment }).then((r) => r.data),
-    onSuccess: (t) => qc.invalidateQueries({ queryKey: ['templates', t.documentTypeId] }),
+      apiClient.post<TemplateMutationResult>(`/templates/${id}/versions`, { content, comment }).then((r) => r.data),
+    onSuccess: (res) => qc.invalidateQueries({ queryKey: ['templates', res.template.documentTypeId] }),
   });
 }
 
@@ -74,7 +81,7 @@ export function useSetTemplateDefault() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id }: { id: string; documentTypeId: string }) =>
-      apiClient.put<Template>(`/templates/${id}/set-default`).then((r) => r.data),
-    onSuccess: (t) => qc.invalidateQueries({ queryKey: ['templates', t.documentTypeId] }),
+      apiClient.put<TemplateMutationResult>(`/templates/${id}/set-default`).then((r) => r.data),
+    onSuccess: (res) => qc.invalidateQueries({ queryKey: ['templates', res.template.documentTypeId] }),
   });
 }

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -187,6 +187,8 @@ builder.Services.AddScoped<IRepository<BHS.CRG.Domain.Objects.DomainObject>>(sp 
 builder.Services.AddScoped<IDomainObjectRepository>(sp => sp.GetRequiredService<DomainObjectRepository>());
 builder.Services.AddScoped<IRepository<Template>, Repository<Template>>();
 builder.Services.AddScoped<IRepository<TemplateAsset>, Repository<TemplateAsset>>();
+builder.Services.AddScoped<BHS.CRG.Application.Templates.IDocumentTemplateInvalidator,
+    BHS.CRG.Application.Templates.DocumentTemplateInvalidator>();
 builder.Services.AddScoped<IRepository<GeneratedFile>, Repository<GeneratedFile>>();
 builder.Services.AddScoped<IRepository<DocumentSetOutput>, Repository<DocumentSetOutput>>();
 builder.Services.AddScoped<IRepository<TypstUserLib>, Repository<TypstUserLib>>();

--- a/src/server/BHS.CRG.Application/Common/IDomainObjectRepository.cs
+++ b/src/server/BHS.CRG.Application/Common/IDomainObjectRepository.cs
@@ -16,6 +16,10 @@ public interface IDomainObjectRepository : IRepository<DomainObject>
     /// <summary>Документы нескольких комплектов (untracked, для списков/пикеров).</summary>
     Task<IReadOnlyList<DomainObject>> GetDocumentsInSetsAsync(IReadOnlyCollection<Guid> setIds, CancellationToken ct = default);
 
+    /// <summary>Все документы заданного типа (с трекингом и фасетой+файлами) — для инвалидации
+    /// вывода при изменении шаблона (issue #362): фильтр по пинам делается в памяти.</summary>
+    Task<IReadOnlyList<DomainObject>> GetDocumentsOfTypeAsync(Guid documentTypeId, CancellationToken ct = default);
+
     /// <summary>Число документов по каждому комплекту (лёгкий COUNT, без JSONB) — для счётчиков навигации
     /// и каскадов удаления в дереве стройки. Комплекты без документов в словарь не попадают.</summary>
     Task<IReadOnlyDictionary<Guid, int>> CountDocumentsInSetsAsync(IReadOnlyCollection<Guid> setIds, CancellationToken ct = default);

--- a/src/server/BHS.CRG.Application/Templates/Commands.cs
+++ b/src/server/BHS.CRG.Application/Templates/Commands.cs
@@ -5,17 +5,21 @@ namespace BHS.CRG.Application.Templates;
 
 public record CreateTemplateCommand(Guid DocumentTypeId, string Name, string Content) : IRequest<Template>;
 
+/// <summary>Результат мутации шаблона, влияющей на вывод (issue #362): шаблон + число документов,
+/// сброшенных в Draft из-за устаревшего PDF (для тоста-предупреждения на фронте).</summary>
+public record TemplateMutationResult(Template Template, int ResetDocuments);
+
 /// <summary>Создаёт новую версию шаблона (форк содержимого), опц. с примечанием к версии (issue #360).</summary>
-public record UpdateTemplateCommand(Guid Id, string Content, string? Comment = null) : IRequest<Template>;
+public record UpdateTemplateCommand(Guid Id, string Content, string? Comment = null) : IRequest<TemplateMutationResult>;
 
 /// <summary>Правит содержимое текущей активной версии на месте, без создания новой (issue #360, Ctrl+S).</summary>
-public record SaveTemplateContentCommand(Guid Id, string Content) : IRequest<Template>;
+public record SaveTemplateContentCommand(Guid Id, string Content) : IRequest<TemplateMutationResult>;
 public record DuplicateTemplateCommand(Guid Id, string? NewName) : IRequest<Template>;
 public record DeleteTemplateCommand(Guid Id) : IRequest;
 public record GetActiveTemplateQuery(Guid DocumentTypeId) : IRequest<Template?>;
 public record ListTemplatesQuery(Guid DocumentTypeId) : IRequest<IReadOnlyList<Template>>;
 
-public record SetTemplateDefaultCommand(Guid Id) : IRequest<Template>;
+public record SetTemplateDefaultCommand(Guid Id) : IRequest<TemplateMutationResult>;
 
 /// <summary>Объявление параметров шаблона (JSON-массив [{name,label,type,default}] или null).</summary>
 public record UpdateTemplateParametersCommand(Guid Id, string? Parameters) : IRequest<Template>;

--- a/src/server/BHS.CRG.Application/Templates/DocumentTemplateInvalidator.cs
+++ b/src/server/BHS.CRG.Application/Templates/DocumentTemplateInvalidator.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Objects;
+using BHS.CRG.Domain.Templates;
+
+namespace BHS.CRG.Application.Templates;
+
+/// <summary>
+/// Инвалидация вывода документов при изменении шаблона (issue #362, фаза 2). Когда содержимое
+/// шаблона (или эффективный default-active) меняется, ранее сгенерированные PDF устаревают —
+/// документы сбрасываются в <see cref="Domain.Documents.DocumentStatus.Draft"/>, их файлы удаляются.
+/// Пины НЕ переставляются («запиннут на конкретную версию» — семантика сохраняется).
+/// </summary>
+public interface IDocumentTemplateInvalidator
+{
+    /// <summary>
+    /// Содержимое версии изменено на месте (Ctrl+S). Сбрасывает документы, запиннутые на эту
+    /// версию; а если версия — активная-дефолтная, то и no-pin документы этого типа (они
+    /// резолвятся в default-active). Возвращает число реально сброшенных документов.
+    /// </summary>
+    Task<int> OnTemplateContentChangedAsync(Guid templateId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Эффективный default-active шаблон типа сменился (смена дефолта или новая версия в дефолтной
+    /// группе). Сбрасывает no-pin документы этого типа. Возвращает число сброшенных документов.
+    /// </summary>
+    Task<int> OnDefaultChangedAsync(Guid documentTypeId, CancellationToken ct = default);
+}
+
+public class DocumentTemplateInvalidator(
+    IRepository<Template> templateRepo,
+    IDomainObjectRepository objRepo,
+    IBlobStorage blobStorage) : IDocumentTemplateInvalidator
+{
+    public async Task<int> OnTemplateContentChangedAsync(Guid templateId, CancellationToken ct = default)
+    {
+        var tpl = await templateRepo.GetByIdAsync(templateId, ct);
+        if (tpl is null) return 0;
+
+        var docs = await objRepo.GetDocumentsOfTypeAsync(tpl.DocumentTypeId, ct);
+        var isDefaultActive = tpl.IsDefault && tpl.IsActive;
+        var affected = docs
+            .Where(o => PinsTemplate(o, templateId) || (isDefaultActive && HasNoPin(o)))
+            .ToList();
+        return await ResetAllAsync(affected, ct);
+    }
+
+    public async Task<int> OnDefaultChangedAsync(Guid documentTypeId, CancellationToken ct = default)
+    {
+        var docs = await objRepo.GetDocumentsOfTypeAsync(documentTypeId, ct);
+        var affected = docs.Where(HasNoPin).ToList();
+        return await ResetAllAsync(affected, ct);
+    }
+
+    // Документ запиннут на версию — явным одиночным TemplateId или в наборе TemplateIds.
+    private static bool PinsTemplate(DomainObject o, Guid templateId)
+        => o.TemplateId == templateId || ParseIds(o.TemplateIds).Contains(templateId);
+
+    // Нет пина — резолвится в default-active шаблон типа.
+    private static bool HasNoPin(DomainObject o)
+        => o.TemplateId is null && ParseIds(o.TemplateIds).Count == 0;
+
+    // Сброс: только не-черновики (у остальных сбрасывать нечего). SaveChanges один раз (атомарно),
+    // удаление блобов — ПОСЛЕ коммита (конвенция reset-хендлеров: откат не осиротит файлы).
+    private async Task<int> ResetAllAsync(List<DomainObject> objs, CancellationToken ct)
+    {
+        var blobs = new List<string>();
+        var count = 0;
+        foreach (var o in objs)
+        {
+            if (o.Status == Domain.Documents.DocumentStatus.Draft) continue; // уже черновик — нечего сбрасывать
+            blobs.AddRange(o.ResetToDraft());
+            objRepo.Update(o);
+            count++;
+        }
+        if (count == 0) return 0;
+        await objRepo.SaveChangesAsync(ct);
+        foreach (var path in blobs) await blobStorage.DeleteAsync(path, ct);
+        return count;
+    }
+
+    private static List<Guid> ParseIds(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return [];
+        try
+        {
+            var arr = JsonSerializer.Deserialize<List<Guid>>(json);
+            return arr ?? [];
+        }
+        catch (JsonException) { return []; }
+    }
+}

--- a/src/server/BHS.CRG.Application/Templates/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Templates/Handlers.cs
@@ -4,16 +4,19 @@ using MediatR;
 
 namespace BHS.CRG.Application.Templates;
 
-public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAsset> templateAssetRepo) :
+public class TemplateHandlers(
+    IRepository<Template> repo,
+    IRepository<TemplateAsset> templateAssetRepo,
+    IDocumentTemplateInvalidator invalidator) :
     IRequestHandler<CreateTemplateCommand, Template>,
-    IRequestHandler<UpdateTemplateCommand, Template>,
-    IRequestHandler<SaveTemplateContentCommand, Template>,
+    IRequestHandler<UpdateTemplateCommand, TemplateMutationResult>,
+    IRequestHandler<SaveTemplateContentCommand, TemplateMutationResult>,
     IRequestHandler<DuplicateTemplateCommand, Template>,
     IRequestHandler<DeleteTemplateCommand>,
     IRequestHandler<GetActiveTemplateQuery, Template?>,
     IRequestHandler<ListTemplatesQuery, IReadOnlyList<Template>>,
     IRequestHandler<UpdateTemplateParametersCommand, Template>,
-    IRequestHandler<SetTemplateDefaultCommand, Template>
+    IRequestHandler<SetTemplateDefaultCommand, TemplateMutationResult>
 {
     public async Task<Template> Handle(CreateTemplateCommand cmd, CancellationToken ct)
     {
@@ -26,7 +29,7 @@ public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAs
         return template;
     }
 
-    public async Task<Template> Handle(UpdateTemplateCommand cmd, CancellationToken ct)
+    public async Task<TemplateMutationResult> Handle(UpdateTemplateCommand cmd, CancellationToken ct)
     {
         var existing = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"Template {cmd.Id} not found");
@@ -35,19 +38,27 @@ public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAs
         await repo.AddAsync(newVersion, ct);
         await repo.SaveChangesAsync(ct);
         await DuplicateTemplateAssetsAsync(existing.Id, newVersion.Id, ct);
-        return newVersion;
+        // Если новая версия — дефолтная, эффективный default-active сместился на неё → no-pin
+        // документы этого типа устарели (issue #362). Запиннутые на старую версию не трогаем.
+        var reset = newVersion.IsDefault
+            ? await invalidator.OnDefaultChangedAsync(newVersion.DocumentTypeId, ct)
+            : 0;
+        return new TemplateMutationResult(newVersion, reset);
     }
 
     // Простое сохранение (issue #360, Ctrl+S): правит содержимое активной версии на месте, без
     // новой версии и без дублирования ассетов (та же версия). Бросает, если версия не активна.
-    public async Task<Template> Handle(SaveTemplateContentCommand cmd, CancellationToken ct)
+    public async Task<TemplateMutationResult> Handle(SaveTemplateContentCommand cmd, CancellationToken ct)
     {
         var template = await repo.GetByIdAsync(cmd.Id, ct)
             ?? throw new KeyNotFoundException($"Template {cmd.Id} not found");
         template.UpdateContent(cmd.Content);
         repo.Update(template);
         await repo.SaveChangesAsync(ct);
-        return template;
+        // Содержимое версии изменилось на месте → устаревают документы, запиннутые на неё
+        // (и no-pin, если версия дефолтная-активная) — сброс в Draft (issue #362).
+        var reset = await invalidator.OnTemplateContentChangedAsync(template.Id, ct);
+        return new TemplateMutationResult(template, reset);
     }
 
     public async Task<Template> Handle(DuplicateTemplateCommand cmd, CancellationToken ct)
@@ -104,7 +115,7 @@ public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAs
         return template;
     }
 
-    public async Task<Template> Handle(SetTemplateDefaultCommand cmd, CancellationToken ct)
+    public async Task<TemplateMutationResult> Handle(SetTemplateDefaultCommand cmd, CancellationToken ct)
     {
         var all = await repo.GetAllAsync(ct);
         var target = all.FirstOrDefault(t => t.Id == cmd.Id)
@@ -119,7 +130,9 @@ public class TemplateHandlers(IRepository<Template> repo, IRepository<TemplateAs
         target.SetDefault(true);
         repo.Update(target);
         await repo.SaveChangesAsync(ct);
-        return target;
+        // Дефолт типа сменился → no-pin документы резолвятся в новый default-active → устарели (issue #362).
+        var reset = await invalidator.OnDefaultChangedAsync(target.DocumentTypeId, ct);
+        return new TemplateMutationResult(target, reset);
     }
 }
 

--- a/src/server/BHS.CRG.Infrastructure/Persistence/DomainObjectRepository.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/DomainObjectRepository.cs
@@ -33,6 +33,12 @@ public class DomainObjectRepository(AppDbContext db) : Repository<DomainObject>(
             .Where(o => o.ScopeLevel == CatalogScope.Set && o.ScopeId != null && setIds.Contains(o.ScopeId.Value) && o.Facet != null)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyList<DomainObject>> GetDocumentsOfTypeAsync(Guid documentTypeId, CancellationToken ct = default)
+        => await Db.Set<DomainObject>()
+            .Include(o => o.Facet).ThenInclude(f => f!.GeneratedFiles)
+            .Where(o => o.CompositeTypeId == documentTypeId && o.Facet != null)
+            .ToListAsync(ct);
+
     public async Task<IReadOnlyDictionary<Guid, int>> CountDocumentsInSetsAsync(IReadOnlyCollection<Guid> setIds, CancellationToken ct = default)
     {
         if (setIds.Count == 0) return new Dictionary<Guid, int>();

--- a/src/server/BHS.CRG.Tests/Integration/TemplateHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/TemplateHandlerTests.cs
@@ -56,8 +56,8 @@ public class TemplateHandlerTests(IntegrationTestFixture fixture) : IAsyncLifeti
             new CreateTemplateCommand(dtId, "Шаблон", "v1 content"));
 
         using var scope2 = fixture.Services.CreateScope();
-        var newVersion = await Mediator(scope2).Send(
-            new UpdateTemplateCommand(original.Id, "v2 content"));
+        var newVersion = (await Mediator(scope2).Send(
+            new UpdateTemplateCommand(original.Id, "v2 content"))).Template;
 
         Assert.Equal(2, newVersion.Version);
         Assert.True(newVersion.IsActive);
@@ -79,8 +79,8 @@ public class TemplateHandlerTests(IntegrationTestFixture fixture) : IAsyncLifeti
         var original = await Mediator(scope).Send(new CreateTemplateCommand(dtId, "Шаблон", "v1"));
 
         using var scope2 = fixture.Services.CreateScope();
-        var newVersion = await Mediator(scope2).Send(
-            new UpdateTemplateCommand(original.Id, "v2 content", "переход на новый штамп"));
+        var newVersion = (await Mediator(scope2).Send(
+            new UpdateTemplateCommand(original.Id, "v2 content", "переход на новый штамп"))).Template;
 
         Assert.Equal(2, newVersion.Version);
         Assert.Equal("переход на новый штамп", newVersion.Comment);
@@ -102,7 +102,7 @@ public class TemplateHandlerTests(IntegrationTestFixture fixture) : IAsyncLifeti
         var original = await Mediator(scope).Send(new CreateTemplateCommand(dtId, "Шаблон", "v1"));
 
         using var scope2 = fixture.Services.CreateScope();
-        var saved = await Mediator(scope2).Send(new SaveTemplateContentCommand(original.Id, "v1 edited"));
+        var saved = (await Mediator(scope2).Send(new SaveTemplateContentCommand(original.Id, "v1 edited"))).Template;
 
         // Тот же Id, та же версия — правка на месте.
         Assert.Equal(original.Id, saved.Id);
@@ -214,7 +214,7 @@ public class TemplateHandlerTests(IntegrationTestFixture fixture) : IAsyncLifeti
             TemplateAssetScope.Template, original.Id, TemplateAssetKind.Image, "logo", "logo.png", "image/png", "blob/logo.png", null));
 
         using var scope2 = fixture.Services.CreateScope();
-        var newVersion = await Mediator(scope2).Send(new UpdateTemplateCommand(original.Id, "v2"));
+        var newVersion = (await Mediator(scope2).Send(new UpdateTemplateCommand(original.Id, "v2"))).Template;
 
         using var scope3 = fixture.Services.CreateScope();
         var newVersionAssets = await Mediator(scope3).Send(
@@ -238,7 +238,7 @@ public class TemplateHandlerTests(IntegrationTestFixture fixture) : IAsyncLifeti
             TemplateAssetScope.Template, original.Id, TemplateAssetKind.Image, "logo", "logo.png", "image/png", "blob/old.png", null));
 
         using var scope2 = fixture.Services.CreateScope();
-        var newVersion = await Mediator(scope2).Send(new UpdateTemplateCommand(original.Id, "v2"));
+        var newVersion = (await Mediator(scope2).Send(new UpdateTemplateCommand(original.Id, "v2"))).Template;
 
         using var scope3 = fixture.Services.CreateScope();
         var newVersionAsset = (await Mediator(scope3).Send(

--- a/src/server/BHS.CRG.Tests/Integration/TemplateInvalidationTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/TemplateInvalidationTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Templates;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Инвалидация вывода документов при изменении шаблона (issue #362, фаза 2): документы, чей
+/// сгенерированный PDF устарел, сбрасываются в Draft. Проверяем три триггера (in-place правка,
+/// смена дефолта, новая версия) и точность выборки (пиннутые vs no-pin).
+/// </summary>
+[Collection("Integration")]
+public class TemplateInvalidationTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private IMediator Mediator(IServiceScope scope) => scope.ServiceProvider.GetRequiredService<IMediator>();
+    private readonly Guid _userId = Guid.NewGuid();
+
+    private async Task<Guid> CreateSetAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = Mediator(scope);
+        var c = await m.Send(new CreateConstructionCommand("Объект", _userId));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "Раздел"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, "Комплект"));
+        return set.Id;
+    }
+
+    private async Task<Guid> CreateDocTypeAsync(string code)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await Mediator(scope).Send(
+            new CreateDocumentTypeCommand(code, code, DocumentTypeKind.Document, null, JsonDocument.Parse(@"{""fields"":[]}")));
+        return dt.Id;
+    }
+
+    private async Task<Domain.Templates.Template> CreateTemplateAsync(Guid dtId, string name)
+    {
+        using var scope = fixture.Services.CreateScope();
+        return await Mediator(scope).Send(new CreateTemplateCommand(dtId, name, "content v1"));
+    }
+
+    // Добавляет документ; опционально пиннит на шаблон; помечает как сгенерированный (Status=Generated + файл).
+    // Каждый шаг — в своём scope (свежий DbContext), иначе токен конкуренции между командами рассинхронится.
+    private async Task<Guid> AddGeneratedDocAsync(Guid setId, Guid dtId, Guid? pinTemplateId = null)
+    {
+        Guid docId;
+        using (var s = fixture.Services.CreateScope())
+            docId = (await Mediator(s).Send(new AddDocumentToSetCommand(setId, dtId))).Id;
+
+        if (pinTemplateId.HasValue)
+            using (var s = fixture.Services.CreateScope())
+                await Mediator(s).Send(new SetDocumentTemplateCommand(docId, pinTemplateId.Value)); // сброс в Draft — ок, до генерации
+
+        using (var s = fixture.Services.CreateScope())
+        {
+            var repo = s.ServiceProvider.GetRequiredService<IDomainObjectRepository>();
+            var fileRepo = s.ServiceProvider.GetRequiredService<IRepository<GeneratedFile>>();
+            var obj = await repo.GetByIdAsync(docId);
+            // Как в GenerateDocumentHandler: файл регистрируем как Added через его репозиторий
+            // (иначе EF в трекнутой коллекции считает его Modified → UPDATE несуществующей строки).
+            var gf = obj!.AddGeneratedFile(OutputFormat.Pdf, $"blob/{docId}.pdf");
+            await fileRepo.AddAsync(gf);
+            await repo.SaveChangesAsync();
+        }
+        return docId;
+    }
+
+    private async Task<DocumentStatus> StatusAsync(Guid instanceId)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IDomainObjectRepository>();
+        return (await repo.GetByIdAsync(instanceId))!.Status;
+    }
+
+    // ── In-place правка ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task InPlaceSave_ResetsDocumentPinnedToVersion()
+    {
+        var dtId = await CreateDocTypeAsync("DT_INV1");
+        var t = await CreateTemplateAsync(dtId, "Шаблон");
+        var setId = await CreateSetAsync();
+        var docId = await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t.Id);
+        Assert.Equal(DocumentStatus.Generated, await StatusAsync(docId));
+
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new SaveTemplateContentCommand(t.Id, "content v1 edited"));
+
+        Assert.Equal(DocumentStatus.Draft, await StatusAsync(docId));
+    }
+
+    [Fact]
+    public async Task InPlaceSave_ResetsNoPinDoc_WhenVersionIsDefaultActive()
+    {
+        var dtId = await CreateDocTypeAsync("DT_INV2");
+        var t = await CreateTemplateAsync(dtId, "Шаблон");
+        using (var s = fixture.Services.CreateScope())
+            await Mediator(s).Send(new SetTemplateDefaultCommand(t.Id));
+        var setId = await CreateSetAsync();
+        var docId = await AddGeneratedDocAsync(setId, dtId); // без пина → резолвится в default-active
+
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new SaveTemplateContentCommand(t.Id, "edited"));
+
+        Assert.Equal(DocumentStatus.Draft, await StatusAsync(docId));
+    }
+
+    [Fact]
+    public async Task InPlaceSave_DoesNotResetNoPinDoc_WhenVersionNotDefault()
+    {
+        var dtId = await CreateDocTypeAsync("DT_INV3");
+        var tDefault = await CreateTemplateAsync(dtId, "Дефолтный");
+        var tOther = await CreateTemplateAsync(dtId, "Другой");
+        using (var s = fixture.Services.CreateScope())
+            await Mediator(s).Send(new SetTemplateDefaultCommand(tDefault.Id));
+        var setId = await CreateSetAsync();
+        var docId = await AddGeneratedDocAsync(setId, dtId); // no-pin → резолвится в tDefault
+
+        // Правим НЕ дефолтный шаблон → no-pin документ не затронут.
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new SaveTemplateContentCommand(tOther.Id, "edited"));
+
+        Assert.Equal(DocumentStatus.Generated, await StatusAsync(docId));
+    }
+
+    [Fact]
+    public async Task InPlaceSave_DoesNotResetDocPinnedToOtherVersion()
+    {
+        var dtId = await CreateDocTypeAsync("DT_INV4");
+        var tEdited = await CreateTemplateAsync(dtId, "Правимый");
+        var tPinned = await CreateTemplateAsync(dtId, "Пиннутый");
+        var setId = await CreateSetAsync();
+        var docId = await AddGeneratedDocAsync(setId, dtId, pinTemplateId: tPinned.Id);
+
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new SaveTemplateContentCommand(tEdited.Id, "edited"));
+
+        Assert.Equal(DocumentStatus.Generated, await StatusAsync(docId));
+    }
+
+    // ── Смена дефолта ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetDefault_ResetsNoPinDocs_ButNotPinned()
+    {
+        var dtId = await CreateDocTypeAsync("DT_INV5");
+        var t1 = await CreateTemplateAsync(dtId, "Первый");
+        var t2 = await CreateTemplateAsync(dtId, "Второй");
+        using (var s = fixture.Services.CreateScope())
+            await Mediator(s).Send(new SetTemplateDefaultCommand(t1.Id));
+        var setId = await CreateSetAsync();
+        var noPin = await AddGeneratedDocAsync(setId, dtId);
+        var pinned = await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t1.Id);
+
+        // Дефолт t1 → t2: no-pin резолвится в новый default → сброс; пиннутый на t1 не трогаем.
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new SetTemplateDefaultCommand(t2.Id));
+
+        Assert.Equal(DocumentStatus.Draft, await StatusAsync(noPin));
+        Assert.Equal(DocumentStatus.Generated, await StatusAsync(pinned));
+    }
+
+    // ── Новая версия ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewVersion_ResetsNoPinDocs_WhenVersionDefault_ButNotPinnedToOld()
+    {
+        var dtId = await CreateDocTypeAsync("DT_INV6");
+        var t = await CreateTemplateAsync(dtId, "Шаблон");
+        using (var s = fixture.Services.CreateScope())
+            await Mediator(s).Send(new SetTemplateDefaultCommand(t.Id));
+        var setId = await CreateSetAsync();
+        var noPin = await AddGeneratedDocAsync(setId, dtId);
+        var pinnedOld = await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t.Id);
+
+        // Новая версия наследует дефолт → default-active сместился → no-pin сброс; пиннутый на
+        // старую версию не трогаем (её содержимое не менялось).
+        using var scope = fixture.Services.CreateScope();
+        await Mediator(scope).Send(new UpdateTemplateCommand(t.Id, "content v2"));
+
+        Assert.Equal(DocumentStatus.Draft, await StatusAsync(noPin));
+        Assert.Equal(DocumentStatus.Generated, await StatusAsync(pinnedOld));
+    }
+}


### PR DESCRIPTION
## Что
Фаза 2 плана. Когда меняется содержимое шаблона (или эффективный default-active), ранее сгенерированные PDF устаревают → документы автоматически сбрасываются в `Draft`, их файлы удаляются. Пины **не** переставляются («запиннут на версию» — семантика сохранена).

## Когда документ устаревает
- **In-place правка версии** (Ctrl+S, #360): сброс документов, запиннутых на эту версию; + no-pin документы типа, если версия — дефолтная-активная.
- **Новая версия в дефолтной группе**: default-active сместился → сброс no-pin (запиннутые на старую версию — нет, её содержимое не менялось).
- **Смена шаблона по умолчанию**: no-pin документы типа резолвятся в новый default-active → сброс.

## Реализация
- `IDocumentTemplateInvalidator` (`OnTemplateContentChangedAsync` / `OnDefaultChangedAsync`): фильтр по пинам в памяти, `ResetToDraft()` → `SaveChanges` → удаление блобов **после** коммита (конвенция 6 reset-хендлеров).
- Репо-метод `GetDocumentsOfTypeAsync` (грузит фасету+файлы).
- Команды `SaveTemplateContent`/`UpdateTemplate`/`SetTemplateDefault` → `TemplateMutationResult(template, resetDocuments)`.
- **Frontend:** неблокирующий тост «N документов переведено в черновик — PDF устарел» (тиеринг Дизайнера).

## Проверка
- `dotnet build` / `tsc -b` — чисто; backend **487** (+6 тестов инвалидации: запиннутые vs no-pin × три триггера), frontend **141**.
- Живой smoke: envelope-контракт `{template, resetDocuments}` на всех трёх эндпоинтах.

## Заметка
«Показать» в тосте (переход к сброшенным документам) отложил — однозначной цели навигации нет (документы разбросаны по комплектам). Фаза 3 (правила удаления версий) — отдельным PR.

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
