### PR TITLE
fix(settings): открывать созданный тип на редактирование (#383)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -288,10 +288,12 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
 // ─── Create form ───────────────────────────────────────────────────────────────
 
 function CreateForm({
-  kind, onClose, allDocTypes,
+  kind, onClose, onCreated, allDocTypes,
 }: {
   kind: DocumentTypeKind;
   onClose: () => void;
+  /** Созданный тип — страница выбирает его в list-detail (issue #383: открыть на редактирование). */
+  onCreated: (created: DocumentType) => void;
   allDocTypes: DocumentType[];
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
@@ -324,12 +326,13 @@ function CreateForm({
     const conflict = fields.find(f => inheritedKeys.has(f.key.trim()));
     if (conflict) { setError(`Ключ "${conflict.key}" уже есть в родительском типе`); return; }
     try {
-      await mutation.mutateAsync({
+      const created = await mutation.mutateAsync({
         name, code, kind,
         parentId: parentId || null,
         schema: schemaToJson(fields, [], {}),
         isAbstract: kind === 'Document' ? isAbstract : false,
       });
+      onCreated(created); // выбрать созданный тип → откроется detail-редактор (issue #383)
       onClose();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Ошибка сохранения');
@@ -997,7 +1000,8 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
         title={kind === 'Document' ? 'Новый тип документа' : 'Новый составной тип'}
         wide flushBody>
         {createOpen && (
-          <CreateForm kind={kind} onClose={() => setCreateOpen(false)} allDocTypes={allDocTypes} />
+          <CreateForm kind={kind} onClose={() => setCreateOpen(false)}
+            onCreated={created => setSelectedId(created.id)} allDocTypes={allDocTypes} />
         )}
       </Modal>
     </>


### PR DESCRIPTION
## Что
После создания типа документа/составного типа модалка закрывалась, но новый тип не выбирался в list-detail — приходилось искать и кликать вручную.

Теперь `CreateForm` возвращает созданный тип через `onCreated`, страница ставит `selectedId` → **сразу открывается detail-редактор** нового типа. Одна `DocumentTypesPage` обслуживает оба вида, поэтому фикс покрывает и типы документов, и составные типы.

## Проверка
`tsc -b` чисто; frontend **146** зелёные. +7/−3.

Closes #383