### PR TITLE
feat(schema): расчётное поле (computed field) — фаза 1 root-level (#368)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Loader2, FileText, Download, Eye, Pencil, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Circle, CircleDot, Mail, Database, X, Info, ChevronDown, ChevronRight, Stethoscope } from 'lucide-react';
+import { Loader2, FileText, Download, Eye, Pencil, Bug, ShieldCheck, AlertTriangle, AlertCircle, CheckCircle2, Circle, CircleDot, Mail, Database, X, Info, ChevronDown, ChevronRight, Stethoscope, FunctionSquare } from 'lucide-react';
 import { Markdown } from '@/shared/ui/Markdown';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
@@ -301,6 +301,7 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   function sectionStats(fields: SchemaField[]) {
     let total = 0, filled = 0, missing = 0;
     for (const f of fields) {
+      if (f.computed) continue; // расчётные поля не заполняются пользователем — вне прогресса (#368)
       total++;
       if (hasValue(values[f.key]) || sourceBoundFields.has(f.key) || baseCoveredFields.has(f.key)) filled++;
       if (isFieldMissing(f, values[f.key])) missing++;
@@ -390,6 +391,23 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       f.type === 'doc-array' || f.type === 'image' || f.type === 'file' || f.type === 'text';
 
     function renderCell(field: SchemaField) {
+          // Расчётное поле (issue #368) — не ввод: read-only fx-дисплей, значение считается при генерации.
+          if (field.computed) {
+            return (
+              <div key={field.key}>
+                <label className="mb-1 flex items-center gap-1 text-xs font-medium text-fg2">
+                  <span className="truncate">{field.title}</span>
+                  <span className="inline-flex items-center gap-0.5 text-[10px] text-brand shrink-0">
+                    <FunctionSquare size={11} /> вычисляется
+                  </span>
+                </label>
+                <div className="w-full rounded-md border border-dashed border-stroke bg-muted/30 px-3 py-1.5 text-sm text-fg4"
+                  title={field.expression}>
+                  Значение вычисляется при генерации
+                </div>
+              </div>
+            );
+          }
           const raw = values[field.key];
           const missing = showValidation && isFieldMissing(field, raw);
           const bound = sourceBoundFields.has(field.key);

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -1,5 +1,5 @@
-import { useId, useMemo, useState } from 'react';
-import { Plus, Trash2, ArrowUp, ArrowDown, Cpu, GripVertical, ChevronDown, ChevronUp, Lock, Link2 } from 'lucide-react';
+import { useId, useMemo, useRef, useState } from 'react';
+import { Plus, Trash2, ArrowUp, ArrowDown, Cpu, GripVertical, ChevronDown, ChevronUp, Lock, Link2, FunctionSquare } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -108,6 +108,8 @@ interface FieldCardProps {
   keyConflict: boolean;
   /** Поле ещё НЕ сохранено (issue #355): ключ авто-следует за именем. У сохранённого — заморожен. */
   isNew: boolean;
+  /** Соседние поля (для пикера ссылок расчётного поля, issue #368) — без самого себя. */
+  siblingFields?: { key: string; title: string; type: string }[];
   /** Смена ключа СОХРАНЁННОГО поля (issue #357) — для предложения миграции данных на сохранении схемы. */
   onKeyRename?: (from: string, to: string) => void;
   open: boolean;
@@ -126,11 +128,74 @@ interface FieldCardProps {
   onDrop?: (e: React.DragEvent) => void;
 }
 
+// Типы, у которых допустимо расчётное поле (issue #368) — скалярный результат формулы.
+const COMPUTABLE_TYPES = new Set(['string', 'text', 'number', 'date', 'boolean']);
+function SchemaFieldKinds_isComputable(type: string): boolean { return COMPUTABLE_TYPES.has(type); }
+
+/** Редактор формулы расчётного поля (issue #368): текст выражения (JS/Jint) + пикер «Вставить поле»
+ *  (вставляет get("ключ") по образцу «Вставить реквизит» в редакторе шаблона). */
+function ComputedFieldEditor({ field, siblingFields, onChange }: {
+  field: SchemaField;
+  siblingFields: { key: string; title: string; type: string }[];
+  onChange: (patch: Partial<SchemaField>) => void;
+}) {
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const [pickOpen, setPickOpen] = useState(false);
+  const refs = siblingFields.filter(f => f.key.trim());
+
+  function insertRef(key: string) {
+    const snippet = `get("${key}")`;
+    const cur = field.expression ?? '';
+    const ta = taRef.current;
+    if (!ta) { onChange({ expression: cur + snippet }); setPickOpen(false); return; }
+    const start = ta.selectionStart ?? cur.length;
+    const end = ta.selectionEnd ?? cur.length;
+    onChange({ expression: cur.slice(0, start) + snippet + cur.slice(end) });
+    setPickOpen(false);
+    requestAnimationFrame(() => { ta.focus(); const p = start + snippet.length; ta.setSelectionRange(p, p); });
+  }
+
+  return (
+    <div className="rounded-md border border-brand/30 bg-brand-subtle/40 p-2 space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] text-fg3 font-medium">Формула (JavaScript)</span>
+        <div className="relative">
+          <button type="button" onClick={() => setPickOpen(o => !o)}
+            className="text-[11px] px-2 py-0.5 rounded border border-stroke-strong text-brand hover:bg-brand/10">
+            + Вставить поле
+          </button>
+          {pickOpen && (
+            <div className="absolute right-0 top-full mt-1 z-50 w-64 max-h-56 overflow-auto bg-surface border border-stroke rounded-lg shadow-lg py-1">
+              {refs.length === 0
+                ? <p className="px-3 py-2 text-xs text-fg4">Нет других полей</p>
+                : refs.map(f => (
+                  <button key={f.key} type="button" onClick={() => insertRef(f.key)}
+                    className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-base">
+                    <code className="text-[11px] font-mono text-brand shrink-0 max-w-[45%] truncate">{f.key}</code>
+                    <span className="text-xs text-fg3 truncate flex-1">{f.title || '—'}</span>
+                    <span className="text-[10px] text-fg4 shrink-0">{f.type}</span>
+                  </button>
+                ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <textarea ref={taRef} value={field.expression ?? ''} spellCheck={false} rows={2}
+        onChange={e => onChange({ expression: e.target.value })}
+        placeholder={'get("Количество") * get("Цена")'}
+        className="w-full font-mono text-xs border border-stroke-strong rounded px-2 py-1.5 bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand resize-y" />
+      <p className="text-[11px] text-fg4">
+        Читайте поля через <code className="font-mono">get("Ключ")</code>. Значения перечислений видны как отображаемое имя.
+      </p>
+    </div>
+  );
+}
+
 /** Одно СВОЁ поле: свёрнутая шапка (drag-ручка + сводка + chip типа + chevron) → раскрытый
  *  редактор (все ветки типов/опций/тэгов). Индекс-независима — переиспользуется в плоском и
  *  группированном представлении (issue #197 Фаза C). */
 export function FieldCard({
-  field, reg, keyConflict, isNew, onKeyRename, open, onToggleOpen, onChange, onRemove,
+  field, reg, keyConflict, isNew, siblingFields, onKeyRename, open, onToggleOpen, onChange, onRemove,
   onMoveUp, onMoveDown, isFirst, isLast, dragging, onDragStart, onDragEnd, onDragOver, onDrop,
 }: FieldCardProps) {
   const { primitiveTypes, enumTypes, tagRegistry } = reg;
@@ -242,16 +307,22 @@ export function FieldCard({
           <span className="truncate text-left">{fieldTypeSummary(field, reg)}</span>
           <ChevronDown size={14} className="text-fg4 shrink-0" />
         </button>
-        {/* Required */}
-        <label className="flex items-center justify-center gap-1.5 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={field.required}
-            onChange={e => onChange({ required: e.target.checked })}
-            className="w-4 h-4 rounded border-stroke-strong text-brand"
-          />
-          <span className="text-xs text-fg3">да</span>
-        </label>
+        {/* Required (у расчётного поля неприменимо — заменяется меткой ƒ) */}
+        {field.computed ? (
+          <span className="flex items-center justify-center gap-1 text-[11px] text-brand" title="Расчётное поле — значение вычисляется формулой">
+            <FunctionSquare size={12} /> вычисл.
+          </span>
+        ) : (
+          <label className="flex items-center justify-center gap-1.5 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={field.required}
+              onChange={e => onChange({ required: e.target.checked })}
+              className="w-4 h-4 rounded border-stroke-strong text-brand"
+            />
+            <span className="text-xs text-fg3">да</span>
+          </label>
+        )}
         {/* Actions */}
         <div className="flex items-center justify-end gap-0.5">
           <button type="button" onClick={onMoveUp} disabled={isFirst}
@@ -287,8 +358,30 @@ export function FieldCard({
         confirmLabel="Изменить ключ"
         onConfirm={() => { setConfirmUnlock(false); setKeyUnlocked(true); }}
       />
+      {/* Расчётное поле (issue #368): switch «Вычисляемое» — мода, не тип. Значение считается
+          формулой при генерации; «обязательное»/«по умолчанию» скрываются. */}
+      {SchemaFieldKinds_isComputable(field.type) && (
+        <>
+          <label className="flex items-center gap-2 cursor-pointer w-fit">
+            <input
+              type="checkbox"
+              checked={!!field.computed}
+              onChange={e => onChange(e.target.checked
+                ? { computed: true, required: false, defaultValue: undefined }
+                : { computed: undefined, expression: undefined })}
+              className="w-4 h-4 rounded border-stroke-strong text-brand"
+            />
+            <span className="text-xs text-fg2 flex items-center gap-1">
+              <FunctionSquare size={13} className="text-brand" /> Вычисляемое (формула)
+            </span>
+          </label>
+          {field.computed && (
+            <ComputedFieldEditor field={field} siblingFields={siblingFields ?? []} onChange={onChange} />
+          )}
+        </>
+      )}
       {/* Default value editor */}
-      {field.type !== 'complex' && field.type !== 'array' && field.type !== 'primitive'
+      {!field.computed && field.type !== 'complex' && field.type !== 'array' && field.type !== 'primitive'
         && field.type !== 'doc-ref' && field.type !== 'doc-array' && (
         <div className="ml-[calc(33%+0.5rem)] mr-[calc(5rem)] flex items-center gap-2">
           <span className="text-xs text-fg4 shrink-0 w-28">Значение по умолч.:</span>
@@ -458,6 +551,7 @@ export function FieldBuilder({ fields, onChange, disabledKeys, persistedKeys, co
           reg={reg}
           keyConflict={!!field.key && !!disabledKeys?.has(field.key.trim())}
           isNew={!persistedKeys?.has(field.key.trim())}
+          siblingFields={fields.filter((_, idx) => idx !== i).map(f => ({ key: f.key, title: f.title, type: f.type }))}
           open={openIndex === i}
           onToggleOpen={() => setOpenIndex(o => o === i ? null : i)}
           onChange={patch => onChange(fields.map((f, idx) => idx === i ? { ...f, ...patch } : f))}

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -14,6 +14,11 @@ export interface SchemaField {
   defaultValue?: unknown;
   /** Functional tags binding this field to hard-coded behaviour (registry: GET /api/tags). */
   tags?: string[];
+  /** Расчётное поле (issue #368): значение вычисляется `expression` по другим полям при генерации,
+   *  вручную не вводится и не хранится. `type` = тип результата. */
+  computed?: boolean;
+  /** JS/Jint-выражение расчётного поля (читает соседние поля через get("ключ")). */
+  expression?: string;
 }
 
 /** Опции отображения картинки (width/height/align/fit). Задаются в значении инстанса (issue #246). */
@@ -116,6 +121,8 @@ export function parseSchemaFields(schema: Record<string, unknown>): SchemaField[
     required: f.required ?? false,
     defaultValue: f.defaultValue,
     tags: f.tags,
+    computed: f.computed,
+    expression: f.expression,
   }));
 }
 

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -199,6 +199,8 @@ builder.Services.AddScoped<IRepository<MaterialQualityLink>, Repository<Material
 builder.Services.AddScoped<BackupService>();
 
 // ── Generation ────────────────────────────────────────────────────────────────
+builder.Services.AddSingleton<BHS.CRG.Application.Generation.IExpressionEvaluator,
+    BHS.CRG.Infrastructure.Generation.JintExpressionEvaluator>();
 builder.Services.AddScoped<IEntityResolver, EntityResolver>();
 builder.Services.AddScoped<BHS.CRG.Application.Documents.ILevelProfileService, BHS.CRG.Infrastructure.Generation.LevelProfileService>();
 builder.Services.AddScoped<IMetadataExtractor, MetadataExtractor>();

--- a/src/server/BHS.CRG.Application/Generation/ComputedFieldResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/ComputedFieldResolver.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BHS.CRG.Application.Schema;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Резолвер расчётных полей (issue #368, фаза 1 — root-level). Чистая Application-логика: извлекает
+/// зависимости из выражений, топосортит (Kahn, как #309 typeblocks), вычисляет через
+/// <see cref="IExpressionEvaluator"/> в порядке зависимостей и инжектит результат в контекст.
+/// Циклы → диагностика-Error; ошибка выражения/отсутствующий sibling → null + Warning.
+/// Значения расчётных полей живут в контексте генерации, в реквизиты (Data) не пишутся.
+/// </summary>
+public static class ComputedFieldResolver
+{
+    // Ссылки на поля в выражении: get("ключ") / get('ключ').
+    private static readonly Regex GetRef = new(@"get\(\s*[""']([^""']+)[""']\s*\)", RegexOptions.Compiled);
+
+    /// <summary>Вычисляет расчётные поля верхнего уровня и инжектит их в <paramref name="ctx"/>.</summary>
+    public static void ResolveRoot(
+        GenerationContext ctx,
+        IReadOnlyList<SchemaFieldInfo> effectiveFields,
+        IExpressionEvaluator evaluator,
+        List<ResolutionDiagnostic> diagnostics)
+    {
+        var computed = effectiveFields
+            .Where(f => f.Computed && !string.IsNullOrWhiteSpace(f.Expression))
+            .ToList();
+        if (computed.Count == 0) return;
+
+        var byKey = computed.ToDictionary(f => f.Key);
+        var computedKeys = byKey.Keys.ToHashSet();
+
+        // Зависимости среди расчётных полей: ключи, на которые ссылается выражение и которые сами computed.
+        var deps = computed.ToDictionary(
+            f => f.Key,
+            f => ReferencedKeys(f.Expression!).Where(computedKeys.Contains).ToHashSet());
+
+        var (order, cyclic) = TopoSort(computed.Select(f => f.Key).ToList(), deps);
+
+        foreach (var key in cyclic)
+            diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Error, key,
+                $"Циклическая зависимость расчётного поля «{Title(byKey[key])}».", "computed-cycle"));
+
+        // Вычисляем в топологическом порядке — уже посчитанные computed видны следующим через get().
+        foreach (var key in order)
+        {
+            var f = byKey[key];
+            var vars = BuildVars(ctx);
+            try
+            {
+                ctx.Set(key, evaluator.Evaluate(f.Expression!, vars));
+            }
+            catch (Exception ex)
+            {
+                diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Warning, key,
+                    $"Ошибка расчётного поля «{Title(f)}»: {ex.Message}", "computed-error"));
+                ctx.Set(key, null);
+            }
+        }
+    }
+
+    /// <summary>Ключи полей, на которые ссылается выражение через get("…").</summary>
+    public static IReadOnlyList<string> ReferencedKeys(string expression)
+        => GetRef.Matches(expression).Select(m => m.Groups[1].Value).Distinct().ToList();
+
+    // Kahn: возвращает порядок вычисления (зависимости раньше зависимых) + ключи в циклах (не вычисляются).
+    // Стабильность: исходный порядок полей сохраняется при равных зависимостях (для детерминизма).
+    private static (List<string> Order, List<string> Cyclic) TopoSort(
+        List<string> nodes, Dictionary<string, HashSet<string>> deps)
+    {
+        var indeg = nodes.ToDictionary(n => n, n => deps[n].Count);
+        var dependents = nodes.ToDictionary(n => n, _ => new List<string>());
+        foreach (var n in nodes)
+            foreach (var d in deps[n])
+                dependents[d].Add(n);
+
+        // Очередь в исходном порядке узлов (стабильно).
+        var ready = new List<string>(nodes.Where(n => indeg[n] == 0));
+        var order = new List<string>();
+        while (ready.Count > 0)
+        {
+            var n = ready[0];
+            ready.RemoveAt(0);
+            order.Add(n);
+            foreach (var m in dependents[n])
+                if (--indeg[m] == 0)
+                    ready.Add(m);
+        }
+        var cyclic = nodes.Where(n => !order.Contains(n)).ToList();
+        return (order, cyclic);
+    }
+
+    private static Dictionary<string, object?> BuildVars(GenerationContext ctx)
+    {
+        var vars = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (k, v) in ctx.Data)
+            vars[k] = ToClr(v);
+        return vars;
+    }
+
+    // JsonElement → CLR-примитив для движка (число → double для арифметики; строка/bool как есть;
+    // объект/массив → сырой JSON-текст, формула их обычно не использует). Не-JSON значения (напр.
+    // резолвнутый enum-label — строка) отдаём как есть.
+    private static object? ToClr(object? v) => v switch
+    {
+        JsonElement el => el.ValueKind switch
+        {
+            JsonValueKind.String => el.GetString(),
+            JsonValueKind.Number => el.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            _ => el.GetRawText(),
+        },
+        _ => v,
+    };
+
+    private static string Title(SchemaFieldInfo f) => f.Title ?? f.Key;
+}

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -81,6 +81,9 @@ public class GenerateDocumentHandler(
             // Наборы данных могли добавить ссылки на каталог ($ref) в составные поля —
             // разрешаем их вторым проходом (для уже разрешённых данных идемпотентно).
             await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
+            // Расчётные поля (issue #368): вычисляем ПОСЛЕ финализации входов (enum-labels/refs),
+            // ДО проверок полноты. Цикл → Error (прервёт генерацию ниже), ошибка формулы → Warning.
+            await entityResolver.ResolveComputedFieldsAsync(context, view, diagnostics, ct);
             // Проверка разрешения ссылок перед генерацией: оставшиеся $ref — ошибки,
             // при их наличии прерываем генерацию с диагностикой.
             ResolutionScanner.ScanLeftoverRefs(context, diagnostics);

--- a/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
+++ b/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
@@ -67,6 +67,8 @@ public class GetGenerationDebugBundleHandler(
         await qualityLinkResolver.InjectAsync(context, view, ct);
         // Тот же второй проход, что и при генерации — разрешаем $ref, добавленные наборами данных.
         await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
+        // Расчётные поля (issue #368) — чтобы data.json отладочного бандла содержал их значения.
+        await entityResolver.ResolveComputedFieldsAsync(context, view, new List<ResolutionDiagnostic>(), ct);
         context.Set("params", TemplateParams.Effective(template.Parameters,
             TemplateParams.OverridesForTemplate(instance.TemplateParams, template.Id)));
 

--- a/src/server/BHS.CRG.Application/Generation/IEntityResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/IEntityResolver.cs
@@ -33,4 +33,12 @@ public interface IEntityResolver
     /// совпадения в реестре остаётся как есть. Только верхнеуровневые скалярные поля.
     /// </summary>
     Task ResolveEnumLabelsAsync(GenerationContext ctx, DocumentView instance, CancellationToken ct = default);
+
+    /// <summary>
+    /// Вычисляет расчётные поля (issue #368, фаза 1 — верхний уровень) и инжектит их значения в контекст.
+    /// Вызывать ПОСЛЕ ResolveEnumLabels/ResolveContextRefs (входы формул финальны), ДО ScanMissingRequired/
+    /// TypeStamper. Диагностики: цикл → Error, ошибка выражения → Warning (генерацию не блокирует).
+    /// </summary>
+    Task ResolveComputedFieldsAsync(GenerationContext ctx, DocumentView instance,
+        List<ResolutionDiagnostic> diagnostics, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Application/Generation/IExpressionEvaluator.cs
+++ b/src/server/BHS.CRG.Application/Generation/IExpressionEvaluator.cs
@@ -1,0 +1,14 @@
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Вычислитель выражений расчётных полей (issue #368). Абстрагирует движок (Jint) от Application:
+/// обход схемы/топосорт/диагностика (<see cref="ComputedFieldResolver"/>) тестируются без движка.
+/// Выражение читает значения полей через функцию <c>get("ключ")</c>. Реализация обязана быть
+/// песочницей (таймаут, лимит рекурсии) — недоверенный ввод админа.
+/// </summary>
+public interface IExpressionEvaluator
+{
+    /// <summary>Вычисляет <paramref name="expression"/>; <c>get(key)</c> возвращает <paramref name="variables"/>[key]
+    /// (или null). Бросает при ошибке выражения/таймауте — вызывающий переводит это в диагностику.</summary>
+    object? Evaluate(string expression, IReadOnlyDictionary<string, object?> variables);
+}

--- a/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
+++ b/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
@@ -84,6 +84,7 @@ public class PreviewDocumentHandler(
             await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
             await qualityLinkResolver.InjectAsync(context, view, ct);
             await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
+            await entityResolver.ResolveComputedFieldsAsync(context, view, diagnostics, ct); // issue #368
             ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 return PreviewDocumentResult.Fail("Не все ссылки разрешены — предпросмотр недоступен.", diagnostics);

--- a/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
+++ b/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
@@ -46,6 +46,7 @@ public static class ResolutionScanner
         foreach (var f in effectiveFields)
         {
             if (!f.Required) continue;
+            if (f.Computed) continue; // расчётные поля производные — «обязательность» к ним не применима (#368)
             ctx.Data.TryGetValue(f.Key, out var v);
             if (IsEmpty(v))
                 diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Error, f.Key,

--- a/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
@@ -32,6 +32,7 @@ public class ValidateInstanceResolutionHandler(
         await entityResolver.ApplyDefaultsAsync(context, view, ct);
         await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
         await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
+        await entityResolver.ResolveComputedFieldsAsync(context, view, diagnostics, ct); // issue #368
         ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
         // Полнота обязательных (issue #296, фаза 0b) — та же проверка, что при генерации.
         var byId = (await docTypeRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);

--- a/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
+++ b/src/server/BHS.CRG.Application/Schema/DocumentTypeSchemaReader.cs
@@ -15,8 +15,12 @@ public record EnumOptionInfo(string Code, string Label);
 /// <param name="Options">Варианты для type="enum" (issue #59) — из собственного инлайн `options`
 /// (легаси: код==имя) либо резолвлены из EnumType по `typeId`. Null — не enum-поле, либо enumTypesById
 /// не передан вызывающим кодом.</param>
+/// <param name="Computed">Расчётное поле (issue #368): значение вычисляется выражением <paramref name="Expression"/>
+/// по другим полям при генерации, вручную не вводится и не хранится. <paramref name="Type"/> = тип результата.</param>
+/// <param name="Expression">JS/Jint-выражение расчётного поля (читает соседние поля через get("ключ")). Null — не computed.</param>
 public record SchemaFieldInfo(string Key, string Type, Guid? TypeId, string? Title = null,
-    JsonElement? DefaultValue = null, IReadOnlyList<EnumOptionInfo>? Options = null, bool Required = false);
+    JsonElement? DefaultValue = null, IReadOnlyList<EnumOptionInfo>? Options = null, bool Required = false,
+    bool Computed = false, string? Expression = null);
 
 /// <summary>Скалярное ли поле (пригодное для табличного распознавания/материализации из плоских колонок).</summary>
 public static class SchemaFieldKinds
@@ -155,7 +159,11 @@ public static class DocumentTypeSchemaReader
                 // обоих представлений, без принудительной миграции).
                 IReadOnlyList<EnumOptionInfo>? options = type == "enum" ? ParseEnumOptions(f, typeId, enumTypesById) : null;
                 var required = f.TryGetProperty("required", out var rq) && rq.ValueKind == JsonValueKind.True;
-                fields.Add(new SchemaFieldInfo(key, type, typeId, title, defaultValue, options, required));
+                // Расчётное поле (issue #368): флаг computed + expression; type остаётся типом результата.
+                var computed = f.TryGetProperty("computed", out var cp) && cp.ValueKind == JsonValueKind.True;
+                var expression = f.TryGetProperty("expression", out var ep) && ep.ValueKind == JsonValueKind.String
+                    ? ep.GetString() : null;
+                fields.Add(new SchemaFieldInfo(key, type, typeId, title, defaultValue, options, required, computed, expression));
             }
 
         if (root.TryGetProperty("excludedFields", out var ex) && ex.ValueKind == JsonValueKind.Array)

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -14,7 +14,7 @@ namespace BHS.CRG.Infrastructure.Generation;
 /// C#-аналог NewElementResolverStyles.xsl: разрешает $ref-объекты в реквизитах,
 /// подмешивает данные сущностей каталога в контекст генерации.
 /// </summary>
-public class EntityResolver(AppDbContext db) : IEntityResolver
+public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEvaluator) : IEntityResolver
 {
     // Максимальная глубина рекурсивного разворачивания вложенных ссылок (защита от патологически
     // глубоких структур). Ортогональна allowInstanceRefs (защита от циклов по документам).
@@ -135,6 +135,20 @@ public class EntityResolver(AppDbContext db) : IEntityResolver
             var match = f.Options.FirstOrDefault(o => o.Code == code);
             if (match is not null) ctx.Set(f.Key, match.Label);
         }
+    }
+
+    /// <summary>
+    /// Вычисляет расчётные поля верхнего уровня (issue #368) через <see cref="ComputedFieldResolver"/>:
+    /// движок делегирован <see cref="IExpressionEvaluator"/> (Jint), обход/топосорт/диагностика — в
+    /// Application-резолвере. enumTypesById передаём, чтобы формула видела enum-siblings как label.
+    /// </summary>
+    public async Task ResolveComputedFieldsAsync(GenerationContext ctx, DocumentView instance,
+        List<ResolutionDiagnostic> diagnostics, CancellationToken ct = default)
+    {
+        var allDocTypes = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
+        var enumTypesById = await db.EnumTypes.AsNoTracking().ToDictionaryAsync(e => e.Id, ct);
+        var fields = DocumentTypeSchemaReader.EffectiveFields(instance.DocumentTypeId, allDocTypes, enumTypesById);
+        ComputedFieldResolver.ResolveRoot(ctx, fields, expressionEvaluator, diagnostics);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Generation/JintExpressionEvaluator.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/JintExpressionEvaluator.cs
@@ -1,0 +1,26 @@
+using BHS.CRG.Application.Generation;
+using Jint;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Jint-реализация <see cref="IExpressionEvaluator"/> (issue #368). Тот же песочный конфиг, что у
+/// вычисляемых колонок наборов данных (<c>DataSetComputedColumnExecutor</c>): таймаут 1с + лимит
+/// рекурсии. Значения полей доступны через <c>get("ключ")</c> — функция, а не переменные, потому что
+/// ключи полей бывают кириллическими/невалидными JS-идентификаторами.
+/// </summary>
+public class JintExpressionEvaluator : IExpressionEvaluator
+{
+    public object? Evaluate(string expression, IReadOnlyDictionary<string, object?> variables)
+    {
+        var engine = new Engine(cfg => cfg
+            .TimeoutInterval(TimeSpan.FromSeconds(1))
+            .LimitRecursion(32));
+
+        engine.SetValue("get", new Func<string, object?>(key =>
+            variables.TryGetValue(key, out var v) ? v : null));
+
+        var result = engine.Evaluate(expression);
+        return result.IsNull() || result.IsUndefined() ? null : result.ToObject();
+    }
+}

--- a/src/server/BHS.CRG.Tests/Generation/ComputedFieldResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ComputedFieldResolverTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Infrastructure.Generation;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>Расчётные поля (issue #368): топосорт зависимостей, циклы, ошибки — без движка (fake eval),
+/// плюс дымовой тест реального Jint-вычислителя.</summary>
+public class ComputedFieldResolverTests
+{
+    // Fake-вычислитель: сопоставляет строку выражения с лямбдой над переменными (Jint не задействован).
+    private sealed class FakeEvaluator(Dictionary<string, Func<IReadOnlyDictionary<string, object?>, object?>> map)
+        : IExpressionEvaluator
+    {
+        public object? Evaluate(string expression, IReadOnlyDictionary<string, object?> variables)
+            => map[expression](variables);
+    }
+
+    private static SchemaFieldInfo Computed(string key, string expr, string type = "number")
+        => new(key, type, null, Computed: true, Expression: expr);
+
+    private static double D(object? v) => Convert.ToDouble(v);
+
+    [Fact]
+    public void ResolveRoot_EvaluatesInDependencyOrder()
+    {
+        var ctx = new GenerationContext();
+        ctx.Set("x", JsonSerializer.SerializeToElement(10));
+        ctx.Set("y", JsonSerializer.SerializeToElement(5));
+
+        // withTax зависит от computed «sum» → sum обязан вычислиться первым (иначе get("sum") == null).
+        var fields = new List<SchemaFieldInfo>
+        {
+            Computed("withTax", "get(\"sum\") * 1.2"),
+            Computed("sum", "get(\"x\") + get(\"y\")"),
+        };
+        var eval = new FakeEvaluator(new()
+        {
+            ["get(\"x\") + get(\"y\")"] = v => D(v["x"]) + D(v["y"]),
+            ["get(\"sum\") * 1.2"] = v => D(v["sum"]) * 1.2,
+        });
+        var diags = new List<ResolutionDiagnostic>();
+
+        ComputedFieldResolver.ResolveRoot(ctx, fields, eval, diags);
+
+        Assert.Empty(diags);
+        Assert.Equal(15.0, D(ctx.Data["sum"]));
+        Assert.Equal(18.0, D(ctx.Data["withTax"]));
+    }
+
+    [Fact]
+    public void ResolveRoot_Cycle_EmitsErrorAndDoesNotEvaluate()
+    {
+        var ctx = new GenerationContext();
+        var fields = new List<SchemaFieldInfo>
+        {
+            Computed("a", "get(\"b\")"),
+            Computed("b", "get(\"a\")"),
+        };
+        var eval = new FakeEvaluator(new()
+        {
+            ["get(\"b\")"] = v => v["b"],
+            ["get(\"a\")"] = v => v["a"],
+        });
+        var diags = new List<ResolutionDiagnostic>();
+
+        ComputedFieldResolver.ResolveRoot(ctx, fields, eval, diags);
+
+        Assert.Equal(2, diags.Count);
+        Assert.All(diags, d => Assert.Equal("computed-cycle", d.Code));
+        Assert.All(diags, d => Assert.Equal(DiagnosticSeverity.Error, d.Severity));
+        Assert.False(ctx.Data.ContainsKey("a")); // циклические не вычисляются
+        Assert.False(ctx.Data.ContainsKey("b"));
+    }
+
+    [Fact]
+    public void ResolveRoot_EvalError_EmitsWarningAndSetsNull()
+    {
+        var ctx = new GenerationContext();
+        var fields = new List<SchemaFieldInfo> { Computed("c", "boom") };
+        var eval = new FakeEvaluator(new()
+        {
+            ["boom"] = _ => throw new InvalidOperationException("bad expr"),
+        });
+        var diags = new List<ResolutionDiagnostic>();
+
+        ComputedFieldResolver.ResolveRoot(ctx, fields, eval, diags);
+
+        var d = Assert.Single(diags);
+        Assert.Equal("computed-error", d.Code);
+        Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+        Assert.True(ctx.Data.ContainsKey("c"));
+        Assert.Null(ctx.Data["c"]);
+    }
+
+    [Theory]
+    [InlineData("get(\"a\") + get('b') + get(\"a\")", "a,b")]
+    [InlineData("1 + 2", "")]
+    public void ReferencedKeys_ExtractsDistinctGetTargets(string expr, string expectedCsv)
+    {
+        var keys = ComputedFieldResolver.ReferencedKeys(expr);
+        Assert.Equal(expectedCsv, string.Join(",", keys));
+    }
+
+    // ── Реальный Jint-вычислитель ────────────────────────────────────────────
+
+    [Fact]
+    public void Jint_Evaluates_Arithmetic_And_Get()
+    {
+        var eval = new JintExpressionEvaluator();
+        var vars = new Dictionary<string, object?> { ["a"] = 2.0, ["b"] = 3.0 };
+        Assert.Equal(5.0, Convert.ToDouble(eval.Evaluate("get('a') + get('b')", vars)));
+        Assert.Equal("2шт", eval.Evaluate("get('a') + 'шт'", vars)); // JS: 2 + строка = конкатенация
+        Assert.Null(eval.Evaluate("get('missing')", vars));          // нет переменной → null
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -69,6 +69,40 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
 
     private static JsonElement E(GenerationContext ctx, string key) => (JsonElement)ctx.Data[key]!;
 
+    // ── Расчётные поля (issue #368) ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Computed_RootField_EvaluatedIntoContext()
+    {
+        var setId = await SetupSetAsync();
+        var schema = JsonSerializer.SerializeToDocument(new
+        {
+            fields = new object[]
+            {
+                new { key = "Кол", type = "number" },
+                new { key = "Цена", type = "number" },
+                new { key = "Итого", type = "number", computed = true, expression = "get(\"Кол\") * get(\"Цена\")" },
+            },
+        });
+        Guid typeId;
+        using (var scope = fixture.Services.CreateScope())
+            typeId = (await M(scope).Send(new CreateDocumentTypeCommand(
+                "DOC_CALC", "DOC_CALC", DocumentTypeKind.Document, null, schema))).Id;
+
+        var docId = await DocAsync(setId, typeId, "{'Кол':3,'Цена':100}");
+
+        using var s = fixture.Services.CreateScope();
+        var inst = await M(s).Send(new GetDocumentInstanceQuery(docId));
+        var resolver = s.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var view = DocumentView.From(inst!);
+        var ctx = await resolver.ResolveAsync(view);
+        var diags = new List<ResolutionDiagnostic>();
+        await resolver.ResolveComputedFieldsAsync(ctx, view, diags);
+
+        Assert.Empty(diags);
+        Assert.Equal(300.0, Convert.ToDouble(ctx.Data["Итого"]));
+    }
+
     // ── Регрессия: поведение, которое должно сохраниться ─────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Что
**Расчётное поле (computed field)** — фаза 1 (root-level). Поле с флагом `computed` вычисляется выражением (JS/Jint) по другим полям при генерации; вручную не вводится и не хранится. `type` = тип результата. Согласовано с Архитектором и Дизайнером.

## Backend
- `SchemaFieldInfo` += `Computed` + `Expression` (парсинг схемы; `computed`-флаг, НЕ магический `type:"computed"`).
- `IExpressionEvaluator` (Application) + `JintExpressionEvaluator` (Infrastructure): песочница как у вычисляемых колонок наборов данных (timeout 1с, LimitRecursion 32); `get("ключ")` читает поля (функция, а не переменные — ключи бывают кириллическими).
- `ComputedFieldResolver` (Application, тестируется без Jint): извлечение `get("…")`, топосорт (Kahn, как #309), цикл → диагностика-Error, ошибка формулы/нет sibling → null + Warning.
- `IEntityResolver.ResolveComputedFieldsAsync` — новый resolve-step в 4 местах пайплайна (Generate/Preview/Validate/DebugBundle), ПОСЛЕ enum-labels/refs, ДО ScanMissingRequired/TypeStamper. Required-скан исключает computed. Enum-siblings видны формуле как резолвнутый label (MVP).
- Значение — в контексте генерации, в реквизиты не пишется; сырьё, форматирует шаблон (#60).

## Frontend
- `FieldBuilder`: switch «Вычисляемое» (мода, не тип), редактор формулы (mono textarea) + «Вставить поле» (пикер соседних ключей → `get("ключ")`); при computed скрываются «обязательное»/«по умолчанию», Required-ячейка → метка «ƒ вычисл.».
- Редактор документа: read-only fx-дисплей «вычисляется» (в порядке схемы); расчётные поля вне прогресса секций.

## Проверка
- `dotnet build` / `tsc -b` чисто; backend **498** (+7: топосорт/цикл/ошибка/ссылки на fake-eval, Jint-дым, e2e `Итого=300`), frontend **141**.
- Живой smoke: схема с computed-полем round-trip через реальный API (`computed:true`+`expression` персистятся и возвращаются).

## Дальше
- Ф2 — рекурсия во вложенные составные (per-object скоуп+топосорт) — целевой объём для составных типов.
- Ф3 — проактивная валидация выражения при сохранении схемы (#311-стиль); клиентский live-предпросмотр значения.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
