### PR TITLE
feat(schema): расчётное поле — фаза 3 (валидация + live-предпросмотр + typeahead) (#372)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -30,6 +30,7 @@ import {
   SCOPE_TIER, ancestorTypeIds, parseBaseRef, BaseInstanceChip, BaseCandidatePicker, type BaseCandidate,
 } from '../fields';
 import { ruCount } from '@/shared/utils/pluralize';
+import { evalComputed, referencedKeys } from '@/shared/utils/computedExpression';
 import { DataSetsTab } from './DataSetsTab';
 import { DocumentPreviewPanel } from './DocumentPreviewPanel';
 import { InstanceAuditModal } from './InstanceAuditModal';
@@ -391,8 +392,14 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
       f.type === 'doc-array' || f.type === 'image' || f.type === 'file' || f.type === 'text';
 
     function renderCell(field: SchemaField) {
-          // Расчётное поле (issue #368) — не ввод: read-only fx-дисплей, значение считается при генерации.
+          // Расчётное поле (issue #368) — не ввод: read-only fx-дисплей с клиентским live-предпросмотром
+          // (авторитет — бэкенд при генерации). До заполнения зависимостей подсказываем, чего не хватает.
           if (field.computed) {
+            const preview = evalComputed(field.expression ?? '', values);
+            const missingInputs = referencedKeys(field.expression ?? '')
+              .filter(k => !hasValue(values[k]))
+              .map(k => schemaFields.find(sf => sf.key === k)?.title ?? k);
+            const empty = preview.value == null || preview.value === '';
             return (
               <div key={field.key}>
                 <label className="mb-1 flex items-center gap-1 text-xs font-medium text-fg2">
@@ -401,9 +408,13 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
                     <FunctionSquare size={11} /> вычисляется
                   </span>
                 </label>
-                <div className="w-full rounded-md border border-dashed border-stroke bg-muted/30 px-3 py-1.5 text-sm text-fg4"
+                <div className="w-full rounded-md border border-dashed border-stroke bg-muted/30 px-3 py-1.5 text-sm"
                   title={field.expression}>
-                  Значение вычисляется при генерации
+                  {preview.error
+                    ? <span className="text-danger">Ошибка формулы</span>
+                    : empty && missingInputs.length > 0
+                      ? <span className="text-fg4">— · заполните {missingInputs.join(', ')}</span>
+                      : <span className="text-fg1">{String(preview.value ?? '—')}</span>}
                 </div>
               </div>
             );

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -154,7 +154,8 @@ export function ArrayTableModal({
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
 
-  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
+  // Расчётные подполя (issue #368) не редактируются вручную — считаются при генерации; в редакторе скрыты.
+  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
   const tableFields = subFields.filter(f => TABLE_SHOWN_TYPES.has(f.type));
   const hiddenFields = subFields.filter(f => !TABLE_SHOWN_TYPES.has(f.type));
 
@@ -427,7 +428,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
   const allItems = Array.isArray(value) ? value as unknown[] : [];
   const inlineItems = allItems.filter(item => !isFieldRef(item)) as Record<string, unknown>[];
-  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
+  // Расчётные подполя (issue #368) не редактируются вручную — считаются при генерации; в редакторе скрыты.
+  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
   // Строка массива union-типа (issue #320): редактируется переключателем варианта, а не стопкой всех
   // полей — иначе диалог строки показывал оба поля union (баг). Тип union = тэг type.union на схеме.
   const isUnionComposite = !!compositeType
@@ -759,7 +761,8 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
 
   const subValues = (value != null && typeof value === 'object' && !isFieldRef(value)
     ? value : {}) as Record<string, unknown>;
-  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
+  // Расчётные подполя (issue #368) не редактируются вручную — считаются при генерации; в редакторе скрыты.
+  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
   const isEmpty = subFields.every(f => { const v = subValues[f.key]; return v == null || v === ''; });
 
   function setSubValue(key: string, val: unknown) {
@@ -942,7 +945,8 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
-  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes) : [];
+  // Расчётные подполя (issue #368) не редактируются вручную — считаются при генерации; в редакторе скрыты.
+  const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
   const subValues = (value != null && typeof value === 'object' && !isFieldRef(value) ? value : {}) as Record<string, unknown>;
 
   const presentKey = subFields.find(sf => isVariantFilled(subValues[sf.key]))?.key;

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -8,6 +8,7 @@ import type { DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/t
 import type { SchemaField, FieldGroup } from '@/shared/api/schema';
 import { TYPE_LABELS, toCamelKey, nextAutoKey } from './schemaConstants';
 import { useTagRegistry, fieldTags, type TagDefinition } from '@/shared/api/tags';
+import { evalComputed, validateComputed, findComputedCycles, referencedKeys } from '@/shared/utils/computedExpression';
 // ─── JSON preview ──────────────────────────────────────────────────────────────
 
 export function JsonPreview({
@@ -108,8 +109,8 @@ interface FieldCardProps {
   keyConflict: boolean;
   /** Поле ещё НЕ сохранено (issue #355): ключ авто-следует за именем. У сохранённого — заморожен. */
   isNew: boolean;
-  /** Соседние поля (для пикера ссылок расчётного поля, issue #368) — без самого себя. */
-  siblingFields?: { key: string; title: string; type: string }[];
+  /** Соседние поля (для пикера ссылок + детекции циклов расчётного поля, issue #368) — без самого себя. */
+  siblingFields?: { key: string; title: string; type: string; computed?: boolean; expression?: string }[];
   /** Смена ключа СОХРАНЁННОГО поля (issue #357) — для предложения миграции данных на сохранении схемы. */
   onKeyRename?: (from: string, to: string) => void;
   open: boolean;
@@ -132,16 +133,32 @@ interface FieldCardProps {
 const COMPUTABLE_TYPES = new Set(['string', 'text', 'number', 'date', 'boolean']);
 function SchemaFieldKinds_isComputable(type: string): boolean { return COMPUTABLE_TYPES.has(type); }
 
-/** Редактор формулы расчётного поля (issue #368): текст выражения (JS/Jint) + пикер «Вставить поле»
- *  (вставляет get("ключ") по образцу «Вставить реквизит» в редакторе шаблона). */
+/** Редактор формулы расчётного поля (issue #368): текст выражения (JS) + пикер-typeahead «Вставить поле»,
+ *  инлайн-валидация (синтаксис/неизвестное поле/цикл, #309/#311) и «Проверить на образце». */
 function ComputedFieldEditor({ field, siblingFields, onChange }: {
   field: SchemaField;
-  siblingFields: { key: string; title: string; type: string }[];
+  siblingFields: { key: string; title: string; type: string; computed?: boolean; expression?: string }[];
   onChange: (patch: Partial<SchemaField>) => void;
 }) {
   const taRef = useRef<HTMLTextAreaElement>(null);
   const [pickOpen, setPickOpen] = useState(false);
+  const [pickFilter, setPickFilter] = useState('');
+  const [testOpen, setTestOpen] = useState(false);
+  const [sample, setSample] = useState<Record<string, string>>({});
+  const expr = field.expression ?? '';
   const refs = siblingFields.filter(f => f.key.trim());
+
+  // Инлайн-валидация: синтаксис + ссылки на несуществующие поля + цикл зависимостей.
+  const knownKeys = useMemo(() => new Set([field.key, ...refs.map(f => f.key)]), [field.key, refs]);
+  const { syntaxError, unknownRefs } = validateComputed(expr, knownKeys);
+  const inCycle = useMemo(() => {
+    const map: Record<string, string> = { [field.key]: expr };
+    for (const f of refs) if (f.computed && f.expression) map[f.key] = f.expression;
+    return findComputedCycles(map).has(field.key);
+  }, [field.key, expr, refs]);
+
+  const filtered = refs.filter(f =>
+    !pickFilter || `${f.key} ${f.title}`.toLowerCase().includes(pickFilter.toLowerCase()));
 
   function insertRef(key: string) {
     const snippet = `get("${key}")`;
@@ -151,39 +168,94 @@ function ComputedFieldEditor({ field, siblingFields, onChange }: {
     const start = ta.selectionStart ?? cur.length;
     const end = ta.selectionEnd ?? cur.length;
     onChange({ expression: cur.slice(0, start) + snippet + cur.slice(end) });
-    setPickOpen(false);
+    setPickOpen(false); setPickFilter('');
     requestAnimationFrame(() => { ta.focus(); const p = start + snippet.length; ta.setSelectionRange(p, p); });
   }
+
+  // «Проверить на образце»: образцовые значения ссылок → результат/ошибка (число если парсится).
+  const testRefs = referencedKeys(expr);
+  const testResult = useMemo(() => {
+    if (!testOpen) return null;
+    const values: Record<string, unknown> = {};
+    for (const k of testRefs) {
+      const raw = sample[k] ?? '';
+      values[k] = raw !== '' && !Number.isNaN(Number(raw)) ? Number(raw) : raw;
+    }
+    return evalComputed(expr, values);
+  }, [testOpen, sample, expr, testRefs]);
 
   return (
     <div className="rounded-md border border-brand/30 bg-brand-subtle/40 p-2 space-y-1.5">
       <div className="flex items-center justify-between gap-2">
         <span className="text-[11px] text-fg3 font-medium">Формула (JavaScript)</span>
-        <div className="relative">
-          <button type="button" onClick={() => setPickOpen(o => !o)}
-            className="text-[11px] px-2 py-0.5 rounded border border-stroke-strong text-brand hover:bg-brand/10">
-            + Вставить поле
+        <div className="flex items-center gap-1.5">
+          <button type="button" onClick={() => setTestOpen(o => !o)}
+            className="text-[11px] px-2 py-0.5 rounded border border-stroke-strong text-fg3 hover:bg-muted">
+            Проверить на образце
           </button>
-          {pickOpen && (
-            <div className="absolute right-0 top-full mt-1 z-50 w-64 max-h-56 overflow-auto bg-surface border border-stroke rounded-lg shadow-lg py-1">
-              {refs.length === 0
-                ? <p className="px-3 py-2 text-xs text-fg4">Нет других полей</p>
-                : refs.map(f => (
-                  <button key={f.key} type="button" onClick={() => insertRef(f.key)}
-                    className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-base">
-                    <code className="text-[11px] font-mono text-brand shrink-0 max-w-[45%] truncate">{f.key}</code>
-                    <span className="text-xs text-fg3 truncate flex-1">{f.title || '—'}</span>
-                    <span className="text-[10px] text-fg4 shrink-0">{f.type}</span>
-                  </button>
-                ))}
-            </div>
-          )}
+          <div className="relative">
+            <button type="button" onClick={() => { setPickOpen(o => !o); setPickFilter(''); }}
+              className="text-[11px] px-2 py-0.5 rounded border border-stroke-strong text-brand hover:bg-brand/10">
+              + Вставить поле
+            </button>
+            {pickOpen && (
+              <div className="absolute right-0 top-full mt-1 z-50 w-64 bg-surface border border-stroke rounded-lg shadow-lg py-1">
+                <input autoFocus value={pickFilter} onChange={e => setPickFilter(e.target.value)}
+                  placeholder="Фильтр…" spellCheck={false}
+                  className="mx-2 mb-1 w-[calc(100%-1rem)] border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand" />
+                <div className="max-h-52 overflow-auto">
+                  {filtered.length === 0
+                    ? <p className="px-3 py-2 text-xs text-fg4">Нет полей</p>
+                    : filtered.map(f => (
+                      <button key={f.key} type="button" onClick={() => insertRef(f.key)}
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-base">
+                        <code className="text-[11px] font-mono text-brand shrink-0 max-w-[45%] truncate">{f.key}</code>
+                        <span className="text-xs text-fg3 truncate flex-1">{f.title || '—'}</span>
+                        <span className="text-[10px] text-fg4 shrink-0">{f.type}</span>
+                      </button>
+                    ))}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
-      <textarea ref={taRef} value={field.expression ?? ''} spellCheck={false} rows={2}
+      <textarea ref={taRef} value={expr} spellCheck={false} rows={2}
         onChange={e => onChange({ expression: e.target.value })}
         placeholder={'get("Количество") * get("Цена")'}
         className="w-full font-mono text-xs border border-stroke-strong rounded px-2 py-1.5 bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand resize-y" />
+
+      {/* Инлайн-статус валидации (#309/#311) */}
+      {inCycle ? (
+        <p className="text-[11px] text-danger">⚠ Циклическая зависимость — поле ссылается само на себя (прямо или через другие расчётные).</p>
+      ) : syntaxError ? (
+        <p className="text-[11px] text-danger" title={syntaxError}>✗ Синтаксическая ошибка: {syntaxError}</p>
+      ) : unknownRefs.length > 0 ? (
+        <p className="text-[11px] text-warning">⚠ Неизвестные поля: {unknownRefs.map(k => `«${k}»`).join(', ')}</p>
+      ) : expr.trim() ? (
+        <p className="text-[11px] text-success">✓ Синтаксис в порядке</p>
+      ) : null}
+
+      {testOpen && (
+        <div className="rounded border border-stroke bg-surface p-2 space-y-1.5">
+          {testRefs.length === 0
+            ? <p className="text-[11px] text-fg4">Формула не ссылается на поля.</p>
+            : testRefs.map(k => (
+              <label key={k} className="flex items-center gap-2 text-[11px]">
+                <code className="font-mono text-fg3 w-28 truncate shrink-0">{k}</code>
+                <input value={sample[k] ?? ''} onChange={e => setSample(s => ({ ...s, [k]: e.target.value }))}
+                  placeholder="образцовое значение"
+                  className="flex-1 border border-stroke rounded px-2 py-1 text-xs bg-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-brand" />
+              </label>
+            ))}
+          <div className="text-[11px] pt-0.5">
+            {testResult?.error
+              ? <span className="text-danger">Ошибка: {testResult.error}</span>
+              : <span className="text-fg2">Результат: <strong className="font-mono">{String(testResult?.value ?? '—')}</strong></span>}
+          </div>
+        </div>
+      )}
+
       <p className="text-[11px] text-fg4">
         Читайте поля через <code className="font-mono">get("Ключ")</code>. Значения перечислений видны как отображаемое имя.
       </p>
@@ -551,7 +623,7 @@ export function FieldBuilder({ fields, onChange, disabledKeys, persistedKeys, co
           reg={reg}
           keyConflict={!!field.key && !!disabledKeys?.has(field.key.trim())}
           isNew={!persistedKeys?.has(field.key.trim())}
-          siblingFields={fields.filter((_, idx) => idx !== i).map(f => ({ key: f.key, title: f.title, type: f.type }))}
+          siblingFields={fields.filter((_, idx) => idx !== i).map(f => ({ key: f.key, title: f.title, type: f.type, computed: f.computed, expression: f.expression }))}
           open={openIndex === i}
           onToggleOpen={() => setOpenIndex(o => o === i ? null : i)}
           onChange={patch => onChange(fields.map((f, idx) => idx === i ? { ...f, ...patch } : f))}

--- a/src/client/src/shared/utils/computedExpression.test.ts
+++ b/src/client/src/shared/utils/computedExpression.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { evalComputed, referencedKeys, validateComputed, findComputedCycles } from './computedExpression';
+
+describe('computedExpression', () => {
+  it('referencedKeys extracts distinct get() targets', () => {
+    expect(referencedKeys('get("a") + get(\'b\') + get("a")')).toEqual(['a', 'b']);
+    expect(referencedKeys('1 + 2')).toEqual([]);
+  });
+
+  it('evalComputed computes arithmetic via get()', () => {
+    expect(evalComputed('get("Кол") * get("Цена")', { Кол: 4, Цена: 25 }).value).toBe(100);
+    expect(evalComputed('get("a") + "шт"', { a: 2 }).value).toBe('2шт');
+    expect(evalComputed('', {}).value).toBeUndefined();
+  });
+
+  it('evalComputed returns error on bad expression', () => {
+    const r = evalComputed('get("a" +', { a: 1 });
+    expect(r.error).toBeTruthy();
+    expect(r.value).toBeUndefined();
+  });
+
+  it('validateComputed flags syntax errors and unknown refs', () => {
+    const known = new Set(['Кол', 'Цена']);
+    expect(validateComputed('get("Кол") * get("Цена")', known)).toEqual({ syntaxError: undefined, unknownRefs: [] });
+    expect(validateComputed('get("Кол") * get("НетТакого")', known).unknownRefs).toEqual(['НетТакого']);
+    expect(validateComputed('get("Кол" *', known).syntaxError).toBeTruthy();
+  });
+
+  it('findComputedCycles detects dependency cycles and self-reference', () => {
+    // sum → withTax (нет цикла)
+    expect([...findComputedCycles({
+      sum: 'get("x") + get("y")',
+      withTax: 'get("sum") * 1.2',
+    })]).toEqual([]);
+    // a ↔ b (цикл)
+    expect(findComputedCycles({ a: 'get("b")', b: 'get("a")' })).toEqual(new Set(['a', 'b']));
+    // самоссылка
+    expect(findComputedCycles({ c: 'get("c") + 1' })).toEqual(new Set(['c']));
+  });
+});

--- a/src/client/src/shared/utils/computedExpression.ts
+++ b/src/client/src/shared/utils/computedExpression.ts
@@ -1,0 +1,81 @@
+/**
+ * Клиентский движок расчётных полей (issue #368, фаза 3). Формула — это JS, поэтому предпросмотр и
+ * проактивная валидация делаются прямо в браузере. Авторитет — бэкенд (Jint) при генерации; клиент
+ * лишь помогает автору (мгновенная валидация) и показывает предварительное значение пользователю.
+ *
+ * Безопасность: `new Function` исполняет авторское (Admin) выражение — та же модель доверия, что у
+ * Typst-шаблонов/userlib (админ доверенный). Не полноценная песочница.
+ */
+
+const GET_RE = /get\(\s*["']([^"']+)["']\s*\)/g;
+
+/** Ключи полей, на которые ссылается выражение через get("…"). */
+export function referencedKeys(expression: string): string[] {
+  const keys = new Set<string>();
+  let m: RegExpExecArray | null;
+  GET_RE.lastIndex = 0;
+  while ((m = GET_RE.exec(expression))) keys.add(m[1]);
+  return [...keys];
+}
+
+/** Вычисляет выражение; get(key) читает values[key] (иначе undefined). Ошибка → { error }. */
+export function evalComputed(expression: string, values: Record<string, unknown>): { value?: unknown; error?: string } {
+  if (!expression.trim()) return { value: undefined };
+  try {
+    const get = (key: string) => values[key];
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    const fn = new Function('get', `"use strict"; return (${expression});`);
+    const value = fn(get);
+    return { value };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Синтаксическая проверка выражения (компиляция без запуска) + ссылки на несуществующие поля. */
+export function validateComputed(
+  expression: string,
+  knownKeys: Set<string>,
+): { syntaxError?: string; unknownRefs: string[] } {
+  const unknownRefs = referencedKeys(expression).filter(k => !knownKeys.has(k));
+  let syntaxError: string | undefined;
+  if (expression.trim()) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+      new Function('get', `"use strict"; return (${expression});`);
+    } catch (e) {
+      syntaxError = e instanceof Error ? e.message : String(e);
+    }
+  }
+  return { syntaxError, unknownRefs };
+}
+
+/**
+ * Ключи расчётных полей, попавших в цикл зависимостей (топосорт Kahn по ссылкам между computed-полями).
+ * `computed` — карта ключ→выражение только расчётных полей.
+ */
+export function findComputedCycles(computed: Record<string, string>): Set<string> {
+  const keys = Object.keys(computed);
+  const keySet = new Set(keys);
+  const deps: Record<string, string[]> = {};
+  const indeg: Record<string, number> = {};
+  for (const k of keys) {
+    deps[k] = referencedKeys(computed[k]).filter(r => keySet.has(r) && r !== k);
+    indeg[k] = 0;
+  }
+  // Самоссылка — тоже цикл.
+  const selfCyclic = new Set(keys.filter(k => referencedKeys(computed[k]).includes(k)));
+  const dependents: Record<string, string[]> = Object.fromEntries(keys.map(k => [k, []]));
+  for (const k of keys) for (const d of deps[k]) { dependents[d].push(k); indeg[k]++; }
+
+  const ready = keys.filter(k => indeg[k] === 0);
+  const ordered: string[] = [];
+  while (ready.length) {
+    const n = ready.shift()!;
+    ordered.push(n);
+    for (const m of dependents[n]) if (--indeg[m] === 0) ready.push(m);
+  }
+  const cyclic = new Set(keys.filter(k => !ordered.includes(k)));
+  for (const k of selfCyclic) cyclic.add(k);
+  return cyclic;
+}


### PR DESCRIPTION
## Что
Фаза 3 (финальная) расчётного поля (#368). Поскольку формула — это JS, проактивная валидация и предпросмотр делаются на клиенте (бэкенд-Jint остаётся авторитетом при генерации; диагностики Ф1/Ф2 сохранены). Новый backend не потребовался.

## Части
- **`shared/utils/computedExpression.ts`**: `evalComputed` (через `new Function` + `get("ключ")`), `referencedKeys`, `validateComputed` (синтаксис + неизвестные ссылки), `findComputedCycles` (топосорт). + **5 vitest**.
- **FieldBuilder / ComputedFieldEditor**: инлайн-валидация под формулой (✗ синтаксис / ⚠ неизвестное поле / ⚠ цикл A→B→A), **«Проверить на образце»** (образцовые значения ссылок → результат/ошибка), пикер «Вставить поле» стал **typeahead** (фильтр по мере ввода).
- **Редактор документа**: клиентский **live-предпросмотр** значения из текущих значений формы; до заполнения — «— · заполните Поле A, Поле B»; ошибка формулы — явно.
- **ComplexFields**: расчётные подполя скрыты в редакторе вложенных составных (не редактируются вручную — считаются при генерации; закрывает gap Ф1/Ф2, где они показывались как редактируемые инпуты).

## Безопасность
`new Function` исполняет авторское (Admin) выражение в браузере — та же модель доверия, что у Typst-шаблонов/userlib. Не полноценная песочница; админ доверенный.

## Проверка
`tsc -b` чисто; frontend **146** (+5 computedExpression: eval/refs/validate/cycles).

Завершает эпик расчётного поля (Ф1 #369, Ф2 #371 — в master).

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
