### PR TITLE
feat(datasets): «Распознать таблицу» в кандидатах источника (#385)

### DIFF
--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -69,13 +69,18 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
   const update = useUpdateDataSetSource();
   const isPending = create.isPending || update.isPending;
 
+  // Готовые кандидаты — без нераспознанных таблиц (issue #385): их создать нельзя, пока таблица
+  // не распознана (это делается в списке кандидатов под источниками кнопкой «Распознать таблицу»).
+  const readyCandidates = candidates.filter(c => c.firstPageIndex == null);
+  const pendingTableCount = candidates.length - readyCandidates.length;
+
   // Новый источник из кандидата (лист/«весь файл»/PDF-проекция): как только приедут кандидаты —
-  // подставить первый и его имя.
+  // подставить первый готовый и его имя.
   useEffect(() => {
-    if (initial || !usesCandidates || candidates.length === 0) return;
-    setSheetOrPath(prev => prev || candidates[0].sheetOrPath);
-    setName(prev => prev || candidates[0].name);
-  }, [initial, usesCandidates, candidates]);
+    if (initial || !usesCandidates || readyCandidates.length === 0) return;
+    setSheetOrPath(prev => prev || readyCandidates[0].sheetOrPath);
+    setName(prev => prev || readyCandidates[0].name);
+  }, [initial, usesCandidates, readyCandidates]);
 
   // Текущее значение может отсутствовать в списке (архив обновился) — не терять его молча.
   const entryOptions = entryPath && !zipEntries.includes(entryPath) ? [entryPath, ...zipEntries] : zipEntries;
@@ -159,12 +164,18 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
             <label className="block text-sm font-medium text-fg1 mb-1">Данные набора</label>
             <Select value={sheetOrPath || undefined} placeholder="— выберите —" aria-label="Данные набора"
               onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
-              {candidates.map(c => (
+              {readyCandidates.map(c => (
                 <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
               ))}
             </Select>
-            {candidates.length === 0 && (
-              <p className="text-xs text-fg4 mt-1">Набор ещё не распознан — сначала запустите «Распознать».</p>
+            {readyCandidates.length === 0 && (
+              <p className="text-xs text-fg4 mt-1">
+                {pendingTableCount > 0
+                  ? 'Все проекции набора уже добавлены. Таблицы документов сначала распознайте — кнопка «Распознать таблицу» в списке кандидатов под источниками.'
+                  : candidates.length === 0
+                    ? 'Нет доступных проекций. Если набор ещё не распознан — запустите «Распознать»; таблицы документов распознаются отдельно (кнопка ✂ разбиения).'
+                    : 'Все проекции набора уже добавлены как источники.'}
+              </p>
             )}
             {selectedCandidate && selectedCandidate.columns.length > 0 && (
               <p className="text-xs text-fg4 mt-1">Колонки: {selectedCandidate.columns.join(', ')}</p>

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -10,6 +10,7 @@ import {
   useDeleteDataSetSource, useDuplicateDataSetSource, useSetDataSetSourceProcessing, useListProcessingTemplates,
   usePreviewDataSetSource, useCreateProcessingTemplate, useApplyProcessingTemplate, useRecognizeFile,
   isManualGroupingConflict, exportDataSetSource, useSourceCandidates, useCreateDataSetSource, useRenameSource,
+  useRecognizeDocumentTable,
 } from '@/shared/api/datasets';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { Modal } from '@/shared/ui/Modal';
@@ -314,6 +315,7 @@ export function SourcesPanel({
   // группировки; XLSX — листы; CSV — «весь файл»; JSON — верхнеуровневые массивы.
   const { data: candidates = [] } = useSourceCandidates(file.id);
   const createSource = useCreateDataSetSource();
+  const recognizeTable = useRecognizeDocumentTable(file.id); // «Распознать таблицу» кандидата (issue #385)
   const availableCandidates = candidates.filter(c => !sources.some(s => s.sheetOrPath === c.sheetOrPath));
 
   return (
@@ -339,16 +341,32 @@ export function SourcesPanel({
         {availableCandidates.length > 0 && (
           <div className="rounded-md border border-dashed border-stroke-strong bg-base px-3 py-2 space-y-1 mt-1">
             <p className="text-[11px] text-fg4">{isPdf ? 'Доступно из распознанного набора:' : 'Доступно из набора:'}</p>
-            {availableCandidates.map(c => (
-              <div key={c.sheetOrPath} className="flex items-center gap-2 text-xs">
-                <span className="text-fg2">{c.name} <span className="text-fg4">· {c.rowCount} строк</span></span>
-                <button type="button" disabled={createSource.isPending}
-                  onClick={() => createSource.mutate({ fileId: file.id, name: c.name, sheetOrPath: c.sheetOrPath })}
-                  className="flex items-center gap-0.5 text-brand hover:text-brand-hover disabled:opacity-50">
-                  <Plus size={11} /> Создать
-                </button>
-              </div>
-            ))}
+            {availableCandidates.map(c => {
+              // Таблица документа ещё не распознана (issue #385): сначала «Распознать таблицу»
+              // (фоновая задача) — после завершения кандидат станет готовым «Создать».
+              const pending = c.firstPageIndex != null;
+              return (
+                <div key={c.sheetOrPath} className="flex items-center gap-2 text-xs">
+                  <span className="text-fg2">
+                    {c.name} <span className="text-fg4">· {pending ? 'таблица не распознана' : `${c.rowCount} строк`}</span>
+                  </span>
+                  {pending ? (
+                    <button type="button" disabled={recognizeTable.isPending}
+                      onClick={() => recognizeTable.mutate(c.firstPageIndex!)}
+                      title="Распознать таблицу этого документа — затем можно создать источник"
+                      className="flex items-center gap-0.5 text-brand hover:text-brand-hover disabled:opacity-50">
+                      <ScanText size={11} /> Распознать таблицу
+                    </button>
+                  ) : (
+                    <button type="button" disabled={createSource.isPending}
+                      onClick={() => createSource.mutate({ fileId: file.id, name: c.name, sheetOrPath: c.sheetOrPath })}
+                      className="flex items-center gap-0.5 text-brand hover:text-brand-hover disabled:opacity-50">
+                      <Plus size={11} /> Создать
+                    </button>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -160,6 +160,9 @@ export interface SourceCandidate {
   sheetOrPath: string;
   columns: string[];
   rowCount: number;
+  /** Задан → таблица документа ещё НЕ распознана (issue #385): сначала «Распознать таблицу»
+   *  (страница документа), после чего кандидат становится готовым. null/undefined — готов сразу. */
+  firstPageIndex?: number | null;
 }
 
 /** Детект кандидатов на источник (без персиста) — подсказки в один клик в диалоге создания. */

--- a/src/client/src/shared/api/jobs.ts
+++ b/src/client/src/shared/api/jobs.ts
@@ -43,6 +43,8 @@ export function useActiveJobs(): ActiveJob[] {
     for (const id of prevIds.current) if (!current.has(id)) { completed = true; break; }
     if (completed) {
       qc.invalidateQueries({ queryKey: ['datasets', 'files'] });
+      // Кандидаты источника меняются после распознавания таблицы (issue #385) — обновляем их тоже.
+      qc.invalidateQueries({ queryKey: ['datasets', 'source-candidates'] });
       qc.invalidateQueries({ queryKey: ['notifications'] });
     }
     prevIds.current = current;

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -77,6 +77,7 @@ public static class DataSetEndpoints
                 sheetOrPath = c.SheetOrPath,
                 columns = c.Columns.Select(col => col.Name).ToList(),
                 rowCount = c.RowCount,
+                firstPageIndex = c.FirstPageIndex, // задан → таблица требует распознавания (issue #385)
             }));
         });
 

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetParser.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetParser.cs
@@ -8,7 +8,10 @@ public record DataSetSourceInfo(
     string Name,
     string SheetOrPath,
     IReadOnlyList<DataSetColumnInfo> Columns,
-    int RowCount
+    int RowCount,
+    // Кандидат-таблица, ещё НЕ распознанная (issue #385): указывает страницу документа для запуска
+    // «Распознать таблицу». null — обычный готовый кандидат (создаётся сразу).
+    int? FirstPageIndex = null
 );
 
 public record DataSetParseResult(

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -84,11 +84,22 @@ public class DataSetSourceService(
         {
             if (g.Kind != GostGroupKind.Document || g.Id == Guid.Empty) continue;
             var hasTableTag = (g.Tags ?? []).Any(t => GostTableFields.ColumnsForTag(t) is not null);
-            if (!hasTableTag || string.IsNullOrEmpty(g.TableData)) continue;
+            if (!hasTableTag) continue;
             var marker = $"{PdfProfiles.GostTableMarkerPrefix}{g.Id}";
             if (existing.Contains(marker)) continue;
             var name = string.IsNullOrWhiteSpace(g.Name) ? "Таблица" : $"Таблица — {g.Name}";
-            candidates.Add(new DataSetSourceInfo(name, marker, ColumnsFromSchemaJson(g.TableColumns), RowCountOf(g.TableData)));
+            if (!string.IsNullOrEmpty(g.TableData))
+            {
+                // Таблица распознана → готовый кандидат (создаётся сразу).
+                candidates.Add(new DataSetSourceInfo(name, marker, ColumnsFromSchemaJson(g.TableColumns), RowCountOf(g.TableData)));
+            }
+            else
+            {
+                // Таблица ещё НЕ распознана (issue #385): кандидат с FirstPageIndex — фронт покажет
+                // «Распознать таблицу»; после распознавания станет обычным готовым кандидатом.
+                var firstPage = g.Pages.Count > 0 ? g.Pages.Min(p => p.PageIndex) : 0;
+                candidates.Add(new DataSetSourceInfo(name, marker, [], 0, firstPage));
+            }
         }
         return candidates;
     }


### PR DESCRIPTION
## Что
Вариант B из диагностики #385. Документы с тэгом таблицы (спецификация/кабельный журнал), у которых таблица ещё **не распознана** (`TableData=null`), раньше **не попадали в кандидаты** источника → «Добавить источник» пусто + ложное «Набор ещё не распознан». Теперь они выведены в кандидаты с действием **«Распознать таблицу»** — без ухода в редактор разбиения.

## Изменения
- **Backend:** `DataSetSourceInfo` += `FirstPageIndex`; `PdfCandidatesAsync` добавляет табличные документы БЕЗ `TableData` как pending-кандидаты (`FirstPageIndex` = страница документа); эндпоинт отдаёт `firstPageIndex`.
- **Frontend:** `SourceCandidate` += `firstPageIndex`; `SourcesExpander` рендерит pending как **«Распознать таблицу»** (`useRecognizeDocumentTable`, фоновая задача) вместо «Создать». `useActiveJobs` при завершении задачи инвалидирует `source-candidates` → pending автоматически становится готовым «Создать».
- **SourceEditorDialog:** нераспознанные таблицы исключены из Select создания + **исправлено ложное сообщение** (различает «не распознан» / «все проекции добавлены» / «таблицы распознайте отдельно»).

## Проверка
Живьём: файл `25-04-063-ЭМ` отдаёт pending-кандидат «Таблица — Спецификация…» с `firstPageIndex=11` (+ готовую «Обложку»). Файл из скрина (`250701-ЭОМ`) отдаёт 0 — корректно, его таблица уже добавлена как источник. dataset-тесты **150**, `tsc -b` чисто, frontend **146**.

Closes #385