### PR TITLE
Материализация в union-тип: показывать один вариант (#391)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Info } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { dtCard, dtTable, dtTh, dtTd, dtRow } from '@/shared/ui/dataTable';
@@ -7,7 +8,9 @@ import type { PickType } from '@/shared/ui/TypePicker';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useSetMaterialization, useMaterializePreview } from '@/shared/api/datasets';
 import { MappingEditor } from '@/features/document-sets/editor/DataSetsTab';
+import { VariantSegmentedSwitch } from '@/features/document-sets/fields/ComplexFields';
 import { resolveEffectiveFields } from '@/shared/api/schema';
+import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
 import type { DataSetSource } from '@/shared/api/types';
 
@@ -27,6 +30,31 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
   const effectiveFields = selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : [];
   // Live-превью по ТЕКУЩИМ (несохранённым) типу+маппингу (issue #294): обновляется на каждую правку.
   const preview = useMaterializePreview(source.id, typeId || undefined, mapping, showPreview && !!typeId);
+
+  // Union-тип (issue #320/#391): «заполняется ровно один вариант» — маппим один активный вариант,
+  // а не все поля union разом. Материализатор кладёт один ключ на строку → корректный union-экземпляр.
+  const isUnion = !!selectedType
+    && ((selectedType.schema as { tags?: string[] }).tags ?? []).includes(FUNCTIONAL_TAG.typeUnion);
+  const presentVariant = isUnion ? effectiveFields.find(f => mapping[f.key])?.key : undefined;
+  const firstVariant = effectiveFields[0]?.key ?? '';
+  const [activeVariant, setActiveVariant] = useState<string>('');
+  // Стэш неактивных вариантов — недеструктивное переключение (как в UnionFieldGroup): persist хранит
+  // ОДИН ключ, токен другого варианта живёт в локальном стэше до закрытия диалога.
+  const [variantStash, setVariantStash] = useState<Record<string, string>>({});
+  // Подхватываем активный вариант из загруженного маппинга / при смене типа сбрасываем на первый.
+  useEffect(() => {
+    if (!isUnion) return;
+    setActiveVariant(presentVariant ?? firstVariant);
+  }, [isUnion, presentVariant, firstVariant]);
+
+  function switchVariant(key: string) {
+    if (key === activeVariant) return;
+    const curToken = mapping[activeVariant];
+    setVariantStash(prev => ({ ...prev, [activeVariant]: curToken ?? '' }));
+    const restored = variantStash[key];
+    setMapping(restored ? { [key]: restored } : {}); // union: ровно один ключ
+    setActiveVariant(key);
+  }
 
   function handleSave() {
     save.mutate(
@@ -65,17 +93,30 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
               section: t.kind === 'Composite' ? 'Составные типы' : 'Типы документов',
             }))}
             value={typeId || undefined}
-            onChange={id => { setTypeId(id ?? ''); setMapping({}); }} />
+            onChange={id => { setTypeId(id ?? ''); setMapping({}); setVariantStash({}); }} />
         </div>
 
         {selectedType && (
           effectiveFields.length === 0 ? (
             <p className="text-xs text-warning">У типа «{selectedType.name}» нет полей — задайте поля типу, чтобы было куда маппить.</p>
           ) : (
-            <div className="rounded-lg border border-stroke p-3">
+            <div className="rounded-lg border border-stroke p-3 space-y-3">
+              {isUnion && (
+                <div className="flex items-center justify-between gap-2">
+                  <VariantSegmentedSwitch
+                    options={effectiveFields.map(f => ({ key: f.key, label: f.title, filled: !!mapping[f.key] || !!variantStash[f.key] }))}
+                    active={activeVariant}
+                    onSelect={switchVariant}
+                  />
+                  <span className="text-[11px] text-fg4 flex items-center gap-1 shrink-0"
+                    title="Заполняется ровно один из вариантов">
+                    <Info size={11} /> заполните одно из
+                  </span>
+                </div>
+              )}
               <MappingEditor
                 source={source}
-                schemaFields={effectiveFields}
+                schemaFields={isUnion ? effectiveFields.filter(f => f.key === activeVariant) : effectiveFields}
                 tabularFields={[]}
                 allDocTypes={allDocTypes}
                 mapping={mapping}

--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -8,7 +8,7 @@ import type { PickType } from '@/shared/ui/TypePicker';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useSetMaterialization, useMaterializePreview } from '@/shared/api/datasets';
 import { MappingEditor } from '@/features/document-sets/editor/DataSetsTab';
-import { VariantSegmentedSwitch } from '@/features/document-sets/fields/ComplexFields';
+import { VariantPicker } from '@/features/document-sets/fields/ComplexFields';
 import { resolveEffectiveFields } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
@@ -102,16 +102,16 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
           ) : (
             <div className="rounded-lg border border-stroke p-3 space-y-3">
               {isUnion && (
-                <div className="flex items-center justify-between gap-2">
-                  <VariantSegmentedSwitch
+                <div className="space-y-1.5">
+                  <span className="text-[11px] text-fg4 flex items-center gap-1"
+                    title="Заполняется ровно один из вариантов">
+                    <Info size={11} /> выберите вариант — заполняется ровно один
+                  </span>
+                  <VariantPicker
                     options={effectiveFields.map(f => ({ key: f.key, label: f.title, filled: !!mapping[f.key] || !!variantStash[f.key] }))}
                     active={activeVariant}
                     onSelect={switchVariant}
                   />
-                  <span className="text-[11px] text-fg4 flex items-center gap-1 shrink-0"
-                    title="Заполняется ровно один из вариантов">
-                    <Info size={11} /> заполните одно из
-                  </span>
                 </div>
               )}
               <MappingEditor

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -915,10 +915,45 @@ function isVariantFilled(v: unknown): boolean {
   return String(v).trim() !== '';
 }
 
-export function VariantSegmentedSwitch({ options, active, onSelect }: {
+/**
+ * Выбор ОДНОГО варианта union (issue #320/#391). Представление зависит от контента (совет Дизайнера):
+ * сегмент — для ≤3 коротких подписей; вертикальный список radio-строк — для многих/длинных
+ * (не обрезаются, масштабируется 2-8). `auto` выбирает сам. В списке разведены два смысла:
+ * ЛЕВО = radio-выбор, ПРАВО = бейдж «задан» (есть ли значение/маппинг) — в сегменте они слипались в точку.
+ */
+export function VariantPicker({ options, active, onSelect, layout = 'auto' }: {
   options: { key: string; label: string; filled: boolean }[];
   active: string; onSelect: (key: string) => void;
+  layout?: 'segmented' | 'list' | 'auto';
 }) {
+  const useList = layout === 'list'
+    || (layout === 'auto' && (options.length > 3 || options.some(o => o.label.length > 18)));
+
+  if (useList) {
+    return (
+      <div role="radiogroup" className="flex flex-col gap-1 text-sm">
+        {options.map(o => {
+          const on = o.key === active;
+          return (
+            <button key={o.key} type="button" role="radio" aria-checked={on} onClick={() => onSelect(o.key)}
+              className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors ${
+                on ? 'border-brand bg-brand/10 text-fg1 font-medium' : 'border-stroke bg-surface text-fg2 hover:bg-base'}`}>
+              <span className={`grid place-items-center w-4 h-4 rounded-full border shrink-0 ${on ? 'border-brand' : 'border-stroke'}`}>
+                {on && <span className="w-2 h-2 rounded-full bg-brand" />}
+              </span>
+              <span className="flex-1 min-w-0 truncate">{o.label}</span>
+              {o.filled && (
+                <span className="text-[11px] text-brand flex items-center gap-1 shrink-0" title="Значение задано">
+                  <span className="w-1.5 h-1.5 rounded-full bg-brand" /> задан
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div role="radiogroup" className="inline-flex rounded-lg border border-stroke overflow-hidden text-sm">
       {options.map((o, i) => {
@@ -989,9 +1024,9 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
       otherInstances={otherInstances} scope={scope} scopeId={scopeId} docRefMode={docRefMode} primitiveTypes={primitiveTypes} />
   );
   const bar = (
-    <div className="flex items-center justify-between gap-2">
-      <VariantSegmentedSwitch options={options} active={activeKey} onSelect={switchTo} />
+    <div className="space-y-1.5">
       {chip}
+      <VariantPicker options={options} active={activeKey} onSelect={switchTo} />
     </div>
   );
 

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -915,7 +915,7 @@ function isVariantFilled(v: unknown): boolean {
   return String(v).trim() !== '';
 }
 
-function VariantSegmentedSwitch({ options, active, onSelect }: {
+export function VariantSegmentedSwitch({ options, active, onSelect }: {
   options: { key: string; label: string; filled: boolean }[];
   active: string; onSelect: (key: string) => void;
 }) {


### PR DESCRIPTION
## Проблема

При материализации источника в составной тип с тэгом `type.union` («заполняется ровно один вариант», #320) диалог показывал ВСЕ поля-варианты как отдельные цели маппинга (в баг-репорте — 5 видов кабельной линии). Нарушение инварианта union.

## Решение (только фронтенд)

`MaterializationDialog.tsx`:
- детект union по `schema.tags` (`FUNCTIONAL_TAG.typeUnion`);
- переключатель варианта — переиспользован `VariantSegmentedSwitch` из `ComplexFields.tsx` (экспортирован), + подпись «заполните одно из»;
- `MappingEditor` получает только активный вариант;
- недеструктивное переключение через локальный стэш токенов (как в `UnionFieldGroup`), persist хранит один ключ.

Материализатор кладёт один ключ на строку → корректный union-экземпляр, **серверных правок не требуется**.

## Проверка
- `tsc -b` зелёный, `npm test` — 146 passed;
- нет циклического импорта (ComplexFields не тянет datasets).

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)