### PR TITLE
Полнота backup: userlib + ассеты шаблонов + перечисления (#403)

### DIFF
--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -79,8 +79,10 @@ function RestoreResultModal({
 }) {
   const total =
     (report.primitiveTypesCreated ?? 0) + (report.primitiveTypesUpdated ?? 0) +
+    (report.enumTypesCreated ?? 0) + (report.enumTypesUpdated ?? 0) +
     report.documentTypesCreated + report.documentTypesUpdated +
     report.templatesCreated + report.templatesUpdated +
+    (report.templateAssetsCreated ?? 0) + (report.templateAssetsUpdated ?? 0) +
     report.catalogEntitiesCreated + report.catalogEntitiesUpdated +
     report.commonDataEntriesCreated + report.commonDataEntriesUpdated;
 
@@ -123,16 +125,23 @@ function RestoreResultModal({
             <tbody className="divide-y divide-muted">
               <StatRow label="Типы полей"
                 created={report.primitiveTypesCreated ?? 0} updated={report.primitiveTypesUpdated ?? 0} />
+              <StatRow label="Перечисления"
+                created={report.enumTypesCreated ?? 0} updated={report.enumTypesUpdated ?? 0} />
               <StatRow label="Типы документов"
                 created={report.documentTypesCreated} updated={report.documentTypesUpdated} />
               <StatRow label="Шаблоны"
                 created={report.templatesCreated} updated={report.templatesUpdated} />
+              <StatRow label="Ассеты шаблонов"
+                created={report.templateAssetsCreated ?? 0} updated={report.templateAssetsUpdated ?? 0} />
               <StatRow label="Записи каталога"
                 created={report.catalogEntitiesCreated} updated={report.catalogEntitiesUpdated} />
               <StatRow label="Общие данные"
                 created={report.commonDataEntriesCreated} updated={report.commonDataEntriesUpdated} />
             </tbody>
           </table>
+          {report.typstUserLibRestored && (
+            <p className="px-4 py-2 text-xs text-fg3 border-t border-stroke">Библиотека Typst (userlib) восстановлена.</p>
+          )}
         </div>
       )}
 

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -253,6 +253,11 @@ export interface RestoreReport {
   commonDataEntriesUpdated: number;
   primitiveTypesCreated: number;
   primitiveTypesUpdated: number;
+  enumTypesCreated?: number;
+  enumTypesUpdated?: number;
+  templateAssetsCreated?: number;
+  templateAssetsUpdated?: number;
+  typstUserLibRestored?: boolean;
 }
 
 // ─── DataSets ─────────────────────────────────────────────────────────────────

--- a/src/server/BHS.CRG.Application/Backup/BackupModels.cs
+++ b/src/server/BHS.CRG.Application/Backup/BackupModels.cs
@@ -10,7 +10,12 @@ public record BackupManifest(
     BackupTemplate[] Templates,
     BackupCatalogEntity[] CatalogEntities,
     BackupCommonDataEntry[] CommonDataEntries,
-    BackupPrimitiveType[]? PrimitiveTypes = null);
+    BackupPrimitiveType[]? PrimitiveTypes = null,
+    // Аддитивные (nullable, в конце) — не ломают чтение прежних v2-копий и не требуют bump схемы:
+    // конфигурация, от которой зависит генерация, но которая раньше в бэкап не попадала (issue #403).
+    BackupEnumType[]? EnumTypes = null,
+    BackupTemplateAsset[]? TemplateAssets = null,
+    BackupTypstUserLib? TypstUserLib = null);
 
 public record BackupPrimitiveType(
     Guid Id, string Name, string Code, string BaseType, string? Description,
@@ -37,6 +42,22 @@ public record BackupCommonDataEntry(
     DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt,
     string[]? Aliases = null);
 
+// Переиспользуемое перечисление (issue #59) — схемы типов ссылаются на него через typeId; без него
+// генерация не резолвит код→имя enum-полей.
+public record BackupEnumType(
+    Guid Id, string Name, string Code, string? Description, JsonElement Values,
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt, string? Group = null);
+
+// Ассет Typst-шаблона (issue #62) — графика/шрифт; сам файл лежит в blob-хранилище (BlobPath собирается
+// в архив как остальные блобы).
+public record BackupTemplateAsset(
+    Guid Id, string Scope, Guid? ScopeId, string Kind,
+    string Name, string FileName, string MimeType, string BlobPath, string? FontFamilyName,
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
+// Общая Typst-библиотека (userlib.typ) — синглтон, подмешивается при компиляции всех шаблонов.
+public record BackupTypstUserLib(string Content, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
 public record RestoreReport(
     bool Success,
     string? ConversionNotice,
@@ -50,4 +71,9 @@ public record RestoreReport(
     int CommonDataEntriesCreated,
     int CommonDataEntriesUpdated,
     int PrimitiveTypesCreated = 0,
-    int PrimitiveTypesUpdated = 0);
+    int PrimitiveTypesUpdated = 0,
+    int EnumTypesCreated = 0,
+    int EnumTypesUpdated = 0,
+    int TemplateAssetsCreated = 0,
+    int TemplateAssetsUpdated = 0,
+    bool TypstUserLibRestored = false);

--- a/src/server/BHS.CRG.Domain/Documents/TypstUserLib.cs
+++ b/src/server/BHS.CRG.Domain/Documents/TypstUserLib.cs
@@ -14,4 +14,7 @@ public class TypstUserLib : Entity
         => new() { Id = SingletonId, Content = content };
 
     public void UpdateContent(string content) { Content = content; TouchUpdatedAt(); }
+
+    public static TypstUserLib Restore(string content, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        => new() { Id = SingletonId, Content = content, CreatedAt = createdAt, UpdatedAt = updatedAt };
 }

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -66,6 +66,9 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         var catalogEntities = await db.CatalogEntities.AsNoTracking().ToListAsync(ct);
         var commonDataEntries = await db.DomainObjects.AsNoTracking().Where(o => o.Facet == null).ToListAsync(ct);
         var primitiveTypes = await db.PrimitiveTypes.AsNoTracking().ToListAsync(ct);
+        var enumTypes = await db.EnumTypes.AsNoTracking().ToListAsync(ct);
+        var templateAssets = await db.TemplateAssets.AsNoTracking().ToListAsync(ct);
+        var userLib = await db.TypstUserLibs.AsNoTracking().FirstOrDefaultAsync(ct);
 
         return new BackupManifest(
             SchemaVersion: CurrentSchemaVersion,
@@ -89,7 +92,16 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             PrimitiveTypes: primitiveTypes.Select(p => new BackupPrimitiveType(
                 p.Id, p.Name, p.Code, p.BaseType, p.Description,
                 p.Constraints.RootElement.Clone(),
-                p.CreatedAt, p.UpdatedAt, p.Group)).ToArray());
+                p.CreatedAt, p.UpdatedAt, p.Group)).ToArray(),
+            EnumTypes: enumTypes.Select(e => new BackupEnumType(
+                e.Id, e.Name, e.Code, e.Description, e.Values.RootElement.Clone(),
+                e.CreatedAt, e.UpdatedAt, e.Group)).ToArray(),
+            TemplateAssets: templateAssets.Select(a => new BackupTemplateAsset(
+                a.Id, a.Scope.ToString(), a.ScopeId, a.Kind.ToString(),
+                a.Name, a.FileName, a.MimeType, a.BlobPath, a.FontFamilyName,
+                a.CreatedAt, a.UpdatedAt)).ToArray(),
+            TypstUserLib: userLib is null ? null
+                : new BackupTypstUserLib(userLib.Content, userLib.CreatedAt, userLib.UpdatedAt));
     }
 
     // ── Import ────────────────────────────────────────────────────────────────
@@ -152,8 +164,11 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         {
             var stats = new RestoreStats();
             await RestorePrimitiveTypesAsync(manifest.PrimitiveTypes ?? [], stats, warnings, ct);
+            await RestoreEnumTypesAsync(manifest.EnumTypes ?? [], stats, warnings, ct);
             await RestoreDocumentTypesAsync(manifest.DocumentTypes, stats, warnings, ct);
             await RestoreTemplatesAsync(manifest.Templates, stats, warnings, ct);
+            await RestoreTemplateAssetsAsync(manifest.TemplateAssets ?? [], stats, warnings, ct);
+            await RestoreTypstUserLibAsync(manifest.TypstUserLib, stats, ct);
             await RestoreCatalogEntitiesAsync(manifest.CatalogEntities, stats, warnings, ct);
             await RestoreCommonDataEntriesAsync(manifest.CommonDataEntries, stats, warnings, ct);
             await tx.CommitAsync(ct);
@@ -163,7 +178,10 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
                 stats.TemplatesCreated, stats.TemplatesUpdated,
                 stats.CatalogEntitiesCreated, stats.CatalogEntitiesUpdated,
                 stats.CommonDataEntriesCreated, stats.CommonDataEntriesUpdated,
-                stats.PrimitiveTypesCreated, stats.PrimitiveTypesUpdated);
+                stats.PrimitiveTypesCreated, stats.PrimitiveTypesUpdated,
+                stats.EnumTypesCreated, stats.EnumTypesUpdated,
+                stats.TemplateAssetsCreated, stats.TemplateAssetsUpdated,
+                stats.TypstUserLibRestored);
         }
         catch (Exception ex)
         {
@@ -182,6 +200,9 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             CollectBlobPaths(e.Data, paths);
         foreach (var e in manifest.CatalogEntities)
             CollectBlobPaths(e.Data, paths);
+        // Файлы ассетов шаблонов (issue #403) — графика/шрифты в blob-хранилище.
+        foreach (var a in manifest.TemplateAssets ?? [])
+            if (!string.IsNullOrEmpty(a.BlobPath)) paths.Add(a.BlobPath);
         return paths;
     }
 
@@ -222,6 +243,9 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             "gif"  => "image/gif",
             "webp" => "image/webp",
             "svg"  => "image/svg+xml",
+            "ttf"  => "font/ttf",
+            "otf"  => "font/otf",
+            "ttc"  => "font/collection",
             _ => "application/octet-stream",
         };
 
@@ -242,6 +266,79 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         }
         await db.SaveChangesAsync(ct);
         db.ChangeTracker.Clear();
+    }
+
+    private async Task RestoreEnumTypesAsync(
+        BackupEnumType[] items, RestoreStats stats, List<string> warnings, CancellationToken ct)
+    {
+        var existingIds = await db.EnumTypes.Select(e => e.Id).ToHashSetAsync(ct);
+        foreach (var item in items)
+        {
+            var entity = EnumType.Restore(
+                item.Id, item.Name, item.Code, item.Description,
+                JsonDocument.Parse(item.Values.GetRawText()),
+                item.CreatedAt, item.UpdatedAt, item.Group);
+            db.Entry(entity).State = existingIds.Contains(item.Id) ? EntityState.Modified : EntityState.Added;
+            if (existingIds.Contains(item.Id)) stats.EnumTypesUpdated++; else stats.EnumTypesCreated++;
+        }
+        await db.SaveChangesAsync(ct);
+        db.ChangeTracker.Clear();
+    }
+
+    private async Task RestoreTemplateAssetsAsync(
+        BackupTemplateAsset[] items, RestoreStats stats, List<string> warnings, CancellationToken ct)
+    {
+        var existingIds = await db.TemplateAssets.Select(e => e.Id).ToHashSetAsync(ct);
+        // scopeId ссылается на шаблон/тип документа (для System — null); проверяем валидность ссылки,
+        // чтобы не оставить осиротевший ассет (зеркалим защиту из RestoreTemplatesAsync).
+        var validTemplateIds = await db.Templates.Select(e => e.Id).ToHashSetAsync(ct);
+        var validDocTypeIds = await db.DocumentTypes.Select(e => e.Id).ToHashSetAsync(ct);
+        foreach (var item in items)
+        {
+            if (!Enum.TryParse<TemplateAssetScope>(item.Scope, out var scope))
+            {
+                warnings.Add($"Ассет шаблона «{item.Name}»: неизвестная область «{item.Scope}», пропущен.");
+                continue;
+            }
+            if (!Enum.TryParse<TemplateAssetKind>(item.Kind, out var kind))
+            {
+                warnings.Add($"Ассет шаблона «{item.Name}»: неизвестный вид «{item.Kind}», пропущен.");
+                continue;
+            }
+            var scopeOk = scope switch
+            {
+                TemplateAssetScope.Template => item.ScopeId is { } sid && validTemplateIds.Contains(sid),
+                TemplateAssetScope.DocumentType => item.ScopeId is { } sid && validDocTypeIds.Contains(sid),
+                _ => true, // System — scopeId == null
+            };
+            if (!scopeOk)
+            {
+                warnings.Add($"Ассет шаблона «{item.Name}»: цель области ({item.Scope} {item.ScopeId}) не найдена, пропущен.");
+                continue;
+            }
+            var entity = TemplateAsset.Restore(
+                item.Id, scope, item.ScopeId, kind,
+                item.Name, item.FileName, item.MimeType, item.BlobPath, item.FontFamilyName,
+                item.CreatedAt, item.UpdatedAt);
+            db.Entry(entity).State = existingIds.Contains(item.Id) ? EntityState.Modified : EntityState.Added;
+            if (existingIds.Contains(item.Id)) stats.TemplateAssetsUpdated++; else stats.TemplateAssetsCreated++;
+        }
+        await db.SaveChangesAsync(ct);
+        db.ChangeTracker.Clear();
+    }
+
+    private async Task RestoreTypstUserLibAsync(
+        BackupTypstUserLib? item, RestoreStats stats, CancellationToken ct)
+    {
+        if (item is null) return; // старый бэкап без userlib — нечего восстанавливать
+        var existing = await db.TypstUserLibs.FirstOrDefaultAsync(l => l.Id == TypstUserLib.SingletonId, ct);
+        if (existing is not null)
+            existing.UpdateContent(item.Content);
+        else
+            db.TypstUserLibs.Add(TypstUserLib.Restore(item.Content, item.CreatedAt, item.UpdatedAt));
+        await db.SaveChangesAsync(ct);
+        db.ChangeTracker.Clear();
+        stats.TypstUserLibRestored = true;
     }
 
     private async Task RestoreDocumentTypesAsync(
@@ -356,8 +453,11 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
     private sealed class RestoreStats
     {
         public int PrimitiveTypesCreated, PrimitiveTypesUpdated;
+        public int EnumTypesCreated, EnumTypesUpdated;
         public int DocumentTypesCreated, DocumentTypesUpdated;
         public int TemplatesCreated, TemplatesUpdated;
+        public int TemplateAssetsCreated, TemplateAssetsUpdated;
+        public bool TypstUserLibRestored;
         public int CatalogEntitiesCreated, CatalogEntitiesUpdated;
         public int CommonDataEntriesCreated, CommonDataEntriesUpdated;
     }

--- a/src/server/BHS.CRG.Tests/Integration/BackupServiceTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/BackupServiceTests.cs
@@ -1,0 +1,146 @@
+using System.IO.Compression;
+using System.Text.Json;
+using BHS.CRG.Application.Backup;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Templates;
+using BHS.CRG.Infrastructure.Backup;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Полнота бэкапа (issue #403): конфигурация, от которой зависит генерация — переиспользуемые
+/// перечисления (EnumType), ассеты шаблонов (TemplateAsset + их блобы) и общая Typst-библиотека
+/// (TypstUserLib, синглтон) — должна пережить export→wipe→import. До #403 эти три сущности в
+/// бэкап не попадали вовсе.
+/// </summary>
+[Collection("Integration")]
+public class BackupServiceTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private const string AssetBlobPath = "assets/logo.png";
+    private static readonly byte[] AssetBytes = [1, 2, 3, 4, 5];
+
+    private BackupService Backup(IServiceScope scope) => new(
+        scope.ServiceProvider.GetRequiredService<AppDbContext>(),
+        scope.ServiceProvider.GetRequiredService<IBlobStorage>(),
+        NullLogger<BackupService>.Instance);
+
+    [Fact]
+    public async Task Export_Import_RoundTrips_EnumTypes_TemplateAssets_And_TypstUserLib()
+    {
+        // ── Seed ──────────────────────────────────────────────────────────────
+        var enumId = Guid.NewGuid();
+        var assetId = Guid.NewGuid();
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var blob = scope.ServiceProvider.GetRequiredService<IBlobStorage>();
+
+            var en = EnumType.Restore(enumId, "Статус", "status", "описание",
+                JsonDocument.Parse("""[{"code":"a","label":"Активен"}]"""),
+                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, group: "Группа");
+            db.EnumTypes.Add(en);
+
+            await blob.PutAsync(AssetBlobPath, new MemoryStream(AssetBytes), "image/png", default);
+            var asset = TemplateAsset.Restore(assetId, TemplateAssetScope.System, null, TemplateAssetKind.Image,
+                "logo", "logo.png", "image/png", AssetBlobPath, null,
+                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+            db.TemplateAssets.Add(asset);
+
+            db.TypstUserLibs.Add(TypstUserLib.Create("#let hello() = [привет]"));
+            await db.SaveChangesAsync();
+        }
+
+        // ── Export ────────────────────────────────────────────────────────────
+        byte[] zipBytes;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var (zip, _) = await Backup(scope).ExportAsync();
+            using var ms = new MemoryStream();
+            await zip.CopyToAsync(ms);
+            zipBytes = ms.ToArray();
+        }
+
+        // Архив должен содержать файл ассета шаблона (раньше блоб терялся).
+        using (var check = new ZipArchive(new MemoryStream(zipBytes), ZipArchiveMode.Read))
+            Assert.Contains(check.Entries, e => e.FullName == $"blobs/{AssetBlobPath}");
+
+        // ── Симулируем чистое окружение: стираем БД и блоб ──────────────────────
+        using (var scope = fixture.Services.CreateScope())
+            await scope.ServiceProvider.GetRequiredService<IBlobStorage>().DeleteAsync(AssetBlobPath);
+        await fixture.ResetDatabaseAsync();
+
+        // ── Import ────────────────────────────────────────────────────────────
+        RestoreReport report;
+        using (var scope = fixture.Services.CreateScope())
+            report = await Backup(scope).ImportAsync(new MemoryStream(zipBytes));
+
+        Assert.True(report.Success);
+        Assert.Equal(1, report.EnumTypesCreated);
+        Assert.Equal(1, report.TemplateAssetsCreated);
+        Assert.True(report.TypstUserLibRestored);
+
+        // ── Проверяем восстановленное состояние ─────────────────────────────────
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var blob = scope.ServiceProvider.GetRequiredService<IBlobStorage>();
+
+            var en = await db.EnumTypes.FirstOrDefaultAsync(e => e.Id == enumId);
+            Assert.NotNull(en);
+            Assert.Equal("status", en!.Code);
+            Assert.Equal("Группа", en.Group);
+
+            var asset = await db.TemplateAssets.FirstOrDefaultAsync(a => a.Id == assetId);
+            Assert.NotNull(asset);
+            Assert.Equal(AssetBlobPath, asset!.BlobPath);
+
+            var lib = await db.TypstUserLibs.FirstOrDefaultAsync();
+            Assert.NotNull(lib);
+            Assert.Equal("#let hello() = [привет]", lib!.Content);
+
+            // Файл ассета восстановлен в хранилище.
+            await using var restored = await blob.DownloadAsync(AssetBlobPath);
+            using var rms = new MemoryStream();
+            await restored.CopyToAsync(rms);
+            Assert.Equal(AssetBytes, rms.ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task Import_OldBackupWithoutNewSections_DoesNotFail()
+    {
+        // Прежний v2-бэкап без новых секций (EnumTypes/TemplateAssets/TypstUserLib == null) — восстановим
+        // без ошибок и без bump схемы (аддитивные nullable-поля).
+        var manifest = new BackupManifest(
+            SchemaVersion: BackupService.CurrentSchemaVersion,
+            AppVersion: BackupService.CurrentAppVersion,
+            CreatedAt: DateTimeOffset.UtcNow,
+            DocumentTypes: [], Templates: [], CatalogEntities: [], CommonDataEntries: []);
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("manifest.json");
+            await using var w = entry.Open();
+            await JsonSerializer.SerializeAsync(w, manifest, new JsonSerializerOptions { WriteIndented = true });
+        }
+        ms.Position = 0;
+
+        using var scope = fixture.Services.CreateScope();
+        var report = await Backup(scope).ImportAsync(ms);
+
+        Assert.True(report.Success);
+        Assert.Equal(0, report.EnumTypesCreated);
+        Assert.Equal(0, report.TemplateAssetsCreated);
+        Assert.False(report.TypstUserLibRestored);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
+++ b/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
@@ -53,6 +53,7 @@ public class IntegrationTestFixture : WebApplicationFactory<Program>
                 constructions,
                 templates,
                 template_assets,
+                typst_user_lib,
                 document_types,
                 catalog_entities,
                 primitive_types,


### PR DESCRIPTION
## Аудит полноты бэкапа

`BackupManifest` покрывал: DocumentTypes, Templates, CatalogEntities, CommonDataEntries, PrimitiveTypes. Пропущена **конфигурация, от которой напрямую зависит генерация PDF**:

| Сущность | Косяк |
|---|---|
| **TypstUserLib** (userlib.typ) | Подмешивается при компиляции всех шаблонов → restore давал несобираемые шаблоны. |
| **TemplateAssets** (+ блобы) | Графика/шрифты (#62); блобы тоже терялись (ExtractBlobPaths их не видел). |
| **EnumTypes** (#59) | Схемы ссылаются через typeId; без них не резолвится код→имя enum-полей. |

Итог до фикса: restore на чистом окружении → молча сломанная генерация.

## Что сделано
- В манифест добавлены `EnumTypes`, `TemplateAssets`, `TypstUserLib` — **аддитивно** (nullable, в конце), **без bump схемы**: старые v2-копии остаются восстановимыми (проверено тестом).
- `ExtractBlobPaths` собирает блобы ассетов в архив; restore кладёт их обратно.
- Restore в порядке зависимостей: enums до типов; ассеты после шаблонов/типов с валидацией `scopeId`; userlib — upsert синглтона.
- `RestoreReport` + таблица отчёта в UI расширены счётчиками (Перечисления / Ассеты шаблонов / строка про userlib).
- Фикстура: `typst_user_lib` добавлен в TRUNCATE (синглтон переживал сброс).

## Осознанно НЕ в бэкапе (не косяк, зафиксировано в issue)
Экземплярные/проектные данные (Constructions/Sections/DocumentSets/QualityDocs/GeneratedFiles), `IntegrationSettings` (секреты), подсистема DataSets, Identity/runtime.

## Тесты
- `BackupServiceTests`: round-trip export→wipe→import (включая блоб ассета, восстановление файла в хранилище); обратная совместимость старого v2-бэкапа.
- **509 backend** (+2) · **153 frontend** · `tsc -b` зелёный.

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)