### PR TITLE
feat(reconciliation): экран замечаний агента (#442)

### DIFF
--- a/src/client/src/features/reconciliations/ObservationsPanel.tsx
+++ b/src/client/src/features/reconciliations/ObservationsPanel.tsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from 'react';
+import { Bot, Check, X, RotateCcw, FileText, Layers } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/shared/ui/Button';
+import { Modal } from '@/shared/ui/Modal';
+import { TextField } from '@/shared/ui/TextField';
+import { EmptyState } from '@/shared/ui/EmptyState';
+import { useToast } from '@/shared/ui/Toast';
+import { useListConstructions } from '@/shared/api/constructions';
+import {
+  useObservations, useReviewObservation,
+  SEVERITY_LABELS, OBSERVATION_STATUS_LABELS, isUnreviewed,
+  type Observation, type ObservationStatus,
+} from '@/shared/api/observations';
+
+/**
+ * Журнал замечаний внешнего анализа (issue #442).
+ *
+ * Ключевое требование к оформлению: замечание — УТВЕРЖДЕНИЕ АГЕНТА, а не результат проверки системы.
+ * Происхождение видно всегда; выдать его за находку системы — худшее, что можно тут сделать.
+ */
+
+const SEVERITY_STYLE: Record<Observation['severity'], string> = {
+  Error: 'bg-danger-subtle text-danger',
+  Warning: 'bg-warning-subtle text-warning',
+  Info: 'bg-muted text-fg3',
+};
+
+const STATUS_STYLE: Record<ObservationStatus, string> = {
+  New: 'bg-brand-subtle text-brand',
+  Confirmed: 'bg-muted text-fg2',
+  Rejected: 'bg-muted text-fg4',
+};
+
+/**
+ * Ссылки на первоисточник: без перехода проверять утверждение неудобно, а непроверенное — мнение.
+ *
+ * Документ открывается deep-link'ом внутрь комплекта, поэтому нужна ещё и стройка: она вычисляется по
+ * области замечания. Не нашлась — показываем идентификатор текстом, но НЕ рисуем ссылку: битая ссылка
+ * хуже её отсутствия.
+ */
+function References({ o, setPath }: { o: Observation; setPath: string | null }) {
+  const docs = o.references.documentIds ?? [];
+  const sourceId = o.references.sourceId;
+  const rows = o.references.rows ?? [];
+  if (docs.length === 0 && !sourceId && !o.references.note) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-[11px]">
+      {docs.map(id => setPath ? (
+        <Link key={id} to={`${setPath}?doc=${id}`}
+          className="inline-flex items-center gap-1 text-brand hover:underline">
+          <FileText size={11} /> документ {id.slice(0, 8)}
+        </Link>
+      ) : (
+        <span key={id} className="inline-flex items-center gap-1 text-fg4">
+          <FileText size={11} /> документ {id.slice(0, 8)}
+        </span>
+      ))}
+      {sourceId && (
+        <Link to="/datasets" className="inline-flex items-center gap-1 text-brand hover:underline">
+          <Layers size={11} /> источник {sourceId.slice(0, 8)}
+          {rows.length > 0 && <span className="text-fg4">· строк {rows.length}</span>}
+        </Link>
+      )}
+      {o.references.note && <span className="text-fg4">{o.references.note}</span>}
+    </div>
+  );
+}
+
+function ReviewDialog({ observation, setPath, onClose }: {
+  observation: Observation; setPath: string | null; onClose: () => void;
+}) {
+  const [note, setNote] = useState(observation.reviewNote ?? '');
+  const review = useReviewObservation();
+  const toast = useToast();
+
+  async function decide(status: ObservationStatus) {
+    await review.mutateAsync({ id: observation.id, status, note: note.trim() || null });
+    onClose();
+    toast.success(status === 'Rejected'
+      // Примечание к отклонению читает агент — иначе он сообщит то же самое в следующий раз.
+      ? 'Отклонено. Причину увидит агент при следующем анализе'
+      : status === 'Confirmed' ? 'Подтверждено' : 'Возвращено в работу');
+  }
+
+  return (
+    <Modal open onOpenChange={o => { if (!o) onClose(); }} title="Разбор замечания" wide
+      footer={
+        <div className="flex items-center gap-2">
+          {observation.status !== 'New' && (
+            <Button disabled={review.isPending} onClick={() => decide('New')}>
+              <RotateCcw size={14} /> Вернуть в работу
+            </Button>
+          )}
+          <span className="flex-1" />
+          <Button disabled={review.isPending} onClick={onClose}>Отмена</Button>
+          <Button danger disabled={review.isPending} onClick={() => decide('Rejected')}>
+            <X size={14} /> Отклонить
+          </Button>
+          <Button variant="filled" loading={review.isPending} onClick={() => decide('Confirmed')}>
+            <Check size={14} /> Подтвердить
+          </Button>
+        </div>
+      }>
+      <div className="space-y-4">
+        <div>
+          <div className="text-sm font-medium text-fg1">{observation.title}</div>
+          {observation.detail && (
+            <p className="text-sm text-fg2 mt-1 whitespace-pre-wrap">{observation.detail}</p>
+          )}
+          <References o={observation} setPath={setPath} />
+        </div>
+
+        <TextField label="Примечание" value={note} onChange={e => setNote(e.target.value)}
+          hint="При отклонении объясните, почему это не ошибка — это прочитает агент и не повторит замечание" />
+      </div>
+    </Modal>
+  );
+}
+
+function ObservationRow({ o, setPath, onReview }: {
+  o: Observation; setPath: string | null; onReview: (o: Observation) => void;
+}) {
+  const dim = !isUnreviewed(o);
+  return (
+    <div className={`px-4 py-3 border-b border-stroke group ${dim ? 'opacity-70' : ''}`}>
+      <div className="flex items-start gap-2">
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 mt-0.5 ${SEVERITY_STYLE[o.severity]}`}>
+          {SEVERITY_LABELS[o.severity]}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm text-fg1">{o.title}</div>
+          {o.detail && <p className="text-xs text-fg3 mt-0.5 line-clamp-3">{o.detail}</p>}
+          <References o={o} setPath={setPath} />
+          {o.reviewNote && (
+            <p className="text-[11px] text-fg3 mt-1">
+              {OBSERVATION_STATUS_LABELS[o.status]}: {o.reviewNote}
+              {o.reviewedBy ? ` (${o.reviewedBy})` : ''}
+            </p>
+          )}
+        </div>
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${STATUS_STYLE[o.status]}`}>
+          {OBSERVATION_STATUS_LABELS[o.status]}
+        </span>
+        <Button variant="text" size="sm" onClick={() => onReview(o)}
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0">
+          Разобрать
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ObservationsPanel() {
+  const { data: items = [], isLoading } = useObservations();
+  const { data: constructions = [] } = useListConstructions();
+  const [reviewing, setReviewing] = useState<Observation | null>(null);
+  const [onlyNew, setOnlyNew] = useState(false);
+
+  // Путь к комплекту по его идентификатору: замечание знает только область (комплект), а deep-link
+  // документа собирается из стройки и комплекта.
+  const setPaths = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of constructions)
+      for (const section of c.sections ?? [])
+        for (const set of section.documentSets ?? [])
+          map.set(set.id, `/document-sets/${c.id}/sets/${set.id}`);
+    return map;
+  }, [constructions]);
+  const pathOf = (o: Observation) => (o.scopeId ? setPaths.get(o.scopeId) ?? null : null);
+
+  const unreviewed = items.filter(isUnreviewed).length;
+  const shown = onlyNew ? items.filter(isUnreviewed) : items;
+
+  return (
+    <div className="flex-1 min-w-0 flex flex-col">
+      <div className="px-4 py-3 border-b border-stroke shrink-0">
+        <h2 className="text-base font-semibold text-fg1 flex items-center gap-2">
+          <Bot size={16} className="text-fg3" /> Замечания анализа
+        </h2>
+        {/* Происхождение — не мелкий шрифт ради приличия, а суть: это не результат проверки системы. */}
+        <p className="text-xs text-fg3 mt-0.5">
+          Утверждения внешнего ИИ-агента. Система их не проверяла — подтвердите или отклоните.
+        </p>
+      </div>
+
+      {items.length > 0 && (
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-stroke text-xs shrink-0">
+          <button type="button" onClick={() => setOnlyNew(v => !v)}
+            className={`px-2 py-1 rounded-full transition-colors ${
+              onlyNew ? 'bg-brand-subtle text-brand font-medium' : 'text-fg3 hover:bg-muted'}`}>
+            Не разобрано: {unreviewed}
+          </button>
+          <span className="text-fg4">всего {items.length}</span>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {isLoading && <p className="px-4 py-3 text-sm text-fg4">Загрузка…</p>}
+        {!isLoading && shown.length === 0 && (
+          <div className="p-6">
+            <EmptyState icon={<Bot size={32} />}
+              title={items.length === 0 ? 'Замечаний нет' : 'Всё разобрано'}
+              description={items.length === 0
+                ? 'Здесь появятся находки внешнего агента, если попросить его записать их в журнал.'
+                : undefined} />
+          </div>
+        )}
+        {shown.map(o => <ObservationRow key={o.id} o={o} setPath={pathOf(o)} onReview={setReviewing} />)}
+      </div>
+
+      {reviewing && (
+        <ReviewDialog observation={reviewing} setPath={pathOf(reviewing)}
+          onClose={() => setReviewing(null)} />
+      )}
+    </div>
+  );
+}

--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
-  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale,
+  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale, Bot,
 } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
@@ -8,7 +8,7 @@ import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { useToast } from '@/shared/ui/Toast';
-import { ListDetailShell, NavSearchInput, NavItem } from '@/shared/ui/ListDetailShell';
+import { ListDetailShell, NavSearchInput, NavItem, NavSection } from '@/shared/ui/ListDetailShell';
 import { useAuth } from '@/shared/hooks/useAuth';
 import {
   useReconciliations, useReconciliationRuns, useFindings, useRunReconciliation,
@@ -18,6 +18,8 @@ import {
 } from '@/shared/api/reconciliations';
 import { ReconciliationEditor } from './ReconciliationEditor';
 import { DecisionDialog } from './DecisionDialog';
+import { ObservationsPanel } from './ObservationsPanel';
+import { useObservations, isUnreviewed } from '@/shared/api/observations';
 
 /**
  * Сверка на непротиворечивость (issue #414, фаза Ф1 — экран находок #436).
@@ -112,8 +114,11 @@ export function ReconciliationsPage() {
   const [deleting, setDeleting] = useState<string | null>(null);
   const [deciding, setDeciding] = useState<Finding | null>(null);
   const [onlyAttention, setOnlyAttention] = useState(false);
+  // Замечания агента — вторая секция того же раздела: оба отвечают «что не так с комплектом».
+  const [view, setView] = useState<'reconciliation' | 'observations'>('reconciliation');
 
   const { data: items = [], isLoading } = useReconciliations();
+  const { data: observations = [] } = useObservations();
   const { data: runs = [] } = useReconciliationRuns(selectedId);
   const { data: findings = [], isLoading: findingsLoading } = useFindings(selectedId, runId);
 
@@ -145,19 +150,28 @@ export function ReconciliationsPage() {
     <>
       <NavSearchInput value={search} onChange={setSearch} placeholder="Поиск сверки…" />
       <div className="flex-1 overflow-y-auto px-2 pb-2">
+        <NavSection label="Сверки" />
         {filtered.map(i => (
           <NavItem key={i.id} icon={<Scale size={16} />} label={i.name}
-            active={i.id === selectedId}
-            onClick={() => { setSelectedId(i.id); setRunId(null); }} />
+            active={view === 'reconciliation' && i.id === selectedId}
+            onClick={() => { setView('reconciliation'); setSelectedId(i.id); setRunId(null); }} />
         ))}
         {filtered.length === 0 && !isLoading && (
           <p className="px-3 py-2 text-sm text-fg4">Сверок нет</p>
         )}
+
+        {/* Отдельной секцией, а не в общем списке: находка сверки — результат арифметики,
+            замечание — утверждение агента. Смешать значит выдать одно за другое. */}
+        <NavSection label="Внешний анализ" />
+        <NavItem icon={<Bot size={16} />} label="Замечания агента"
+          count={observations.filter(isUnreviewed).length}
+          active={view === 'observations'}
+          onClick={() => setView('observations')} />
       </div>
     </>
   );
 
-  const detail = !selected ? (
+  const detail = view === 'observations' ? <ObservationsPanel /> : !selected ? (
     <EmptyState icon={<Scale size={32} />} title="Выберите сверку"
       description="Сверка сопоставляет два источника по доменному ключу и показывает расхождения." />
   ) : (

--- a/src/client/src/shared/api/observations.ts
+++ b/src/client/src/shared/api/observations.ts
@@ -1,0 +1,87 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from './client';
+
+/**
+ * Замечания внешнего анализа (issue #440). Пишет их агент через MCP; здесь их только читают и
+ * разбирают — подтверждать собственные утверждения агент не может.
+ *
+ * Это НЕ результат проверки системы, а утверждение, ждущее человека. Оформление обязано это
+ * показывать: выдать замечание за находку системы — худшее, что можно тут сделать.
+ */
+
+export type ObservationSeverity = 'Info' | 'Warning' | 'Error';
+export type ObservationStatus = 'New' | 'Confirmed' | 'Rejected';
+
+/** На что опирается утверждение — то, по чему человек проверит его глазами. */
+export interface ObservationReferences {
+  documentIds?: string[];
+  sourceId?: string;
+  rows?: number[];
+  note?: string;
+  [key: string]: unknown;
+}
+
+export interface Observation {
+  id: string;
+  scope: string;
+  scopeId: string | null;
+  /** Устойчивый ключ утверждения: повтор анализа обновляет запись, а не плодит дубли. */
+  key: string;
+  title: string;
+  detail: string | null;
+  severity: ObservationSeverity;
+  status: ObservationStatus;
+  references: ObservationReferences;
+  reportedBy: string | null;
+  reviewedBy: string | null;
+  /** Причину отклонения читает агент при следующем анализе. */
+  reviewNote: string | null;
+  reviewedAt: string | null;
+  updatedAt: string;
+}
+
+const KEY = ['observations'] as const;
+
+export function useObservations(scopeId?: string | null, status?: ObservationStatus) {
+  return useQuery({
+    queryKey: [...KEY, scopeId ?? null, status ?? null],
+    queryFn: async () => (await apiClient.get<Observation[]>('/observations', {
+      params: { scopeId: scopeId ?? undefined, status },
+    })).data,
+  });
+}
+
+export function useReviewObservation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, status, note }: {
+      id: string; status: ObservationStatus; note?: string | null;
+    }) => (await apiClient.put<Observation>(`/observations/${id}/review`, { status, note })).data,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useDeleteObservation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => { await apiClient.delete(`/observations/${id}`); },
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export const SEVERITY_LABELS: Record<ObservationSeverity, string> = {
+  Error: 'Существенно',
+  Warning: 'Внимание',
+  Info: 'К сведению',
+};
+
+export const OBSERVATION_STATUS_LABELS: Record<ObservationStatus, string> = {
+  New: 'Не разобрано',
+  Confirmed: 'Подтверждено',
+  Rejected: 'Отклонено',
+};
+
+/** Ждёт человека. Разобранное остаётся в журнале как память, но в работу не просится. */
+export function isUnreviewed(o: Observation): boolean {
+  return o.status === 'New';
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ObservationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ObservationEndpoints.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using BHS.CRG.Application.Reconciliation;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Reconciliation;
@@ -56,7 +56,9 @@ public static class ObservationEndpoints
         o.Detail,
         severity = o.Severity.ToString(),
         status = o.Status.ToString(),
-        references = o.References.RootElement,
+        // Разворачиваем и на чтении: иначе уже записанные строкой ссылки остались бы
+        // непроверяемыми (#442).
+        references = ObservationReferences.Unwrap(o.References.RootElement),
         o.ReportedBy,
         o.ReviewedBy,
         o.ReviewNote,

--- a/src/server/BHS.CRG.Api/Mcp/ObservationTools.cs
+++ b/src/server/BHS.CRG.Api/Mcp/ObservationTools.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Security.Claims;
 using System.Text.Json;
 using BHS.CRG.Application.Reconciliation;
@@ -35,7 +35,8 @@ public class ObservationTools(IMediator mediator, IHttpContextAccessor http)
 
     private static ObservationInfo ToInfo(AgentObservation o) => new(
         o.Id, o.Scope.ToString(), o.ScopeId, o.Key, o.Title, o.Detail,
-        o.Severity.ToString(), o.Status.ToString(), o.References.RootElement.Clone(),
+        o.Severity.ToString(), o.Status.ToString(),
+        ObservationReferences.Unwrap(o.References.RootElement).Clone(),
         o.ReportedBy, o.ReviewedBy, o.ReviewNote, o.UpdatedAt);
 
     [McpServerTool(Name = "list_observations", ReadOnly = true, Idempotent = true, Destructive = false,
@@ -96,8 +97,9 @@ public class ObservationTools(IMediator mediator, IHttpContextAccessor http)
             throw new McpException("Ключ обязателен: без него повторный анализ создаст дубль.");
         if (string.IsNullOrWhiteSpace(title))
             throw new McpException("Суть замечания обязательна.");
-        if (references.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null
-            || (references.ValueKind == JsonValueKind.Object && !references.EnumerateObject().Any()))
+        // Модель одинаково охотно шлёт и объект, и строку с тем же объектом внутри — разворачиваем.
+        var refs = ObservationReferences.Unwrap(references);
+        if (ObservationReferences.IsEmpty(refs))
             throw new McpException(
                 "Ссылки обязательны: замечание без адреса непроверяемо. Укажите документы либо источник со строками.");
 
@@ -106,7 +108,7 @@ public class ObservationTools(IMediator mediator, IHttpContextAccessor http)
 
         var observation = await mediator.Send(new ReportObservationCommand(
             CatalogScope.Set, setId, key.Trim(), title.Trim(), detail,
-            sev, JsonDocument.Parse(references.GetRawText()), CurrentUser), ct);
+            sev, JsonDocument.Parse(refs.GetRawText()), CurrentUser), ct);
 
         return ToInfo(observation);
     }

--- a/src/server/BHS.CRG.Application/Reconciliation/ObservationReferences.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ObservationReferences.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+
+namespace BHS.CRG.Application.Reconciliation;
+
+/// <summary>
+/// Ссылки замечания приходят от языковой модели, и она с одинаковой охотой пришлёт и объект, и строку
+/// с тем же объектом внутри. На рабочих данных случилось именно второе: тринадцать замечаний легли в
+/// журнал со ссылками-строкой, и потребитель, ждавший объект, не увидел ни одной — то есть находки
+/// стали непроверяемы ровно из-за формата.
+///
+/// Поэтому строку с объектом внутри разворачиваем — и на приёме, и на чтении: разворот только на
+/// приёме оставил бы уже записанные замечания сломанными.
+/// </summary>
+public static class ObservationReferences
+{
+    /// <summary>Строка с JSON-объектом внутри → сам объект. Остальное — как есть.</summary>
+    public static JsonElement Unwrap(JsonElement value)
+    {
+        if (value.ValueKind != JsonValueKind.String) return value;
+
+        var raw = value.GetString();
+        if (string.IsNullOrWhiteSpace(raw)) return value;
+
+        try
+        {
+            using var parsed = JsonDocument.Parse(raw);
+            // Только объект и массив: строка «не смотрел» — это заметка, а не ссылки, и превращать её
+            // в число или булево бессмысленно.
+            return parsed.RootElement.ValueKind is JsonValueKind.Object or JsonValueKind.Array
+                ? parsed.RootElement.Clone()
+                : value;
+        }
+        catch (JsonException)
+        {
+            return value; // не JSON — значит и правда просто текст
+        }
+    }
+
+    /// <summary>Есть ли в ссылках хоть что-то, по чему человек проверит утверждение.</summary>
+    public static bool IsEmpty(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Undefined or JsonValueKind.Null => true,
+        JsonValueKind.Object => !value.EnumerateObject().Any(),
+        JsonValueKind.Array => value.GetArrayLength() == 0,
+        JsonValueKind.String => string.IsNullOrWhiteSpace(value.GetString()),
+        _ => false,
+    };
+}

--- a/src/server/BHS.CRG.Tests/Integration/AgentObservationsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/AgentObservationsTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Api.Mcp;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Reconciliation;
@@ -100,6 +100,44 @@ public class AgentObservationsTests(IntegrationTestFixture fixture) : IAsyncLife
         Assert.Equal("Rejected", again.Status);
         Assert.Equal("Согласовано, давальческий", again.ReviewNote);
         Assert.Equal("alex", again.ReviewedBy);
+    }
+
+    /// <summary>
+    /// Модель одинаково охотно шлёт объект и строку с тем же объектом внутри. На рабочих данных
+    /// случилось второе — тринадцать замечаний легли со ссылками-строкой, и потребитель, ждавший
+    /// объект, не увидел ни одной ссылки: находки стали непроверяемы из-за формата.
+    /// </summary>
+    [Fact]
+    public async Task StringifiedReferences_AreUnwrapped()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var tools = Tools(scope);
+
+        var stringified = JsonDocument.Parse(
+            JsonSerializer.Serialize("""{"documentIds":["d1"],"note":"акт 5"}""")).RootElement;
+
+        var reported = await tools.ReportObservationAsync(
+            SetId, "строкой", "Ссылки пришли строкой", stringified, CancellationToken.None);
+
+        Assert.Equal(JsonValueKind.Object, reported.References.ValueKind);
+        Assert.Equal("d1", reported.References.GetProperty("documentIds")[0].GetString());
+
+        // И на чтении тоже — иначе уже записанные строкой остались бы сломанными.
+        var listed = Assert.Single(await tools.ListObservationsAsync(CancellationToken.None, scopeId: SetId));
+        Assert.Equal(JsonValueKind.Object, listed.References.ValueKind);
+    }
+
+    /// <summary>Строка, не содержащая JSON, — это заметка, а не ссылки: её не выбрасываем.</summary>
+    [Fact]
+    public async Task PlainTextReferences_AreKept()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var refs = JsonDocument.Parse(JsonSerializer.Serialize("смотрел лист 3 глазами")).RootElement;
+
+        var reported = await Tools(scope).ReportObservationAsync(
+            SetId, "текстом", "Ссылка обычным текстом", refs, CancellationToken.None);
+
+        Assert.Equal(JsonValueKind.String, reported.References.ValueKind);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #442

Замечания писались и читались через API и MCP, но в приложении их не было видно — а разбирает их человек. На рабочих данных агент уже записал **13 замечаний** по комплекту.

## Где

Второй секцией раздела «Сверка»: оба ответа на вопрос «что не так с комплектом» лежат в одном месте. В общий список не сваливаем — находка сверки это результат арифметики, замечание это утверждение агента.

**Происхождение видно всегда**, прямо в шапке: «утверждения внешнего ИИ-агента, система их не проверяла». Выдать замечание за находку системы — худшее, что тут можно сделать.

## Разбор

Подтвердить, отклонить, вернуть в работу. Форма прямо подсказывает, что примечание к отклонению **прочитает агент** — иначе пользователь напишет «нет» и не поймёт, почему замечание вернулось в следующий раз.

Ссылки на первоисточник кликабельны. Документ открывается deep-link'ом внутрь комплекта, поэтому нужна ещё и стройка: вычисляется по области замечания. Не нашлась — показываем идентификатор текстом **без** ссылки: битая ссылка хуже её отсутствия.

## Что нашлось при проверке на живых данных

Экран открылся, 13 замечаний на месте — и **ни одной ссылки**. Причина: модель прислала `references` **строкой** с JSON внутри, а мы приняли как есть. Потребитель, ждавший объект, не увидел ничего: находки стали непроверяемы просто из-за формата.

Строку с объектом внутри теперь разворачиваем **и на приёме, и на чтении** — разворот только на приёме оставил бы уже записанные тринадцать замечаний сломанными, и пришлось бы просить агента переделать работу. Строка без JSON внутри — это заметка («смотрел лист 3 глазами»), её сохраняем как есть.

Это ровно тот случай, который не ловится ни типами, ни тестами по спецификации: увидеть можно было только открыв экран на настоящих данных.

## Проверка

- `dotnet test` — 639 зелёных (+2); `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём: 13 замечаний, счётчик неразобранных, ссылки на документы и источники отображаются, ошибок страницы нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
