### PR TITLE
Профили распознавания D: привязка к набору (штамп/обложка/счёт) (#412)

### DIFF
--- a/src/client/src/features/datasets/FileProfilesDialog.tsx
+++ b/src/client/src/features/datasets/FileProfilesDialog.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
+import { useSetFileRecognitionProfiles } from '@/shared/api/datasets';
+import { useListRecognitionProfiles, useRecognitionKinds } from '@/shared/api/recognitionProfiles';
+import type { DataSetFile } from '@/shared/api/types';
+
+/**
+ * Профили распознавания НАБОРА (issue #412): штамп, обложка/титул и счёт читают файл целиком, поэтому
+ * их профиль задаётся здесь — в отличие от таблиц, где профиль привязывается к группе листов.
+ *
+ * Какие виды сюда попадают, решает сервер (kindInfo.scope), а не зашитый на клиенте список: иначе
+ * добавление вида требовало бы правки фронта.
+ */
+export function FileProfilesDialog({ file, onClose }: { file: DataSetFile; onClose: () => void }) {
+  const { data: kinds = [] } = useRecognitionKinds();
+  const { data: profiles = [] } = useListRecognitionProfiles();
+  const save = useSetFileRecognitionProfiles(file.id);
+
+  const fileKinds = useMemo(() => kinds.filter(k => k.scope === 'File'), [kinds]);
+  const [map, setMap] = useState<Record<string, string>>(() => ({ ...(file.recognitionProfiles ?? {}) }));
+  const [error, setError] = useState('');
+
+  const dirty = JSON.stringify(map) !== JSON.stringify(file.recognitionProfiles ?? {});
+
+  async function handleSave() {
+    setError('');
+    // Отправляем ВСЕ виды: снятые приходят как null, иначе сервер не отличит «не трогали» от «сняли».
+    const payload: Record<string, string | null> = {};
+    for (const k of fileKinds) payload[k.kind] = map[k.kind] ?? null;
+    try {
+      await save.mutateAsync(payload);
+      onClose();
+    } catch (e) {
+      const resp = (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setError(resp ?? 'Не удалось сохранить');
+    }
+  }
+
+  return (
+    <Modal open onOpenChange={o => { if (!o) onClose(); }} title="Профили распознавания набора" wide
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
+          <Button type="button" variant="filled" onClick={handleSave} disabled={!dirty} loading={save.isPending}>
+            {save.isPending ? 'Сохранение…' : 'Сохранить'}
+          </Button>
+        </div>
+      }>
+      <div className="px-6 py-4 space-y-4 min-w-[520px]">
+        <p className="text-xs text-fg4">
+          Промпты распознавания задаём мы — здесь выбирается, с какими параметрами (набором полей) они
+          применяются к этому набору. Не выбрано — используется встроенный профиль.
+          Параметры таблиц задаются у групп листов в «Разбиении».
+        </p>
+
+        {fileKinds.map(k => {
+          const options = profiles.filter(p => p.kind === k.kind);
+          return (
+            <div key={k.kind}>
+              <label className="block text-sm font-medium text-fg1 mb-1">{k.label}</label>
+              <select value={map[k.kind] ?? ''}
+                onChange={e => setMap(m => {
+                  const next = { ...m };
+                  if (e.target.value) next[k.kind] = e.target.value; else delete next[k.kind];
+                  return next;
+                })}
+                className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1">
+                <option value="">— встроенный профиль</option>
+                {options.map(p => (
+                  <option key={p.id} value={p.id}>{p.name}{p.isBuiltIn ? ' (встроенный)' : ''}</option>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+        <p className="text-[11px] text-fg4">
+          Смена профиля не перезапускает распознавание — новые параметры применятся при следующем запуске.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Plus, Pencil, Trash2, Copy, Eye, Filter, FunctionSquare, ArrowUpDown, Loader2,
-  BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes, Scissors, Type,
+  BookmarkPlus, ScanText, FileDown, Download, AlertTriangle, Boxes, Scissors, Type, SlidersHorizontal,
 } from 'lucide-react';
 import { parseSourceColumnNames, countFilterConditions } from '@/shared/api/datasetHelpers';
 import { useSourceRecognizing } from '@/shared/api/jobs';
+import { FileProfilesDialog } from './FileProfilesDialog';
 import {
   useDeleteDataSetSource, useDuplicateDataSetSource, useSetDataSetSourceProcessing, useListProcessingTemplates,
   usePreviewDataSetSource, useCreateProcessingTemplate, useApplyProcessingTemplate, useRecognizeFile,
@@ -252,6 +253,7 @@ export function FileRecognizeActions({ file }: { file: DataSetFile }) {
   const recognizeFile = useRecognizeFile();
   const [recognizeConflict, setRecognizeConflict] = useState(false);
   const [profileDialog, setProfileDialog] = useState(false);
+  const [fileProfilesDialog, setFileProfilesDialog] = useState(false);
   const navigate = useNavigate();
   const isPdf = file.format === 'Pdf';
   const profile = file.preprocessingProfile;
@@ -285,7 +287,13 @@ export function FileRecognizeActions({ file }: { file: DataSetFile }) {
           <Scissors size={15} />
         </IconButton>
       )}
+      {/* Профили распознавания набора (issue #412) — параметры к промптам штампа/обложки/счёта. */}
+      <IconButton label="Профили распознавания набора — какими параметрами читать штамп, обложку, счёт" size="sm"
+        onClick={() => setFileProfilesDialog(true)}>
+        <SlidersHorizontal size={15} />
+      </IconButton>
       {profileDialog && <PdfSourceDialog fileId={file.id} onClose={() => setProfileDialog(false)} />}
+      {fileProfilesDialog && <FileProfilesDialog file={file} onClose={() => setFileProfilesDialog(false)} />}
       <ConfirmDialog open={recognizeConflict} onOpenChange={o => { if (!o) setRecognizeConflict(false); }}
         title="Разбиение было скорректировано вручную"
         description={<p>Повторное автораспознавание сотрёт ручные правки разбиения на документы. Продолжить?</p>}

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -316,6 +316,16 @@ export function useSetDocumentProfile(fileId: string) {
   });
 }
 
+/** Профили распознавания НАБОРА (issue #412): {вид: id профиля}; null снимает привязку вида. */
+export function useSetFileRecognitionProfiles(fileId: string) {
+  const qc = useQueryClient();
+  return useMutation<void, Error, Record<string, string | null>>({
+    mutationFn: (profiles) =>
+      apiClient.put(`/datasets/files/${fileId}/recognition-profiles`, { profiles }).then(() => undefined),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['datasets', 'files'] }); },
+  });
+}
+
 /** Точечное перераспознавание ОДНОГО документа (не всего альбома) — фоновая задача, 202+jobId. */
 export function useRecognizeDocument(fileId: string) {
   const qc = useQueryClient();

--- a/src/client/src/shared/api/recognitionProfiles.ts
+++ b/src/client/src/shared/api/recognitionProfiles.ts
@@ -31,6 +31,8 @@ export interface RecognitionKindInfo {
   isTabular: boolean;
   /** Поля, на которых завязан код: удалять/переименовывать нельзя. */
   systemFieldNames: string[];
+  /** Куда привязывается: 'File' (набор целиком) или 'PageGroup' (группа листов). */
+  scope: 'File' | 'PageGroup';
 }
 
 export interface RecognitionProfile {

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -340,6 +340,8 @@ export interface DataSetFile {
   createdAt: string;
   /** Профиль препроцессинга PDF (issue #38): 'gost-titleblock' | 'invoice' | null (ещё не выбран). */
   preprocessingProfile?: string | null;
+  /** Профили распознавания набора: {вид: id профиля} (issue #412); нет ключа — встроенный. */
+  recognitionProfiles?: Record<string, string> | null;
 }
 
 /** Привязка набора данных к объекту — только Mapping. Filter/Transformation/Sort — на DataSetSource.

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -309,6 +309,19 @@ public static class DataSetEndpoints
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
+        // Профили распознавания НАБОРА (issue #412): штамп/обложка-титул/счёт — они работают на уровне
+        // файла целиком, в отличие от таблиц (те привязываются к группе листов).
+        g.MapPut("/files/{fileId:guid}/recognition-profiles", async (
+            Guid fileId, SetFileProfilesRequest req, IDataSetService svc, CancellationToken ct) =>
+        {
+            try
+            {
+                var ok = await svc.SetFileRecognitionProfilesAsync(fileId, req.Profiles ?? new Dictionary<string, Guid?>(), ct);
+                return ok ? Results.NoContent() : Results.NotFound();
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
         // Распознать таблицу помеченного документа (спецификация/кабельный журнал) → отдельный табличный
         // источник. Vision-вызов (минуты на большом документе) → фоновая задача, 202+jobId сразу.
         g.MapPost("/files/{fileId:guid}/recognize-table", async (
@@ -409,6 +422,7 @@ public static class DataSetEndpoints
     private record SetDocumentTagsRequest(int FirstPageIndex, string[]? Tags);
     private record RecognizeTableRequest(int FirstPageIndex);
     private record SetDocumentProfileRequest(int FirstPageIndex, Guid? ProfileId);
+    private record SetFileProfilesRequest(Dictionary<string, Guid?>? Profiles);
 
     private static Guid UserId(ClaimsPrincipal user)
         => Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub")!);

--- a/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
+++ b/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
@@ -1,4 +1,4 @@
-namespace BHS.CRG.Application.DataSets;
+﻿namespace BHS.CRG.Application.DataSets;
 
 // ── Output DTOs (JSON shapes consumed by the SPA) ───────────────────────────────
 
@@ -15,7 +15,9 @@ public record MaterializePreviewDto(Guid? TypeId, int TotalRows, IReadOnlyList<D
 public record DataSetFileDto(
     Guid Id, string Name, string Format, string Scope, Guid? ScopeId,
     IReadOnlyList<DataSetSourceDto> Sources, DateTimeOffset CreatedAt,
-    string? PreprocessingProfile = null);
+    string? PreprocessingProfile = null,
+    /// <summary>Профили распознавания набора: {вид: id профиля} (issue #412); null — все встроенные.</summary>
+    IReadOnlyDictionary<string, Guid>? RecognitionProfiles = null);
 
 public record BindingFileDto(Guid Id, string Name, string Format, string Scope, Guid? ScopeId);
 

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -98,6 +98,9 @@ public interface IDataSetService
 
     /// <summary>Привязать профиль распознавания к группе листов (issue #410); null — снять привязку.</summary>
     Task<GostGroupingDto?> SetDocumentProfileAsync(Guid fileId, int firstPageIndex, Guid? profileId, CancellationToken ct);
+
+    /// <summary>Привязать профили распознавания к НАБОРУ (issue #412): {вид: id профиля}, null снимает.</summary>
+    Task<bool> SetFileRecognitionProfilesAsync(Guid fileId, IReadOnlyDictionary<string, Guid?> map, CancellationToken ct);
     /// <summary>Распознать таблицу помеченного документа ГОСТ-профиля (спецификация/кабельный журнал):
     /// пишет строки как СЫРЬЁ на группу (Grouping) — доступна как кандидат «Таблица …», источник создаёт
     /// пользователь (issue #42). Источника НЕ создаёт. firstPageIndex — любая страница документа.</summary>

--- a/src/server/BHS.CRG.Application/Recognition/RecognitionProfileDtos.cs
+++ b/src/server/BHS.CRG.Application/Recognition/RecognitionProfileDtos.cs
@@ -1,17 +1,21 @@
-namespace BHS.CRG.Application.Recognition;
+﻿namespace BHS.CRG.Application.Recognition;
 
 /// <summary>
 /// Что вид профиля означает для UI (issue #408). Отдаётся с сервера, чтобы фронт НЕ знал частных
 /// случаев видов: показывать ли редактор скалярных полей, колонок, флагов формы и какие поля
 /// защищены — всё выводится отсюда, а не из зашитых на клиенте условий вида.
 /// </summary>
+/// <param name="Scope">Куда привязывается профиль этого вида: "File" (набор целиком — штамп/обложка/
+/// счёт) или "PageGroup" (группа листов — таблицы). «Есть табличная часть» для этого не годится:
+/// у счёта она есть, но привязывается он к набору.</param>
 public record RecognitionKindInfo(
     string Kind,
     string Label,
     bool SupportsShape,
     bool HasScalarFields,
     bool IsTabular,
-    IReadOnlyList<string> SystemFieldNames);
+    IReadOnlyList<string> SystemFieldNames,
+    string Scope = "File");
 
 /// <summary>Профиль распознавания для UI. Признак «системное поле» приходит списком имён из
 /// дескриптора вида — в данных профиля он не хранится (иначе снимался бы импортом).</summary>

--- a/src/server/BHS.CRG.Domain/DataSets/DataSetFile.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetFile.cs
@@ -40,6 +40,18 @@ public class DataSetFile : Entity
     /// Пишется распознаванием; источники «Шапка»/«Товары» — кандидаты, проецируются пользователем.</summary>
     public string? InvoiceRawData { get; private set; }
 
+    /// <summary>
+    /// Профили распознавания, привязанные к НАБОРУ (issue #412) — JSON-карта {вид: id профиля}, напр.
+    /// <c>{"TitleBlock":"…","CoverTitle":"…"}</c>. Нужна для не-табличных видов, которые работают на
+    /// уровне файла целиком (штамп, обложка/титул, счёт), — в отличие от таблиц, где профиль
+    /// привязывается к конкретной группе листов (issue #410).
+    ///
+    /// <see cref="PreprocessingProfile"/> при этом остаётся: он выбирает СЦЕНАРИЙ («ГОСТ-альбом» или
+    /// «счёт»), а эта карта — ПАРАМЕТРЫ применяемых в сценарии промптов. Null/нет ключа — берётся
+    /// встроенный профиль вида.
+    /// </summary>
+    public string? RecognitionProfiles { get; private set; }
+
     private DataSetFile() { }
 
     public static DataSetFile Create(string name, DataSetFormat format, string blobPath,
@@ -75,6 +87,15 @@ public class DataSetFile : Entity
     public void SetPreprocessingProfile(string? profile)
     {
         PreprocessingProfile = string.IsNullOrWhiteSpace(profile) ? null : profile.Trim();
+        TouchUpdatedAt();
+    }
+
+    /// <summary>Задать карту профилей распознавания набора (issue #412). Пустая карта → null,
+    /// чтобы «нет привязок» имело единственное представление.</summary>
+    public void SetRecognitionProfiles(string? profilesJson)
+    {
+        RecognitionProfiles = string.IsNullOrWhiteSpace(profilesJson) || profilesJson.Trim() == "{}"
+            ? null : profilesJson;
         TouchUpdatedAt();
     }
 

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Domain.DataSets;
@@ -65,7 +65,9 @@ public static class DataSetDtoMapper
 
     public static DataSetFileDto MapFile(DataSetFile f) => new(
         f.Id, f.Name, f.Format.ToString(), f.Scope.ToString(), f.ScopeId,
-        f.Sources.Select(MapSource).ToList(), f.CreatedAt, f.PreprocessingProfile);
+        f.Sources.Select(MapSource).ToList(), f.CreatedAt, f.PreprocessingProfile,
+        f.RecognitionProfiles is null ? null
+            : JsonSerializer.Deserialize<Dictionary<string, Guid>>(f.RecognitionProfiles));
 
     public static DataSetSourceDto MapSource(DataSetSource s) => new(
         s.Id, s.FileId, s.Name, s.SheetOrPath, s.ColumnExpressions, s.CachedSchema, s.CachedRowCount,

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetPdfRecognitionService.cs
@@ -194,7 +194,7 @@ public class DataSetPdfRecognitionService(
             throw new ArgumentException($"Не удалось подготовить страницы PDF: {ex.Message}");
         }
 
-        var fields = (await profiles.GetBuiltInAsync(BuiltInProfileCodes.TitleBlock, ct)).ToRecognitionFields();
+        var fields = (await ProfileForFileAsync(source.File, RecognitionProfileKind.TitleBlock, ct)).ToRecognitionFields();
         var rows = new List<IReadOnlyDictionary<string, string?>>();
         for (var i = 0; i < pages.Count; i++)
         {
@@ -244,7 +244,7 @@ public class DataSetPdfRecognitionService(
         var bytes = ms.ToArray();
 
         // Счёт — ОДИН вызов: шапка (скаляры) и товары (колонки строк) лежат в одном профиле.
-        var invoiceProfile = await profiles.GetBuiltInAsync(BuiltInProfileCodes.Invoice, ct);
+        var invoiceProfile = await ProfileForFileAsync(file, RecognitionProfileKind.Invoice, ct);
         var headerFields = invoiceProfile.ToRecognitionFields();
         var lineItemFields = invoiceProfile.ToRowColumns();
 
@@ -361,9 +361,9 @@ public class DataSetPdfRecognitionService(
             logger.LogWarning(ex, "Не удалось проверить текстовый слой PDF источника {SourceId} — второй проход штампа отключён", file.Id);
         }
 
-        var stampFields = (await profiles.GetBuiltInAsync(BuiltInProfileCodes.TitleBlock, ct)).ToRecognitionFields();
+        var stampFields = (await ProfileForFileAsync(file, RecognitionProfileKind.TitleBlock, ct)).ToRecognitionFields();
         var fields = GostTitleBlockFields.WithClassifiers(stampFields);
-        var coverFields = (await profiles.GetBuiltInAsync(BuiltInProfileCodes.CoverTitle, ct)).ToRecognitionFields();
+        var coverFields = (await ProfileForFileAsync(file, RecognitionProfileKind.CoverTitle, ct)).ToRecognitionFields();
         var rows = new List<IReadOnlyDictionary<string, string?>>();
         var failedPages = 0; // листы, распознавание которых не удалось (строка осталась пустой) — для уведомления
         for (var i = 0; i < pngPages.Count; i++)
@@ -493,7 +493,7 @@ public class DataSetPdfRecognitionService(
         file.SetGrouping(JsonSerializer.Serialize(withBlobs));
 
         var projected = GostGroupingProjection.Project(withBlobs);
-        await RefreshProjectionSourcesAsync(file.Id, projected, ct);
+        await RefreshProjectionSourcesAsync(file, projected, ct);
         var invalidatedTables = await ReprojectTableSourcesAsync(file.Id, withBlobs, ct);
 
         await db.SaveChangesAsync(ct);
@@ -534,11 +534,15 @@ public class DataSetPdfRecognitionService(
 
     // Переспроецирует СУЩЕСТВУЮЩИЕ источники-проекции набора (обложка/титул/документы) из новой группировки.
     // Таблицы — отдельно (ReprojectTableSourcesAsync). Источники, которых нет — не создаёт (кандидаты).
-    private async Task RefreshProjectionSourcesAsync(Guid fileId, ProjectedRows projected, CancellationToken ct)
+    private async Task RefreshProjectionSourcesAsync(
+        Domain.DataSets.DataSetFile file, ProjectedRows projected, CancellationToken ct)
     {
-        var coverColumnPaths = (await profiles.GetBuiltInAsync(BuiltInProfileCodes.CoverTitle, ct))
+        var fileId = file.Id;
+        // Колонки проекций берём из ТЕХ ЖЕ профилей, которыми распознавали, — иначе добавленное
+        // пользователем поле не доехало бы до схемы источника.
+        var coverColumnPaths = (await ProfileForFileAsync(file, RecognitionProfileKind.CoverTitle, ct))
             .Fields.Select(f => f.Name).ToArray();
-        var documentsColumnPaths = (await profiles.GetBuiltInAsync(BuiltInProfileCodes.TitleBlock, ct))
+        var documentsColumnPaths = (await ProfileForFileAsync(file, RecognitionProfileKind.TitleBlock, ct))
             .Fields.Select(f => f.Name)
             .Concat(["КоличествоЛистов", "ФайлПуть", "РазмерБайт"]).ToArray();
 
@@ -750,6 +754,64 @@ public class DataSetPdfRecognitionService(
     }
 
     /// <summary>
+    /// Профиль НЕ-табличного вида для набора (issue #412): привязанный к файлу → встроенный по виду.
+    /// Штамп, обложка/титул и счёт работают на уровне файла целиком, поэтому их профиль живёт на
+    /// наборе, а не на группе листов (в отличие от таблиц, issue #410).
+    ///
+    /// Привязка с чужим или удалённым профилем деградирует к встроенному, а не роняет распознавание:
+    /// потерять альбом из-за удалённого профиля хуже, чем распознать его дефолтными параметрами.
+    /// </summary>
+    /// <summary>Привязка профилей распознавания к НАБОРУ (issue #412): карта {вид: id профиля}.
+    /// Значение null снимает привязку конкретного вида. Распознавание не перезапускает — параметры
+    /// применятся при следующем запуске (он дорогой, решает пользователь).</summary>
+    public async Task<bool> SetFileRecognitionProfilesAsync(
+        Guid fileId, IReadOnlyDictionary<string, Guid?> map, CancellationToken ct)
+    {
+        var file = await db.DataSetFiles.FirstOrDefaultAsync(f => f.Id == fileId, ct);
+        if (file == null) return false;
+
+        var current = ParseFileProfileMap(file.RecognitionProfiles);
+        foreach (var (kindName, profileId) in map)
+        {
+            if (!Enum.TryParse<RecognitionProfileKind>(kindName, out var kind))
+                throw new ArgumentException($"Неизвестный вид профиля «{kindName}».");
+            if (RecognitionKinds.IsGroupScoped(kind))
+                throw new ArgumentException(
+                    $"Профиль вида «{RecognitionKinds.Describe(kind).Label}» привязывается к группе листов, а не к набору.");
+
+            if (profileId is null) { current.Remove(kindName); continue; }
+
+            var profile = await profiles.GetByIdAsync(profileId.Value, ct)
+                ?? throw new ArgumentException("Профиль распознавания не найден.");
+            if (profile.Kind != kind)
+                throw new ArgumentException(
+                    $"Профиль «{profile.Name}» имеет вид «{RecognitionKinds.Describe(profile.Kind).Label}» — он не подходит для «{RecognitionKinds.Describe(kind).Label}».");
+            current[kindName] = profileId.Value;
+        }
+
+        file.SetRecognitionProfiles(current.Count > 0 ? JsonSerializer.Serialize(current) : null);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    private async Task<ResolvedRecognitionProfile> ProfileForFileAsync(
+        Domain.DataSets.DataSetFile file, RecognitionProfileKind kind, CancellationToken ct)
+    {
+        var bound = ParseFileProfileMap(file.RecognitionProfiles).GetValueOrDefault(kind.ToString());
+        if (bound is { } id && await profiles.GetByIdAsync(id, ct) is { } p && p.Kind == kind) return p;
+        return await profiles.GetBuiltInAsync(BuiltInRecognitionProfiles.CodeForKind(kind), ct);
+    }
+
+    /// <summary>Карта {вид: id профиля} набора. Сломанный JSON — пустая карта (не падаем: распознавание
+    /// важнее привязки, оно продолжится на встроенных профилях).</summary>
+    public static Dictionary<string, Guid> ParseFileProfileMap(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return [];
+        try { return JsonSerializer.Deserialize<Dictionary<string, Guid>>(json) ?? []; }
+        catch (JsonException) { return []; }
+    }
+
+    /// <summary>
     /// Спецификация распознавания таблицы группы — ЕДИНСТВЕННОЕ место, где решается «таблична ли
     /// группа и по каким колонкам её читать» (issue #410). Раньше этот предикат был размазан по пяти
     /// точкам в виде «есть известный табличный тэг», и одна из них (<c>ReprojectTableSourcesAsync</c>)
@@ -817,9 +879,11 @@ public class DataSetPdfRecognitionService(
         {
             var profile = await profiles.GetByIdAsync(pid, ct)
                 ?? throw new ArgumentException("Профиль распознавания не найден.");
-            if (RecognitionKinds.Describe(profile.Kind).RowsKey is null)
+            // Проверяем ОБЛАСТЬ, а не «есть ли табличная часть»: у счёта она есть, но привязывается
+            // он к набору целиком, а не к группе листов.
+            if (!RecognitionKinds.IsGroupScoped(profile.Kind))
                 throw new ArgumentException(
-                    $"Профиль «{profile.Name}» не табличный — к группе листов привязывается профиль таблицы.");
+                    $"Профиль «{profile.Name}» привязывается к набору, а не к группе листов.");
         }
 
         var updated = grouping.Groups
@@ -986,7 +1050,7 @@ public class DataSetPdfRecognitionService(
 
         // Перераспознаём страницы документа (пасс-1 grounding + пасс-2 кроп штампа — тот же путь, что для
         // листов-документов в RecognizeGostSetAsync).
-        var stampFields = (await profiles.GetBuiltInAsync(BuiltInProfileCodes.TitleBlock, ct)).ToRecognitionFields();
+        var stampFields = (await ProfileForFileAsync(file, RecognitionProfileKind.TitleBlock, ct)).ToRecognitionFields();
         var fields = GostTitleBlockFields.WithClassifiers(stampFields);
         var freshRows = new Dictionary<int, IReadOnlyDictionary<string, string?>>();
         var done = 0;

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -90,6 +90,9 @@ public class DataSetService(
 
     public Task<GostGroupingDto?> SetDocumentProfileAsync(Guid fileId, int firstPageIndex, Guid? profileId, CancellationToken ct) =>
         pdfRecognition.SetDocumentProfileAsync(fileId, firstPageIndex, profileId, ct);
+
+    public Task<bool> SetFileRecognitionProfilesAsync(Guid fileId, IReadOnlyDictionary<string, Guid?> map, CancellationToken ct) =>
+        pdfRecognition.SetFileRecognitionProfilesAsync(fileId, map, ct);
     public Task<GostGroupingDto?> RecognizeDocumentTableAsync(Guid fileId, int firstPageIndex, CancellationToken ct) =>
         pdfRecognition.RecognizeDocumentTableAsync(fileId, firstPageIndex, ct);
 

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260725034258_AddFileRecognitionProfiles.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260725034258_AddFileRecognitionProfiles.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260725034258_AddFileRecognitionProfiles")]
+    partial class AddFileRecognitionProfiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260725034258_AddFileRecognitionProfiles.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260725034258_AddFileRecognitionProfiles.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFileRecognitionProfiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RecognitionProfiles",
+                table: "dataset_files",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RecognitionProfiles",
+                table: "dataset_files");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
@@ -1,4 +1,4 @@
-using BHS.CRG.Domain.DataSets;
+﻿using BHS.CRG.Domain.DataSets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -12,6 +12,7 @@ public class DataSetFileConfiguration : IEntityTypeConfiguration<DataSetFile>
         b.Property(e => e.PreprocessingProfile).HasMaxLength(64);
         b.Property(e => e.Grouping).HasColumnType("jsonb");
         b.Property(e => e.InvoiceRawData).HasColumnType("jsonb");
+        b.Property(e => e.RecognitionProfiles).HasColumnType("jsonb");
         b.Property(e => e.RecognitionStale).HasDefaultValue(false);
         b.HasKey(e => e.Id);
         b.Property(e => e.Name).HasMaxLength(512).IsRequired();

--- a/src/server/BHS.CRG.Infrastructure/Recognition/BuiltInRecognitionProfiles.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/BuiltInRecognitionProfiles.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 using BHS.CRG.Application.QualityDocs;
 using BHS.CRG.Application.Recognition;
@@ -65,6 +65,18 @@ public static class BuiltInRecognitionProfiles
         FunctionalTag.GostDocSpecification => BuiltInProfileCodes.SpecificationTable,
         FunctionalTag.GostDocCableJournal => BuiltInProfileCodes.CableJournal,
         _ => null,
+    };
+
+    /// <summary>Код встроенного профиля по виду — фолбэк, когда к набору/группе профиль не привязан.
+    /// Встроенные профили и виды соотносятся 1:1, поэтому карта однозначна.</summary>
+    public static string CodeForKind(RecognitionProfileKind kind) => kind switch
+    {
+        RecognitionProfileKind.TitleBlock => BuiltInProfileCodes.TitleBlock,
+        RecognitionProfileKind.CoverTitle => BuiltInProfileCodes.CoverTitle,
+        RecognitionProfileKind.Invoice => BuiltInProfileCodes.Invoice,
+        RecognitionProfileKind.Table => BuiltInProfileCodes.SpecificationTable,
+        RecognitionProfileKind.CableJournal => BuiltInProfileCodes.CableJournal,
+        _ => throw new InvalidOperationException($"Нет встроенного профиля для вида {kind}."),
     };
 
     /// <summary>Хеш заводского содержимого — по нему сидер понимает, что дефолт ушёл вперёд, пока

--- a/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionKinds.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionKinds.cs
@@ -4,6 +4,12 @@ using BHS.CRG.Domain.Recognition;
 
 namespace BHS.CRG.Infrastructure.Recognition;
 
+/// <summary>К чему применяется вид профиля: к НАБОРУ целиком (штамп/обложка/счёт — они читают весь
+/// файл) или к отдельной ГРУППЕ ЛИСТОВ (таблицы документа). Определяет, куда профиль вообще можно
+/// привязать; «есть ли табличная часть» для этого не годится — у счёта она есть, но привязывается он
+/// к файлу.</summary>
+public enum RecognitionProfileScope { File = 1, PageGroup = 2 }
+
 /// <summary>
 /// Что вид профиля означает ДЛЯ КОДА (issue #406) — реестр в духе <c>TagRegistry</c>. Без него
 /// проверки вида (`if (kind == Table)`) расползлись бы по сервисам и фронту, и вид перестал бы быть
@@ -21,6 +27,7 @@ namespace BHS.CRG.Infrastructure.Recognition;
 /// печатаются ДВАЖДЫ (по одной + склейкой в описании массива), у счёта — только склейкой в описании
 /// «Товары». Менять здесь = менять промпт, т.е. качество распознавания; отдельное решение.</param>
 /// <param name="Label">Человекочитаемое имя вида — для выбора при создании профиля.</param>
+/// <param name="Scope">Куда привязывается профиль этого вида: к набору или к группе листов.</param>
 public record RecognitionKindDescriptor(
     RecognitionProfileKind Kind,
     string? RowsKey,
@@ -28,7 +35,8 @@ public record RecognitionKindDescriptor(
     bool HasScalarFields,
     IReadOnlyList<string> SystemFieldNames,
     bool ListRowColumnsAsFields = false,
-    string Label = "");
+    string Label = "",
+    RecognitionProfileScope Scope = RecognitionProfileScope.File);
 
 public static class RecognitionKinds
 {
@@ -55,12 +63,14 @@ public static class RecognitionKinds
         [RecognitionProfileKind.Table] = new(
             RecognitionProfileKind.Table, RowsKey: GostTableFields.RowsPath,
             SupportsShape: true, HasScalarFields: false, [], ListRowColumnsAsFields: true,
-            Label: "Таблица документа"),
+            Label: "Таблица документа",
+            Scope: RecognitionProfileScope.PageGroup),
 
         [RecognitionProfileKind.CableJournal] = new(
             RecognitionProfileKind.CableJournal, RowsKey: GostTableFields.RowsPath,
             SupportsShape: true, HasScalarFields: false, [], ListRowColumnsAsFields: true,
-            Label: "Кабельный журнал"),
+            Label: "Кабельный журнал",
+            Scope: RecognitionProfileScope.PageGroup),
     };
 
     public static RecognitionKindDescriptor Describe(RecognitionProfileKind kind) =>
@@ -75,6 +85,10 @@ public static class RecognitionKinds
 
     /// <summary>Табличные виды — те, у которых распознаётся массив строк.</summary>
     public static bool IsTabular(RecognitionProfileKind kind) => Describe(kind).RowsKey is not null;
+
+    /// <summary>Привязывается ли вид к группе листов (а не к набору целиком).</summary>
+    public static bool IsGroupScoped(RecognitionProfileKind kind)
+        => Describe(kind).Scope == RecognitionProfileScope.PageGroup;
 
     /// <summary>Собирает полный список полей ОДНОГО вызова распознавания: скаляры профиля +
     /// синтетическое поле-массив под строки (если вид табличный). Само поле-массив в профиль не

--- a/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionProfileProvider.cs
+++ b/src/server/BHS.CRG.Infrastructure/Recognition/RecognitionProfileProvider.cs
@@ -1,4 +1,4 @@
-using BHS.CRG.Application.Recognition;
+﻿using BHS.CRG.Application.Recognition;
 using BHS.CRG.Domain.Recognition;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -58,5 +58,5 @@ public class RecognitionProfileProvider(AppDbContext db) : IRecognitionProfilePr
 
     private static RecognitionKindInfo ToInfo(RecognitionKindDescriptor d) => new(
         d.Kind.ToString(), d.Label, d.SupportsShape, d.HasScalarFields,
-        IsTabular: d.RowsKey is not null, d.SystemFieldNames);
+        IsTabular: d.RowsKey is not null, d.SystemFieldNames, d.Scope.ToString());
 }

--- a/src/server/BHS.CRG.Tests/Integration/FileRecognitionProfileTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/FileRecognitionProfileTests.cs
@@ -1,0 +1,152 @@
+﻿using BHS.CRG.Application.Common;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Recognition;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Recognition;
+using BHS.CRG.Infrastructure.DataSets;
+using BHS.CRG.Infrastructure.Persistence;
+using BHS.CRG.Infrastructure.Recognition;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SharpPdfDocument = PdfSharpCore.Pdf.PdfDocument;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Профили распознавания, привязанные к НАБОРУ (issue #412): штамп, обложка/титул и счёт читают файл
+/// целиком, поэтому их профиль живёт на наборе — в отличие от таблиц (issue #410, привязка к группе).
+/// </summary>
+[Collection("Integration")]
+public class FileRecognitionProfileTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private async Task<(Guid fileId, IServiceScope scope)> SeedAsync()
+    {
+        var scope = fixture.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.RecognitionProfiles.RemoveRange(db.RecognitionProfiles.Where(p => p.Code == null));
+        await db.SaveChangesAsync();
+        await RecognitionProfileSeeder.SeedAsync(db);
+        db.ChangeTracker.Clear();
+
+        using var doc = new SharpPdfDocument();
+        doc.AddPage();
+        using var ms = new MemoryStream();
+        doc.Save(ms, false);
+        var blobPath = await scope.ServiceProvider.GetRequiredService<IBlobStorage>()
+            .UploadAsync("a.pdf", new MemoryStream(ms.ToArray()), "application/pdf");
+
+        var file = DataSetFile.Create("Альбом", DataSetFormat.Pdf, blobPath, CatalogScope.System, null);
+        db.DataSetFiles.Add(file);
+        await db.SaveChangesAsync();
+        return (file.Id, scope);
+    }
+
+    private static async Task<Guid> CustomStampProfileAsync(AppDbContext db)
+    {
+        // Свой штамп: заводские поля + собственное «Стадия». Системные поля обязаны остаться.
+        var builtIn = await db.RecognitionProfiles.AsNoTracking()
+            .FirstAsync(p => p.Code == BuiltInProfileCodes.TitleBlock);
+        var fields = RecognitionProfileJson.ReadFields(builtIn.Fields).ToList();
+        fields.Add(new RecognitionProfileField("Стадия", "Стадия документации"));
+
+        var profile = RecognitionProfile.Create(
+            "Штамп с полем Стадия", RecognitionProfileKind.TitleBlock,
+            fields: RecognitionProfileJson.WriteFields(fields));
+        db.RecognitionProfiles.Add(profile);
+        await db.SaveChangesAsync();
+        return profile.Id;
+    }
+
+    [Fact]
+    public async Task SetAndResolve_BoundProfileWins_OverBuiltIn()
+    {
+        var (fileId, scope) = await SeedAsync();
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var profileId = await CustomStampProfileAsync(db);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+
+            Assert.True(await svc.SetFileRecognitionProfilesAsync(
+                fileId, new Dictionary<string, Guid?> { ["TitleBlock"] = profileId }, default));
+
+            var file = await db.DataSetFiles.AsNoTracking().FirstAsync(f => f.Id == fileId);
+            var map = DataSetPdfRecognitionService.ParseFileProfileMap(file.RecognitionProfiles);
+            Assert.Equal(profileId, map["TitleBlock"]);
+
+            // Снятие привязки → пустая карта схлопывается в null, «нет привязок» единообразно.
+            await svc.SetFileRecognitionProfilesAsync(
+                fileId, new Dictionary<string, Guid?> { ["TitleBlock"] = null }, default);
+            var cleared = await db.DataSetFiles.AsNoTracking().FirstAsync(f => f.Id == fileId);
+            Assert.Null(cleared.RecognitionProfiles);
+        }
+    }
+
+    [Fact]
+    public async Task Set_RejectsKindMismatch_AndGroupScopedKinds()
+    {
+        var (fileId, scope) = await SeedAsync();
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var stampId = await CustomStampProfileAsync(db);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+
+            // Профиль штампа в слот обложки не годится — вид определяет применяемый промпт.
+            await Assert.ThrowsAsync<ArgumentException>(() => svc.SetFileRecognitionProfilesAsync(
+                fileId, new Dictionary<string, Guid?> { ["CoverTitle"] = stampId }, default));
+
+            // Табличные виды привязываются к ГРУППЕ ЛИСТОВ, а не к набору.
+            await Assert.ThrowsAsync<ArgumentException>(() => svc.SetFileRecognitionProfilesAsync(
+                fileId, new Dictionary<string, Guid?> { ["Table"] = null }, default));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => svc.SetFileRecognitionProfilesAsync(
+                fileId, new Dictionary<string, Guid?> { ["НетТакого"] = null }, default));
+        }
+    }
+
+    [Fact]
+    public async Task ParseFileProfileMap_BrokenJson_DoesNotBreakRecognition()
+    {
+        // Распознавание важнее привязки: сломанная карта → работаем на встроенных профилях, не падаем.
+        Assert.Empty(DataSetPdfRecognitionService.ParseFileProfileMap("не json"));
+        Assert.Empty(DataSetPdfRecognitionService.ParseFileProfileMap(null));
+        Assert.Empty(DataSetPdfRecognitionService.ParseFileProfileMap("{}"));
+    }
+
+    [Fact]
+    public void Scope_SeparatesFileLevelKindsFromGroupLevel()
+    {
+        // «Есть табличная часть» для этого не годится: у счёта она есть (Товары), но привязывается
+        // он к набору. Поэтому область — отдельное свойство вида.
+        Assert.True(RecognitionKinds.IsTabular(RecognitionProfileKind.Invoice));
+        Assert.False(RecognitionKinds.IsGroupScoped(RecognitionProfileKind.Invoice));
+
+        Assert.True(RecognitionKinds.IsGroupScoped(RecognitionProfileKind.Table));
+        Assert.True(RecognitionKinds.IsGroupScoped(RecognitionProfileKind.CableJournal));
+        Assert.False(RecognitionKinds.IsGroupScoped(RecognitionProfileKind.TitleBlock));
+        Assert.False(RecognitionKinds.IsGroupScoped(RecognitionProfileKind.CoverTitle));
+    }
+
+    [Fact]
+    public async Task FileDto_ExposesProfileMap()
+    {
+        var (fileId, scope) = await SeedAsync();
+        using (scope)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var profileId = await CustomStampProfileAsync(db);
+            var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+            await svc.SetFileRecognitionProfilesAsync(
+                fileId, new Dictionary<string, Guid?> { ["TitleBlock"] = profileId }, default);
+
+            var files = await svc.ListFilesAsync(nameof(CatalogScope.System), null, default);
+            var dto = files.Single(f => f.Id == fileId);
+            Assert.Equal(profileId, dto.RecognitionProfiles!["TitleBlock"]);
+        }
+    }
+}


### PR DESCRIPTION
Часть **D** эпика #405 — хвост, вынесенный из #410, чтобы тот PR остался обозримым.

## Зачем

Не-табличные виды (штамп, обложка/титул, счёт) читают файл **целиком**, поэтому их профиль живёт на наборе, а не на группе листов. Теперь для набора можно выбрать свой профиль вместо встроенного.

## Состав

- `RecognitionProfiles` — карта `{вид: id профиля}` nullable jsonb-колонкой на `dataset_files`. **Миграция только добавляет колонку.**
- `ProfileForFileAsync` применён во **всех** точках распознавания, включая колонки проекций «Обложка»/«Документы» — иначе добавленное пользователем поле не доехало бы до схемы источника.
- Битая или чужая привязка **деградирует к встроенному профилю**, а не роняет распознавание: потерять альбом из-за удалённого профиля хуже, чем распознать его дефолтными параметрами.
- `PUT /files/{id}/recognition-profiles` с валидацией вида и совпадения вида профиля; пустая карта схлопывается в null, чтобы «нет привязок» имело одно представление.
- UI: диалог «Профили распознавания набора» в тулбаре. Список видов приходит **с сервера** по области применения — не зашит на клиенте.

## Попутно закрыта дырка из #410

Там привязка к **группе** проверялась предикатом «табличный», а у счёта табличная часть есть (`Товары`) — профиль счёта прошёл бы к группе листов. Введена явная **область вида** (`File | PageGroup`), проверки переведены на неё. «Есть табличная часть» для этого не годится в принципе, что и подтверждается живым выводом:

```
TitleBlock     scope=File       tabular=false
Invoice        scope=File       tabular=true    ← табличный, но привязывается к набору
Table          scope=PageGroup  tabular=true
CableJournal   scope=PageGroup  tabular=true
```

## Проверка

- **547 backend** (+5) · **153 frontend** · `tsc -b` зелёный.
- Живьём: миграция применилась (`RecognitionProfiles : jsonb`), области видов отдаются корректно.

Closes #412
Refs #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)