### PR TITLE
Составной маппинг: дефолт «Встроенный» (#395)

### DIFF
--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -69,7 +69,8 @@ function CompositeFieldMapping({ field, token, onChange, columnNames, allDocType
   const inlineMap = parseInlineMapping(token);
   const refMap = parseRefMapping(token);
   const [modeOverride, setModeOverride] = useState<'ref' | 'inline' | null>(null);
-  const mode = modeOverride ?? (inlineMap ? 'inline' : 'ref');
+  // Дефолт для пустого токена — «Встроенный» (issue #395); существующий ref-токен всё равно открывается как ref.
+  const mode = modeOverride ?? (inlineMap ? 'inline' : refMap ? 'ref' : 'inline');
   const [refModeOverride, setRefModeOverride] = useState<'name' | 'identity' | null>(null);
   const refModeVal = refModeOverride ?? (refMap?.identityColumns ? 'identity' : 'name');
   const [expanded, setExpanded] = useState<Set<string>>(new Set());


### PR DESCRIPTION
Во всех составных маппингах (`CompositeFieldMapping` — общий для материализации и вкладки наборов данных) при пустом токене сегмент по умолчанию встаёт в «🔗 По ссылке». Пользователь хочет дефолт **«{} Встроенный»**.

`mode = modeOverride ?? (inlineMap ? 'inline' : refMap ? 'ref' : 'inline')` — существующий ref-токен открывается как ref, пустой → inline.

`tsc -b` зелёный · `npm test` — 153 passed.

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)