### PR TITLE
feat(templates): правила удаления версий шаблона (фаза 3, #364)

### DIFF
--- a/src/client/src/features/templates/TemplateSidebar.tsx
+++ b/src/client/src/features/templates/TemplateSidebar.tsx
@@ -1,11 +1,16 @@
 import { useState, useEffect } from 'react';
-import { Plus, Trash2, Star, ChevronDown, ChevronUp, AlertTriangle, Copy } from 'lucide-react';
+import { Plus, Trash2, Star, ChevronDown, ChevronUp, AlertTriangle, Copy, Lock, FileText, ExternalLink } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { TypePickerField } from '@/shared/ui/TypePickerField';
+import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import type { PickType } from '@/shared/ui/TypePicker';
 import type { Template, DocumentType } from '@/shared/api/types';
-import { useDeleteTemplate } from '@/shared/api/templates';
+import { useDeleteTemplate, type TemplateUsage } from '@/shared/api/templates';
+import { ruCount } from '@/shared/utils/pluralize';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
+
+/** Карта использования версий (templateId → usage); пустой объект, пока не загружено. */
+export type TemplateUsageMap = Record<string, TemplateUsage>;
 // ─── Template grouping ────────────────────────────────────────────────────────
 
 export interface TemplateGroup {
@@ -28,14 +33,23 @@ export function groupTemplates(templates: Template[]): TemplateGroup[] {
 
 // ─── Version cleanup modal ────────────────────────────────────────────────────
 
-export function VersionCleanupModal({ group, onClose, onDeleted }: {
+export function VersionCleanupModal({ group, usage = {}, onClose, onDeleted }: {
   group: TemplateGroup;
+  usage?: TemplateUsageMap;
   onClose: () => void;
   onDeleted: (deletedIds: Set<string>) => void;
 }) {
   const deleteMutation = useDeleteTemplate();
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState('');
+
+  // Причина защиты версии от массового удаления (issue #364): рабочая / по умолчанию / запиннута.
+  function protectReason(t: Template, isLatest: boolean): string | null {
+    if (usage[t.id]?.count) return `🔒 используется в ${ruCount(usage[t.id].count, 'докум.', 'докум.', 'докум.')} — по одной`;
+    if (t.isDefault) return '★ по умолчанию';
+    if (isLatest) return 'рабочая версия';
+    return null;
+  }
 
   const allDefault = group.versions.length > 0 && group.versions.every(t => t.isDefault);
   const protectedIds = new Set<string>();
@@ -44,6 +58,10 @@ export function VersionCleanupModal({ group, onClose, onDeleted }: {
     for (const t of group.versions) {
       if (t.isDefault) protectedIds.add(t.id);
     }
+  }
+  // Запиннутые версии массово не удаляем — только индивидуально с предупреждением.
+  for (const t of group.versions) {
+    if (usage[t.id]?.count) protectedIds.add(t.id);
   }
 
   const [toDeleteIds, setToDeleteIds] = useState<Set<string>>(
@@ -92,7 +110,8 @@ export function VersionCleanupModal({ group, onClose, onDeleted }: {
       <div className="space-y-4">
         <p className="text-sm text-fg2">
           Шаблон <strong>«{group.name}»</strong> — {group.versions.length} версий.
-          Отметьте версии для удаления. Активные и дефолтные защищены.
+          Отметьте версии для удаления. Рабочая, по умолчанию и запиннутые документами версии защищены —
+          запиннутые удаляются по одной, с предупреждением.
         </p>
         <div className="border border-stroke rounded-lg overflow-hidden">
           {group.versions.map((t, i) => {
@@ -117,7 +136,12 @@ export function VersionCleanupModal({ group, onClose, onDeleted }: {
                   {i === 0 && !t.isActive && <span className="text-xs text-fg4 shrink-0">последняя</span>}
                   {t.comment && <span className="text-xs text-fg4 truncate" title={t.comment}>{t.comment}</span>}
                 </span>
-                {protected_ && <span className="text-xs text-fg4 shrink-0">защищена</span>}
+                {protected_ && (
+                  <span className="flex items-center gap-1 text-xs text-fg4 shrink-0">
+                    {usage[t.id]?.count ? <Lock size={11} className="text-fg3" /> : null}
+                    {protectReason(t, i === 0) ?? 'защищена'}
+                  </span>
+                )}
                 {!protected_ && checked && <span className="text-xs text-danger shrink-0">удалить</span>}
               </label>
             );
@@ -150,11 +174,12 @@ export function DocTypeSelector({ docTypes, selected, onSelect }: {
 
 // ─── Grouped sidebar ──────────────────────────────────────────────────────────
 
-export function TemplateSidebar({ groups, selectedTemplate, maxVersions, documentTypeId, onSelect, onNew, onDelete, onDeleteGroup, onDuplicate, onCleanup }: {
+export function TemplateSidebar({ groups, selectedTemplate, maxVersions, documentTypeId, usage = {}, onSelect, onNew, onDelete, onDeleteGroup, onDuplicate, onCleanup }: {
   groups: TemplateGroup[];
   selectedTemplate: Template | null;
   maxVersions: number;
   documentTypeId: string;
+  usage?: TemplateUsageMap;
   onSelect: (t: Template) => void;
   onNew: () => void;
   onDelete: (t: Template) => void;
@@ -252,33 +277,47 @@ export function TemplateSidebar({ groups, selectedTemplate, maxVersions, documen
 
               {isExpanded && (
                 <div className="border-b border-muted">
-                  {group.versions.map(t => (
+                  {group.versions.map(t => {
+                    const used = usage[t.id]?.count ?? 0;
+                    // Удалять индивидуально нельзя рабочую/дефолтную версию (защита active/default — на уровне UI).
+                    const deleteBlocked = t.isActive || t.isDefault;
+                    return (
                     <div key={t.id}
                       className={`flex items-center group/ver transition-colors pl-5
                         ${selectedTemplate?.id === t.id ? 'bg-brand-subtle' : 'hover:bg-base'}`}>
                       <button
                         onClick={() => onSelect(t)}
-                        className={`flex-1 flex items-center gap-1.5 px-2 py-1.5 text-left
+                        className={`flex-1 flex items-center gap-1.5 px-2 py-1.5 text-left min-w-0
                           ${selectedTemplate?.id === t.id ? 'text-brand-hover' : 'text-fg2'}`}
                       >
                         <span className="text-xs font-mono shrink-0 w-6">v{t.version}</span>
                         <span className="flex items-center gap-1 flex-1 min-w-0">
                           {t.isActive && <span className="text-xs text-success shrink-0">активный</span>}
                           {t.isDefault && <span className="text-xs text-yellow-600 shrink-0">по умолч.</span>}
+                          {used > 0 && (
+                            <span className="flex items-center gap-0.5 text-xs text-fg4 shrink-0" title={`Используется в ${used} докум.`}>
+                              <FileText size={10} /> {used}
+                            </span>
+                          )}
                           {t.comment && (
                             <span className="text-xs text-fg4 truncate" title={t.comment}>{t.comment}</span>
                           )}
                         </span>
                       </button>
-                      <button
-                        onClick={() => onDelete(t)}
-                        className="px-2 py-1.5 text-stroke-strong hover:text-danger opacity-0 group-hover/ver:opacity-100 transition-all shrink-0"
-                        title="Удалить версию"
-                      >
-                        <Trash2 size={12} />
-                      </button>
+                      <div className="pr-1 opacity-0 group-hover/ver:opacity-100 focus-within:opacity-100 transition-all shrink-0">
+                        <RowActionsMenu ariaLabel={`Действия версии v${t.version}`} actions={[
+                          { key: 'open', label: 'Открыть', icon: <ExternalLink size={13} />, onSelect: () => onSelect(t) },
+                          {
+                            key: 'delete', label: 'Удалить версию…', danger: true, icon: <Trash2 size={13} />,
+                            disabled: deleteBlocked,
+                            badge: used > 0 ? `${used} докум.` : undefined,
+                            onSelect: () => onDelete(t),
+                          },
+                        ]} />
+                      </div>
                     </div>
-                  ))}
+                    );
+                  })}
                   {tooMany && (
                     <div className="mx-3 mb-2 mt-1 px-2 py-1.5 bg-warning-subtle border border-warning-border rounded-md flex items-center gap-2">
                       <AlertTriangle size={11} className="text-warning shrink-0" />

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -5,9 +5,10 @@ import { useDocumentTitle } from '@/shared/ui/DocumentTitle';
 import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { ConfirmDialog, CascadeList } from '@/shared/ui/ConfirmDialog';
+import { useToast } from '@/shared/ui/Toast';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
-import { useListTemplates, useCreateTemplate, useDeleteTemplate, useDuplicateTemplate } from '@/shared/api/templates';
+import { useListTemplates, useCreateTemplate, useDeleteTemplate, useDuplicateTemplate, useTemplatesUsage } from '@/shared/api/templates';
 import type { Template, DocumentType } from '@/shared/api/types';
 import { useMaxTemplateVersions } from '@/features/settings/SettingsPage';
 import { buildBlankTypst } from './templateBlank';
@@ -78,8 +79,10 @@ export function TemplatesPage() {
 
   const { data: docTypes = [] } = useListDocumentTypes();
   const { data: templates = [], isLoading: templatesLoading } = useListTemplates(selectedTypeId || undefined);
+  const { data: usage = {} } = useTemplatesUsage(selectedTypeId || undefined);
   const deleteMutation = useDeleteTemplate();
   const duplicateMutation = useDuplicateTemplate();
+  const toast = useToast();
 
   const selectedDocType = docTypes.find(dt => dt.id === selectedTypeId) ?? null;
   const groups = groupTemplates(templates);
@@ -112,21 +115,33 @@ export function TemplatesPage() {
     setDeleteTarget(t);
   }
 
-  function confirmDelete() {
+  async function confirmDelete() {
     if (!deleteTarget) return;
-    if (selectedTemplate?.id === deleteTarget.id) setSelectedTemplate(null);
-    deleteMutation.mutate({ id: deleteTarget.id, documentTypeId: deleteTarget.documentTypeId });
+    const target = deleteTarget;
+    if (selectedTemplate?.id === target.id) setSelectedTemplate(null);
+    // Если версия запиннута — сбрасываем документы на дефолт (reassign). Иначе обычное удаление.
+    const reassign = (usage[target.id]?.count ?? 0) > 0;
+    try {
+      await deleteMutation.mutateAsync({ id: target.id, documentTypeId: target.documentTypeId, reassign });
+      if (reassign) toast.info(`${ruCount(usage[target.id].count, 'документ', 'документа', 'документов')} переведено в черновик — вернулись на шаблон по умолчанию`);
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Не удалось удалить версию');
+    }
   }
 
   function handleDeleteGroup(group: TemplateGroup) {
     setDeleteGroupTarget(group);
   }
 
-  function confirmDeleteGroup() {
+  async function confirmDeleteGroup() {
     if (!deleteGroupTarget) return;
     if (selectedTemplate?.name === deleteGroupTarget.name) setSelectedTemplate(null);
-    for (const t of deleteGroupTarget.versions) {
-      deleteMutation.mutate({ id: t.id, documentTypeId: t.documentTypeId });
+    // Удаление всего шаблона: снимаем пины у всех документов (→ дефолт) и удаляем все версии.
+    try {
+      for (const t of deleteGroupTarget.versions)
+        await deleteMutation.mutateAsync({ id: t.id, documentTypeId: t.documentTypeId, reassign: true });
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Не удалось удалить шаблон');
     }
   }
 
@@ -212,6 +227,7 @@ export function TemplatesPage() {
             selectedTemplate={selectedTemplate}
             maxVersions={maxVersions}
             documentTypeId={selectedTypeId}
+            usage={usage}
             onSelect={setSelectedTemplate}
             onNew={() => setNewModalOpen(true)}
             onDelete={handleDelete}
@@ -252,6 +268,7 @@ export function TemplatesPage() {
       {cleanupGroup && (
         <VersionCleanupModal
           group={cleanupGroup}
+          usage={usage}
           onClose={() => setCleanupGroup(null)}
           onDeleted={handleCleanupDeleted}
         />
@@ -261,6 +278,19 @@ export function TemplatesPage() {
         open={!!deleteTarget}
         onOpenChange={o => { if (!o) setDeleteTarget(null); }}
         title={`Удалить версию v${deleteTarget?.version ?? ''} шаблона «${deleteTarget?.name ?? ''}»?`}
+        description={deleteTarget && (usage[deleteTarget.id]?.count ?? 0) > 0 ? (
+          <div className="space-y-2">
+            <p>
+              Версия используется в <strong>{ruCount(usage[deleteTarget.id].count, 'документе', 'документах', 'документах')}</strong>.
+              Они вернутся на шаблон по умолчанию и станут черновиками — PDF придётся перегенерировать. Необратимо.
+            </p>
+            <CascadeList items={[
+              ...usage[deleteTarget.id].names,
+              ...(usage[deleteTarget.id].count > usage[deleteTarget.id].names.length
+                ? [`…и ещё ${usage[deleteTarget.id].count - usage[deleteTarget.id].names.length}`] : []),
+            ]} />
+          </div>
+        ) : undefined}
         confirmLabel="Удалить версию"
         onConfirm={confirmDelete}
       />

--- a/src/client/src/shared/api/templates.ts
+++ b/src/client/src/shared/api/templates.ts
@@ -31,12 +31,31 @@ export function useDuplicateTemplate() {
   });
 }
 
+/** Использование версии шаблона (issue #364): сколько документов запиннуто + примеры имён. */
+export interface TemplateUsage { count: number; names: string[] }
+
+/** Карта использования версий типа (templateId → usage). Версии без пинов отсутствуют (= 0). */
+export function useTemplatesUsage(documentTypeId: string | undefined) {
+  return useQuery({
+    queryKey: ['template-usage', documentTypeId],
+    enabled: !!documentTypeId,
+    queryFn: () =>
+      apiClient
+        .get<Record<string, TemplateUsage>>('/templates/usage', { params: { documentTypeId } })
+        .then((r) => r.data),
+  });
+}
+
 export function useDeleteTemplate() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, documentTypeId }: { id: string; documentTypeId: string }) =>
-      apiClient.delete(`/templates/${id}`).then(() => documentTypeId),
-    onSuccess: (documentTypeId) => qc.invalidateQueries({ queryKey: ['templates', documentTypeId] }),
+    // reassign=true — снять пин у документов (→ дефолт) + сброс в Draft; иначе бэк откажет (409), если версия используется.
+    mutationFn: ({ id, documentTypeId, reassign }: { id: string; documentTypeId: string; reassign?: boolean }) =>
+      apiClient.delete(`/templates/${id}`, { params: reassign ? { reassign: true } : undefined }).then(() => documentTypeId),
+    onSuccess: (documentTypeId) => {
+      qc.invalidateQueries({ queryKey: ['templates', documentTypeId] });
+      qc.invalidateQueries({ queryKey: ['template-usage', documentTypeId] });
+    },
   });
 }
 

--- a/src/server/BHS.CRG.Api/Endpoints/Templates/TemplateEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Templates/TemplateEndpoints.cs
@@ -42,10 +42,20 @@ public static class TemplateEndpoints
         admin.MapPost("/{id:guid}/duplicate", async (Guid id, DuplicateTemplateRequest? req, IMediator m)
             => Results.Ok(await m.Send(new DuplicateTemplateCommand(id, req?.Name))));
 
-        admin.MapDelete("/{id:guid}", async (Guid id, IMediator m) =>
+        // Использование версий шаблона (issue #364) — сколько документов запиннуто на каждую версию.
+        g.MapGet("/usage", async (Guid documentTypeId, IMediator m)
+            => Results.Ok(await m.Send(new GetTemplatesUsageQuery(documentTypeId))));
+
+        // Удаление версии (issue #364). reassign=true → снять пин у документов (→ дефолт) + сброс в Draft;
+        // reassign=false и версия используется → 409 (защита bulk/случайного удаления).
+        admin.MapDelete("/{id:guid}", async (Guid id, bool? reassign, IMediator m) =>
         {
-            await m.Send(new DeleteTemplateCommand(id));
-            return Results.NoContent();
+            try
+            {
+                await m.Send(new DeleteTemplateCommand(id, reassign ?? false));
+                return Results.NoContent();
+            }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
         admin.MapPut("/{id:guid}/set-default", async (Guid id, IMediator m)

--- a/src/server/BHS.CRG.Application/Templates/Commands.cs
+++ b/src/server/BHS.CRG.Application/Templates/Commands.cs
@@ -15,7 +15,20 @@ public record UpdateTemplateCommand(Guid Id, string Content, string? Comment = n
 /// <summary>Правит содержимое текущей активной версии на месте, без создания новой (issue #360, Ctrl+S).</summary>
 public record SaveTemplateContentCommand(Guid Id, string Content) : IRequest<TemplateMutationResult>;
 public record DuplicateTemplateCommand(Guid Id, string? NewName) : IRequest<Template>;
-public record DeleteTemplateCommand(Guid Id) : IRequest;
+
+/// <summary>Удаление версии шаблона (issue #364). Если на версию запиннуты документы:
+/// <paramref name="ReassignUsersToDefault"/>=false → отказ (защита bulk/случайного удаления);
+/// =true → снять пин у документов (→ резолв в дефолт) + сброс в Draft, затем удалить.</summary>
+public record DeleteTemplateCommand(Guid Id, bool ReassignUsersToDefault = false) : IRequest;
+
+/// <summary>Использование версий шаблона (issue #364): по типу документа — сколько документов
+/// запиннуто на каждую версию (для защиты в bulk-очистке и предупреждения при индивидуальном удалении).
+/// Ключ — templateId; версии без пинов в словарь не попадают (на фронте = 0).</summary>
+public record GetTemplatesUsageQuery(Guid DocumentTypeId) : IRequest<IReadOnlyDictionary<Guid, TemplateUsage>>;
+
+/// <summary>Сколько документов запиннуто на версию + примеры имён (для диалога удаления).</summary>
+public record TemplateUsage(int Count, IReadOnlyList<string> Names);
+
 public record GetActiveTemplateQuery(Guid DocumentTypeId) : IRequest<Template?>;
 public record ListTemplatesQuery(Guid DocumentTypeId) : IRequest<IReadOnlyList<Template>>;
 

--- a/src/server/BHS.CRG.Application/Templates/DocumentTemplateInvalidator.cs
+++ b/src/server/BHS.CRG.Application/Templates/DocumentTemplateInvalidator.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Domain.Objects;
 using BHS.CRG.Domain.Templates;
@@ -40,7 +39,7 @@ public class DocumentTemplateInvalidator(
         var docs = await objRepo.GetDocumentsOfTypeAsync(tpl.DocumentTypeId, ct);
         var isDefaultActive = tpl.IsDefault && tpl.IsActive;
         var affected = docs
-            .Where(o => PinsTemplate(o, templateId) || (isDefaultActive && HasNoPin(o)))
+            .Where(o => o.PinsTemplate(templateId) || (isDefaultActive && o.HasNoTemplatePin))
             .ToList();
         return await ResetAllAsync(affected, ct);
     }
@@ -48,17 +47,9 @@ public class DocumentTemplateInvalidator(
     public async Task<int> OnDefaultChangedAsync(Guid documentTypeId, CancellationToken ct = default)
     {
         var docs = await objRepo.GetDocumentsOfTypeAsync(documentTypeId, ct);
-        var affected = docs.Where(HasNoPin).ToList();
+        var affected = docs.Where(o => o.HasNoTemplatePin).ToList();
         return await ResetAllAsync(affected, ct);
     }
-
-    // Документ запиннут на версию — явным одиночным TemplateId или в наборе TemplateIds.
-    private static bool PinsTemplate(DomainObject o, Guid templateId)
-        => o.TemplateId == templateId || ParseIds(o.TemplateIds).Contains(templateId);
-
-    // Нет пина — резолвится в default-active шаблон типа.
-    private static bool HasNoPin(DomainObject o)
-        => o.TemplateId is null && ParseIds(o.TemplateIds).Count == 0;
 
     // Сброс: только не-черновики (у остальных сбрасывать нечего). SaveChanges один раз (атомарно),
     // удаление блобов — ПОСЛЕ коммита (конвенция reset-хендлеров: откат не осиротит файлы).
@@ -77,16 +68,5 @@ public class DocumentTemplateInvalidator(
         await objRepo.SaveChangesAsync(ct);
         foreach (var path in blobs) await blobStorage.DeleteAsync(path, ct);
         return count;
-    }
-
-    private static List<Guid> ParseIds(string? json)
-    {
-        if (string.IsNullOrWhiteSpace(json)) return [];
-        try
-        {
-            var arr = JsonSerializer.Deserialize<List<Guid>>(json);
-            return arr ?? [];
-        }
-        catch (JsonException) { return []; }
     }
 }

--- a/src/server/BHS.CRG.Application/Templates/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Templates/Handlers.cs
@@ -7,12 +7,15 @@ namespace BHS.CRG.Application.Templates;
 public class TemplateHandlers(
     IRepository<Template> repo,
     IRepository<TemplateAsset> templateAssetRepo,
+    IDomainObjectRepository objRepo,
+    IBlobStorage blobStorage,
     IDocumentTemplateInvalidator invalidator) :
     IRequestHandler<CreateTemplateCommand, Template>,
     IRequestHandler<UpdateTemplateCommand, TemplateMutationResult>,
     IRequestHandler<SaveTemplateContentCommand, TemplateMutationResult>,
     IRequestHandler<DuplicateTemplateCommand, Template>,
     IRequestHandler<DeleteTemplateCommand>,
+    IRequestHandler<GetTemplatesUsageQuery, IReadOnlyDictionary<Guid, TemplateUsage>>,
     IRequestHandler<GetActiveTemplateQuery, Template?>,
     IRequestHandler<ListTemplatesQuery, IReadOnlyList<Template>>,
     IRequestHandler<UpdateTemplateParametersCommand, Template>,
@@ -92,8 +95,41 @@ public class TemplateHandlers(
     public async Task Handle(DeleteTemplateCommand cmd, CancellationToken ct)
     {
         var t = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
+
+        // Документы, запиннутые на удаляемую версию, надо разрулить — иначе они осиротеют.
+        var docs = await objRepo.GetDocumentsOfTypeAsync(t.DocumentTypeId, ct);
+        var pinned = docs.Where(o => o.PinsTemplate(t.Id)).ToList();
+
+        if (pinned.Count > 0 && !cmd.ReassignUsersToDefault)
+            throw new InvalidOperationException(
+                $"Версия используется в {pinned.Count} докум. Удаление снимет привязку (документы вернутся на шаблон по умолчанию).");
+
+        // Снимаем пин (→ резолв в дефолт) + сбрасываем PDF (контекст резолва сменится). Блобы — после коммита.
+        var blobs = new List<string>();
+        foreach (var o in pinned)
+        {
+            o.UnpinTemplate(t.Id);
+            blobs.AddRange(o.ResetToDraft());
+            objRepo.Update(o);
+        }
         repo.Remove(t);
         await repo.SaveChangesAsync(ct);
+        foreach (var path in blobs) await blobStorage.DeleteAsync(path, ct);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, TemplateUsage>> Handle(GetTemplatesUsageQuery q, CancellationToken ct)
+    {
+        var docs = await objRepo.GetDocumentsOfTypeAsync(q.DocumentTypeId, ct);
+        // Проходим версии типа один раз, накапливая пины по templateId (+ примеры имён).
+        var templates = await repo.FindAsync(t => t.DocumentTypeId == q.DocumentTypeId, ct);
+        var acc = new Dictionary<Guid, (int Count, List<string> Names)>();
+        foreach (var t in templates)
+        {
+            var users = docs.Where(o => o.PinsTemplate(t.Id)).ToList();
+            if (users.Count == 0) continue;
+            acc[t.Id] = (users.Count, users.Take(5).Select(o => o.DisplayName ?? "(без имени)").ToList());
+        }
+        return acc.ToDictionary(kv => kv.Key, kv => new TemplateUsage(kv.Value.Count, kv.Value.Names));
     }
 
     public async Task<Template?> Handle(GetActiveTemplateQuery q, CancellationToken ct)

--- a/src/server/BHS.CRG.Domain/Objects/DomainObject.cs
+++ b/src/server/BHS.CRG.Domain/Objects/DomainObject.cs
@@ -120,6 +120,35 @@ public class DomainObject : Entity
     public void SetSortOrder(int order) { Doc.SortOrder = order; TouchUpdatedAt(); }
     public void SetTemplate(Guid? templateId) { Doc.TemplateId = templateId; TouchUpdatedAt(); }
     public void SetTemplateIds(string? json) { Doc.TemplateIds = json; TouchUpdatedAt(); }
+
+    // ── Пины шаблонов (issue #362/#364) — единая точка семантики «на что запиннут документ» ──
+    private List<Guid> ParsedTemplateIds()
+    {
+        if (string.IsNullOrWhiteSpace(Doc.TemplateIds)) return [];
+        try { return JsonSerializer.Deserialize<List<Guid>>(Doc.TemplateIds) ?? []; }
+        catch (JsonException) { return []; }
+    }
+
+    /// <summary>Документ запиннут на версию — явным одиночным <see cref="TemplateId"/> или в наборе <see cref="TemplateIds"/>.</summary>
+    public bool PinsTemplate(Guid templateId) => Doc.TemplateId == templateId || ParsedTemplateIds().Contains(templateId);
+
+    /// <summary>Нет пина — документ резолвится в default-active шаблон типа.</summary>
+    public bool HasNoTemplatePin => Doc.TemplateId is null && ParsedTemplateIds().Count == 0;
+
+    /// <summary>Убирает пин на версию (issue #364): из одиночного <see cref="TemplateId"/> и из набора
+    /// <see cref="TemplateIds"/> (пустой набор → null). После снятия документ резолвится в дефолт.</summary>
+    public void UnpinTemplate(Guid templateId)
+    {
+        var changed = false;
+        if (Doc.TemplateId == templateId) { Doc.TemplateId = null; changed = true; }
+        var ids = ParsedTemplateIds();
+        if (ids.Remove(templateId))
+        {
+            Doc.TemplateIds = ids.Count == 0 ? null : JsonSerializer.Serialize(ids);
+            changed = true;
+        }
+        if (changed) TouchUpdatedAt();
+    }
     public void SetTemplateParams(string? json) { Doc.TemplateParams = json; TouchUpdatedAt(); }
     public void UpdatePluginData(JsonDocument pluginData) { Doc.PluginData = pluginData; TouchUpdatedAt(); }
 

--- a/src/server/BHS.CRG.Tests/Integration/TemplateInvalidationTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/TemplateInvalidationTests.cs
@@ -79,6 +79,86 @@ public class TemplateInvalidationTests(IntegrationTestFixture fixture) : IAsyncL
         return (await repo.GetByIdAsync(instanceId))!.Status;
     }
 
+    private async Task<Guid?> PinAsync(Guid instanceId)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IDomainObjectRepository>();
+        return (await repo.GetByIdAsync(instanceId))!.TemplateId;
+    }
+
+    private async Task<bool> TemplateExistsAsync(Guid dtId, Guid templateId)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var list = await Mediator(scope).Send(new ListTemplatesQuery(dtId));
+        return list.Any(t => t.Id == templateId);
+    }
+
+    // ── Удаление версий (issue #364) ─────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteVersion_PinnedWithoutReassign_Throws_AndKeepsTemplate()
+    {
+        var dtId = await CreateDocTypeAsync("DT_DEL1");
+        var t = await CreateTemplateAsync(dtId, "Шаблон");
+        var setId = await CreateSetAsync();
+        var docId = await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t.Id);
+
+        using (var scope = fixture.Services.CreateScope())
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                Mediator(scope).Send(new DeleteTemplateCommand(t.Id, ReassignUsersToDefault: false)));
+
+        Assert.True(await TemplateExistsAsync(dtId, t.Id));           // не удалён
+        Assert.Equal(t.Id, await PinAsync(docId));                    // пин на месте
+        Assert.Equal(DocumentStatus.Generated, await StatusAsync(docId)); // PDF не тронут
+    }
+
+    [Fact]
+    public async Task DeleteVersion_PinnedWithReassign_UnpinsResetsAndDeletes()
+    {
+        var dtId = await CreateDocTypeAsync("DT_DEL2");
+        var t = await CreateTemplateAsync(dtId, "Шаблон");
+        var setId = await CreateSetAsync();
+        var docId = await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t.Id);
+
+        using (var scope = fixture.Services.CreateScope())
+            await Mediator(scope).Send(new DeleteTemplateCommand(t.Id, ReassignUsersToDefault: true));
+
+        Assert.False(await TemplateExistsAsync(dtId, t.Id));  // удалён
+        Assert.Null(await PinAsync(docId));                   // пин снят → резолв в дефолт
+        Assert.Equal(DocumentStatus.Draft, await StatusAsync(docId)); // сброшен в черновик
+    }
+
+    [Fact]
+    public async Task DeleteVersion_Unused_Deletes()
+    {
+        var dtId = await CreateDocTypeAsync("DT_DEL3");
+        var t = await CreateTemplateAsync(dtId, "Шаблон");
+
+        using (var scope = fixture.Services.CreateScope())
+            await Mediator(scope).Send(new DeleteTemplateCommand(t.Id)); // reassign по умолчанию false — ок, не используется
+
+        Assert.False(await TemplateExistsAsync(dtId, t.Id));
+    }
+
+    [Fact]
+    public async Task Usage_ReportsPinCountsPerVersion()
+    {
+        var dtId = await CreateDocTypeAsync("DT_USE");
+        var t1 = await CreateTemplateAsync(dtId, "Первый");
+        var t2 = await CreateTemplateAsync(dtId, "Второй");
+        var setId = await CreateSetAsync();
+        await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t1.Id);
+        await AddGeneratedDocAsync(setId, dtId, pinTemplateId: t1.Id);
+        await AddGeneratedDocAsync(setId, dtId); // no-pin — не должен считаться
+
+        using var scope = fixture.Services.CreateScope();
+        var usage = await Mediator(scope).Send(new GetTemplatesUsageQuery(dtId));
+
+        Assert.Equal(2, usage[t1.Id].Count);
+        Assert.Equal(2, usage[t1.Id].Names.Count);
+        Assert.False(usage.ContainsKey(t2.Id)); // без пинов — отсутствует
+    }
+
     // ── In-place правка ──────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Что
Фаза 3 (финальная) плана. Правила удаления версий шаблона + закрытие реального бага: `DeleteTemplateCommand` был голым `Remove` без guard'а — удаление запиннутой версии молча осиротляло документы.

## Правила
1. **Bulk «Очистить»** не удаляет запиннутые версии — защита в UI (disabled-строка + замок + «🔒 используется в N докум.») + guard на бэке (409).
2. **Индивидуальное удаление запиннутой версии** — жёсткий деструктивный ConfirmDialog (N + примеры имён + «вернутся на дефолт, станут черновиками, необратимо»). Документы **обнуляют пин** (→ резолв в дефолт) + сброс в Draft.

## Backend
- `DomainObject`: пин-предикаты `PinsTemplate`/`HasNoTemplatePin` + `UnpinTemplate` (обнуляет пин; пустой набор → null). Инвалидатор Ф2 переведён на них — без дублирования JSON-парса.
- `DeleteTemplateCommand(Id, ReassignUsersToDefault=false)`: used && !reassign → 409; reassign → unpin + `ResetToDraft` запиннутых → удаление; блобы после коммита.
- `GetTemplatesUsageQuery(documentTypeId) → {templateId:{count,names}}`; `GET /api/templates/usage`, `DELETE /api/templates/{id}?reassign=true`.

## Frontend
- `useTemplatesUsage`; VersionCleanupModal защищает запиннутые; kebab «⋮» на строке версии (Открыть · Удалить версию…), удаление disabled для active/default; удаление всего шаблона → reassign=true; тост-факт после переноса.

## Проверка
- backend **491** (+4: guard-409, unpin+reset, удаление неиспользуемой, счётчик usage), frontend **141**, `tsc -b` чисто.
- Живой smoke: usage `{count:1}`; DELETE без reassign → **409**; с reassign → **204**; пин документа после → **null** (вернулся на дефолт).

## Примечание
Жёсткий guard «нельзя удалять active/default» в команду НЕ вносил — сломал бы «удалить шаблон целиком»; защита active/default осталась на уровне UI (protectedIds в bulk + disabled пункт kebab). «Сделать по умолчанию» в kebab не добавлял (есть в тулбаре редактора).

Зависит от #362 (переиспользует инвалидатор) — **стекнут на его ветку**, ребейзну на master после мёрджа #363.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
