### PR TITLE
Предпросмотр материализации: разворот вложенного в колонки (#393)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Info } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -63,9 +63,17 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
     );
   }
 
-  const previewCols = preview.data
-    ? [...new Set(preview.data.rows.flatMap(r => Object.keys(r)))]
-    : [];
+  // Модель предпросмотра (issue #393): разворачиваем вложенные объекты в колонки-листья (столбец на
+  // лист = прямое «колонка источника → поле»); single-child unwrap разматывает общий верхний ключ
+  // (кейс union — поля варианта показываются напрямую, имя — подписью над таблицей); двухэтажная шапка.
+  const previewModel = useMemo(
+    () => buildPreviewModel(
+      (preview.data?.rows ?? []) as Record<string, unknown>[],
+      key => effectiveFields.find(f => f.key === key)?.title,
+    ),
+    [preview.data, effectiveFields],
+  );
+  const previewHasGroups = previewModel.groups.some(g => g.parentKey !== '');
 
   return (
     <Modal open onOpenChange={o => { if (!o) onClose(); }} title={`Материализация источника «${source.name}»`} wide
@@ -141,22 +149,47 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
                 ) : preview.data?.error ? (
                   <p className="text-xs text-danger p-3">{preview.data.error}</p>
                 ) : preview.data && preview.data.rows.length > 0 ? (
-                  <table className={dtTable}>
-                    <thead>
-                      <tr>
-                        {previewCols.map(c => <th key={c} className={dtTh}>{c}</th>)}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {preview.data.rows.map((row, i) => (
-                        <tr key={i} className={dtRow}>
-                          {previewCols.map(c => (
-                            <td key={c} className={`${dtTd} text-fg2 align-top`}>{renderCell(row[c])}</td>
+                  previewModel.leaves.length === 0 ? (
+                    <p className="text-xs text-fg4 p-3">Нет заполненных полей — задайте маппинг.</p>
+                  ) : (
+                    <>
+                      {previewModel.unwrappedLabel && (
+                        <p className="text-[11px] text-fg4 px-2 pt-2">Вариант: <span className="text-fg2">{previewModel.unwrappedLabel}</span></p>
+                      )}
+                      <table className={dtTable}>
+                        <thead>
+                          {/* Верхний этаж: группы-родители (colSpan) + листья-без-родителя (rowSpan 2, если есть вложенность). */}
+                          <tr>
+                            {previewModel.groups.map(g => g.parentKey === ''
+                              ? g.leaves.map(l => (
+                                  <th key={l.key} rowSpan={previewHasGroups ? 2 : 1} className={dtTh} title={l.key}>{leafLabel(l)}</th>
+                                ))
+                              : (
+                                <th key={g.parentKey} colSpan={g.leaves.length} className={`${dtTh} text-center`} title={g.parentKey}>
+                                  {lastSeg(g.parentKey)}
+                                </th>
+                              ))}
+                          </tr>
+                          {/* Нижний этаж: только листья сгруппированных родителей (нет вложенности — нет ряда). */}
+                          {previewHasGroups && (
+                            <tr>
+                              {previewModel.groups.filter(g => g.parentKey !== '').flatMap(g =>
+                                g.leaves.map(l => <th key={l.key} className={dtTh} title={l.key}>{leafLabel(l)}</th>))}
+                            </tr>
+                          )}
+                        </thead>
+                        <tbody>
+                          {previewModel.rows.map((row, i) => (
+                            <tr key={i} className={dtRow}>
+                              {previewModel.leaves.map(l => (
+                                <td key={l.key} className={`${dtTd} text-fg2 align-top`}>{renderCell(getPath(row, l.path))}</td>
+                              ))}
+                            </tr>
                           ))}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                        </tbody>
+                      </table>
+                    </>
+                  )
                 ) : (
                   <p className="text-xs text-fg4 p-3">Нет строк.</p>
                 )}
@@ -173,6 +206,100 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
 function renderCell(v: unknown) {
   if (v == null) return <span className="text-fg4">—</span>;
   if (isFileAttachment(v)) return <span>{v.fileName} <span className="text-fg4">({formatBytes(v.size)})</span></span>;
+  // Массивы/doc-array — сводкой (issue #393): «одна материализованная строка = один ряд», не разворачиваем.
+  if (Array.isArray(v)) return <span className="text-fg4">▦ {v.length} элем.</span>;
   if (typeof v === 'object') return <span className="text-fg4">{JSON.stringify(v)}</span>;
   return String(v);
 }
+
+// ── Модель предпросмотра: разворот вложенного в колонки-листья (issue #393) ────────────────────
+export interface LeafCol { path: string[]; key: string }
+export interface LeafGroup { parentKey: string; leaves: LeafCol[] }
+export interface PreviewModel {
+  rows: Record<string, unknown>[];
+  leaves: LeafCol[];
+  groups: LeafGroup[];
+  /** Подпись размотанного верхнего ключа (кейс union) над таблицей, либо '' . */
+  unwrappedLabel: string;
+}
+
+/** Собирает модель предпросмотра из сырых материализованных строк (чистая, тестируемая). */
+export function buildPreviewModel(
+  rawRows: Record<string, unknown>[],
+  titleFor: (key: string) => string | undefined = () => undefined,
+): PreviewModel {
+  const { rows, unwrapped } = unwrapSingleChild(rawRows);
+  // Порядок листьев — натуральный (DFS): у согласованных строк материализатора соседи-поля одного
+  // родителя уже идут подряд и совпадают с порядком полей типа (что и ждёт пользователь).
+  const leaves = collectLeaves(rows);
+  const unwrappedLabel = unwrapped
+    .map((seg, i) => (i === 0 ? titleFor(seg) ?? seg : seg))
+    .join(' → ');
+  return { rows, leaves, groups: coalesceByParent(leaves), unwrappedLabel };
+}
+
+/** Составной объект, разворачиваемый в колонки (не null, не массив, не файл-вложение). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v) && !isFileAttachment(v);
+}
+
+/** Пока ВСЕ строки лежат под одним общим верхним ключом-объектом — разматываем его (кейс union:
+ * поля варианта наружу, имя ключа — в подпись над таблицей). Возвращает размотанные строки + цепочку ключей. */
+function unwrapSingleChild(rows: Record<string, unknown>[]): { rows: Record<string, unknown>[]; unwrapped: string[] } {
+  const unwrapped: string[] = [];
+  let cur = rows;
+  while (cur.length > 0) {
+    const keys0 = Object.keys(cur[0] ?? {});
+    if (keys0.length !== 1) break;
+    const k = keys0[0];
+    if (!cur.every(r => {
+      const ks = Object.keys(r ?? {});
+      return ks.length === 1 && ks[0] === k && isPlainObject(r[k]);
+    })) break;
+    unwrapped.push(k);
+    cur = cur.map(r => r[k] as Record<string, unknown>);
+  }
+  return { rows: cur, unwrapped };
+}
+
+/** Обходит строки, собирая пути листьев (значения-НЕ-объекты) в порядке первого появления. */
+function collectLeaves(rows: Record<string, unknown>[]): LeafCol[] {
+  const seen = new Set<string>();
+  const cols: LeafCol[] = [];
+  function walk(obj: Record<string, unknown>, prefix: string[]) {
+    for (const [k, v] of Object.entries(obj)) {
+      const path = [...prefix, k];
+      if (isPlainObject(v)) walk(v, path);
+      else {
+        const key = path.join('.');
+        if (!seen.has(key)) { seen.add(key); cols.push({ path, key }); }
+      }
+    }
+  }
+  for (const r of rows) walk(r ?? {}, []);
+  return cols;
+}
+
+/** Схлопывает подряд идущие листья с общим родителем в группы (родитель '' = лист без родителя). */
+function coalesceByParent(leaves: LeafCol[]): LeafGroup[] {
+  const groups: LeafGroup[] = [];
+  for (const l of leaves) {
+    const pk = l.path.slice(0, -1).join('.');
+    const last = groups[groups.length - 1];
+    if (last && last.parentKey === pk) last.leaves.push(l);
+    else groups.push({ parentKey: pk, leaves: [l] });
+  }
+  return groups;
+}
+
+export function getPath(row: Record<string, unknown>, path: string[]): unknown {
+  let cur: unknown = row;
+  for (const seg of path) {
+    if (!isPlainObject(cur)) return undefined;
+    cur = cur[seg];
+  }
+  return cur;
+}
+
+const leafLabel = (l: LeafCol) => l.path[l.path.length - 1];
+const lastSeg = (key: string) => key.split('.').pop() ?? key;

--- a/src/client/src/features/datasets/materializePreviewModel.test.ts
+++ b/src/client/src/features/datasets/materializePreviewModel.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { buildPreviewModel, getPath } from './MaterializationDialog';
+
+describe('buildPreviewModel (issue #393)', () => {
+  it('разворачивает вложенные объекты в колонки-листья с точечными путями', () => {
+    const rows = [
+      { Обозначение: 'ВРЦ', Кабель: { Марка: 'ВВГ', Сечение: '5x16' } },
+      { Обозначение: 'ГРЩ', Кабель: { Марка: 'ПуГВ', Сечение: '4x25' } },
+    ];
+    const m = buildPreviewModel(rows);
+    expect(m.leaves.map(l => l.key)).toEqual(['Обозначение', 'Кабель.Марка', 'Кабель.Сечение']);
+    expect(m.unwrappedLabel).toBe(''); // верхних ключей несколько — размотки нет
+    // значение достаётся по пути
+    expect(getPath(m.rows[0], ['Кабель', 'Марка'])).toBe('ВВГ');
+  });
+
+  it('single-child unwrap: общий верхний ключ размотан, имя — в подписи (кейс union)', () => {
+    const rows = [
+      { КабельнаяЛинияТрасса: { Обозначение: 'ВРЦ', КабельПоПроекту: { Марка: 'ВВГ' } } },
+      { КабельнаяЛинияТрасса: { Обозначение: 'ГРЩ', КабельПоПроекту: { Марка: 'ПуГВ' } } },
+    ];
+    const m = buildPreviewModel(rows, k => (k === 'КабельнаяЛинияТрасса' ? 'Кабельная линия методом трасс' : undefined));
+    // префикс варианта размотан — колонки без него
+    expect(m.leaves.map(l => l.key)).toEqual(['Обозначение', 'КабельПоПроекту.Марка']);
+    expect(m.unwrappedLabel).toBe('Кабельная линия методом трасс'); // берётся title, не ключ
+    expect(getPath(m.rows[1], ['КабельПоПроекту', 'Марка'])).toBe('ПуГВ');
+  });
+
+  it('НЕ разматывает, если у строк разные верхние ключи', () => {
+    const rows = [{ A: { x: 1 } }, { B: { y: 2 } }];
+    const m = buildPreviewModel(rows);
+    expect(m.unwrappedLabel).toBe('');
+    expect(m.leaves.map(l => l.key)).toEqual(['A.x', 'B.y']);
+  });
+
+  it('двухэтажная шапка: листья одного родителя идут подряд, группы схлопнуты', () => {
+    const rows = [{ Обозначение: 'ВРЦ', Кабель: { Марка: 'ВВГ', Сечение: '5x16' }, Примечание: 'ok' }];
+    const m = buildPreviewModel(rows);
+    // группы: [Обозначение(без родителя)], [Кабель: Марка,Сечение], [Примечание(без родителя)]
+    expect(m.groups.map(g => ({ p: g.parentKey, n: g.leaves.length }))).toEqual([
+      { p: '', n: 1 },
+      { p: 'Кабель', n: 2 },
+      { p: '', n: 1 },
+    ]);
+  });
+
+  it('порядок листьев — натуральный (порядок полей типа), depth-1 не хоистятся к группам', () => {
+    const rows = [{ Обозначение: 'ВРЦ', Кабель: { Марка: 'ВВГ' }, Примечание: 'ok' }];
+    const m = buildPreviewModel(rows);
+    // Примечание остаётся ПОСЛЕ группы Кабель, а не подтягивается к другим листьям-без-родителя
+    expect(m.leaves.map(l => l.key)).toEqual(['Обозначение', 'Кабель.Марка', 'Примечание']);
+  });
+
+  it('массивы и файлы — листья (не разворачиваются в объект)', () => {
+    const rows = [{ Работы: [1, 2, 3], Файл: { $type: 'file', blobPath: 'b/x', fileName: 'a.pdf', size: 10 } }];
+    const m = buildPreviewModel(rows);
+    expect(m.leaves.map(l => l.key)).toEqual(['Работы', 'Файл']);
+    expect(getPath(m.rows[0], ['Работы'])).toEqual([1, 2, 3]);
+  });
+
+  it('пустые строки → нет колонок', () => {
+    expect(buildPreviewModel([{}, {}]).leaves).toEqual([]);
+    expect(buildPreviewModel([]).leaves).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Проблема

Блок «Предпросмотр материализации» показывал вложенные значения сырым `JSON.stringify`. У union-типа вся сущность лежит под одним ключом активного варианта → одна колонка большого JSON на все строки (баг-репорт со скрином).

## Решение (согласовано с Дизайнером, раздел 33 отчёта)

`MaterializationDialog.tsx`:
- **Разворот листьев в колонки** с точечными путями — столбец на лист = прямое «колонка источника → поле»;
- **single-child unwrap**: общий верхний ключ разматывается (кейс union — поля варианта показываются напрямую, имя варианта — подписью «Вариант: …» над таблицей; берётся title поля);
- **двухэтажная шапка** — родитель (`colSpan`) сверху, листья снизу; полный путь в `title`; для плоских типов шапка одноэтажная;
- **массивы/doc-array** — сводкой «N элем.», не разворачиваются построчно (одна материализованная строка = один ряд).

Логика вынесена в чистую `buildPreviewModel` + **7 unit-тестов** (`materializePreviewModel.test.ts`).

## Отложено (follow-up)
Предохранитель при глубине (>~15 колонок): сворачивание вложенных групп в чип-колонку `{…N} ▸`.

## Проверка
`tsc -b` зелёный · `npm test` — 153 passed.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)