### PR TITLE
feat(schema): расчётное поле — фаза 2 (вложенные составные) (#370)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/ComputedFieldResolver.cs
+++ b/src/server/BHS.CRG.Application/Generation/ComputedFieldResolver.cs
@@ -1,37 +1,116 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Application.Generation;
 
 /// <summary>
-/// Резолвер расчётных полей (issue #368, фаза 1 — root-level). Чистая Application-логика: извлекает
-/// зависимости из выражений, топосортит (Kahn, как #309 typeblocks), вычисляет через
-/// <see cref="IExpressionEvaluator"/> в порядке зависимостей и инжектит результат в контекст.
-/// Циклы → диагностика-Error; ошибка выражения/отсутствующий sibling → null + Warning.
-/// Значения расчётных полей живут в контексте генерации, в реквизиты (Data) не пишутся.
+/// Резолвер расчётных полей (issue #368). Фаза 1 — верхний уровень (<see cref="ResolveRoot"/>); фаза 2
+/// (#370) — рекурсивный обход дерева контекста (<see cref="ResolveTree"/>) по образцу
+/// <see cref="TypeStamper"/>: расчётные поля вычисляются в КАЖДОМ объекте (inline complex, элементы
+/// array/doc-array, вложенные) в его собственном скоупе (siblings объекта). Тип объекта = сырой
+/// <c>_typeId</c> (факт. тип ссылки) ⟶ объявленный тип поля. Скоуп строго локальный — межобъектных
+/// ссылок/циклов нет, топосорт per-object (Kahn, как #309). Цикл → Error, ошибка/нет sibling → null+Warning.
+/// Значения живут в контексте, в реквизиты не пишутся; <c>_typeId</c> сохраняется для TypeStamper.
 /// </summary>
 public static class ComputedFieldResolver
 {
     // Ссылки на поля в выражении: get("ключ") / get('ключ').
     private static readonly Regex GetRef = new(@"get\(\s*[""']([^""']+)[""']\s*\)", RegexOptions.Compiled);
 
-    /// <summary>Вычисляет расчётные поля верхнего уровня и инжектит их в <paramref name="ctx"/>.</summary>
+    /// <summary>
+    /// Фаза 2 (#370): вычисляет расчётные поля по всему дереву — верхний уровень + вложенные составные.
+    /// </summary>
+    public static void ResolveTree(
+        GenerationContext ctx, Guid documentTypeId,
+        IReadOnlyDictionary<Guid, DocumentType> byId,
+        IExpressionEvaluator evaluator, List<ResolutionDiagnostic> diagnostics)
+    {
+        var fields = DocumentTypeSchemaReader.EffectiveFields(documentTypeId, byId).ToDictionary(f => f.Key);
+
+        // 1) Верхний уровень (ctx.Data).
+        ResolveRoot(ctx, fields.Values.ToList(), evaluator, diagnostics);
+
+        // 2) Рекурсия в составные подполя (значения — JsonElement; расчётные корня уже стали CLR и не объекты).
+        foreach (var key in ctx.Data.Keys.ToList())
+        {
+            if (ctx.Data[key] is not JsonElement je) continue;
+            var childType = CompositeTypeOf(key, fields);
+            ctx.Set(key, ProcessObject(je, childType, byId, evaluator, diagnostics, key));
+        }
+    }
+
+    /// <summary>Фаза 1: расчётные поля верхнего уровня; результат инжектится в <paramref name="ctx"/>.</summary>
     public static void ResolveRoot(
-        GenerationContext ctx,
-        IReadOnlyList<SchemaFieldInfo> effectiveFields,
-        IExpressionEvaluator evaluator,
-        List<ResolutionDiagnostic> diagnostics)
+        GenerationContext ctx, IReadOnlyList<SchemaFieldInfo> effectiveFields,
+        IExpressionEvaluator evaluator, List<ResolutionDiagnostic> diagnostics)
     {
         var computed = effectiveFields
             .Where(f => f.Computed && !string.IsNullOrWhiteSpace(f.Expression))
             .ToList();
         if (computed.Count == 0) return;
 
+        var scope = BuildVars(ctx);
+        var evaluated = RunComputedInScope(computed, scope, evaluator, diagnostics, path: "");
+        foreach (var key in evaluated)
+            ctx.Set(key, scope.GetValueOrDefault(key));
+    }
+
+    // Рекурсивная пересборка значения с вычислением computed на каждом уровне-объекте (по образцу TypeStamper.Process).
+    private static JsonElement ProcessObject(
+        JsonElement v, Guid? declaredTypeId,
+        IReadOnlyDictionary<Guid, DocumentType> byId,
+        IExpressionEvaluator evaluator, List<ResolutionDiagnostic> diagnostics, string path)
+    {
+        if (v.ValueKind == JsonValueKind.Array)
+            return JsonSerializer.SerializeToElement(
+                v.EnumerateArray().Select((it, i) => ProcessObject(it, declaredTypeId, byId, evaluator, diagnostics, $"{path}[{i}]")).ToList());
+        if (v.ValueKind != JsonValueKind.Object) return v;
+
+        Guid? actualFromRef = null;
+        foreach (var p in v.EnumerateObject())
+        {
+            if (p.Name == "$ref") return v; // неразрешённая ссылка — не данные
+            if (p.Name == TypeStamper.TypeIdKey && Guid.TryParse(p.Value.GetString(), out var tid)) actualFromRef = tid;
+        }
+
+        var typeId = actualFromRef ?? declaredTypeId;
+        var fields = typeId is { } t
+            ? DocumentTypeSchemaReader.EffectiveFields(t, byId).ToDictionary(f => f.Key)
+            : null;
+
+        // Пересобираем объект, рекурсируя в подполя (все ключи сохраняем, включая _typeId для TypeStamper).
+        var dict = new Dictionary<string, JsonElement>();
+        foreach (var p in v.EnumerateObject())
+        {
+            var childDeclared = fields is not null ? CompositeTypeOf(p.Name, fields) : null;
+            dict[p.Name] = ProcessObject(p.Value, childDeclared, byId, evaluator, diagnostics, $"{path}.{p.Name}");
+        }
+
+        // Вычисляем computed-поля ЭТОГО типа против siblings объекта.
+        if (fields is not null)
+        {
+            var computed = fields.Values.Where(f => f.Computed && !string.IsNullOrWhiteSpace(f.Expression)).ToList();
+            if (computed.Count > 0)
+            {
+                var scope = dict.ToDictionary(kv => kv.Key, kv => ToClr(kv.Value), StringComparer.OrdinalIgnoreCase);
+                var evaluated = RunComputedInScope(computed, scope, evaluator, diagnostics, path);
+                foreach (var key in evaluated)
+                    dict[key] = JsonSerializer.SerializeToElement(scope.GetValueOrDefault(key));
+            }
+        }
+        return JsonSerializer.SerializeToElement(dict);
+    }
+
+    // Топосорт + вычисление computed-полей одного объекта; результаты пишутся в scope (для зависимых
+    // computed). Возвращает вычисленные ключи (в порядке; циклические исключены — их не пишем в вывод).
+    private static List<string> RunComputedInScope(
+        List<SchemaFieldInfo> computed, Dictionary<string, object?> scope,
+        IExpressionEvaluator evaluator, List<ResolutionDiagnostic> diagnostics, string path)
+    {
         var byKey = computed.ToDictionary(f => f.Key);
         var computedKeys = byKey.Keys.ToHashSet();
-
-        // Зависимости среди расчётных полей: ключи, на которые ссылается выражение и которые сами computed.
         var deps = computed.ToDictionary(
             f => f.Key,
             f => ReferencedKeys(f.Expression!).Where(computedKeys.Contains).ToHashSet());
@@ -39,33 +118,37 @@ public static class ComputedFieldResolver
         var (order, cyclic) = TopoSort(computed.Select(f => f.Key).ToList(), deps);
 
         foreach (var key in cyclic)
-            diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Error, key,
+            diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Error, PathOf(path, key),
                 $"Циклическая зависимость расчётного поля «{Title(byKey[key])}».", "computed-cycle"));
 
-        // Вычисляем в топологическом порядке — уже посчитанные computed видны следующим через get().
         foreach (var key in order)
         {
             var f = byKey[key];
-            var vars = BuildVars(ctx);
             try
             {
-                ctx.Set(key, evaluator.Evaluate(f.Expression!, vars));
+                scope[key] = evaluator.Evaluate(f.Expression!, scope);
             }
             catch (Exception ex)
             {
-                diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Warning, key,
+                diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Warning, PathOf(path, key),
                     $"Ошибка расчётного поля «{Title(f)}»: {ex.Message}", "computed-error"));
-                ctx.Set(key, null);
+                scope[key] = null;
             }
         }
+        return order; // только вычисленные (не циклические) — их пишем в вывод
     }
+
+    /// <summary>Объявленный composite-тип поля (complex/doc-ref/array/doc-array), иначе null.</summary>
+    private static Guid? CompositeTypeOf(string key, IReadOnlyDictionary<string, SchemaFieldInfo> fields)
+        => fields.TryGetValue(key, out var f) && f.TypeId is { } tid
+           && (DocumentTypeSchemaReader.IsSingleComposite(f.Type) || DocumentTypeSchemaReader.IsMultiValued(f.Type))
+            ? tid : null;
 
     /// <summary>Ключи полей, на которые ссылается выражение через get("…").</summary>
     public static IReadOnlyList<string> ReferencedKeys(string expression)
         => GetRef.Matches(expression).Select(m => m.Groups[1].Value).Distinct().ToList();
 
-    // Kahn: возвращает порядок вычисления (зависимости раньше зависимых) + ключи в циклах (не вычисляются).
-    // Стабильность: исходный порядок полей сохраняется при равных зависимостях (для детерминизма).
+    // Kahn: порядок вычисления (зависимости раньше зависимых) + ключи в циклах (не вычисляются). Стабильно.
     private static (List<string> Order, List<string> Cyclic) TopoSort(
         List<string> nodes, Dictionary<string, HashSet<string>> deps)
     {
@@ -75,7 +158,6 @@ public static class ComputedFieldResolver
             foreach (var d in deps[n])
                 dependents[d].Add(n);
 
-        // Очередь в исходном порядке узлов (стабильно).
         var ready = new List<string>(nodes.Where(n => indeg[n] == 0));
         var order = new List<string>();
         while (ready.Count > 0)
@@ -99,9 +181,8 @@ public static class ComputedFieldResolver
         return vars;
     }
 
-    // JsonElement → CLR-примитив для движка (число → double для арифметики; строка/bool как есть;
-    // объект/массив → сырой JSON-текст, формула их обычно не использует). Не-JSON значения (напр.
-    // резолвнутый enum-label — строка) отдаём как есть.
+    // JsonElement → CLR-примитив для движка (число → double; строка/bool как есть; объект/массив → сырой
+    // JSON-текст). Не-JSON значения (напр. резолвнутый enum-label — строка) отдаём как есть.
     private static object? ToClr(object? v) => v switch
     {
         JsonElement el => el.ValueKind switch
@@ -116,5 +197,6 @@ public static class ComputedFieldResolver
         _ => v,
     };
 
+    private static string PathOf(string path, string key) => string.IsNullOrEmpty(path) ? key : $"{path}.{key}";
     private static string Title(SchemaFieldInfo f) => f.Title ?? f.Key;
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -145,10 +145,9 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     public async Task ResolveComputedFieldsAsync(GenerationContext ctx, DocumentView instance,
         List<ResolutionDiagnostic> diagnostics, CancellationToken ct = default)
     {
+        // Фаза 2 (#370): весь тип-граф — верхний уровень + вложенные составные, каждый в своём скоупе.
         var allDocTypes = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
-        var enumTypesById = await db.EnumTypes.AsNoTracking().ToDictionaryAsync(e => e.Id, ct);
-        var fields = DocumentTypeSchemaReader.EffectiveFields(instance.DocumentTypeId, allDocTypes, enumTypesById);
-        ComputedFieldResolver.ResolveRoot(ctx, fields, expressionEvaluator, diagnostics);
+        ComputedFieldResolver.ResolveTree(ctx, instance.DocumentTypeId, allDocTypes, expressionEvaluator, diagnostics);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -103,6 +103,50 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Assert.Equal(300.0, Convert.ToDouble(ctx.Data["Итого"]));
     }
 
+    [Fact]
+    public async Task Computed_NestedComposite_EvaluatedInOwnScope()
+    {
+        var setId = await SetupSetAsync();
+        // Составной тип «Строка сметы» с расчётным полем Сумма = Кол * Цена (в СВОЁМ скоупе).
+        var rowSchema = JsonSerializer.SerializeToDocument(new
+        {
+            fields = new object[]
+            {
+                new { key = "Кол", type = "number" },
+                new { key = "Цена", type = "number" },
+                new { key = "Сумма", type = "number", computed = true, expression = "get(\"Кол\") * get(\"Цена\")" },
+            },
+        });
+        Guid rowTypeId;
+        using (var scope = fixture.Services.CreateScope())
+            rowTypeId = (await M(scope).Send(new CreateDocumentTypeCommand(
+                "СтрокаСметы", "СтрокаСметы", DocumentTypeKind.Composite, null, rowSchema))).Id;
+
+        // Тип документа с complex-полем «Строка» этого составного типа.
+        var docSchema = JsonSerializer.SerializeToDocument(new
+        {
+            fields = new object[] { new { key = "Строка", type = "complex", typeId = rowTypeId.ToString() } },
+        });
+        Guid docTypeId;
+        using (var scope = fixture.Services.CreateScope())
+            docTypeId = (await M(scope).Send(new CreateDocumentTypeCommand(
+                "СмётаДок", "СмётаДок", DocumentTypeKind.Document, null, docSchema))).Id;
+
+        var docId = await DocAsync(setId, docTypeId, "{'Строка':{'Кол':4,'Цена':25}}");
+
+        using var s = fixture.Services.CreateScope();
+        var inst = await M(s).Send(new GetDocumentInstanceQuery(docId));
+        var resolver = s.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var view = DocumentView.From(inst!);
+        var ctx = await resolver.ResolveAsync(view);
+        var diags = new List<ResolutionDiagnostic>();
+        await resolver.ResolveComputedFieldsAsync(ctx, view, diags);
+
+        Assert.Empty(diags);
+        var row = E(ctx, "Строка");
+        Assert.Equal(100.0, row.GetProperty("Сумма").GetDouble()); // 4 * 25 вычислено во вложенном объекте
+    }
+
     // ── Регрессия: поведение, которое должно сохраниться ─────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Что
Фаза 2 расчётного поля (#368). Ф1 вычисляла computed только на верхнем уровне; полноценная поддержка составных типов требует рекурсии — расчётное поле, объявленное ВНУТРИ составного типа, теперь вычисляется в КАЖДОМ экземпляре этого объекта (inline complex, элементы array/doc-array, вложенные), каждый в своём скоупе.

## Реализация
- `ComputedFieldResolver.ResolveTree` — схема-осведомлённый рекурсивный обход дерева контекста (по образцу `TypeStamper`): верхний уровень (`ResolveRoot`) + `ProcessObject` рекурсия в составные подполя (пересборка JsonElement).
- Тип объекта = сырой `_typeId` (факт. тип ссылки от резолвера) ?? объявленный тип поля; `_typeId` сохраняется для последующего `TypeStamper`.
- Скоуп строго локальный (siblings объекта) → топосорт per-object, межобъектных циклов нет.
- `RunComputedInScope` — общее ядро (root + вложенные), возвращает вычисленные (не циклические) ключи — только их пишем в вывод.
- `EntityResolver.ResolveComputedFieldsAsync` → `ResolveTree` (byId, без enumTypes — как TypeStamper).

Фронт Ф1 (switch «Вычисляемое» / формула / read-only) уже позволяет объявлять computed в составных типах — доп. UI не требуется.

## Проверка
- `dotnet build` чисто; backend **499** (+1 e2e: вложенный complex «Строка сметы», `Сумма = Кол*Цена = 100` вычислено в своём скоупе). Unit-тесты `ResolveRoot` (топосорт/цикл/ошибка) без изменений.

## Дальше
Ф3 — проактивная валидация выражения при сохранении схемы (#311-стиль) + клиентский live-предпросмотр значения.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
