### PR TITLE
feat(reconciliation): экран находок (#436)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -16,6 +16,7 @@ import { SystemCommonDataPage } from '@/features/common-data/SystemCommonDataPag
 import { SettingsPage } from '@/features/settings/SettingsPage';
 import { PrimitiveTypesPage } from '@/features/settings/PrimitiveTypesPage';
 import { RecognitionProfilesPage } from '@/features/settings/RecognitionProfilesPage';
+import { ReconciliationsPage } from '@/features/reconciliations/ReconciliationsPage';
 import { UsersPage } from '@/features/settings/UsersPage';
 import { DataSetsPage } from '@/features/datasets/DataSetsPage';
 import { PdfGroupingEditor } from '@/features/datasets/PdfGroupingEditor';
@@ -54,6 +55,7 @@ export default function App() {
                 <Route path="datasets" element={<DataSetsPage />} />
                 <Route path="datasets/files/:fileId/grouping" element={<PdfGroupingEditor />} />
                 <Route path="quality-docs" element={<QualityDocsPage />} />
+                <Route path="reconciliations" element={<ReconciliationsPage />} />
                 <Route path="profile" element={<ProfilePage />} />
                 <Route element={<AdminRoute />}>
                   <Route path="document-types/*" element={<DocumentTypesPage kind="Document" />} />

--- a/src/client/src/features/reconciliations/DecisionDialog.tsx
+++ b/src/client/src/features/reconciliations/DecisionDialog.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
+import { Select, SelectItem } from '@/shared/ui/Select';
+import { DECISION_LABELS, STATUS_LABELS, type DecisionKind, type Finding } from '@/shared/api/reconciliations';
+
+/**
+ * Разбор находки. Решение адресуется КЛЮЧОМ позиции, а не идентификатором находки, поэтому переживает
+ * следующий прогон — иначе журнал терял бы память о разобранном при каждом пересчёте (issue #414).
+ */
+export function DecisionDialog({ finding, onClose, onSave, onRemove }: {
+  finding: Finding;
+  onClose: () => void;
+  onSave: (kind: DecisionKind, note: string | null) => Promise<void>;
+  /** Задан, только если решение уже есть. */
+  onRemove?: () => Promise<void>;
+}) {
+  const [kind, setKind] = useState<DecisionKind>(finding.decision?.kind ?? 'Accepted');
+  const [note, setNote] = useState(finding.decision?.note ?? '');
+  const [busy, setBusy] = useState(false);
+
+  async function run(action: () => Promise<void>) {
+    setBusy(true);
+    try { await action(); } finally { setBusy(false); }
+  }
+
+  return (
+    <Modal open onOpenChange={o => { if (!o) onClose(); }} title="Разбор находки"
+      footer={
+        <div className="flex items-center gap-2">
+          {onRemove && (
+            <Button danger disabled={busy} onClick={() => run(onRemove)}>Снять решение</Button>
+          )}
+          <span className="flex-1" />
+          <Button disabled={busy} onClick={onClose}>Отмена</Button>
+          <Button variant="filled" loading={busy}
+            onClick={() => run(() => onSave(kind, note.trim() || null))}>
+            Сохранить
+          </Button>
+        </div>
+      }>
+      <div className="space-y-4">
+        <div className="rounded-lg bg-muted px-3 py-2">
+          <div className="text-sm font-medium text-fg1">{finding.label}</div>
+          <div className="text-xs text-fg3 mt-0.5">
+            {STATUS_LABELS[finding.status]} · слева {finding.leftValue ?? '—'} · справа {finding.rightValue ?? '—'}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs text-fg3 mb-1">Решение</label>
+          <Select value={kind} onValueChange={v => setKind(v as DecisionKind)} aria-label="Решение">
+            <SelectItem value="Accepted">{DECISION_LABELS.Accepted}</SelectItem>
+            <SelectItem value="Suppressed">{DECISION_LABELS.Suppressed}</SelectItem>
+          </Select>
+          <p className="text-[11px] text-fg4 mt-1">
+            «Признано нормой» — расхождение реально и объяснимо (давальческое оборудование, учтено в
+            другом разделе). «Исключено» — позиция к этой сверке неприменима.
+          </p>
+        </div>
+
+        <TextField label="Примечание" value={note} onChange={e => setNote(e.target.value)}
+          hint="Почему это не ошибка" />
+
+        <p className="text-[11px] text-fg4">
+          Решение сохраняется за позицией, а не за прогоном, и останется после следующего пересчёта.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/client/src/features/reconciliations/ReconciliationEditor.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationEditor.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useState } from 'react';
+import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
+import { TextField } from '@/shared/ui/TextField';
+import { Select, SelectItem } from '@/shared/ui/Select';
+import { useToast } from '@/shared/ui/Toast';
+import { useListDataSetFiles } from '@/shared/api/datasets';
+import type { DataSetSource } from '@/shared/api/types';
+import {
+  useCreateReconciliation, useUpdateReconciliation,
+  OPERATOR_LABELS,
+  type ComparisonOperator, type Reconciliation, type ReconciliationSide, type ToleranceKind,
+} from '@/shared/api/reconciliations';
+
+/**
+ * Редактор определения сверки (issue #436, Admin).
+ *
+ * Колонки выбираются из схемы источника, а не вводятся руками: опечатка в имени колонки даёт пустую
+ * сторону и находки «нет слева» по всему списку — молчаливая неверность, которую пользователь примет
+ * за реальное расхождение.
+ */
+
+const EMPTY_SIDE: ReconciliationSide = { sourceId: '', keyColumns: [], valueColumn: '' };
+
+function columnsOf(source: DataSetSource | undefined): string[] {
+  if (!source?.cachedSchema) return [];
+  try {
+    const parsed: unknown = JSON.parse(source.cachedSchema);
+    return Array.isArray(parsed)
+      ? parsed.map(c => (c as { name?: string }).name).filter((n): n is string => !!n)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function SideEditor({ title, side, onChange, sources }: {
+  title: string;
+  side: ReconciliationSide;
+  onChange: (s: ReconciliationSide) => void;
+  sources: { source: DataSetSource; fileName: string }[];
+}) {
+  const current = sources.find(s => s.source.id === side.sourceId)?.source;
+  const columns = columnsOf(current);
+
+  function toggleKey(col: string) {
+    // Порядок значим: стороны обязаны перечислять ключевые колонки согласованно, иначе ключи не сойдутся.
+    onChange({
+      ...side,
+      keyColumns: side.keyColumns.includes(col)
+        ? side.keyColumns.filter(c => c !== col)
+        : [...side.keyColumns, col],
+    });
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-stroke p-3">
+      <div className="text-xs font-semibold uppercase tracking-wide text-fg4">{title}</div>
+
+      <Select value={side.sourceId} onValueChange={v => onChange({ ...EMPTY_SIDE, sourceId: v })}
+        placeholder="Источник данных" aria-label={`${title}: источник`}>
+        {sources.map(({ source, fileName }) => (
+          <SelectItem key={source.id} value={source.id}>
+            {fileName} — {source.name}
+          </SelectItem>
+        ))}
+      </Select>
+
+      {side.sourceId && columns.length === 0 && (
+        <p className="text-xs text-danger">У источника нет разобранной схемы — колонки не выбрать.</p>
+      )}
+
+      {columns.length > 0 && (
+        <>
+          <div>
+            <div className="text-xs text-fg3 mb-1">
+              Ключевые колонки {side.keyColumns.length > 0 && (
+                <span className="text-fg4">— порядок: {side.keyColumns.join(' + ')}</span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {columns.map(c => {
+                const on = side.keyColumns.includes(c);
+                return (
+                  <button key={c} type="button" onClick={() => toggleKey(c)}
+                    className={`text-xs px-2 py-1 rounded-full transition-colors ${
+                      on ? 'bg-brand-subtle text-brand font-medium' : 'bg-muted text-fg3 hover:text-fg1'}`}>
+                    {c}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <div className="text-xs text-fg3 mb-1">Колонка количества (строки с одним ключом суммируются)</div>
+            <Select value={side.valueColumn} onValueChange={v => onChange({ ...side, valueColumn: v })}
+              placeholder="Выберите колонку" aria-label={`${title}: количество`}>
+              {columns.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+            </Select>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function ReconciliationEditor({ existing, onClose }: {
+  existing: Reconciliation | null;
+  onClose: () => void;
+}) {
+  const toast = useToast();
+  const create = useCreateReconciliation();
+  const update = useUpdateReconciliation();
+
+  const [name, setName] = useState(existing?.name ?? '');
+  const [left, setLeft] = useState<ReconciliationSide>(existing?.spec.left ?? EMPTY_SIDE);
+  const [right, setRight] = useState<ReconciliationSide>(existing?.spec.right ?? EMPTY_SIDE);
+  const [operator, setOperator] = useState<ComparisonOperator>(
+    existing?.spec.comparison.operator ?? 'GreaterOrEqual');
+  const [tolerance, setTolerance] = useState(String(existing?.spec.comparison.tolerance ?? 0));
+  const [toleranceKind, setToleranceKind] = useState<ToleranceKind>(
+    existing?.spec.comparison.toleranceKind ?? 'Absolute');
+  const [busy, setBusy] = useState(false);
+
+  const { data: files = [] } = useListDataSetFiles('System');
+
+  const sources = useMemo(
+    () => files.flatMap(f => (f.sources ?? []).map(s => ({ source: s, fileName: f.name }))),
+    [files]);
+
+  const valid = name.trim() !== ''
+    && left.sourceId && left.valueColumn && left.keyColumns.length > 0
+    && right.sourceId && right.valueColumn && right.keyColumns.length > 0;
+
+  async function save() {
+    const spec = {
+      left, right,
+      comparison: { operator, tolerance: Number(tolerance) || 0, toleranceKind },
+    };
+    setBusy(true);
+    try {
+      if (existing) await update.mutateAsync({ id: existing.id, name: name.trim(), spec });
+      else await create.mutateAsync({ name: name.trim(), scope: 'System', spec });
+      toast.success(existing ? 'Сверка изменена' : 'Сверка создана');
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal open onOpenChange={o => { if (!o) onClose(); }} wide
+      title={existing ? 'Изменить сверку' : 'Новая сверка'}
+      footer={
+        <div className="flex items-center gap-2 justify-end">
+          <Button disabled={busy} onClick={onClose}>Отмена</Button>
+          <Button variant="filled" disabled={!valid} loading={busy} onClick={save}>Сохранить</Button>
+        </div>
+      }>
+      <div className="space-y-4">
+        <TextField label="Название" value={name} onChange={e => setName(e.target.value)}
+          hint="Например: Кабель — проложено против реестра материалов" />
+
+        <div className="grid grid-cols-2 gap-3">
+          <SideEditor title="Слева" side={left} onChange={setLeft} sources={sources} />
+          <SideEditor title="Справа" side={right} onChange={setRight} sources={sources} />
+        </div>
+
+        <div className="rounded-lg border border-stroke p-3 space-y-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-fg4">Правило</div>
+          <div className="flex items-center gap-2 text-sm text-fg2">
+            <span>Слева должно быть</span>
+            <Select value={operator} onValueChange={v => setOperator(v as ComparisonOperator)}
+              aria-label="Оператор" className="w-40">
+              {(Object.keys(OPERATOR_LABELS) as ComparisonOperator[]).map(op => (
+                <SelectItem key={op} value={op}>{OPERATOR_LABELS[op]}</SelectItem>
+              ))}
+            </Select>
+            <span>чем справа</span>
+          </div>
+          <div className="flex items-end gap-2">
+            <TextField label="Допуск" value={tolerance} inputMode="decimal"
+              onChange={e => setTolerance(e.target.value)} containerClassName="w-32"
+              hint="0 — точное сравнение" />
+            <Select value={toleranceKind} onValueChange={v => setToleranceKind(v as ToleranceKind)}
+              aria-label="Вид допуска" className="w-40">
+              <SelectItem value="Absolute">в единицах</SelectItem>
+              <SelectItem value="Percent">в процентах</SelectItem>
+            </Select>
+          </div>
+          <p className="text-[11px] text-fg4">
+            Допуск гасит расхождения округления — без него отчёт забьётся находками на сотые доли.
+          </p>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -1,0 +1,279 @@
+import { useMemo, useState } from 'react';
+import {
+  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale,
+} from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { Select, SelectItem } from '@/shared/ui/Select';
+import { EmptyState } from '@/shared/ui/EmptyState';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
+import { useToast } from '@/shared/ui/Toast';
+import { ListDetailShell, NavSearchInput, NavItem } from '@/shared/ui/ListDetailShell';
+import { useAuth } from '@/shared/hooks/useAuth';
+import {
+  useReconciliations, useReconciliationRuns, useFindings, useRunReconciliation,
+  useDeleteReconciliation, useSetDecision, useRemoveDecision,
+  STATUS_LABELS, DECISION_LABELS, needsAttention, runSummary,
+  type Finding, type ReconciliationRun,
+} from '@/shared/api/reconciliations';
+import { ReconciliationEditor } from './ReconciliationEditor';
+import { DecisionDialog } from './DecisionDialog';
+
+/**
+ * Сверка на непротиворечивость (issue #414, фаза Ф1 — экран находок #436).
+ *
+ * До этой страницы результаты анализа жили только в переписке с внешним агентом: память между
+ * прогонами не копилась, отчёт не с чем было сравнить. Здесь они становятся объектом системы.
+ */
+
+function StatusBadge({ f }: { f: Finding }) {
+  if (f.resolved) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full bg-brand-subtle text-brand shrink-0">
+        <CheckCircle2 size={12} /> Устранено
+      </span>
+    );
+  }
+  if (f.status === 'Match') {
+    return <span className="text-xs text-fg4 shrink-0">Совпадает</span>;
+  }
+  // Решение снимает вопрос, даже если расхождение осталось: в этом и смысл персистентного решения —
+  // «давальческое оборудование» не должно всплывать каждый прогон.
+  const muted = !!f.decision;
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full shrink-0 ${
+      muted ? 'bg-muted text-fg3' : 'bg-danger-subtle text-danger'}`}>
+      {muted ? <CircleSlash size={12} /> : <AlertTriangle size={12} />} {STATUS_LABELS[f.status]}
+    </span>
+  );
+}
+
+function num(v: number | null): string {
+  return v == null ? '—' : String(Math.round(v * 1000) / 1000);
+}
+
+function FindingRow({ f, onDecide }: { f: Finding; onDecide: (f: Finding) => void }) {
+  const left = f.provenance.left;
+  const right = f.provenance.right;
+  return (
+    <div className="px-3 py-2 border-b border-stroke hover:bg-muted/40 group">
+      <div className="flex items-center gap-2">
+        <StatusBadge f={f} />
+        <span className="flex-1 truncate text-sm text-fg1" title={f.label}>{f.label}</span>
+        <span className="text-sm tabular-nums text-fg2 shrink-0">
+          {num(f.leftValue)} <span className="text-fg4">/</span> {num(f.rightValue)}
+        </span>
+        <Button variant="text" size="sm" onClick={() => onDecide(f)}
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0">
+          {f.decision ? 'Изменить' : 'Разобрать'}
+        </Button>
+      </div>
+      <div className="flex items-center gap-3 mt-0.5 text-[11px] text-fg4">
+        {/* Провенанс: без него находку нельзя проверить глазами по документу. */}
+        {left && <span>слева: {left.column}, строк {left.rows.length}</span>}
+        {right && <span>справа: {right.column}, строк {right.rows.length}</span>}
+        {f.decision && (
+          <span className="text-fg3">
+            {DECISION_LABELS[f.decision.kind]}
+            {f.decision.note ? ` — ${f.decision.note}` : ''}
+            {f.decision.decidedBy ? ` (${f.decision.decidedBy})` : ''}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RunPicker({ runs, value, onChange }: {
+  runs: ReconciliationRun[]; value: string | null; onChange: (v: string | null) => void;
+}) {
+  if (runs.length === 0) return null;
+  return (
+    <Select value={value ?? runs[0]?.id ?? ''} onValueChange={onChange} aria-label="Прогон"
+      className="w-56">
+      {runs.map((r, i) => (
+        <SelectItem key={r.id} value={r.id}>
+          {new Date(r.startedAt).toLocaleString('ru-RU')}{i === 0 ? ' — последний' : ''}
+        </SelectItem>
+      ))}
+    </Select>
+  );
+}
+
+export function ReconciliationsPage() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'Admin';
+  const toast = useToast();
+
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<'new' | string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [deciding, setDeciding] = useState<Finding | null>(null);
+  const [onlyAttention, setOnlyAttention] = useState(false);
+
+  const { data: items = [], isLoading } = useReconciliations();
+  const { data: runs = [] } = useReconciliationRuns(selectedId);
+  const { data: findings = [], isLoading: findingsLoading } = useFindings(selectedId, runId);
+
+  const run = useRunReconciliation();
+  const remove = useDeleteReconciliation();
+  const setDecision = useSetDecision();
+  const removeDecision = useRemoveDecision();
+
+  const selected = items.find(i => i.id === selectedId) ?? null;
+  const currentRun = runs.find(r => r.id === (runId ?? runs[0]?.id)) ?? runs[0] ?? null;
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q ? items.filter(i => i.name.toLowerCase().includes(q)) : items;
+  }, [items, search]);
+
+  const attentionCount = findings.filter(needsAttention).length;
+  const shown = onlyAttention ? findings.filter(needsAttention) : findings;
+
+  async function onRun() {
+    if (!selectedId) return;
+    const result = await run.mutateAsync(selectedId);
+    setRunId(null); // после прогона смотрим последний
+    if (result.status === 'Failed') toast.error(result.error ?? 'Прогон не выполнен');
+    else toast.success(runSummary(result));
+  }
+
+  const nav = (
+    <>
+      <NavSearchInput value={search} onChange={setSearch} placeholder="Поиск сверки…" />
+      <div className="flex-1 overflow-y-auto px-2 pb-2">
+        {filtered.map(i => (
+          <NavItem key={i.id} icon={<Scale size={16} />} label={i.name}
+            active={i.id === selectedId}
+            onClick={() => { setSelectedId(i.id); setRunId(null); }} />
+        ))}
+        {filtered.length === 0 && !isLoading && (
+          <p className="px-3 py-2 text-sm text-fg4">Сверок нет</p>
+        )}
+      </div>
+    </>
+  );
+
+  const detail = !selected ? (
+    <EmptyState icon={<Scale size={32} />} title="Выберите сверку"
+      description="Сверка сопоставляет два источника по доменному ключу и показывает расхождения." />
+  ) : (
+    <div className="flex-1 min-w-0 flex flex-col">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-stroke shrink-0">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-base font-semibold text-fg1 truncate">{selected.name}</h2>
+          <p className="text-xs text-fg3 mt-0.5">
+            {currentRun ? runSummary(currentRun) : 'Прогонов ещё не было'}
+          </p>
+        </div>
+        {runs.length > 1 && (
+          <div className="shrink-0 flex items-center gap-1.5 text-fg4">
+            <History size={14} />
+            <RunPicker runs={runs} value={runId} onChange={setRunId} />
+          </div>
+        )}
+        <Button variant="filled" onClick={onRun} disabled={run.isPending} className="shrink-0">
+          <Play size={14} /> {run.isPending ? 'Считаю…' : 'Прогнать'}
+        </Button>
+        {isAdmin && (
+          <RowActionsMenu actions={[
+            { key: 'edit', label: 'Изменить', onSelect: () => setEditing(selected.id) },
+            { key: 'delete', label: 'Удалить', danger: true, onSelect: () => setDeleting(selected.id) },
+          ]} />
+        )}
+      </div>
+
+      {/* Неудачный прогон обязан быть виден: пустой список читается как «расхождений нет», и это
+          самое опасное недоразумение в подсистеме. */}
+      {currentRun?.status === 'Failed' && (
+        <div className="mx-4 mt-3 px-3 py-2 rounded-lg bg-danger-subtle text-danger text-sm">
+          <strong>Прогон не выполнен.</strong> {currentRun.error}
+        </div>
+      )}
+
+      {currentRun?.status === 'Completed' && (
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-stroke text-xs shrink-0">
+          <button type="button" onClick={() => setOnlyAttention(v => !v)}
+            className={`px-2 py-1 rounded-full transition-colors ${
+              onlyAttention ? 'bg-brand-subtle text-brand font-medium' : 'text-fg3 hover:bg-muted'}`}>
+            Требует внимания: {attentionCount}
+          </button>
+          <span className="text-fg4">
+            совпало {currentRun.matchCount} · расхождений {currentRun.mismatchCount} ·
+            нет слева {currentRun.missingLeftCount} · нет справа {currentRun.missingRightCount}
+          </span>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {findingsLoading && <p className="px-4 py-3 text-sm text-fg4">Загрузка…</p>}
+        {!findingsLoading && shown.length === 0 && (
+          <p className="px-4 py-3 text-sm text-fg4">
+            {runs.length === 0
+              ? 'Нажмите «Прогнать», чтобы сверить источники.'
+              : onlyAttention ? 'Всё разобрано.' : 'Находок нет.'}
+          </p>
+        )}
+        {shown.map(f => <FindingRow key={f.id} f={f} onDecide={setDeciding} />)}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <ListDetailShell
+        title="Сверка"
+        subtitle="Сопоставление источников по доменному ключу"
+        headerAction={isAdmin ? (
+          <Button variant="filled" onClick={() => setEditing('new')}><Plus size={14} /> Создать</Button>
+        ) : undefined}
+        nav={nav}
+        detail={detail}
+      />
+
+      {editing && (
+        <ReconciliationEditor
+          existing={editing === 'new' ? null : items.find(i => i.id === editing) ?? null}
+          onClose={() => setEditing(null)}
+        />
+      )}
+
+      {deciding && selectedId && (
+        <DecisionDialog
+          finding={deciding}
+          onClose={() => setDeciding(null)}
+          onSave={async (kind, note) => {
+            await setDecision.mutateAsync({ id: selectedId, key: deciding.key, kind, note });
+            setDeciding(null);
+            // Решение адресовано ключом позиции, поэтому переживёт следующий прогон — говорим это
+            // прямо, иначе непонятно, почему отметка не исчезает после пересчёта.
+            toast.success('Решение сохранено и переживёт следующий прогон');
+          }}
+          onRemove={deciding.decision ? async () => {
+            await removeDecision.mutateAsync({ id: selectedId, key: deciding.key });
+            setDeciding(null);
+            toast.info('Решение снято');
+          } : undefined}
+        />
+      )}
+
+      <ConfirmDialog
+        open={!!deleting}
+        title="Удалить сверку?"
+        description="Вместе с ней будут удалены все прогоны, находки и принятые решения."
+        confirmLabel="Удалить"
+        onOpenChange={open => { if (!open) setDeleting(null); }}
+        onConfirm={async () => {
+          const id = deleting!;
+          await remove.mutateAsync(id);
+          if (selectedId === id) setSelectedId(null);
+          setDeleting(null);
+          toast.success('Сверка удалена');
+        }}
+      />
+    </>
+  );
+}

--- a/src/client/src/shared/api/reconciliations.test.ts
+++ b/src/client/src/shared/api/reconciliations.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { needsAttention, runSummary, type Finding, type ReconciliationRun } from './reconciliations';
+
+function finding(p: Partial<Finding>): Finding {
+  return {
+    id: 'f', key: 'k', label: 'ВВГнг(А)-LS 3х2.5',
+    leftValue: 50, rightValue: 100, status: 'Mismatch',
+    provenance: { left: null, right: null },
+    resolved: false, decision: null,
+    ...p,
+  };
+}
+
+function run(p: Partial<ReconciliationRun>): ReconciliationRun {
+  return {
+    id: 'r', definitionId: 'd', status: 'Completed',
+    startedAt: '2026-07-26T00:00:00Z', finishedAt: '2026-07-26T00:00:01Z', error: null,
+    matchCount: 0, mismatchCount: 0, missingLeftCount: 0, missingRightCount: 0,
+    ...p,
+  };
+}
+
+describe('needsAttention', () => {
+  it('расхождение без решения требует внимания', () => {
+    expect(needsAttention(finding({ status: 'Mismatch' }))).toBe(true);
+    expect(needsAttention(finding({ status: 'MissingLeft' }))).toBe(true);
+  });
+
+  it('совпадение не требует', () => {
+    expect(needsAttention(finding({ status: 'Match' }))).toBe(false);
+  });
+
+  // Смысл персистентного решения: «давальческое оборудование» не должно всплывать каждый прогон.
+  it('принятое решение снимает вопрос, даже если расхождение осталось', () => {
+    const decided = finding({
+      status: 'Mismatch',
+      decision: { id: 'x', key: 'k', kind: 'Accepted', note: null, decidedBy: 'alex', updatedAt: '' },
+    });
+    expect(needsAttention(decided)).toBe(false);
+  });
+});
+
+describe('runSummary', () => {
+  it('неудачный прогон не выдаёт себя за «расхождений нет»', () => {
+    expect(runSummary(run({ status: 'Failed', error: 'Источник не найден' })))
+      .toBe('Прогон не выполнен');
+  });
+
+  it('чистый прогон', () => {
+    expect(runSummary(run({ matchCount: 10 }))).toBe('Расхождений нет (позиций: 10)');
+  });
+
+  // Отсутствующие позиции — такая же проблема, как расхождение в количестве, и в сводку входят.
+  it('считает все виды проблем, а не только расхождения', () => {
+    expect(runSummary(run({ matchCount: 8, mismatchCount: 1, missingLeftCount: 1, missingRightCount: 2 })))
+      .toBe('Требует внимания: 4 из 12');
+  });
+});

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -1,0 +1,215 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from './client';
+
+/**
+ * Сверка на непротиворечивость (issue #414, фаза Ф1).
+ *
+ * Арифметику и сопоставление считает сервер — ИИ в пути сравнения нет, иначе отчёт «прыгал» бы от
+ * прогона к прогону. Клиент показывает находки и принимает человеческие решения.
+ */
+
+export type ComparisonOperator = 'Equal' | 'GreaterOrEqual' | 'LessOrEqual';
+export type ToleranceKind = 'Absolute' | 'Percent';
+export type FindingStatus = 'Match' | 'Mismatch' | 'MissingLeft' | 'MissingRight';
+export type DecisionKind = 'Accepted' | 'Suppressed';
+export type RunStatus = 'Running' | 'Completed' | 'Failed';
+
+/** Одна сторона: источник и что из него брать. Строки с одним ключом суммируются. */
+export interface ReconciliationSide {
+  sourceId: string;
+  /** Колонки доменного ключа. Порядок значим — стороны обязаны перечислять их согласованно. */
+  keyColumns: string[];
+  valueColumn: string;
+  labelColumn?: string | null;
+}
+
+export interface ComparisonRule {
+  operator: ComparisonOperator;
+  tolerance: number;
+  toleranceKind: ToleranceKind;
+}
+
+export interface ReconciliationSpec {
+  left: ReconciliationSide;
+  right: ReconciliationSide;
+  comparison: ComparisonRule;
+}
+
+export interface Reconciliation {
+  id: string;
+  name: string;
+  scope: string;
+  scopeId: string | null;
+  spec: ReconciliationSpec;
+  updatedAt: string;
+}
+
+export interface ReconciliationRun {
+  id: string;
+  definitionId: string;
+  status: RunStatus;
+  startedAt: string;
+  finishedAt: string | null;
+  /** Заполнен только у неудачного прогона. Пустой список находок без него читался бы как
+   *  «расхождений нет» — самое опасное недоразумение в подсистеме. */
+  error: string | null;
+  matchCount: number;
+  mismatchCount: number;
+  missingLeftCount: number;
+  missingRightCount: number;
+}
+
+export interface FindingDecision {
+  id: string;
+  key: string;
+  kind: DecisionKind;
+  note: string | null;
+  decidedBy: string | null;
+  updatedAt: string;
+}
+
+/** Провенанс стороны: до ячейки не дотягиваем намеренно — строки из PDF приходят от зрительной модели. */
+export interface FindingSideProvenance {
+  sourceId: string;
+  column: string;
+  /** Номера строк источника, сложившихся в эту позицию. */
+  rows: number[];
+}
+
+export interface Finding {
+  id: string;
+  /** Доменный ключ (нормализованные марка/сечение) — им же адресуется решение. */
+  key: string;
+  label: string;
+  leftValue: number | null;
+  rightValue: number | null;
+  status: FindingStatus;
+  provenance: { left: FindingSideProvenance | null; right: FindingSideProvenance | null };
+  /** Вычислено сервером из истории прогонов, не хранится. */
+  resolved: boolean;
+  decision: FindingDecision | null;
+}
+
+const KEY = ['reconciliations'] as const;
+
+export function useReconciliations(scope?: string, scopeId?: string) {
+  return useQuery({
+    queryKey: [...KEY, scope ?? null, scopeId ?? null],
+    queryFn: async () => (await apiClient.get<Reconciliation[]>('/reconciliations', {
+      params: { scope, scopeId },
+    })).data,
+  });
+}
+
+export function useReconciliationRuns(definitionId: string | null) {
+  return useQuery({
+    queryKey: [...KEY, definitionId, 'runs'],
+    enabled: !!definitionId,
+    queryFn: async () => (await apiClient.get<ReconciliationRun[]>(
+      `/reconciliations/${definitionId}/runs`)).data,
+  });
+}
+
+export function useFindings(definitionId: string | null, runId?: string | null) {
+  return useQuery({
+    queryKey: [...KEY, definitionId, 'findings', runId ?? 'latest'],
+    enabled: !!definitionId,
+    queryFn: async () => (await apiClient.get<Finding[]>(
+      `/reconciliations/${definitionId}/findings`, { params: { runId: runId ?? undefined } })).data,
+  });
+}
+
+export function useCreateReconciliation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: { name: string; scope: string; scopeId?: string | null; spec: ReconciliationSpec }) =>
+      (await apiClient.post<Reconciliation>('/reconciliations', body)).data,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useUpdateReconciliation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: { id: string; name: string; spec: ReconciliationSpec }) =>
+      (await apiClient.put<Reconciliation>(`/reconciliations/${id}`, body)).data,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useDeleteReconciliation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => { await apiClient.delete(`/reconciliations/${id}`); },
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useRunReconciliation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) =>
+      (await apiClient.post<ReconciliationRun>(`/reconciliations/${id}/run`)).data,
+    // Инвалидируем по префиксу: прогон меняет и историю, и находки всех её срезов.
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useSetDecision() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, key, kind, note }: {
+      id: string; key: string; kind: DecisionKind; note?: string | null;
+    }) => (await apiClient.put<FindingDecision>(`/reconciliations/${id}/decisions`,
+      { key, kind, note })).data,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useRemoveDecision() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, key }: { id: string; key: string }) => {
+      await apiClient.delete(`/reconciliations/${id}/decisions`, { params: { key } });
+    },
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+// ─── Представление ────────────────────────────────────────────────────────────
+
+export const STATUS_LABELS: Record<FindingStatus, string> = {
+  Match: 'Совпадает',
+  Mismatch: 'Расхождение',
+  MissingLeft: 'Нет слева',
+  MissingRight: 'Нет справа',
+};
+
+export const OPERATOR_LABELS: Record<ComparisonOperator, string> = {
+  Equal: 'равно',
+  GreaterOrEqual: 'не меньше',
+  LessOrEqual: 'не больше',
+};
+
+export const DECISION_LABELS: Record<DecisionKind, string> = {
+  Accepted: 'Признано нормой',
+  Suppressed: 'Исключено из сверки',
+};
+
+/**
+ * Требует ли находка внимания. Решение человека снимает вопрос, даже если расхождение осталось: в
+ * этом и смысл персистентного решения — «давальческое оборудование» не должно всплывать каждый прогон.
+ */
+export function needsAttention(f: Finding): boolean {
+  return f.status !== 'Match' && !f.decision;
+}
+
+/** Сводка прогона одной строкой — то, что человек хочет увидеть, не читая список. */
+export function runSummary(run: ReconciliationRun): string {
+  if (run.status === 'Failed') return 'Прогон не выполнен';
+  if (run.status === 'Running') return 'Выполняется…';
+  const problems = run.mismatchCount + run.missingLeftCount + run.missingRightCount;
+  return problems === 0
+    ? `Расхождений нет (позиций: ${run.matchCount})`
+    : `Требует внимания: ${problems} из ${problems + run.matchCount}`;
+}

--- a/src/client/src/shared/ui/DocumentTitle.tsx
+++ b/src/client/src/shared/ui/DocumentTitle.tsx
@@ -18,6 +18,7 @@ const SECTION_TITLES: Record<string, string> = {
   'common-data': 'Общие данные',
   'datasets': 'Наборы данных',
   'quality-docs': 'Документы качества',
+  'reconciliations': 'Сверка',
   'templates': 'Шаблоны',
   'document-types': 'Типы документов',
   'composite-types': 'Составные типы',

--- a/src/client/src/shared/ui/navConfig.ts
+++ b/src/client/src/shared/ui/navConfig.ts
@@ -1,4 +1,4 @@
-import { FolderOpen, BookOpen, FileText, Settings, Layers, Database, Tag, ShieldCheck, Users, ScanText } from 'lucide-react';
+import { FolderOpen, BookOpen, FileText, Settings, Layers, Database, Tag, ShieldCheck, Users, ScanText, Scale } from 'lucide-react';
 
 /** Пункты навигации — общий источник для сайдбара (AppShell) и командной палитры (Ctrl+K). */
 export interface NavItem { to: string; label: string; icon: typeof FolderOpen }
@@ -8,6 +8,7 @@ export const workNav: NavItem[] = [
   { to: '/common-data',   label: 'Общие данные',       icon: Database   },
   { to: '/datasets',      label: 'Наборы данных',      icon: Layers     },
   { to: '/quality-docs',  label: 'Документы качества', icon: ShieldCheck },
+  { to: '/reconciliations', label: 'Сверка',             icon: Scale      },
 ];
 
 export const settingsNav: NavItem[] = [


### PR DESCRIPTION
Closes #436 · третья часть Ф1 из #414

Ядро (#432) и API (#435) были, но результаты сверки не были видны в приложении — а именно этого не хватало, когда анализ делался внешним агентом: память между прогонами не копилась, отчёт не с чем было сравнить, находка не переживала разговор.

Раздел **«Сверка»**: список определений слева, разбор находок справа. Находка несёт статус, значения обеих сторон, провенанс (колонка и число сложившихся строк) и принятое решение.

## Решения, которые стоит отметить

**Фильтр «Требует внимания» считает не расхождения, а НЕРАЗОБРАННЫЕ расхождения.** Решение снимает вопрос, даже если расхождение осталось — в этом и смысл персистентного решения: «давальческое оборудование» не должно всплывать каждый прогон.

**Неудачный прогон показывается с текстом ошибки, а не пустым списком.** Пустой список читается как «расхождений нет», и это самое опасное недоразумение в подсистеме.

**«Устранено» приходит с сервера вычисленным**, а рядом — выбор прогона. Без истории признак повисает в воздухе: не видно, относительно чего устранено.

**Колонки в редакторе выбираются из схемы источника, а не вводятся руками.** Опечатка в имени колонки дала бы пустую сторону и находки «нет слева» по всему списку — молчаливая неверность, которую пользователь принял бы за реальное расхождение.

**После сохранения решения тост говорит прямо, что оно переживёт следующий прогон** — иначе непонятно, почему отметка не исчезает после пересчёта.

## Вне этой части

Экспорт отчёта в xlsx и алиасы — Ф2/Ф3 в #414.

## Проверка

- `npx tsc -b --force` — чисто; `npm test` — 159 зелёных (+6).
- Чистые хелперы покрыты тестами: «принятое решение снимает вопрос», «неудачный прогон не выдаёт себя за „расхождений нет“», «в сводку входят все виды проблем, а не только расхождения».

🤖 Generated with [Claude Code](https://claude.com/claude-code)
