### PR TITLE
feat(reconciliation): отчёт о расхождениях в xlsx (#444)

### DIFF
--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react';
 import {
-  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale, Bot,
+  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale, Bot, FileSpreadsheet,
 } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { useListConstructions } from '@/shared/api/constructions';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
@@ -12,7 +13,7 @@ import { ListDetailShell, NavSearchInput, NavItem, NavSection } from '@/shared/u
 import { useAuth } from '@/shared/hooks/useAuth';
 import {
   useReconciliations, useReconciliationRuns, useFindings, useRunReconciliation,
-  useDeleteReconciliation, useSetDecision, useRemoveDecision,
+  useDeleteReconciliation, useSetDecision, useRemoveDecision, downloadDiscrepancyReport,
   STATUS_LABELS, DECISION_LABELS, needsAttention, runSummary,
   type Finding, type ReconciliationRun,
 } from '@/shared/api/reconciliations';
@@ -119,6 +120,29 @@ export function ReconciliationsPage() {
 
   const { data: items = [], isLoading } = useReconciliations();
   const { data: observations = [] } = useObservations();
+  const { data: constructions = [] } = useListConstructions();
+
+  // Отчёт собирается по КОМПЛЕКТУ — как и тот, что сегодня ведут руками.
+  const sets = useMemo(
+    () => constructions.flatMap(c => (c.sections ?? []).flatMap(sec =>
+      (sec.documentSets ?? []).map(ds => ({ id: ds.id, label: `${c.name} / ${sec.name} / ${ds.name}` })))),
+    [constructions]);
+  const [reportSetId, setReportSetId] = useState<string>('');
+  const [reportBusy, setReportBusy] = useState(false);
+
+  async function downloadReport() {
+    const target = sets.find(s => s.id === reportSetId) ?? sets[0];
+    if (!target) return;
+    setReportBusy(true);
+    try {
+      await downloadDiscrepancyReport(target.id, target.label);
+      toast.success('Отчёт выгружен');
+    } catch {
+      toast.error('Не удалось выгрузить отчёт');
+    } finally {
+      setReportBusy(false);
+    }
+  }
   const { data: runs = [] } = useReconciliationRuns(selectedId);
   const { data: findings = [], isLoading: findingsLoading } = useFindings(selectedId, runId);
 
@@ -241,9 +265,24 @@ export function ReconciliationsPage() {
       <ListDetailShell
         title="Сверка"
         subtitle="Сопоставление источников по доменному ключу"
-        headerAction={isAdmin ? (
-          <Button variant="filled" onClick={() => setEditing('new')}><Plus size={14} /> Создать</Button>
-        ) : undefined}
+        headerAction={
+          <div className="flex items-center gap-2">
+            {sets.length > 0 && (
+              <>
+                <Select value={reportSetId || sets[0].id} onValueChange={setReportSetId}
+                  aria-label="Комплект для отчёта" className="w-72">
+                  {sets.map(s => <SelectItem key={s.id} value={s.id}>{s.label}</SelectItem>)}
+                </Select>
+                <Button onClick={downloadReport} loading={reportBusy}>
+                  <FileSpreadsheet size={14} /> Отчёт
+                </Button>
+              </>
+            )}
+            {isAdmin && (
+              <Button variant="filled" onClick={() => setEditing('new')}><Plus size={14} /> Создать</Button>
+            )}
+          </div>
+        }
         nav={nav}
         detail={detail}
       />

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from './client';
+import { filenameFromContentDisposition } from './attachments';
 
 /**
  * Сверка на непротиворечивость (issue #414, фаза Ф1).
@@ -212,4 +213,25 @@ export function runSummary(run: ReconciliationRun): string {
   return problems === 0
     ? `Расхождений нет (позиций: ${run.matchCount})`
     : `Требует внимания: ${problems} из ${problems + run.matchCount}`;
+}
+
+/**
+ * «Отчёт о расхождениях» по комплекту — тот артефакт, который сегодня ведут руками (#444).
+ * Две вкладки: находки сверки и замечания внешнего анализа. CSV нет намеренно — у него нет вкладок,
+ * а склеить их в один лист значило бы выдать утверждения агента за результат системы.
+ */
+export async function downloadDiscrepancyReport(setId: string, setName: string) {
+  const response = await apiClient.get(`/reconciliations/report/${setId}`, {
+    params: { format: 'xlsx' }, responseType: 'blob',
+  });
+  const disposition = response.headers['content-disposition'] as string | undefined;
+  const filename = filenameFromContentDisposition(disposition, `Отчёт о расхождениях — ${setName}.xlsx`);
+  const url = URL.createObjectURL(response.data as Blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
@@ -1,6 +1,8 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Text.Json;
+using BHS.CRG.Application.DataSnapshots;
 using BHS.CRG.Application.Reconciliation;
+using BHS.CRG.Infrastructure.DataSets;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Reconciliation;
 using MediatR;
@@ -72,6 +74,43 @@ public static class ReconciliationEndpoints
         user.MapGet("/{id:guid}/findings", async (Guid id, Guid? runId, IMediator m) =>
             Results.Ok((await m.Send(new ListFindingsQuery(id, runId))).Select(ToDto)));
 
+        // ── Отчёт ───────────────────────────────────────────────────────────────
+
+        // Отчёт собирается по КОМПЛЕКТУ, а не по сверке: наружу уходит один файл про комплект, как и
+        // тот, что сегодня ведут руками. Сверок на комплекте может быть несколько.
+        user.MapGet("/report/{setId:guid}", async (
+            Guid setId, string? format, IMediator m, IDomainSnapshotService domain, CancellationToken ct) =>
+        {
+            var set = await domain.GetDocumentSetAsync(setId, ct);
+            if (set is null) return Results.NotFound();
+
+            var sheets = new List<SpreadsheetExporter.Sheet>();
+
+            foreach (var definition in await m.Send(new ListReconciliationsQuery(null, null), ct))
+            {
+                var runs = await m.Send(new ListReconciliationRunsQuery(definition.Id, 1), ct);
+                var findings = await m.Send(new ListFindingsQuery(definition.Id), ct);
+                sheets.Add(ToSheet(DiscrepancyReport.Findings(definition.Name, runs.FirstOrDefault(), findings)));
+            }
+
+            var observations = await m.Send(
+                new ListObservationsQuery(CatalogScope.Set, setId, null), ct);
+            sheets.Add(ToSheet(DiscrepancyReport.Observations(observations)));
+
+            // Комплект без сверок: пустой лист с шапкой, а не ошибка — «расхождений нет» тоже
+            // результат, и его тоже показывают заказчику.
+            if (sheets.Count == 1)
+                sheets.Insert(0, ToSheet(DiscrepancyReport.Findings("Сверок не настроено", null, [])));
+
+            var fmt = SpreadsheetExporter.ParseFormat(format);
+            if (fmt == SpreadsheetFormat.Csv)
+                return Results.BadRequest(new { error = "Отчёт состоит из нескольких вкладок — выгрузите его в XLSX." });
+
+            var (bytes, ext, contentType) = SpreadsheetExporter.ExportSheets(fmt, sheets);
+            var name = $"Отчёт о расхождениях — {set.ConstructionName} {set.Name}.{ext}";
+            return Results.File(bytes, contentType, name);
+        });
+
         // ── Решения ─────────────────────────────────────────────────────────────
 
         user.MapPut("/{id:guid}/decisions", async (Guid id, DecisionReq req, IMediator m, ClaimsPrincipal u) =>
@@ -88,6 +127,10 @@ public static class ReconciliationEndpoints
             return Results.NoContent();
         });
     }
+
+    /// <summary>Смысловой лист → лист выгрузки: сборка отчёта не знает про NPOI, выгрузка — про домен.</summary>
+    private static SpreadsheetExporter.Sheet ToSheet(ReportSheet s)
+        => new(s.Name, s.Columns, s.Rows, s.Preamble);
 
     // ── DTO ─────────────────────────────────────────────────────────────────────
 

--- a/src/server/BHS.CRG.Application/Reconciliation/DiscrepancyReport.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/DiscrepancyReport.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using System.Text.Json;
+using BHS.CRG.Domain.Reconciliation;
+
+namespace BHS.CRG.Application.Reconciliation;
+
+/// <summary>Готовый лист отчёта, независимый от библиотеки выгрузки.</summary>
+public record ReportSheet(
+    string Name,
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<IReadOnlyList<string?>> Rows,
+    IReadOnlyList<string> Preamble);
+
+/// <summary>
+/// «Отчёт о расхождениях» (issue #444) — тот самый артефакт, который сегодня ведут руками.
+///
+/// Сборка листов вынесена из инфраструктуры: она вся про смысл (какие колонки, как назвать статус,
+/// что написать в шапке), а не про NPOI, и проверяется без файлов на диске.
+/// </summary>
+public static class DiscrepancyReport
+{
+    private static readonly CultureInfo Ru = CultureInfo.GetCultureInfo("ru-RU");
+
+    private static readonly Dictionary<FindingStatus, string> FindingStatusLabels = new()
+    {
+        [FindingStatus.Match] = "Совпадает",
+        [FindingStatus.Mismatch] = "Расхождение",
+        [FindingStatus.MissingLeft] = "Нет слева",
+        [FindingStatus.MissingRight] = "Нет справа",
+    };
+
+    private static readonly Dictionary<DecisionKind, string> DecisionLabels = new()
+    {
+        [DecisionKind.Accepted] = "Признано нормой",
+        [DecisionKind.Suppressed] = "Исключено из сверки",
+    };
+
+    private static readonly Dictionary<ObservationSeverity, string> SeverityLabels = new()
+    {
+        [ObservationSeverity.Error] = "Существенно",
+        [ObservationSeverity.Warning] = "Внимание",
+        [ObservationSeverity.Info] = "К сведению",
+    };
+
+    private static readonly Dictionary<ObservationStatus, string> ObservationStatusLabels = new()
+    {
+        [ObservationStatus.New] = "Не разобрано",
+        [ObservationStatus.Confirmed] = "Подтверждено",
+        [ObservationStatus.Rejected] = "Отклонено",
+    };
+
+    private static string Num(double? v) =>
+        v is null ? "" : (Math.Round(v.Value, 3)).ToString(Ru);
+
+    /// <summary>
+    /// Находки сверки. Разница считается здесь, а не оставляется читателю: отчёт смотрят глазами, и
+    /// вычитание в уме по сотне строк — ровно то, от чего этот файл должен избавить.
+    /// </summary>
+    public static ReportSheet Findings(
+        string title, ReconciliationRun? run,
+        IReadOnlyList<FindingView> findings)
+    {
+        var preamble = new List<string> { title };
+        if (run is null)
+        {
+            preamble.Add("Прогонов не было.");
+        }
+        else if (run.Status == ReconciliationRunStatus.Failed)
+        {
+            // Пустая таблица без объяснения читается как «расхождений нет» — самое опасное
+            // недоразумение в подсистеме, и в выгрузке оно опаснее всего.
+            preamble.Add($"ПРОГОН НЕ ВЫПОЛНЕН: {run.Error}");
+        }
+        else
+        {
+            preamble.Add($"Прогон: {run.StartedAt.ToLocalTime():dd.MM.yyyy HH:mm}");
+            preamble.Add($"Совпало: {run.MatchCount} · расхождений: {run.MismatchCount} · "
+                       + $"нет слева: {run.MissingLeftCount} · нет справа: {run.MissingRightCount}");
+        }
+
+        var rows = findings.Select(v =>
+        {
+            var f = v.Finding;
+            var diff = f.LeftValue is { } l && f.RightValue is { } r ? Num(l - r) : "";
+            return (IReadOnlyList<string?>)
+            [
+                FindingStatusLabels[f.Status],
+                v.Resolved ? "да" : "",
+                f.Label,
+                Num(f.LeftValue),
+                Num(f.RightValue),
+                diff,
+                Provenance(f.Provenance),
+                v.Decision is null ? "" : DecisionLabels[v.Decision.Kind],
+                v.Decision?.Note ?? "",
+                v.Decision?.DecidedBy ?? "",
+            ];
+        }).ToList();
+
+        return new ReportSheet("Сверка",
+            ["Статус", "Устранено", "Позиция", "Слева", "Справа", "Разница",
+             "Где смотреть", "Решение", "Примечание", "Кто разобрал"],
+            rows, preamble);
+    }
+
+    /// <summary>
+    /// Замечания внешнего анализа. Происхождение написано в шапке листа: файл уходит в переписку и на
+    /// совещания, и там утверждение агента не должно сойти за результат проверки.
+    /// </summary>
+    public static ReportSheet Observations(IReadOnlyList<AgentObservation> items)
+    {
+        var preamble = new List<string>
+        {
+            "Замечания внешнего ИИ-анализа",
+            "Это утверждения агента, а НЕ результат проверки системы. Каждое требует подтверждения человеком.",
+        };
+
+        var rows = items.Select(o => (IReadOnlyList<string?>)
+        [
+            SeverityLabels[o.Severity],
+            ObservationStatusLabels[o.Status],
+            o.Title,
+            o.Detail ?? "",
+            References(o.References),
+            o.ReviewNote ?? "",
+            o.ReviewedBy ?? "",
+            o.ReportedBy ?? "",
+        ]).ToList();
+
+        return new ReportSheet("Замечания",
+            ["Существенность", "Разбор", "Суть", "Подробности", "Где смотреть",
+             "Примечание", "Кто разобрал", "Кто сообщил"],
+            rows, preamble);
+    }
+
+    /// <summary>Провенанс находки человеческим текстом: голый JSON в отчёте бесполезен.</summary>
+    private static string Provenance(JsonDocument provenance)
+    {
+        var parts = new List<string>();
+        foreach (var side in (string[])["left", "right"])
+        {
+            if (!provenance.RootElement.TryGetProperty(side, out var s)
+                || s.ValueKind != JsonValueKind.Object) continue;
+
+            var column = s.TryGetProperty("column", out var c) ? c.GetString() : null;
+            var rows = s.TryGetProperty("rows", out var r) && r.ValueKind == JsonValueKind.Array
+                ? r.GetArrayLength() : 0;
+            parts.Add($"{(side == "left" ? "слева" : "справа")}: {column}, строк {rows}");
+        }
+        return string.Join("; ", parts);
+    }
+
+    /// <summary>Ссылки замечания человеческим текстом.</summary>
+    private static string References(JsonDocument references)
+    {
+        var root = ObservationReferences.Unwrap(references.RootElement);
+        if (root.ValueKind == JsonValueKind.String) return root.GetString() ?? "";
+        if (root.ValueKind != JsonValueKind.Object) return root.GetRawText();
+
+        var parts = new List<string>();
+        if (root.TryGetProperty("documentIds", out var docs) && docs.ValueKind == JsonValueKind.Array)
+            parts.Add($"документов: {docs.GetArrayLength()}");
+        if (root.TryGetProperty("sourceId", out var src) && src.ValueKind == JsonValueKind.String)
+        {
+            var rows = root.TryGetProperty("rows", out var r) && r.ValueKind == JsonValueKind.Array
+                ? $", строк {r.GetArrayLength()}" : "";
+            parts.Add($"источник {src.GetString()?[..8]}{rows}");
+        }
+        if (root.TryGetProperty("note", out var note) && note.ValueKind == JsonValueKind.String)
+            parts.Add(note.GetString() ?? "");
+        return string.Join("; ", parts.Where(p => !string.IsNullOrWhiteSpace(p)));
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/SpreadsheetExporter.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/SpreadsheetExporter.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using CsvHelper;
 using NPOI.HSSF.UserModel;
@@ -35,6 +35,58 @@ public static class SpreadsheetExporter
         _ => (Workbook(new XSSFWorkbook(), columns, rows, sheetName), "xlsx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
     };
+
+    /// <summary>
+    /// Один лист выгрузки. <paramref name="Preamble"/> — строки над таблицей: отчёт уходит из системы и
+    /// живёт своей жизнью, а без них через неделю не понять, к чему он относился и насколько свеж.
+    /// </summary>
+    public record Sheet(
+        string Name,
+        IReadOnlyList<string> Columns,
+        IReadOnlyList<IReadOnlyList<string?>> Rows,
+        IReadOnlyList<string>? Preamble = null);
+
+    /// <summary>
+    /// Многолистовая выгрузка (issue #444). Вкладки отвечают на разные вопросы — находки арифметики и
+    /// утверждения агента, — и сваливать их на один лист значило бы выдать одно за другое.
+    ///
+    /// Только XLS/XLSX: у CSV вкладок нет, и молча склеить их в один файл — потерять эту границу.
+    /// </summary>
+    public static (byte[] Bytes, string Extension, string ContentType) ExportSheets(
+        SpreadsheetFormat format, IReadOnlyList<Sheet> sheets)
+    {
+        if (format == SpreadsheetFormat.Csv)
+            throw new ArgumentException("CSV не поддерживает вкладки — выгрузите отчёт в XLSX.", nameof(format));
+
+        IWorkbook wb = format == SpreadsheetFormat.Xls ? new HSSFWorkbook() : new XSSFWorkbook();
+        foreach (var sheet in sheets) WriteSheet(wb, sheet);
+
+        using var ms = new MemoryStream();
+        wb.Write(ms, leaveOpen: true);
+        return format == SpreadsheetFormat.Xls
+            ? (ms.ToArray(), "xls", "application/vnd.ms-excel")
+            : (ms.ToArray(), "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    }
+
+    private static void WriteSheet(IWorkbook wb, Sheet s)
+    {
+        var sheet = wb.CreateSheet(SafeSheetName(s.Name));
+        var r = 0;
+
+        foreach (var line in s.Preamble ?? [])
+            sheet.CreateRow(r++).CreateCell(0).SetCellValue(line);
+        if (s.Preamble is { Count: > 0 }) r++; // пустая строка между шапкой и таблицей
+
+        var header = sheet.CreateRow(r++);
+        for (var c = 0; c < s.Columns.Count; c++) header.CreateCell(c).SetCellValue(s.Columns[c]);
+
+        foreach (var row in s.Rows)
+        {
+            var line = sheet.CreateRow(r++);
+            for (var c = 0; c < s.Columns.Count; c++)
+                line.CreateCell(c).SetCellValue(c < row.Count ? row[c] ?? "" : "");
+        }
+    }
 
     private static byte[] Csv(IReadOnlyList<string> columns, IReadOnlyList<IReadOnlyList<string?>> rows)
     {

--- a/src/server/BHS.CRG.Tests/Reconciliation/DiscrepancyReportTests.cs
+++ b/src/server/BHS.CRG.Tests/Reconciliation/DiscrepancyReportTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using BHS.CRG.Application.Reconciliation;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Reconciliation;
+using BHS.CRG.Infrastructure.DataSets;
+
+namespace BHS.CRG.Tests.Reconciliation;
+
+/// <summary>
+/// «Отчёт о расхождениях» (issue #444) — артефакт, который сегодня ведут руками. Он уходит из системы
+/// в переписку и на совещания, поэтому должен быть самодостаточным и не смазывать происхождение данных.
+/// </summary>
+public class DiscrepancyReportTests
+{
+    private static ReconciliationFinding Finding(
+        string label, double? left, double? right, FindingStatus status)
+        => ReconciliationFinding.Create(Guid.NewGuid(), label.ToLowerInvariant(), label, left, right, status,
+            JsonDocument.Parse("""{"left":{"column":"ДлинаФакт","rows":[1,2]},"right":null}"""));
+
+    private static ReconciliationRun CompletedRun()
+    {
+        var run = ReconciliationRun.Start(Guid.NewGuid());
+        run.Complete(8, 1, 1, 0);
+        return run;
+    }
+
+    [Fact]
+    public void Findings_ComputeDifference_SoReaderDoesNotSubtractInHead()
+    {
+        var sheet = DiscrepancyReport.Findings("Кабель", CompletedRun(),
+            [new FindingView(Finding("ВВГнг 3х2.5", 441, 430.5, FindingStatus.Mismatch), false, null)]);
+
+        var row = Assert.Single(sheet.Rows);
+        var diff = row[Array.IndexOf([.. sheet.Columns], "Разница")];
+        Assert.Equal("10,5", diff);
+    }
+
+    /// <summary>
+    /// Пустая таблица без объяснения читается как «расхождений нет» — самое опасное недоразумение
+    /// подсистемы, и в файле, уходящем заказчику, оно опаснее всего.
+    /// </summary>
+    [Fact]
+    public void FailedRun_SaysSoInPreamble()
+    {
+        var run = ReconciliationRun.Start(Guid.NewGuid());
+        run.Fail("Источник не найден");
+
+        var sheet = DiscrepancyReport.Findings("Кабель", run, []);
+
+        Assert.Empty(sheet.Rows);
+        Assert.Contains(sheet.Preamble, p => p.Contains("НЕ ВЫПОЛНЕН") && p.Contains("Источник не найден"));
+    }
+
+    [Fact]
+    public void NoRuns_SaysSo_InsteadOfLookingClean()
+    {
+        var sheet = DiscrepancyReport.Findings("Кабель", null, []);
+        Assert.Contains(sheet.Preamble, p => p.Contains("Прогонов не было"));
+    }
+
+    [Fact]
+    public void Findings_CarryDecisionAndResolved()
+    {
+        var decision = ReconciliationDecision.Create(
+            Guid.NewGuid(), "k", DecisionKind.Accepted, "Давальческий", "alex");
+        var sheet = DiscrepancyReport.Findings("Кабель", CompletedRun(),
+            [new FindingView(Finding("ВВГ", 50, 100, FindingStatus.Mismatch), Resolved: true, decision)]);
+
+        var row = Assert.Single(sheet.Rows);
+        Assert.Equal("да", row[Array.IndexOf([.. sheet.Columns], "Устранено")]);
+        Assert.Equal("Признано нормой", row[Array.IndexOf([.. sheet.Columns], "Решение")]);
+        Assert.Equal("Давальческий", row[Array.IndexOf([.. sheet.Columns], "Примечание")]);
+        // Провенанс человеческим текстом: голый JSON в отчёте бесполезен.
+        Assert.Contains("ДлинаФакт", row[Array.IndexOf([.. sheet.Columns], "Где смотреть")]);
+    }
+
+    /// <summary>
+    /// Файл уходит в переписку и на совещания — там утверждение агента не должно сойти за результат
+    /// проверки системы.
+    /// </summary>
+    [Fact]
+    public void Observations_DeclareTheirOrigin()
+    {
+        var o = AgentObservation.Create(CatalogScope.Set, Guid.NewGuid(), "k",
+            "Организация не совпадает", "Подробности", ObservationSeverity.Error,
+            JsonDocument.Parse("""{"documentIds":["a","b"],"note":"акт 5"}"""), "агент");
+
+        var sheet = DiscrepancyReport.Observations([o]);
+
+        Assert.Contains(sheet.Preamble, p => p.Contains("НЕ результат проверки системы"));
+        var row = Assert.Single(sheet.Rows);
+        Assert.Equal("Существенно", row[0]);
+        Assert.Equal("Не разобрано", row[1]);
+        Assert.Contains("документов: 2", row[Array.IndexOf([.. sheet.Columns], "Где смотреть")]);
+    }
+
+    /// <summary>Ссылки, пришедшие строкой с JSON внутри, разворачиваются и в отчёте (#442).</summary>
+    [Fact]
+    public void Observations_UnwrapStringifiedReferences()
+    {
+        var stringified = JsonDocument.Parse(
+            JsonSerializer.Serialize("""{"documentIds":["a"],"note":"строкой"}"""));
+        var o = AgentObservation.Create(CatalogScope.Set, Guid.NewGuid(), "k", "Заголовок", null,
+            ObservationSeverity.Info, stringified, "агент");
+
+        var row = Assert.Single(DiscrepancyReport.Observations([o]).Rows);
+        Assert.Contains("документов: 1", row[4]);
+    }
+
+    [Fact]
+    public void MultiSheetExport_ProducesReadableWorkbook()
+    {
+        var findings = DiscrepancyReport.Findings("Кабель", CompletedRun(),
+            [new FindingView(Finding("ВВГ", 1, 2, FindingStatus.Mismatch), false, null)]);
+        var observations = DiscrepancyReport.Observations([]);
+
+        var (bytes, ext, _) = SpreadsheetExporter.ExportSheets(SpreadsheetFormat.Xlsx,
+        [
+            new(findings.Name, findings.Columns, findings.Rows, findings.Preamble),
+            new(observations.Name, observations.Columns, observations.Rows, observations.Preamble),
+        ]);
+
+        Assert.Equal("xlsx", ext);
+        using var wb = new NPOI.XSSF.UserModel.XSSFWorkbook(new MemoryStream(bytes));
+        Assert.Equal(2, wb.NumberOfSheets);
+        Assert.Equal("Сверка", wb.GetSheetAt(0).SheetName);
+        Assert.Equal("Замечания", wb.GetSheetAt(1).SheetName);
+        // Шапка выше таблицы: без неё через неделю не понять, к чему относился файл.
+        Assert.Contains("Кабель", wb.GetSheetAt(0).GetRow(0).GetCell(0).StringCellValue);
+    }
+
+    /// <summary>У CSV вкладок нет, и молча склеить их в один файл — потерять границу между ними.</summary>
+    [Fact]
+    public void CsvIsRejected_RatherThanFlattened()
+        => Assert.Throws<ArgumentException>(() =>
+            SpreadsheetExporter.ExportSheets(SpreadsheetFormat.Csv, [new("A", ["c"], [], null)]));
+}


### PR DESCRIPTION
Closes #444 · часть Ф3 из #414

Сегодня этот отчёт ведут руками — версионируемый xlsx, к настоящему моменту редакция 8. Именно он и есть рабочий артефакт процесса, а система уже знает всё, из чего он складывается.

## Живая выгрузка на рабочих данных

```
вкладки: ['Сверка', 'Замечания']

--- Сверка (15 строк) ---
  Кабель: проложено ≥ проектного
  Прогон: 26.07.2026 12:59
  Совпало: 10 · расхождений: 0 · нет слева: 0 · нет справа: 0
  Статус | Устранено | Позиция | Слева | Справа | Разница | Где смотреть | Решение | …
  Совпадает | | ВВГнг(А)-FRLS | 16 | 16 | 0 | слева: ДлинаФакт, строк 1; справа: …

--- Замечания (17 строк) ---
  Замечания внешнего ИИ-анализа
  Это утверждения агента, а НЕ результат проверки системы…
  Существенность | Разбор | Суть | Подробности | Где смотреть | …
  Существенно | Не разобрано | Основные марки кабеля комплекта не имеют привязки… | документов: 2; источник 7e995fb5 | alex
```

## Решения

**Две вкладки, а не одна.** Находка сверки — результат арифметики, замечание — утверждение агента. В файле, уходящем в переписку и на совещания, эта граница важнее, чем где-либо: на вкладке замечаний происхождение написано прямо в шапке.

**Шапка листа обязательна.** Отчёт уходит из системы и живёт своей жизнью; без строк «какая сверка, когда прогон, каковы итоги» через неделю не понять, к чему он относился и насколько свеж.

**Неудачный прогон пишет «ПРОГОН НЕ ВЫПОЛНЕН» с причиной.** Пустая таблица без объяснения читается как «расхождений нет» — самое опасное недоразумение подсистемы, и в выгружаемом файле оно опаснее, чем на экране.

**Разницу считаем мы.** Отчёт смотрят глазами, и вычитание в уме по сотне строк — ровно то, от чего этот файл должен избавить. Провенанс тоже человеческим текстом, а не сырым JSON.

**CSV отклоняется явно**, а не сплющивается: вкладок у него нет, и склеить их в один лист значило бы потерять ту самую границу.

Комплект без настроенных сверок даёт файл с шапкой и пустой вкладкой, а не ошибку: «расхождений нет» — тоже результат, и его тоже показывают заказчику.

## Где

Кнопка «Отчёт» в шапке раздела «Сверка», рядом — выбор комплекта: отчёт собирается по комплекту, как и тот, что ведут руками.

Сборка листов живёт в `Application` — она вся про смысл (колонки, названия статусов, что писать в шапке), а не про NPOI, и проверяется без файлов на диске. Многолистовая выгрузка добавлена в существующий `SpreadsheetExporter`, второго не заводим.

## Проверка

- `dotnet test` — 647 зелёных (+8); `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём: файл 11 КБ, обе вкладки, кириллица цела, 13 замечаний и 10 находок на месте.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
