### PR TITLE
Фильтр строк: не сбрасывать значение при смене оператора (#401)

### DIFF
--- a/src/client/src/features/datasets/RowFilterDialog.tsx
+++ b/src/client/src/features/datasets/RowFilterDialog.tsx
@@ -91,7 +91,12 @@ function FilterConditionRow({
       {/* Operator */}
       <select
         value={cond.op}
-        onChange={e => onChange({ ...cond, op: e.target.value as FilterOp, value: undefined })}
+        // Значение НЕ сбрасываем при смене оператора (issue #401) — очищаем только при переходе
+        // на оператор без значения (isEmpty и т.п.), чтобы не тащить мусор в сериализацию.
+        onChange={e => {
+          const op = e.target.value as FilterOp;
+          onChange({ ...cond, op, ...(FILTER_OPS_NO_VALUE.includes(op) ? { value: undefined } : {}) });
+        }}
         className={`${FIELD_CLS} shrink-0`}
         style={{ width: '148px' }}
       >


### PR DESCRIPTION
В диалоге «Фильтрация строк» при смене оператора значение сбрасывалось (`value: undefined`). Теперь значение сохраняется; очищается только при переходе на оператор БЕЗ значения (`FILTER_OPS_NO_VALUE`, напр. isEmpty) — чтобы не тащить мусор в сериализацию.

`tsc -b` зелёный · `npm test` — 153 passed.

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)