### PR TITLE
feat(datasets): inline-маппинг составного поля — бэкенд-инфраструктура (ф1a, #374)

### DIFF
--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -92,21 +92,22 @@ public class DataSetBindingService(
                     var data = new Dictionary<string, object?>();
                     foreach (var (fieldKey, colName) in mapping)
                         if (!string.IsNullOrEmpty(colName))
-                            data[fieldKey] = DataSetDtoMapper.PreviewCell(colName, row);
+                            data[fieldKey] = await DataSetDtoMapper.PreviewCellAsync(colName, row, ct);
 
                     results.Add(new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
                         "scalar", null, rows.Count, data, null));
                 }
                 else
                 {
-                    var mapped = rows.Select(row =>
+                    var mapped = new List<Dictionary<string, object?>>();
+                    foreach (var row in rows)
                     {
                         var obj = new Dictionary<string, object?>();
                         foreach (var (fieldKey, colName) in mapping)
                             if (!string.IsNullOrEmpty(colName))
-                                obj[fieldKey] = DataSetDtoMapper.PreviewCell(colName, row);
-                        return obj;
-                    }).ToList();
+                                obj[fieldKey] = await DataSetDtoMapper.PreviewCellAsync(colName, row, ct);
+                        mapped.Add(obj);
+                    }
 
                     results.Add(new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
                         "tabular", binding.TargetFieldKey, mapped.Count, mapped, null));

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -46,29 +46,21 @@ public static class DataSetDtoMapper
     public static object? DeserializeJson(string? json) =>
         json is null ? null : JsonSerializer.Deserialize<object>(json);
 
-    // Значение ячейки для предпросмотра. Для ссылочного маппинга (@@ref) показываем
-    // искомое значение колонки с маркером — фактический резолвинг в каталог выполняется
-    // при генерации. Для файлового маппинга (@@file) — уже полноценный объект-вложение
-    // (используется напрямую и при синхронизации CommonDataEntry.Data, не только для показа).
-    public static object? PreviewCell(string mapVal, IReadOnlyDictionary<string, string?>? row)
-    {
-        var fileMap = DataSetMappingValue.ParseFile(mapVal);
-        if (fileMap is not null)
-            return row is null ? null : DataSetMappingValue.ResolveFileValue(fileMap, row);
+    // Значение ячейки для предпросмотра — через общий DataSetMappingApplier (issue #374). Для ссылочного
+    // маппинга (@@ref) показываем искомое значение колонки с маркером «🔗 …» — фактический резолвинг в
+    // каталог выполняется при генерации. Для @@file — полноценный объект-вложение; для @@inline —
+    // встроенный объект (под-поля рекурсивно, @@ref-под-поля тоже как маркеры).
+    public static Task<object?> PreviewCellAsync(string mapVal, IReadOnlyDictionary<string, string?>? row, CancellationToken ct = default)
+        => DataSetMappingApplier.ApplyAsync(mapVal, row, PreviewRefMarker, path: "", ct);
 
-        var refMap = DataSetMappingValue.ParseRef(mapVal);
-        if (refMap is not null)
-        {
-            string? v;
-            if (refMap.IsIdentity)
-                v = string.Join(" · ", refMap.IdentityColumns!.Values
-                    .Select(c => row != null && row.TryGetValue(c, out var cv) ? cv : null)
-                    .Where(s => !string.IsNullOrWhiteSpace(s)));
-            else
-                v = row != null && refMap.Column != null && row.TryGetValue(refMap.Column, out var lv) ? lv : null;
-            return string.IsNullOrWhiteSpace(v) ? null : $"🔗 {v}";
-        }
-        return row != null && row.TryGetValue(mapVal, out var val) ? val : null;
+    private static Task<object?> PreviewRefMarker(DataSetRefMapping refMap, IReadOnlyDictionary<string, string?> row, string path, CancellationToken ct)
+    {
+        var v = refMap.IsIdentity
+            ? string.Join(" · ", refMap.IdentityColumns!.Values
+                .Select(c => row.TryGetValue(c, out var cv) ? cv : null)
+                .Where(s => !string.IsNullOrWhiteSpace(s)))
+            : refMap.Column != null && row.TryGetValue(refMap.Column, out var lv) ? lv : null;
+        return Task.FromResult<object?>(string.IsNullOrWhiteSpace(v) ? null : $"🔗 {v}");
     }
 
     public static DataSetFileDto MapFile(DataSetFile f) => new(

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingApplier.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingApplier.cs
@@ -1,0 +1,46 @@
+namespace BHS.CRG.Infrastructure.DataSets;
+
+/// <summary>
+/// Единая точка применения одного значения маппинга «токен → значение поля» (issue #374). Раньше логика
+/// дублировалась у генерации (<c>DataSetResolver.MapValueAsync</c>) и превью (<c>DataSetDtoMapper.PreviewCell</c>);
+/// они расходились ТОЛЬКО в ветке <c>@@ref</c> (генерация резолвит запись каталога, превью показывает
+/// маркер). Здесь общие ветки — обычная колонка, <c>@@file</c> и рекурсивный <c>@@inline</c> — а <c>@@ref</c>
+/// делегируется вызывающему через <see cref="RefResolver"/>. Грамматика рекурсивна: под-поля inline —
+/// те же токены (колонка / @@ref / вложенный @@inline).
+/// </summary>
+public static class DataSetMappingApplier
+{
+    /// <summary>Разрешение ссылочного (@@ref) токена: генерация → {$ref:catalog,entryId}; превью → маркер «🔗 …».</summary>
+    public delegate Task<object?> RefResolver(
+        DataSetRefMapping refMap, IReadOnlyDictionary<string, string?> row, string path, CancellationToken ct);
+
+    public static async Task<object?> ApplyAsync(
+        string mapVal, IReadOnlyDictionary<string, string?>? row,
+        RefResolver resolveRef, string path, CancellationToken ct)
+    {
+        var fileMap = DataSetMappingValue.ParseFile(mapVal);
+        if (fileMap is not null)
+            return row is null ? null : DataSetMappingValue.ResolveFileValue(fileMap, row);
+
+        var inlineMap = DataSetMappingValue.ParseInline(mapVal);
+        if (inlineMap is not null)
+        {
+            // Inline это ДАННЫЕ: строим встроенный объект из под-маппинга той же строки. Под-поля @@ref
+            // дают $ref (доразрешит 2-й проход резолвера). Пустой (все под-поля пусты) → null.
+            var obj = new Dictionary<string, object?>();
+            foreach (var (subKey, subToken) in inlineMap.Fields)
+            {
+                var v = await ApplyAsync(subToken, row, resolveRef, $"{path}.{subKey}", ct);
+                if (v is not null) obj[subKey] = v;
+            }
+            return obj.Count == 0 ? null : obj;
+        }
+
+        var refMap = DataSetMappingValue.ParseRef(mapVal);
+        if (refMap is not null)
+            return row is null ? null : await resolveRef(refMap, row, path, ct);
+
+        // Обычная колонка.
+        return row is not null && row.TryGetValue(mapVal, out var val) ? val : null;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingValue.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetMappingValue.cs
@@ -36,10 +36,20 @@ public record DataSetRefMapping(
 /// </summary>
 public record DataSetFileMapping(string Column, string? SizeColumn);
 
+/// <summary>
+/// Inline-маппинг составного поля (issue #374): значение поля собирается КАК ВСТРОЕННЫЙ ОБЪЕКТ из
+/// колонок ТОЙ ЖЕ строки (в отличие от <see cref="DataSetRefMapping"/> — без cross-table lookup).
+/// <see cref="Fields"/> — под-поле → токен (та же грамматика маппинга: имя колонки / <c>@@ref:…</c> /
+/// вложенный <c>@@inline:…</c>) — рекурсивно. <see cref="TypeId"/> — объявленный составной тип поля.
+/// Кодируется строкой <c>@@inline:{"typeId":"&lt;guid&gt;","fields":{"Подполе":"Колонка",…}}</c>.
+/// </summary>
+public record DataSetInlineMapping(Guid TypeId, Dictionary<string, string> Fields);
+
 public static class DataSetMappingValue
 {
     public const string RefPrefix = "@@ref:";
     public const string FilePrefix = "@@file:";
+    public const string InlinePrefix = "@@inline:";
 
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
@@ -57,6 +67,25 @@ public static class DataSetMappingValue
             var noSource = string.IsNullOrWhiteSpace(parsed?.Column)
                 && (parsed?.IdentityColumns is null || parsed.IdentityColumns.Count == 0);
             return parsed is null || parsed.TypeId == Guid.Empty || noSource ? null : parsed;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool IsInline(string? value) =>
+        value is not null && value.StartsWith(InlinePrefix, StringComparison.Ordinal);
+
+    public static DataSetInlineMapping? ParseInline(string? value)
+    {
+        if (!IsInline(value)) return null;
+        try
+        {
+            var json = value![InlinePrefix.Length..];
+            var parsed = JsonSerializer.Deserialize<DataSetInlineMapping>(json, JsonOpts);
+            // Валиден, если задан хотя бы один под-маппинг (иначе строить нечего).
+            return parsed is null || parsed.Fields is null || parsed.Fields.Count == 0 ? null : parsed;
         }
         catch
         {

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -218,16 +218,17 @@ public class DataSetSourceService(
             var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
             var take = maxRows <= 0 ? 50 : maxRows;
 
-            var mapped = rows.Take(take).Select(row =>
+            var mapped = new List<Dictionary<string, object?>>();
+            foreach (var row in rows.Take(take))
             {
                 var obj = new Dictionary<string, object?>();
                 foreach (var (fieldKey, mapVal) in effMapping)
                 {
-                    var v = DataSetDtoMapper.PreviewCell(mapVal, row);
+                    var v = await DataSetDtoMapper.PreviewCellAsync(mapVal, row, ct);
                     if (v is not null) obj[fieldKey] = v;
                 }
-                return obj;
-            }).ToList();
+                mapped.Add(obj);
+            }
 
             return new MaterializePreviewDto(effTypeId, rows.Count, mapped, null);
         }

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -80,7 +80,7 @@ public class DataSetResolver(
                         var row = rows[0];
                         foreach (var (fieldKey, mapVal) in mapping)
                         {
-                            var value = await MapValueAsync(mapVal, row, ownerId, scopeLevel, scopeId, diagnostics, fieldKey, ct);
+                            var value = await ApplyMappedAsync(mapVal, row, ownerId, scopeLevel, scopeId, diagnostics, fieldKey, ct);
                             if (value is not null)
                                 ctx.Set(fieldKey, value);
                         }
@@ -118,7 +118,7 @@ public class DataSetResolver(
                         foreach (var (fieldKey, mapVal) in mapping)
                         {
                             var path = $"{binding.TargetFieldKey}[{rowIndex}].{fieldKey}";
-                            var value = await MapValueAsync(mapVal, row, ownerId, scopeLevel, scopeId, diagnostics, path, ct);
+                            var value = await ApplyMappedAsync(mapVal, row, ownerId, scopeLevel, scopeId, diagnostics, path, ct);
                             if (value is not null)
                                 obj[fieldKey] = value;
                         }
@@ -158,13 +158,12 @@ public class DataSetResolver(
     }
 
     /// <summary>
-    /// Преобразует одно значение маппинга: обычная колонка → строка;
-    /// ссылочный маппинг (@@ref) → объект {$ref:catalog, entryId} по найденной записи каталога.
-    /// Поиск существующего объекта делегируется единому <see cref="IObjectResolver"/> (issue #183):
-    /// матч по конкретному полю (@@ref с match) или по имени/алиасам (пустой match). Нет матча →
-    /// WARNING + поле не добавляется (создание объектов не выполняется — резолвер read-only).
+    /// Применяет одно значение маппинга через общий <see cref="DataSetMappingApplier"/> (issue #374):
+    /// колонка/@@file/@@inline — общие ветки, @@ref делегируется <see cref="ResolveRefAsync"/> (резолв в
+    /// существующую запись каталога). Inline строит встроенный объект; его @@ref-под-поля дают $ref,
+    /// доразрешаемый 2-м проходом резолвера.
     /// </summary>
-    private async Task<object?> MapValueAsync(
+    private Task<object?> ApplyMappedAsync(
         string mapVal,
         IReadOnlyDictionary<string, string?> row,
         Guid ownerId,
@@ -173,15 +172,24 @@ public class DataSetResolver(
         List<ResolutionDiagnostic>? diagnostics,
         string path,
         CancellationToken ct)
+        => DataSetMappingApplier.ApplyAsync(mapVal, row,
+            (rm, r, p, c) => ResolveRefAsync(rm, r, ownerId, scopeLevel, scopeId, diagnostics, p, c), path, ct);
+
+    /// <summary>
+    /// @@ref: резолвит строку в существующий объект каталога через единый <see cref="IObjectResolver"/>
+    /// (issue #183) — по имени/алиасам или составному identity-ключу. Нет матча → WARNING + null (создание
+    /// объектов не выполняется, резолвер read-only). Возвращает {$ref:catalog, entryId} по найденной записи.
+    /// </summary>
+    private async Task<object?> ResolveRefAsync(
+        DataSetRefMapping refMap,
+        IReadOnlyDictionary<string, string?> row,
+        Guid ownerId,
+        CatalogScope scopeLevel,
+        Guid? scopeId,
+        List<ResolutionDiagnostic>? diagnostics,
+        string path,
+        CancellationToken ct)
     {
-        var fileMap = DataSetMappingValue.ParseFile(mapVal);
-        if (fileMap is not null)
-            return DataSetMappingValue.ResolveFileValue(fileMap, row);
-
-        var refMap = DataSetMappingValue.ParseRef(mapVal);
-        if (refMap is null)
-            return row.TryGetValue(mapVal, out var val) ? val : null;
-
         // Ссылочное поле: резолвим строку в существующий объект каталога по одной из двух стратегий
         // (issue #243): Identity (составной ключ identity-полей) либо Name (по имени/алиасам); legacy
         // с непустым match — Field (произвольное поле, из UI больше не создаётся, читается вечно).

--- a/src/server/BHS.CRG.Tests/DataSets/DataSetMappingApplierTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/DataSetMappingApplierTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using BHS.CRG.Infrastructure.DataSets;
+
+namespace BHS.CRG.Tests.DataSets;
+
+/// <summary>Общий применитель маппинга (issue #374): колонка/@@inline/@@ref-делегат + парсер @@inline.</summary>
+public class DataSetMappingApplierTests
+{
+    private static readonly Guid TypeId = Guid.NewGuid();
+
+    private static string Inline(Dictionary<string, string> fields)
+        => DataSetMappingValue.InlinePrefix + JsonSerializer.Serialize(new DataSetInlineMapping(TypeId, fields));
+
+    // Фейковый @@ref-резолвер: помечает, что делегат вызван, значением колонки.
+    private static Task<object?> FakeRef(DataSetRefMapping rm, IReadOnlyDictionary<string, string?> row, string path, CancellationToken ct)
+        => Task.FromResult<object?>($"REF:{(rm.Column is not null && row.TryGetValue(rm.Column, out var v) ? v : null)}");
+
+    private static Task<object?> Apply(string token, Dictionary<string, string?> row)
+        => DataSetMappingApplier.ApplyAsync(token, row, FakeRef, "path", default);
+
+    // ── ParseInline ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseInline_ValidToken_Parsed()
+    {
+        var map = DataSetMappingValue.ParseInline(Inline(new() { ["Наим"] = "КолНаим" }));
+        Assert.NotNull(map);
+        Assert.Equal(TypeId, map!.TypeId);
+        Assert.Equal("КолНаим", map.Fields["Наим"]);
+    }
+
+    [Fact]
+    public void ParseInline_EmptyFieldsOrNonInline_Null()
+    {
+        Assert.Null(DataSetMappingValue.ParseInline(Inline(new())));       // нет под-полей
+        Assert.Null(DataSetMappingValue.ParseInline("КолонкаНаим"));       // обычная колонка
+        Assert.Null(DataSetMappingValue.ParseInline("@@ref:{}"));          // это ref, не inline
+    }
+
+    // ── ApplyAsync ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Apply_PlainColumn_ReturnsCellValue()
+    {
+        var v = await Apply("Цена", new() { ["Цена"] = "100" });
+        Assert.Equal("100", v);
+    }
+
+    [Fact]
+    public async Task Apply_Inline_BuildsObjectFromColumns()
+    {
+        var token = Inline(new() { ["Наименование"] = "КолНаим", ["Код"] = "КолКод" });
+        var v = await Apply(token, new() { ["КолНаим"] = "ООО Ромашка", ["КолКод"] = "7701" });
+
+        var obj = Assert.IsType<Dictionary<string, object?>>(v);
+        Assert.Equal("ООО Ромашка", obj["Наименование"]);
+        Assert.Equal("7701", obj["Код"]);
+    }
+
+    [Fact]
+    public async Task Apply_Inline_AllSubFieldsEmpty_ReturnsNull()
+    {
+        var token = Inline(new() { ["Наименование"] = "КолНаим" });
+        var v = await Apply(token, new() { ["КолНаим"] = null }); // пусто → объект пуст → null
+        Assert.Null(v);
+    }
+
+    [Fact]
+    public async Task Apply_Inline_WithRefSubField_DelegatesToRefResolver()
+    {
+        // Под-поле «Материал» — @@ref: должно уйти в делегат (в генерации → $ref, здесь → фейк-маркер).
+        var refToken = DataSetMappingValue.RefPrefix + JsonSerializer.Serialize(
+            new DataSetRefMapping("КолМат", null, Guid.NewGuid(), "Name"));
+        var token = Inline(new() { ["Кол"] = "КолКол", ["Материал"] = refToken });
+        var v = await Apply(token, new() { ["КолКол"] = "3", ["КолМат"] = "Кабель" });
+
+        var obj = Assert.IsType<Dictionary<string, object?>>(v);
+        Assert.Equal("3", obj["Кол"]);
+        Assert.Equal("REF:Кабель", obj["Материал"]); // @@ref-под-поле прошло через делегат
+    }
+}


### PR DESCRIPTION
## Что
Бэкенд-инфраструктура для inline-маппинга составного поля (Ф1a issue #374). Устанавливает грамматику и **закрывает главный риск — консолидацию двух applier'ов маппинга**. Авторская UI (сегмент режима «По ссылке | Встроенный») — следующий срез Ф1 (отдельный PR).

## Backend
- **Модель:** токен `@@inline:{typeId, fields:{подполе: "Колонка"|"@@ref:…"|"@@inline:…"}}` — рекурсивная грамматика (payload та же мапа); `record DataSetInlineMapping` + `IsInline/ParseInline` в `DataSetMappingValue`.
- **Консолидация (был риск/объём):** применение маппинга «токен→значение» дублировалось у генерации (`DataSetResolver.MapValueAsync`) и превью (`DataSetDtoMapper.PreviewCell`) — расходились ТОЛЬКО в ветке `@@ref` (ген резолвит через `IObjectResolver`, превью → маркер `🔗`). Извлечён **один async-билдер `DataSetMappingApplier.ApplyAsync(mapVal, row, refResolver, …)`**: column/@@file/@@inline — общие, @@ref — делегат. `DataSetResolver` → `ApplyMappedAsync` + `ResolveRefAsync`; `PreviewCell` → `PreviewCellAsync` (+2 вызывающих стали async).
- **Inline это данные:** строит объект сразу; `@@ref`-под-поля внутри inline → `$ref`, доразрешает существующий 2-й проход резолвера. Пустой inline → null. Инвариант порядка `inject(inline)→refs→compute→required→stamp` сохранён → TypeStamper/required/ComputedFieldResolver обрабатывают inline-объект **без спецкода**.

## Проверка
`dotnet build` чисто; backend **505** (+6: `ParseInline` валид/невалид; `ApplyAsync` колонка / inline-объект / пустой→null / @@ref-делегат). **144 dataset-теста зелёные** — рефактор двух applier'ов безопасен.

## Дальше (Ф1b, отдельный PR)
UI-сегмент `🔗 По ссылке | {} Встроенный` в `FieldSourceBinding`/`ContainerFieldBinding`/`MappingEditor` + суб-редактор «под-поле ← колонка». Ф2 — вложенный @@inline + унификация PasteMappingModal. Ф3 — подсказки в авто-маппере.

Relates to #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
