### PR TITLE
Профили распознавания C: привязка к группе — произвольные таблицы (#410)

### DIFF
--- a/src/client/src/features/datasets/PdfGroupingEditor.tsx
+++ b/src/client/src/features/datasets/PdfGroupingEditor.tsx
@@ -2,9 +2,10 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { ArrowLeft, ChevronDown, Loader2, Pencil, Trash2, AlertTriangle, Save, ZoomIn, Table2, RefreshCw } from 'lucide-react';
 import {
-  useFilePages, useApplyGrouping, useRecognizeDocumentTable, useRecognizeDocument,
+  useFilePages, useApplyGrouping, useRecognizeDocumentTable, useRecognizeDocument, useSetDocumentProfile,
   loadPageThumbnailUrl, loadPageImageUrl,
 } from '@/shared/api/datasets';
+import { useListRecognitionProfiles } from '@/shared/api/recognitionProfiles';
 import type { GostGroupingGroup, GostGroupKind } from '@/shared/api/types';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -27,6 +28,8 @@ interface EditableGroup {
   name: string | null;
   pageIndices: number[];
   tags: string[];
+  /** Привязанный профиль распознавания (issue #410); правится точечным PUT, а не сохранением разбиения. */
+  profileId: string | null;
 }
 
 /** Подпись группы для меню переноса и заголовка. */
@@ -48,10 +51,11 @@ function makeGroups(groups: GostGroupingGroup[]): EditableGroup[] {
     name: g.name,
     pageIndices: [...g.pageIndices].sort((a, b) => a - b),
     tags: g.tags ?? [],
+    profileId: g.profileId ?? null,
   }));
   // Обложка и титульный лист всегда присутствуют как группы (пустые — как цель для переноса).
   const ensure = (kind: Exclude<GostGroupKind, 'Document'>): EditableGroup[] =>
-    mapped.some(g => g.kind === kind) ? [] : [{ id: crypto.randomUUID(), kind, code: DEFAULT_CODE, name: null, pageIndices: [], tags: [] }];
+    mapped.some(g => g.kind === kind) ? [] : [{ id: crypto.randomUUID(), kind, code: DEFAULT_CODE, name: null, pageIndices: [], tags: [], profileId: null }];
   const cover = mapped.filter(g => g.kind === 'Cover');
   const title = mapped.filter(g => g.kind === 'TitlePage');
   const docs = mapped.filter(g => g.kind === 'Document');
@@ -213,6 +217,7 @@ function SelectionActionBar({
 function GroupSection({
   fileId, group, otherGroups, selected, suspiciousOnly, dirty,
   onToggle, onRename, onMoveSelected, onSplitSelected, onDisband, onView, onSetTag,
+  onSetProfile, tableProfiles, savingProfile,
   onRecognizeTable, onRecognizeDoc, tableBusyPage, docBusyPage,
 }: {
   fileId: string;
@@ -228,6 +233,9 @@ function GroupSection({
   onDisband: (groupId: string) => void;
   onView: (pageIndex: number) => void;
   onSetTag: (groupId: string, tag: string) => void;
+  onSetProfile: (firstPageIndex: number, profileId: string | null) => void;
+  tableProfiles: { id: string; name: string }[];
+  savingProfile: boolean;
   onRecognizeTable: (firstPageIndex: number) => void;
   onRecognizeDoc: (firstPageIndex: number) => void;
   tableBusyPage: number | null;
@@ -298,7 +306,17 @@ function GroupSection({
             <option value="">— тип таблицы</option>
             {TABLE_TAGS.map(t => <option key={t.code} value={t.code}>{t.label}</option>)}
           </select>
-          {currentTag && (
+          {/* Профиль распознавания (issue #410): для ПРОИЗВОЛЬНОЙ таблицы, у которой типа/тэга нет.
+              Привязка снимает требование тэга — иначе такую таблицу не распознать вовсе. */}
+          <select value={group.profileId ?? ''}
+            onChange={e => onSetProfile(firstPage, e.target.value || null)}
+            disabled={savingProfile}
+            title="Профиль распознавания — набор колонок для произвольной таблицы (задаётся в «Профили распознавания»)"
+            className="text-[11px] border border-stroke rounded px-1 py-0.5 bg-surface text-fg3 max-w-[190px] disabled:opacity-50">
+            <option value="">— профиль таблицы</option>
+            {tableProfiles.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+          </select>
+          {(currentTag || group.profileId) && (
             <button onClick={() => onRecognizeTable(firstPage)} disabled={dirty || tableBusyPage === firstPage}
               title={dirty ? 'Сначала сохраните разбиение' : 'Распознать таблицу этого документа как отдельный источник данных'}
               className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-stroke text-fg2 hover:bg-base disabled:opacity-50">
@@ -348,6 +366,13 @@ export function PdfGroupingEditor() {
   const applyMutation = useApplyGrouping(fileId!);
   const recognizeTable = useRecognizeDocumentTable(fileId!);
   const recognizeDoc = useRecognizeDocument(fileId!);
+  // Привязка профиля — точечный PUT (issue #410): не проходит через сохранение разбиения, поэтому
+  // не стирает уже распознанное сырьё таблицы и не требует предварительного сохранения.
+  const setProfile = useSetDocumentProfile(fileId!);
+  const { data: allProfiles = [] } = useListRecognitionProfiles();
+  const tableProfiles = allProfiles
+    .filter(p => p.kindInfo.isTabular)
+    .map(p => ({ id: p.id, name: p.name }));
 
   const [groups, setGroups] = useState<EditableGroup[] | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -406,7 +431,7 @@ export function PdfGroupingEditor() {
     mutateGroups(prev => {
       const cleared = removeFromAllGroups(prev, selected);
       if (targetGroupId === 'new') {
-        return [...cleared, { id: crypto.randomUUID(), kind: 'Document', code: DEFAULT_CODE, name: null, pageIndices: [...selected].sort((a, b) => a - b), tags: [] }];
+        return [...cleared, { id: crypto.randomUUID(), kind: 'Document', code: DEFAULT_CODE, name: null, pageIndices: [...selected].sort((a, b) => a - b), tags: [], profileId: null }];
       }
       return cleared.map(g => g.id === targetGroupId
         ? { ...g, pageIndices: [...g.pageIndices, ...selected].sort((a, b) => a - b) }
@@ -500,6 +525,9 @@ export function PdfGroupingEditor() {
             onToggle={toggle} onRename={handleRename} onMoveSelected={handleMoveSelected}
             onSplitSelected={handleSplitSelected} onDisband={handleDisband} onView={setViewerPage}
             onSetTag={handleSetTag}
+            onSetProfile={(page, profileId) => setProfile.mutate({ firstPageIndex: page, profileId })}
+            tableProfiles={tableProfiles}
+            savingProfile={setProfile.isPending}
             onRecognizeTable={p => recognizeTable.mutate(p)}
             onRecognizeDoc={p => recognizeDoc.mutate(p)}
             tableBusyPage={recognizeTable.isPending ? (recognizeTable.variables ?? null) : null}

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -303,6 +303,19 @@ export function useSetDocumentTags(fileId: string) {
   });
 }
 
+/** Привязка профиля распознавания к группе листов (issue #410); profileId=null снимает привязку. */
+export function useSetDocumentProfile(fileId: string) {
+  const qc = useQueryClient();
+  return useMutation<GostGrouping, unknown, { firstPageIndex: number; profileId: string | null }>({
+    mutationFn: ({ firstPageIndex, profileId }) =>
+      apiClient.put(`/datasets/files/${fileId}/document-profile`, { firstPageIndex, profileId }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['datasets', 'files', fileId, 'pages'] });
+      qc.invalidateQueries({ queryKey: ['datasets', 'source-candidates', fileId] });
+    },
+  });
+}
+
 /** Точечное перераспознавание ОДНОГО документа (не всего альбома) — фоновая задача, 202+jobId. */
 export function useRecognizeDocument(fileId: string) {
   const qc = useQueryClient();

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -318,6 +318,9 @@ export interface GostGroupingGroup {
   pageIndices: number[];
   /** Функциональные тэги документа (тип таблицы — спецификация/кабельный журнал). */
   tags?: string[] | null;
+  /** Привязанный профиль распознавания (issue #410): снимает требование тэга — так распознаются
+   *  произвольные таблицы, для которых функционального тэга не существует. */
+  profileId?: string | null;
 }
 
 export interface GostGrouping {

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Jobs;
@@ -296,6 +296,19 @@ public static class DataSetEndpoints
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
+        // Привязка профиля распознавания к группе листов (issue #410) — тоже точечно, без пересборки
+        // разбиения: иначе правка параметров стирала бы уже распознанное сырьё таблицы.
+        g.MapPut("/files/{fileId:guid}/document-profile", async (
+            Guid fileId, SetDocumentProfileRequest req, IDataSetService svc, CancellationToken ct) =>
+        {
+            try
+            {
+                var result = await svc.SetDocumentProfileAsync(fileId, req.FirstPageIndex, req.ProfileId, ct);
+                return result is null ? Results.NotFound() : Results.Ok(result);
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
         // Распознать таблицу помеченного документа (спецификация/кабельный журнал) → отдельный табличный
         // источник. Vision-вызов (минуты на большом документе) → фоновая задача, 202+jobId сразу.
         g.MapPost("/files/{fileId:guid}/recognize-table", async (
@@ -395,6 +408,7 @@ public static class DataSetEndpoints
     private record ApplyGroupingGroupRequest(GostGroupKind Kind, string? Code, string? Name, int[] PageIndices, string[]? Tags);
     private record SetDocumentTagsRequest(int FirstPageIndex, string[]? Tags);
     private record RecognizeTableRequest(int FirstPageIndex);
+    private record SetDocumentProfileRequest(int FirstPageIndex, Guid? ProfileId);
 
     private static Guid UserId(ClaimsPrincipal user)
         => Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub")!);

--- a/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
+++ b/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
@@ -79,9 +79,10 @@ public record GostGroupingDto(IReadOnlyList<GostGroupingGroupDto> Groups, bool M
 
 /// <summary>Одна группа страниц. Для документа Code/Name как в реестре; для обложки/титула — null.
 /// PageIndices — 0-based индексы исходного PDF. Tags — функциональные тэги документа (тип таблицы).</summary>
+/// <param name="ProfileId">Привязанный профиль распознавания (issue #410); null — привязки нет.</param>
 public record GostGroupingGroupDto(
     GostGroupKind Kind, string? Code, string? Name, IReadOnlyList<int> PageIndices,
-    IReadOnlyList<string>? Tags = null);
+    IReadOnlyList<string>? Tags = null, Guid? ProfileId = null);
 
 // ── Input DTOs (assembled by the HTTP layer, free of ASP.NET types) ─────────────
 

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -1,4 +1,4 @@
-namespace BHS.CRG.Application.DataSets;
+﻿namespace BHS.CRG.Application.DataSets;
 
 /// <summary>
 /// Application-level operations for data sets, bindings and binding templates.
@@ -95,6 +95,9 @@ public interface IDataSetService
     Task<GostGroupingDto?> ApplyGroupingAsync(Guid fileId, ApplyGroupingInput input, CancellationToken ct);
     /// <summary>Лёгкая установка тэгов документа (тип таблицы) без пересборки разбиения.</summary>
     Task<GostGroupingDto?> SetDocumentTagsAsync(Guid fileId, int firstPageIndex, IReadOnlyList<string> tags, CancellationToken ct);
+
+    /// <summary>Привязать профиль распознавания к группе листов (issue #410); null — снять привязку.</summary>
+    Task<GostGroupingDto?> SetDocumentProfileAsync(Guid fileId, int firstPageIndex, Guid? profileId, CancellationToken ct);
     /// <summary>Распознать таблицу помеченного документа ГОСТ-профиля (спецификация/кабельный журнал):
     /// пишет строки как СЫРЬЁ на группу (Grouping) — доступна как кандидат «Таблица …», источник создаёт
     /// пользователь (issue #42). Источника НЕ создаёт. firstPageIndex — любая страница документа.</summary>

--- a/src/server/BHS.CRG.Application/Recognition/IRecognitionProfileProvider.cs
+++ b/src/server/BHS.CRG.Application/Recognition/IRecognitionProfileProvider.cs
@@ -23,6 +23,14 @@ public interface IRecognitionProfileProvider
     /// <summary>Есть ли для тэга табличный профиль — предикат «это тэг таблицы».</summary>
     bool IsTableTag(string tag);
 
+    /// <summary>
+    /// Таблична ли группа листов: привязан ТАБЛИЧНЫЙ профиль ИЛИ есть табличный тэг (issue #410).
+    /// Единственная реализация предиката на всю систему — он используется и для показа кандидата
+    /// источника, и для решения «источник осиротел» (там по нему УДАЛЯЮТСЯ данные), поэтому две
+    /// разошедшиеся копии молча сносили бы источники произвольных таблиц.
+    /// </summary>
+    Task<bool> IsTableGroupAsync(Guid? profileId, IReadOnlyList<string>? tags, CancellationToken ct = default);
+
     /// <summary>Все профили заданного вида (для выбора в UI).</summary>
     Task<IReadOnlyList<RecognitionProfile>> ListByKindAsync(RecognitionProfileKind kind, CancellationToken ct = default);
 

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Notifications;
@@ -635,11 +635,16 @@ public class DataSetPdfRecognitionService(
             .ToList();
         if (tableSources.Count == 0) return 0;
 
-        // Стабильные id текущих документов, всё ещё помеченных табличным тэгом (issue #28).
-        var validGroups = unified.Groups
-            .Where(g => g.Kind == GostGroupKind.Document && g.Pages.Count > 0
-                        && (g.Tags ?? []).Any(profiles.IsTableTag))
-            .ToDictionary(g => g.Id);
+        // Стабильные id текущих документов, всё ещё ТАБЛИЧНЫХ (issue #28). Предикат — общий резолвер
+        // (issue #410): «привязан профиль ИЛИ есть табличный тэг». Критично: не попавшая сюда группа
+        // считается осиротевшей, и её источник удаляется ВМЕСТЕ С ПРИВЯЗКАМИ — оставь здесь проверку
+        // только по тэгу, и источники произвольных таблиц сносились бы при каждой ре-группировке.
+        var validGroups = new Dictionary<Guid, GostGroupingGroup>();
+        foreach (var g in unified.Groups)
+        {
+            if (g.Kind != GostGroupKind.Document || g.Pages.Count == 0) continue;
+            if (await IsTableGroupAsync(g, ct)) validGroups[g.Id] = g;
+        }
 
         var removed = 0;
         foreach (var ts in tableSources)
@@ -684,7 +689,7 @@ public class DataSetPdfRecognitionService(
         var pageCount = await GetPdfPageCountAsync(file.BlobPath, ct);
         var grouping = ParseGrouping(file.Grouping);
         var groups = (grouping?.Groups ?? [])
-            .Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags))
+            .Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags, g.ProfileId))
             .ToList();
         return new GostGroupingDto(groups, grouping?.ManuallyEdited ?? false, pageCount);
     }
@@ -741,10 +746,101 @@ public class DataSetPdfRecognitionService(
         file.SetGrouping(JsonSerializer.Serialize(new GostGroupingData(updated, grouping.ManuallyEdited)));
         await db.SaveChangesAsync(ct);
 
+        return await ToGroupingDtoAsync(file, updated, grouping.ManuallyEdited, ct);
+    }
+
+    /// <summary>
+    /// Спецификация распознавания таблицы группы — ЕДИНСТВЕННОЕ место, где решается «таблична ли
+    /// группа и по каким колонкам её читать» (issue #410). Раньше этот предикат был размазан по пяти
+    /// точкам в виде «есть известный табличный тэг», и одна из них (<c>ReprojectTableSourcesAsync</c>)
+    /// на его основании УДАЛЯЕТ источники: разъехавшись, они молча сносили бы данные.
+    ///
+    /// Приоритет: профиль на группе → тип, объявивший тэг (#29) → встроенный профиль по тэгу.
+    /// null — группа не табличная (ни профиля, ни тэга).
+    /// </summary>
+    public async Task<(IReadOnlyList<RecognitionField> Columns, RecognitionProfileKind Kind, RecognitionTableShape? Shape)?>
+        ResolveTableSpecAsync(GostGroupingGroup group, CancellationToken ct)
+    {
+        // 1. Профиль, привязанный к группе — высший приоритет и единственный путь для произвольных
+        //    таблиц (тэга у них нет). Если профиль удалён — деградируем к остальной цепочке.
+        if (group.ProfileId is { } pid && await profiles.GetByIdAsync(pid, ct) is { } bound
+            && RecognitionKinds.Describe(bound.Kind).RowsKey is not null)
+            return (bound.ToRowColumns(), bound.Kind, bound.Shape);
+
+        var tag = (group.Tags ?? []).FirstOrDefault(profiles.IsTableTag);
+        if (tag is null) return null;
+
+        var builtIn = (await profiles.GetForTagAsync(tag, ct))!;
+
+        // 2. Тип документа, объявивший тэг (#29): таблица распознаётся прямо в ключи полей типа и
+        //    материализуется в него (#19).
+        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var targetType = allTypes.FirstOrDefault(t => SchemaTags.TypeHasTag(t, allTypes, tag));
+        if (targetType is not null)
+        {
+            var typesById = allTypes.ToDictionary(t => t.Id);
+            var typeFields = DocumentTypeSchemaReader.EffectiveFields(targetType.Id, typesById)
+                .Where(f => SchemaFieldKinds.IsScalar(f.Type))
+                .ToList();
+            if (typeFields.Count == 0)
+                throw new ArgumentException($"У типа «{targetType.Name}» нет скалярных полей для распознавания таблицы.");
+            return (
+                typeFields.Select(f => new RecognitionField(f.Key, f.Title ?? f.Key, MapRecognitionType(f.Type))).ToList(),
+                builtIn.Kind, builtIn.Shape);
+        }
+
+        // 3. Встроенный профиль по тэгу.
+        return (builtIn.ToRowColumns(), builtIn.Kind, builtIn.Shape);
+    }
+
+    /// <summary>Таблична ли группа — тот же единый предикат, без разбора колонок.</summary>
+    public Task<bool> IsTableGroupAsync(GostGroupingGroup group, CancellationToken ct)
+        => profiles.IsTableGroupAsync(group.ProfileId, group.Tags, ct);
+
+    /// <summary>Привязка профиля распознавания к группе листов (issue #410). Точечно, как и тэги:
+    /// <c>g with { … }</c> сохраняет прочие поля группы, включая уже распознанное сырьё таблицы.
+    /// Выставляет <c>TableStale</c> — смена параметров обесценивает распознанные строки, но НЕ
+    /// перезапускает распознавание: это дорогой LLM-вызов, пользователь решает сам.
+    /// profileId = null снимает привязку (возврат к цепочке «тип → встроенный профиль по тэгу»).</summary>
+    public async Task<GostGroupingDto?> SetDocumentProfileAsync(
+        Guid fileId, int firstPageIndex, Guid? profileId, CancellationToken ct)
+    {
+        var file = await db.DataSetFiles.FirstOrDefaultAsync(f => f.Id == fileId, ct);
+        if (file == null) return null;
+        if (file.Format != DataSetFormat.Pdf)
+            throw new ArgumentException("Профиль распознавания задаётся только для PDF-набора.");
+
+        var grouping = ParseGrouping(file.Grouping)
+            ?? throw new ArgumentException("Группировка ещё не распознана.");
+
+        if (profileId is { } pid)
+        {
+            var profile = await profiles.GetByIdAsync(pid, ct)
+                ?? throw new ArgumentException("Профиль распознавания не найден.");
+            if (RecognitionKinds.Describe(profile.Kind).RowsKey is null)
+                throw new ArgumentException(
+                    $"Профиль «{profile.Name}» не табличный — к группе листов привязывается профиль таблицы.");
+        }
+
+        var updated = grouping.Groups
+            .Select(g => g.Kind == GostGroupKind.Document && g.Pages.Any(p => p.PageIndex == firstPageIndex)
+                ? g with { ProfileId = profileId, TableStale = g.TableStale || !string.IsNullOrEmpty(g.TableData) }
+                : g)
+            .ToList();
+        file.SetGrouping(JsonSerializer.Serialize(new GostGroupingData(updated, grouping.ManuallyEdited)));
+        await db.SaveChangesAsync(ct);
+
+        return await ToGroupingDtoAsync(file, updated, grouping.ManuallyEdited, ct);
+    }
+
+    private async Task<GostGroupingDto> ToGroupingDtoAsync(
+        Domain.DataSets.DataSetFile file, IReadOnlyList<GostGroupingGroup> groups, bool manuallyEdited, CancellationToken ct)
+    {
         var pageCount = await GetPdfPageCountAsync(file.BlobPath, ct);
         return new GostGroupingDto(
-            updated.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
-            grouping.ManuallyEdited, pageCount);
+            groups.Select(g => new GostGroupingGroupDto(
+                g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags, g.ProfileId)).ToList(),
+            manuallyEdited, pageCount);
     }
 
     public async Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct)
@@ -760,37 +856,15 @@ public class DataSetPdfRecognitionService(
         if (group is null)
             throw new ArgumentException("Документ с указанной страницей не найден в группировке.");
 
-        // Тэг таблицы документа → целевой ТИП, объявивший этот тэг (issue #29, «тип объявляет тэг»):
-        // таблица распознаётся в поля типа и материализуется в него (#19). Fallback — легаси
-        // хардкод-колонки GostTableFields, пока целевой тип не объявлен (переходный период).
-        var tag = (group.Tags ?? []).FirstOrDefault(profiles.IsTableTag);
-        if (tag is null)
-            throw new ArgumentException("У документа не задан тип таблицы (спецификация/кабельный журнал).");
-
-        // Встроенный профиль по тэгу — низший уровень цепочки приоритета (issue #406) и источник
-        // как колонок-фолбэка, так и вида (Kind), который выбирает применяемый промпт.
-        var builtIn = (await profiles.GetForTagAsync(tag, ct))!;
-
-        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
-        var targetType = allTypes.FirstOrDefault(t => SchemaTags.TypeHasTag(t, allTypes, tag));
-
-        IReadOnlyList<RecognitionField> columns;
-        if (targetType is not null)
-        {
-            var typesById = allTypes.ToDictionary(t => t.Id);
-            var typeFields = DocumentTypeSchemaReader.EffectiveFields(targetType.Id, typesById)
-                .Where(f => SchemaFieldKinds.IsScalar(f.Type))
-                .ToList();
-            if (typeFields.Count == 0)
-                throw new ArgumentException($"У типа «{targetType.Name}» нет скалярных полей для распознавания таблицы.");
-            columns = typeFields
-                .Select(f => new RecognitionField(f.Key, f.Title ?? f.Key, MapRecognitionType(f.Type)))
-                .ToList();
-        }
-        else
-        {
-            columns = builtIn.ToRowColumns();
-        }
+        // ЕДИНАЯ цепочка приоритета (issue #410), а не параллельные механизмы:
+        //   профиль, привязанный к группе  →  тип, объявивший тэг (#29)  →  встроенный профиль по тэгу.
+        // Привязанный профиль СНИМАЕТ требование тэга — именно этим разблокируются произвольные
+        // таблицы, для которых функционального тэга не существует и не может существовать.
+        var spec = await ResolveTableSpecAsync(group, ct)
+            ?? throw new ArgumentException(
+                "У документа не задан ни профиль распознавания, ни тип таблицы — " +
+                "привяжите профиль в свойствах группы либо укажите тип таблицы.");
+        var (columns, kind, shape) = spec;
 
         // Под-PDF документа для vision: переиспользуем уже вырезанный при распознавании блок (group.BlobPath,
         // issue #38) — не режем заново. Fallback — вырезать из полного PDF (старые наборы без BlobPath).
@@ -815,9 +889,8 @@ public class DataSetPdfRecognitionService(
         // Промпт выбирает ВИД профиля (issue #406; прежде — прямое сравнение с тэгом, issue #389):
         // кабельный журнал имеет свой промпт (двойная форма По проекту/Проложен), иначе общий
         // табличный. Флаги формы — параметр профиля; у встроенных они дефолтные, т.е. промпт прежний.
-        var shape = builtIn.Shape;
         Func<IReadOnlyList<RecognitionField>, string> tablePrompt =
-            builtIn.Kind == RecognitionProfileKind.CableJournal
+            kind == RecognitionProfileKind.CableJournal
                 ? f => RecognitionShared.BuildCableJournalPrompt(f, shape)
                 : f => RecognitionShared.BuildTablePrompt(f, shape);
 
@@ -825,7 +898,7 @@ public class DataSetPdfRecognitionService(
         try
         {
             result = await recognizer.RecognizeAsync(subPdf, "application/pdf",
-                RecognitionKinds.ComposeCallFields(builtIn.Kind, [], columns), tablePrompt, ct: ct);
+                RecognitionKinds.ComposeCallFields(kind, [], columns), tablePrompt, ct: ct);
         }
         catch (Exception ex) when (ex is RecognitionUnavailableException or RecognitionLimitException)
         {
@@ -861,7 +934,7 @@ public class DataSetPdfRecognitionService(
 
         var pageCount = await GetPdfPageCountAsync(file.BlobPath, ct);
         return new GostGroupingDto(
-            updated.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
+            updated.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags, g.ProfileId)).ToList(),
             updated.ManuallyEdited, pageCount);
     }
 
@@ -985,7 +1058,7 @@ public class DataSetPdfRecognitionService(
         await notifications.PublishAsync(NotificationSeverity.Info, "Документ перераспознан",
             $"«{(string.IsNullOrWhiteSpace(freshName) ? freshShifr : freshName)}» — обновлены поля {target.Pages.Count} листов.", "Распознавание PDF", ct: ct);
         return new GostGroupingDto(
-            unified.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
+            unified.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags, g.ProfileId)).ToList(),
             unified.ManuallyEdited, pageCount);
     }
 
@@ -1036,7 +1109,7 @@ public class DataSetPdfRecognitionService(
 
         var pageCount = GetPdfPageCount(bytes);
         return new GostGroupingDto(
-            unified.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags)).ToList(),
+            unified.Groups.Select(g => new GostGroupingGroupDto(g.Kind, g.Code, g.Name, g.Pages.Select(p => p.PageIndex).ToList(), g.Tags, g.ProfileId)).ToList(),
             true, pageCount);
     }
 

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -1,4 +1,4 @@
-using BHS.CRG.Application.DataSets;
+﻿using BHS.CRG.Application.DataSets;
 
 namespace BHS.CRG.Infrastructure.DataSets;
 
@@ -87,6 +87,9 @@ public class DataSetService(
         pdfRecognition.ApplyGroupingAsync(fileId, input, ct);
     public Task<GostGroupingDto?> SetDocumentTagsAsync(Guid fileId, int firstPageIndex, IReadOnlyList<string> tags, CancellationToken ct) =>
         pdfRecognition.SetDocumentTagsAsync(fileId, firstPageIndex, tags, ct);
+
+    public Task<GostGroupingDto?> SetDocumentProfileAsync(Guid fileId, int firstPageIndex, Guid? profileId, CancellationToken ct) =>
+        pdfRecognition.SetDocumentProfileAsync(fileId, firstPageIndex, profileId, ct);
     public Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct) =>
         pdfRecognition.RecognizeDocumentTableAsync(fileId, firstPageIndex, ct);
 

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -85,8 +85,9 @@ public class DataSetSourceService(
         foreach (var g in grouping.Groups)
         {
             if (g.Kind != GostGroupKind.Document || g.Id == Guid.Empty) continue;
-            var hasTableTag = (g.Tags ?? []).Any(profiles.IsTableTag);
-            if (!hasTableTag) continue;
+            // Табличность — общий предикат (issue #410): привязан профиль ИЛИ есть табличный тэг.
+            // Проверка только по тэгу скрывала бы кандидата произвольной таблицы.
+            if (!await profiles.IsTableGroupAsync(g.ProfileId, g.Tags, ct)) continue;
             var marker = $"{PdfProfiles.GostTableMarkerPrefix}{g.Id}";
             if (existing.Contains(marker)) continue;
             var name = string.IsNullOrWhiteSpace(g.Name) ? "Таблица" : $"Таблица — {g.Name}";

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostGroupingData.cs
@@ -40,11 +40,17 @@ public record GostGroupingData(IReadOnlyList<GostGroupingGroup> Groups, bool Man
 /// <param name="TableColumns">Схема строк таблицы (JSON [{name,sampleValues}]) — для кандидата/проекции.</param>
 /// <param name="TableStale">true — состав страниц группы изменился после распознавания таблицы: строки
 /// относятся к прежним границам, нужно перераспознать. Тэги переносятся всегда, TableData — с этим флагом.</param>
+/// <param name="ProfileId">Профиль распознавания, привязанный к этой группе (issue #410) — высший
+/// уровень цепочки приоритета колонок: профиль → тип, объявивший тэг (#29) → встроенный профиль по
+/// тэгу. Привязанный профиль СНИМАЕТ требование тэга: именно так распознаются произвольные таблицы,
+/// для которых функционального тэга не существует. Null — привязки нет, работает прежняя цепочка.
+/// Пользовательская настройка: переносится при ре-распознавании и ручной правке наравне с Id.</param>
 public record GostGroupingGroup(
     GostGroupKind Kind, string? Code, string? Name, IReadOnlyList<GostGroupingPage> Pages,
     IReadOnlyList<string>? Tags = null, Guid Id = default,
     string? BlobPath = null, long? BlobSize = null,
-    string? TableData = null, string? TableColumns = null, bool TableStale = false);
+    string? TableData = null, string? TableColumns = null, bool TableStale = false,
+    Guid? ProfileId = null);
 
 /// <param name="PageIndex">Индекс страницы исходного PDF (0-based).</param>
 /// <param name="Fields">Распознанные поля штампа этой страницы (без служебных ТипСтраницы/Форма).</param>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/GostStableIds.cs
@@ -54,7 +54,10 @@ public static class GostStableIds
             // табличное сырьё (TableData/Columns) тоже, но если состав страниц изменился — помечаем stale.
             // Порог доминирования: сырьё переносим только при существенном пересечении (иначе чужая группа
             // унаследовала бы таблицу). При ручной правке (carryUserData=false) тэги во fresh авторитетны.
-            var carried = g with { Id = id };
+            // Привязка профиля — пользовательская НАСТРОЙКА группы, а не распознанное сырьё: переносим
+            // ВСЕГДА (наравне с Id), независимо от carryUserData. Свежая группировка её не несёт, и без
+            // явного переноса привязка молча терялась бы при любой ре-группировке.
+            var carried = g with { Id = id, ProfileId = g.ProfileId ?? matched?.ProfileId };
             if (matched is not null && carryUserData)
             {
                 var freshPages = g.Pages.Select(p => p.PageIndex).ToHashSet();

--- a/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionProfileProvider.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionProfileProvider.cs
@@ -30,6 +30,21 @@ public class RecognitionProfileProvider(AppDbContext db) : IRecognitionProfilePr
 
     public bool IsTableTag(string tag) => BuiltInRecognitionProfiles.CodeForTag(tag) is not null;
 
+    public async Task<bool> IsTableGroupAsync(
+        Guid? profileId, IReadOnlyList<string>? tags, CancellationToken ct = default)
+    {
+        // Привязанный профиль перекрывает тэг: он и есть способ сделать табличной группу, у которой
+        // функционального тэга нет и быть не может (произвольная таблица).
+        if (profileId is { } pid)
+        {
+            var profile = await db.RecognitionProfiles.AsNoTracking().FirstOrDefaultAsync(p => p.Id == pid, ct);
+            // Профиль удалён — деградируем к тэгу, а не считаем группу нетабличной: иначе удаление
+            // профиля молча снесло бы источники, которые ещё держатся на тэге.
+            if (profile is not null) return RecognitionKinds.Describe(profile.Kind).RowsKey is not null;
+        }
+        return (tags ?? []).Any(IsTableTag);
+    }
+
     public async Task<IReadOnlyList<RecognitionProfile>> ListByKindAsync(
         RecognitionProfileKind kind, CancellationToken ct = default)
         => await db.RecognitionProfiles.AsNoTracking()

--- a/src/server/BHS.CRG.Tests/Integration/RecognitionProfileBindingTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/RecognitionProfileBindingTests.cs
@@ -1,0 +1,250 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Recognition;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Recognition;
+using BHS.CRG.Infrastructure.DataSets;
+using BHS.CRG.Infrastructure.Persistence;
+using BHS.CRG.Infrastructure.Recognition;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SharpPdfDocument = PdfSharpCore.Pdf.PdfDocument;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Привязка профиля распознавания к группе листов (issue #410) — ради неё делался весь эпик #405:
+/// группа БЕЗ функционального тэга становится распознаваемой таблицей.
+///
+/// Под защитой два молчаливых способа всё сломать: (1) привязка теряется при любой пересборке
+/// группировки, потому что группы собираются позиционным конструктором; (2) группа без тэга не
+/// проходит предикат «табличная» — и её источник УДАЛЯЕТСЯ вместе с привязками как осиротевший.
+/// </summary>
+[Collection("Integration")]
+public class RecognitionProfileBindingTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static readonly Guid DocId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static byte[] MakePdf(int pageCount)
+    {
+        using var doc = new SharpPdfDocument();
+        for (var i = 0; i < pageCount; i++) doc.AddPage();
+        using var ms = new MemoryStream();
+        doc.Save(ms, false);
+        return ms.ToArray();
+    }
+
+    /// <summary>Группа-документ БЕЗ тэга таблицы — «произвольная таблица» вроде «Список деталей ТКШ».</summary>
+    private static GostGroupingData UntaggedGrouping(Guid? profileId = null) => new(
+        [new GostGroupingGroup(GostGroupKind.Document, "A113", "Список деталей ТКШ1",
+            [new GostGroupingPage(0, new Dictionary<string, string?>()), new GostGroupingPage(1, new Dictionary<string, string?>())],
+            Tags: null, Id: DocId, ProfileId: profileId)],
+        ManuallyEdited: false);
+
+    private async Task<(Guid fileId, IServiceScope scope)> SeedAsync(GostGroupingData grouping)
+    {
+        var scope = fixture.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await RecognitionProfileSeeder.SeedAsync(db);
+        db.ChangeTracker.Clear();
+
+        var blobStorage = scope.ServiceProvider.GetRequiredService<IBlobStorage>();
+        using var upload = new MemoryStream(MakePdf(3));
+        var blobPath = await blobStorage.UploadAsync("test.pdf", upload, "application/pdf");
+
+        var file = DataSetFile.Create("Альбом", DataSetFormat.Pdf, blobPath, CatalogScope.System, null);
+        file.SetGrouping(JsonSerializer.Serialize(grouping));
+        db.DataSetFiles.Add(file);
+        await db.SaveChangesAsync();
+        return (file.Id, scope);
+    }
+
+    private static async Task<Guid> CustomTableProfileAsync(AppDbContext db)
+    {
+        var profile = RecognitionProfile.Create(
+            "Список деталей шкафа", RecognitionProfileKind.Table,
+            fields: RecognitionProfileJson.WriteFields([]),
+            rowColumns: RecognitionProfileJson.WriteFields([
+                new RecognitionProfileField("Поз", "Позиция"),
+                new RecognitionProfileField("Наименование", "Наименование детали"),
+                new RecognitionProfileField("Количество", "Количество, шт", "number"),
+            ]),
+            shape: RecognitionProfileJson.WriteShape(new RecognitionTableShape(TwoTierHeader: true)));
+        db.RecognitionProfiles.Add(profile);
+        await db.SaveChangesAsync();
+        return profile.Id;
+    }
+
+    private static async Task<Guid> AddTableSourceAsync(AppDbContext db, Guid fileId, Guid groupId)
+    {
+        var file = await db.DataSetFiles.Include(f => f.Sources).FirstAsync(f => f.Id == fileId);
+        var table = file.AddSource("Таблица", PdfProfiles.GostTableMarkerPrefix + groupId, "[]", 0);
+        db.DataSetSources.Add(table);
+        await db.SaveChangesAsync();
+        return table.Id;
+    }
+
+    // ── Разблокировка произвольных таблиц ────────────────────────────────────────
+
+    [Fact]
+    public async Task TableSpec_UntaggedGroup_ResolvesOnlyWithBoundProfile()
+    {
+        var (fileId, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var svc = scope.ServiceProvider.GetRequiredService<DataSetPdfRecognitionService>();
+            var group = UntaggedGrouping().Groups[0];
+
+            // Без тэга и без профиля таблица нераспознаваема — это исходное состояние произвольной формы.
+            Assert.Null(await svc.ResolveTableSpecAsync(group, default));
+            Assert.False(await svc.IsTableGroupAsync(group, default));
+
+            var profileId = await CustomTableProfileAsync(db);
+            var bound = group with { ProfileId = profileId };
+
+            var spec = await svc.ResolveTableSpecAsync(bound, default);
+            Assert.NotNull(spec);
+            Assert.Equal(["Поз", "Наименование", "Количество"], spec!.Value.Columns.Select(c => c.Path));
+            Assert.Equal(RecognitionProfileKind.Table, spec.Value.Kind);
+            Assert.True(spec.Value.Shape!.TwoTierHeader);   // флаги формы доезжают до промпта
+            Assert.True(await svc.IsTableGroupAsync(bound, default));
+        }
+        _ = fileId;
+    }
+
+    [Fact]
+    public async Task TableSpec_BoundProfile_WinsOverTag()
+    {
+        var (_, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var svc = scope.ServiceProvider.GetRequiredService<DataSetPdfRecognitionService>();
+            var profileId = await CustomTableProfileAsync(db);
+
+            // Единая цепочка приоритета: профиль на группе перекрывает встроенный профиль по тэгу.
+            var group = UntaggedGrouping().Groups[0] with
+            {
+                Tags = ["gostDoc.cableJournal"],
+                ProfileId = profileId,
+            };
+            var spec = await svc.ResolveTableSpecAsync(group, default);
+            Assert.Equal(RecognitionProfileKind.Table, spec!.Value.Kind);   // не CableJournal
+            Assert.Contains(spec.Value.Columns, c => c.Path == "Поз");
+        }
+    }
+
+    [Fact]
+    public async Task TableSpec_DeletedProfile_FallsBackToTag_NotBroken()
+    {
+        var (_, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var svc = scope.ServiceProvider.GetRequiredService<DataSetPdfRecognitionService>();
+            // Профиль удалён (или ещё не создан), но тэг остался — деградируем к тэгу, а не считаем
+            // группу нетабличной: иначе удаление профиля молча снесло бы её источник.
+            var group = UntaggedGrouping().Groups[0] with
+            {
+                Tags = ["gostDoc.specification"],
+                ProfileId = Guid.NewGuid(),
+            };
+            var spec = await svc.ResolveTableSpecAsync(group, default);
+            Assert.NotNull(spec);
+            Assert.Equal(RecognitionProfileKind.Table, spec!.Value.Kind);
+            Assert.True(await svc.IsTableGroupAsync(group, default));
+        }
+    }
+
+    // ── Сохранность привязки ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetDocumentProfile_Persists_AndMarksTableStale()
+    {
+        var (fileId, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var profileId = await CustomTableProfileAsync(db);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+
+            var dto = await svc.SetDocumentProfileAsync(fileId, firstPageIndex: 0, profileId, default);
+            Assert.NotNull(dto);
+            Assert.Equal(profileId, dto!.Groups[0].ProfileId);
+
+            // Снятие привязки возвращает группу к прежней цепочке.
+            var cleared = await svc.SetDocumentProfileAsync(fileId, 0, null, default);
+            Assert.Null(cleared!.Groups[0].ProfileId);
+        }
+    }
+
+    [Fact]
+    public async Task SetDocumentProfile_RejectsNonTabularProfile()
+    {
+        var (fileId, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var stamp = await db.RecognitionProfiles.AsNoTracking()
+                .FirstAsync(p => p.Code == BuiltInProfileCodes.TitleBlock);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+
+            // К группе листов привязывается профиль ТАБЛИЦЫ — штамп сюда не годится.
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => svc.SetDocumentProfileAsync(fileId, 0, stamp.Id, default));
+        }
+    }
+
+    [Fact]
+    public async Task ApplyGrouping_KeepsProfileBinding_AndDoesNotOrphanSource()
+    {
+        var (fileId, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var profileId = await CustomTableProfileAsync(db);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+            await svc.SetDocumentProfileAsync(fileId, 0, profileId, default);
+            var tableId = await AddTableSourceAsync(db, fileId, DocId);
+
+            // Ручная правка разбиения: группа пересобирается с нуля позиционным конструктором и
+            // приходит БЕЗ тэга. Привязка обязана пережить это, а источник — не осиротеть.
+            await svc.ApplyGroupingAsync(fileId, new ApplyGroupingInput(
+                [new GostGroupingGroupDto(GostGroupKind.Document, "A113", "Список деталей ТКШ1", [0, 1], null)]), default);
+
+            var file = await db.DataSetFiles.AsNoTracking().FirstAsync(f => f.Id == fileId);
+            var grouping = GostGroupingSerialization.Parse(file.Grouping)!;
+            Assert.Equal(profileId, grouping.Groups.Single(g => g.Kind == GostGroupKind.Document).ProfileId);
+
+            Assert.NotNull(await db.DataSetSources.AsNoTracking().FirstOrDefaultAsync(s => s.Id == tableId));
+        }
+    }
+
+    [Fact]
+    public async Task Candidates_UntaggedGroupWithProfile_AppearsAsPendingTable()
+    {
+        var (fileId, scope) = await SeedAsync(UntaggedGrouping());
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var profileId = await CustomTableProfileAsync(db);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+
+            // До привязки кандидата нет — группа не табличная.
+            Assert.DoesNotContain(await svc.DetectSourceCandidatesAsync(fileId, default),
+                c => c.SheetOrPath.StartsWith(PdfProfiles.GostTableMarkerPrefix, StringComparison.Ordinal));
+
+            await svc.SetDocumentProfileAsync(fileId, 0, profileId, default);
+
+            var candidate = Assert.Single(await svc.DetectSourceCandidatesAsync(fileId, default),
+                c => c.SheetOrPath == PdfProfiles.GostTableMarkerPrefix + DocId);
+            Assert.Equal(0, candidate.FirstPageIndex);   // «таблица не распознана» → кнопка «Распознать»
+            Assert.Contains("Список деталей ТКШ1", candidate.Name);
+        }
+    }
+}


### PR DESCRIPTION
Часть **C** эпика #405 — ради неё делался весь эпик.

## Что было невозможно

Распознать можно было **только две** известные формы таблиц: цепочка упиралась в функциональный тэг, и без него `RecognizeDocumentTableAsync` просто бросал «У документа не задан тип таблицы». Произвольная таблица — например «Список деталей ТКШ» на листах A113–A116 из кейса — была недоступна **в принципе**, и добавление каждой новой формы означало правку C# и релиз.

## Что теперь

К группе листов привязывается профиль распознавания, и **привязка снимает требование тэга** — именно этим разблокируются произвольные формы.

- `ProfileId` в записи группы (внутри `Grouping` jsonb — **миграции не требует**).
- **`ResolveTableSpecAsync` — единственное место**, где решается «таблична ли группа и по каким колонкам её читать»: `профиль на группе` → `тип, объявивший тэг (#29)` → `встроенный профиль по тэгу`. Раньше этот предикат был размазан по пяти точкам, и одна из них (`ReprojectTableSourcesAsync`) на его основании **удаляет источники вместе с привязками** — разъехавшись, копии молча сносили бы данные.
- Предикат «группа табличная» — одна реализация в провайдере, общая для показа кандидата и для решения «источник осиротел». Удалённый профиль **деградирует к тэгу**, а не делает группу нетабличной: иначе удаление профиля снесло бы источники, которые ещё держатся на тэге.
- **Сохранность привязки**: переносится в `GostStableIds.Assign` всегда, наравне с `Id` (независимо от `carryUserData`) — иначе терялась бы при любой пересборке групп, включая ручную правку разбиения, где группы собираются позиционным конструктором.
- Точечный `PUT /document-profile` по образцу тэгов: `g with { … }` сохраняет уже распознанное сырьё. Выставляет `TableStale`, но **не перезапускает** распознавание — это дорогой LLM-вызов, решает пользователь.
- UI: выбор профиля в свойствах группы (предлагаются только табличные профили); кнопка «Таблица» доступна при тэге **или** привязанном профиле.

## Тесты (7 интеграционных)

Целятся в два молчаливых способа всё сломать:
- привязка переживает ручную ре-группировку, источник **не** осиротел;
- группа без тэга с профилем даёт кандидата «таблица не распознана»;
- профиль на группе перекрывает тэг; удалённый профиль откатывается к тэгу;
- нетабличный профиль (штамп) к группе листов привязать нельзя.

## Проверка

- **542 backend** (+7) · **153 frontend** · `tsc -b` зелёный.
- Живьём через API создан профиль произвольной таблицы («Список деталей шкафа», 3 колонки, двухэтажная шапка) — помечен табличным, т.е. доступен для привязки к группе.
- Попутно: замечание разведки про недостающую инвалидацию страниц после задачи **не подтвердилось** — `['datasets','files']` является префиксом ключа страниц, а React Query инвалидирует по префиксу. Пустую правку не вносил.

## Не вошло (предлагаю отдельным PR D)

Привязка профилей **к файлу** (`{вид: профиль}` для штампа/обложки/титула/счёта) — требует миграции и своего UI, к разблокировке произвольных таблиц отношения не имеет. Вынес, чтобы этот PR остался обозримым.

Closes #410
Refs #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)