### PR TITLE
Изменение фильтра источника обновляет счётчик/предпросмотр (#399)

### DIFF
--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -335,7 +335,14 @@ export function useSetDataSetSourceProcessing() {
   }>({
     mutationFn: ({ id, ...data }) =>
       apiClient.put(`/datasets/sources/${id}/processing`, data).then(r => r.data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['datasets', 'files'] }),
+    // Инвалидируем и предпросмотр источника (issue #399): счётчик строк и превью считаются пост-пайплайна
+    // через usePreviewDataSetSource (['datasets','preview',sourceId,...]) — без этого фильтр не виден до
+    // перемонтирования. Префикс-матч покрывает maxRows=1 (счётчик) и maxRows=50 (превью).
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: ['datasets', 'files'] });
+      qc.invalidateQueries({ queryKey: ['datasets', 'preview', id] });
+      qc.invalidateQueries({ queryKey: ['datasets', 'materialize-preview', id] });
+    },
   });
 }
 
@@ -396,7 +403,12 @@ export function useApplyProcessingTemplate() {
   return useMutation<DataSetSource, Error, { sourceId: string; templateId: string }>({
     mutationFn: ({ sourceId, templateId }) =>
       apiClient.post(`/datasets/sources/${sourceId}/apply-template/${templateId}`).then(r => r.data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['datasets', 'files'] }),
+    // Тот же пробел, что в useSetDataSetSourceProcessing (issue #399) — освежаем предпросмотр источника.
+    onSuccess: (_data, { sourceId }) => {
+      qc.invalidateQueries({ queryKey: ['datasets', 'files'] });
+      qc.invalidateQueries({ queryKey: ['datasets', 'preview', sourceId] });
+      qc.invalidateQueries({ queryKey: ['datasets', 'materialize-preview', sourceId] });
+    },
   });
 }
 


### PR DESCRIPTION
## Симптом
Изменение фильтра (RowFilter) источника применяется на бэке, но UI не обновляется — счётчик строк и предпросмотр остаются старыми до ухода/возврата в раздел.

## Причина
Счётчик (`SourcesExpander`) и предпросмотр (`SourcePreviewDialog`) берутся из `usePreviewDataSetSource` → ключ `['datasets','preview',sourceId,maxRows]`. Мутации `useSetDataSetSourceProcessing` и `useApplyProcessingTemplate` инвалидировали только `['datasets','files']` → preview-запрос оставался stale.

## Фикс
В обеих мутациях дополнительно инвалидируем `['datasets','preview', sourceId]` (префикс-матч покрывает счётчик maxRows=1 и превью maxRows=50) и `['datasets','materialize-preview', sourceId]`.

`tsc -b` зелёный · `npm test` — 153 passed.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)