### PR TITLE
feat(reconciliation): алиасы позиций (#446)

### DIFF
--- a/src/client/src/features/reconciliations/AliasesPanel.tsx
+++ b/src/client/src/features/reconciliations/AliasesPanel.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Link2, Link2Off, Check, X } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { EmptyState } from '@/shared/ui/EmptyState';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { useToast } from '@/shared/ui/Toast';
+import {
+  useAliases, useReviewAlias, useDeleteAlias,
+  ALIAS_STATUS_LABELS, type ReconciliationAlias,
+} from '@/shared/api/reconciliations';
+
+/**
+ * Алиасы позиций (issue #446): утверждения, что два по-разному записанных наименования обозначают
+ * одно и то же — знание, которое в ручном процессе держит в голове человек.
+ *
+ * В сравнении участвуют ТОЛЬКО подтверждённые, и это видно: «Применяется» против «Предложено».
+ */
+
+const STATUS_STYLE: Record<ReconciliationAlias['status'], string> = {
+  Confirmed: 'bg-brand-subtle text-brand',
+  Proposed: 'bg-warning-subtle text-warning',
+  Rejected: 'bg-muted text-fg4',
+};
+
+export function AliasesPanel() {
+  const { data: items = [], isLoading } = useAliases();
+  const review = useReviewAlias();
+  const remove = useDeleteAlias();
+  const toast = useToast();
+  const [breaking, setBreaking] = useState<ReconciliationAlias | null>(null);
+
+  return (
+    <div className="flex-1 min-w-0 flex flex-col">
+      <div className="px-4 py-3 border-b border-stroke shrink-0">
+        <h2 className="text-base font-semibold text-fg1 flex items-center gap-2">
+          <Link2 size={16} className="text-fg3" /> Алиасы позиций
+        </h2>
+        <p className="text-xs text-fg3 mt-0.5">
+          Наименования, признанные одним и тем же. В сверке участвуют только применяемые.
+        </p>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {isLoading && <p className="px-4 py-3 text-sm text-fg4">Загрузка…</p>}
+        {!isLoading && items.length === 0 && (
+          <div className="p-6">
+            <EmptyState icon={<Link2 size={32} />} title="Алиасов нет"
+              description="Свяжите две позиции в списке находок, если они называются по-разному, но означают одно." />
+          </div>
+        )}
+        {items.map(a => (
+          <div key={a.id} className="px-4 py-3 border-b border-stroke group">
+            <div className="flex items-center gap-2">
+              <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${STATUS_STYLE[a.status]}`}>
+                {ALIAS_STATUS_LABELS[a.status]}
+              </span>
+              <span className="min-w-0 flex-1 text-sm text-fg1 truncate">
+                {a.aliasLabel} <span className="text-fg4">→</span> {a.canonicalLabel}
+              </span>
+              {a.status !== 'Confirmed' && (
+                <Button variant="text" size="sm" className="shrink-0"
+                  onClick={async () => {
+                    await review.mutateAsync({ id: a.id, status: 'Confirmed' });
+                    toast.success('Применяется. Прогоните сверку, чтобы позиции слились');
+                  }}>
+                  <Check size={14} /> Применять
+                </Button>
+              )}
+              {a.status !== 'Rejected' && (
+                <Button variant="text" size="sm" className="shrink-0 opacity-0 group-hover:opacity-100"
+                  onClick={async () => {
+                    await review.mutateAsync({ id: a.id, status: 'Rejected' });
+                    toast.info('Отклонено');
+                  }}>
+                  <X size={14} /> Отклонить
+                </Button>
+              )}
+              <Button variant="text" size="sm" danger className="shrink-0 opacity-0 group-hover:opacity-100"
+                onClick={() => setBreaking(a)}>
+                <Link2Off size={14} /> Разорвать
+              </Button>
+            </div>
+            {(a.note || a.confirmedBy || a.proposedBy) && (
+              <p className="text-[11px] text-fg4 mt-0.5">
+                {a.note}
+                {a.note && (a.confirmedBy || a.proposedBy) ? ' · ' : ''}
+                {a.confirmedBy ? `подтвердил ${a.confirmedBy}` : a.proposedBy ? `предложил ${a.proposedBy}` : ''}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={!!breaking}
+        title="Разорвать связь позиций?"
+        // Последствие неочевидно и проявится не сразу — говорим прямо.
+        description="В следующем прогоне эти позиции снова разъедутся на две находки."
+        confirmLabel="Разорвать"
+        onOpenChange={o => { if (!o) setBreaking(null); }}
+        onConfirm={async () => {
+          await remove.mutateAsync(breaking!.id);
+          setBreaking(null);
+          toast.success('Связь разорвана');
+        }}
+      />
+    </div>
+  );
+}

--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
-  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale, Bot, FileSpreadsheet,
+  Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale, Bot, FileSpreadsheet, Link2,
 } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { Select, SelectItem } from '@/shared/ui/Select';
@@ -14,12 +14,14 @@ import { useAuth } from '@/shared/hooks/useAuth';
 import {
   useReconciliations, useReconciliationRuns, useFindings, useRunReconciliation,
   useDeleteReconciliation, useSetDecision, useRemoveDecision, downloadDiscrepancyReport,
+  useAliases, useCreateAlias, isUnmatched,
   STATUS_LABELS, DECISION_LABELS, needsAttention, runSummary,
   type Finding, type ReconciliationRun,
 } from '@/shared/api/reconciliations';
 import { ReconciliationEditor } from './ReconciliationEditor';
 import { DecisionDialog } from './DecisionDialog';
 import { ObservationsPanel } from './ObservationsPanel';
+import { AliasesPanel } from './AliasesPanel';
 import { useObservations, isUnreviewed } from '@/shared/api/observations';
 
 /**
@@ -55,12 +57,20 @@ function num(v: number | null): string {
   return v == null ? '—' : String(Math.round(v * 1000) / 1000);
 }
 
-function FindingRow({ f, onDecide }: { f: Finding; onDecide: (f: Finding) => void }) {
+function FindingRow({ f, onDecide, linkable, checked, onToggle }: {
+  f: Finding; onDecide: (f: Finding) => void;
+  linkable: boolean; checked: boolean; onToggle: () => void;
+}) {
   const left = f.provenance.left;
   const right = f.provenance.right;
   return (
     <div className="px-3 py-2 border-b border-stroke hover:bg-muted/40 group">
       <div className="flex items-center gap-2">
+        {/* Связывать имеет смысл только позиции, не нашедшие пары: у остальных пара уже есть. */}
+        {linkable && (
+          <input type="checkbox" checked={checked} onChange={onToggle}
+            aria-label={`Выбрать «${f.label}» для связывания`} className="shrink-0 accent-brand" />
+        )}
         <StatusBadge f={f} />
         <span className="flex-1 truncate text-sm text-fg1" title={f.label}>{f.label}</span>
         <span className="text-sm tabular-nums text-fg2 shrink-0">
@@ -116,11 +126,15 @@ export function ReconciliationsPage() {
   const [deciding, setDeciding] = useState<Finding | null>(null);
   const [onlyAttention, setOnlyAttention] = useState(false);
   // Замечания агента — вторая секция того же раздела: оба отвечают «что не так с комплектом».
-  const [view, setView] = useState<'reconciliation' | 'observations'>('reconciliation');
+  const [view, setView] = useState<'reconciliation' | 'observations' | 'aliases'>('reconciliation');
+  // Связывание позиций: выбираем ровно две несопоставленные находки.
+  const [linking, setLinking] = useState<string[]>([]);
 
   const { data: items = [], isLoading } = useReconciliations();
   const { data: observations = [] } = useObservations();
   const { data: constructions = [] } = useListConstructions();
+  const { data: aliases = [] } = useAliases();
+  const createAlias = useCreateAlias();
 
   // Отчёт собирается по КОМПЛЕКТУ — как и тот, что сегодня ведут руками.
   const sets = useMemo(
@@ -191,11 +205,17 @@ export function ReconciliationsPage() {
           count={observations.filter(isUnreviewed).length}
           active={view === 'observations'}
           onClick={() => setView('observations')} />
+        <NavItem icon={<Link2 size={16} />} label="Алиасы позиций"
+          count={aliases.filter(a => a.status === 'Proposed').length}
+          active={view === 'aliases'}
+          onClick={() => setView('aliases')} />
       </div>
     </>
   );
 
-  const detail = view === 'observations' ? <ObservationsPanel /> : !selected ? (
+  const detail = view === 'observations' ? <ObservationsPanel />
+    : view === 'aliases' ? <AliasesPanel />
+    : !selected ? (
     <EmptyState icon={<Scale size={32} />} title="Выберите сверку"
       description="Сверка сопоставляет два источника по доменному ключу и показывает расхождения." />
   ) : (
@@ -246,6 +266,30 @@ export function ReconciliationsPage() {
         </div>
       )}
 
+      {linking.length > 0 && (
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-stroke bg-brand-subtle shrink-0">
+          <Link2 size={14} className="text-brand shrink-0" />
+          <span className="text-xs text-brand flex-1 truncate">
+            {linking.length === 1
+              ? 'Выберите вторую позицию, чтобы связать их как одну'
+              : findings.filter(f => linking.includes(f.id)).map(f => f.label).join('  →  ')}
+          </span>
+          <Button variant="text" size="sm" onClick={() => setLinking([])}>Отмена</Button>
+          <Button variant="filled" size="sm" disabled={linking.length !== 2}
+            onClick={async () => {
+              const [a, b] = linking.map(id => findings.find(f => f.id === id)!);
+              await createAlias.mutateAsync({
+                aliasKey: a.key, aliasLabel: a.label,
+                canonicalKey: b.key, canonicalLabel: b.label,
+              });
+              setLinking([]);
+              toast.success('Связано. Прогоните сверку, чтобы позиции слились');
+            }}>
+            Связать
+          </Button>
+        </div>
+      )}
+
       <div className="flex-1 min-h-0 overflow-y-auto">
         {findingsLoading && <p className="px-4 py-3 text-sm text-fg4">Загрузка…</p>}
         {!findingsLoading && shown.length === 0 && (
@@ -255,7 +299,15 @@ export function ReconciliationsPage() {
               : onlyAttention ? 'Всё разобрано.' : 'Находок нет.'}
           </p>
         )}
-        {shown.map(f => <FindingRow key={f.id} f={f} onDecide={setDeciding} />)}
+        {shown.map(f => (
+          <FindingRow key={f.id} f={f} onDecide={setDeciding}
+            linkable={isUnmatched(f)}
+            checked={linking.includes(f.id)}
+            onToggle={() => setLinking(prev => prev.includes(f.id)
+              ? prev.filter(x => x !== f.id)
+              // Больше двух — уже не пара: держим последние две.
+              : [...prev, f.id].slice(-2))} />
+        ))}
       </div>
     </div>
   );

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -177,6 +177,75 @@ export function useRemoveDecision() {
   });
 }
 
+// ─── Алиасы позиций (#446) ────────────────────────────────────────────────────
+
+export type AliasStatus = 'Proposed' | 'Confirmed' | 'Rejected';
+
+/**
+ * Утверждение, что два по-разному записанных наименования обозначают одно и то же.
+ * В сравнении участвуют ТОЛЬКО подтверждённые: неподтверждённый алиас в пути сравнения и есть
+ * модель внутри арифметики — отчёт начал бы меняться сам по себе.
+ */
+export interface ReconciliationAlias {
+  id: string;
+  aliasKey: string;
+  aliasLabel: string;
+  canonicalKey: string;
+  canonicalLabel: string;
+  status: AliasStatus;
+  note: string | null;
+  proposedBy: string | null;
+  confirmedBy: string | null;
+  updatedAt: string;
+}
+
+export const ALIAS_STATUS_LABELS: Record<AliasStatus, string> = {
+  Proposed: 'Предложено',
+  Confirmed: 'Применяется',
+  Rejected: 'Отклонено',
+};
+
+export function useAliases(status?: AliasStatus) {
+  return useQuery({
+    queryKey: [...KEY, 'aliases', status ?? null],
+    queryFn: async () => (await apiClient.get<ReconciliationAlias[]>('/reconciliations/aliases', {
+      params: { status },
+    })).data,
+  });
+}
+
+export function useCreateAlias() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: {
+      aliasKey: string; aliasLabel: string; canonicalKey: string; canonicalLabel: string; note?: string | null;
+    }) => (await apiClient.post<ReconciliationAlias>('/reconciliations/aliases', body)).data,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useReviewAlias() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, status, note }: { id: string; status: AliasStatus; note?: string | null }) =>
+      (await apiClient.put<ReconciliationAlias>(`/reconciliations/aliases/${id}`, { status, note })).data,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+export function useDeleteAlias() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => { await apiClient.delete(`/reconciliations/aliases/${id}`); },
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+  });
+}
+
+/** Кандидат на связывание: позиция, не нашедшая пары на другой стороне. */
+export function isUnmatched(f: Finding): boolean {
+  return f.status === 'MissingLeft' || f.status === 'MissingRight';
+}
+
 // ─── Представление ────────────────────────────────────────────────────────────
 
 export const STATUS_LABELS: Record<FindingStatus, string> = {

--- a/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
@@ -74,6 +74,42 @@ public static class ReconciliationEndpoints
         user.MapGet("/{id:guid}/findings", async (Guid id, Guid? runId, IMediator m) =>
             Results.Ok((await m.Send(new ListFindingsQuery(id, runId))).Select(ToDto)));
 
+        // ── Алиасы позиций ──────────────────────────────────────────────────────
+
+        user.MapGet("/aliases", async (string? status, IMediator m) =>
+        {
+            AliasStatus? st = Enum.TryParse<AliasStatus>(status, true, out var v) ? v : null;
+            return Results.Ok((await m.Send(new ListAliasesQuery(st))).Select(ToDto));
+        });
+
+        user.MapPost("/aliases", async (AliasReq req, IMediator m, ClaimsPrincipal u) =>
+        {
+            var by = u.FindFirst("displayName")?.Value ?? u.FindFirstValue(ClaimTypes.Email);
+            try
+            {
+                // Человек связывает позиции сам — подтверждать отдельным шагом незачем.
+                return Results.Ok(ToDto(await m.Send(new ProposeAliasCommand(
+                    req.AliasKey, req.AliasLabel, req.CanonicalKey, req.CanonicalLabel,
+                    req.Note, by, Confirm: true))));
+            }
+            catch (InvalidOperationException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        user.MapPut("/aliases/{id:guid}", async (Guid id, AliasReviewReq req, IMediator m, ClaimsPrincipal u) =>
+        {
+            if (!Enum.TryParse<AliasStatus>(req.Status, true, out var status))
+                return Results.BadRequest(new { error = $"Неизвестный статус: «{req.Status}»." });
+            var by = u.FindFirst("displayName")?.Value ?? u.FindFirstValue(ClaimTypes.Email);
+            try { return Results.Ok(ToDto(await m.Send(new ReviewAliasCommand(id, status, req.Note, by)))); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
+        user.MapDelete("/aliases/{id:guid}", async (Guid id, IMediator m) =>
+        {
+            try { await m.Send(new DeleteAliasCommand(id)); return Results.NoContent(); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
+
         // ── Отчёт ───────────────────────────────────────────────────────────────
 
         // Отчёт собирается по КОМПЛЕКТУ, а не по сверке: наружу уходит один файл про комплект, как и
@@ -134,11 +170,29 @@ public static class ReconciliationEndpoints
 
     // ── DTO ─────────────────────────────────────────────────────────────────────
 
+    private record AliasReq(string AliasKey, string AliasLabel, string CanonicalKey,
+        string CanonicalLabel, string? Note);
+    private record AliasReviewReq(string Status, string? Note);
+
     private record CreateReq(string Name, string Scope, Guid? ScopeId, JsonElement Spec);
     private record UpdateReq(string Name, JsonElement Spec);
     /// <summary>Решение адресуется ключом позиции, а не идентификатором находки: находка живёт один
     /// прогон, решение обязано пережить любое их число.</summary>
     private record DecisionReq(string Key, string Kind, string? Note);
+
+    private static object ToDto(ReconciliationAlias a) => new
+    {
+        a.Id,
+        a.AliasKey,
+        a.AliasLabel,
+        a.CanonicalKey,
+        a.CanonicalLabel,
+        status = a.Status.ToString(),
+        a.Note,
+        a.ProposedBy,
+        a.ConfirmedBy,
+        a.UpdatedAt,
+    };
 
     private static object ToDto(ReconciliationDefinition d) => new
     {

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -205,6 +205,8 @@ builder.Services.AddScoped<IRepository<BHS.CRG.Domain.Reconciliation.Reconciliat
     Repository<BHS.CRG.Domain.Reconciliation.ReconciliationDecision>>();
 builder.Services.AddScoped<IRepository<BHS.CRG.Domain.Reconciliation.AgentObservation>,
     Repository<BHS.CRG.Domain.Reconciliation.AgentObservation>>();
+builder.Services.AddScoped<IRepository<BHS.CRG.Domain.Reconciliation.ReconciliationAlias>,
+    Repository<BHS.CRG.Domain.Reconciliation.ReconciliationAlias>>();
 builder.Services.AddScoped<IRepository<DocumentSetOutput>, Repository<DocumentSetOutput>>();
 builder.Services.AddScoped<IRepository<TypstUserLib>, Repository<TypstUserLib>>();
 builder.Services.AddScoped<IRepository<QualityDocument>, Repository<QualityDocument>>();

--- a/src/server/BHS.CRG.Application/Reconciliation/AliasCommands.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/AliasCommands.cs
@@ -1,0 +1,87 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Reconciliation;
+using MediatR;
+
+namespace BHS.CRG.Application.Reconciliation;
+
+public record ListAliasesQuery(AliasStatus? Status = null) : IRequest<IReadOnlyList<ReconciliationAlias>>;
+
+/// <param name="AliasKey">Ключ варианта — тот, что сводим. Именно он обязан быть уникален.</param>
+/// <param name="Confirm">Заводит человек — сразу подтверждаем; предложение агента ждёт разбора.</param>
+public record ProposeAliasCommand(
+    string AliasKey, string AliasLabel, string CanonicalKey, string CanonicalLabel,
+    string? Note, string? By, bool Confirm) : IRequest<ReconciliationAlias>;
+
+public record ReviewAliasCommand(Guid Id, AliasStatus Status, string? Note, string? By)
+    : IRequest<ReconciliationAlias>;
+
+public record DeleteAliasCommand(Guid Id) : IRequest;
+
+public class AliasHandlers(IRepository<ReconciliationAlias> repo) :
+    IRequestHandler<ListAliasesQuery, IReadOnlyList<ReconciliationAlias>>,
+    IRequestHandler<ProposeAliasCommand, ReconciliationAlias>,
+    IRequestHandler<ReviewAliasCommand, ReconciliationAlias>,
+    IRequestHandler<DeleteAliasCommand>
+{
+    public async Task<IReadOnlyList<ReconciliationAlias>> Handle(ListAliasesQuery q, CancellationToken ct)
+    {
+        var items = await repo.FindAsync(a => !q.Status.HasValue || a.Status == q.Status.Value, ct);
+        // Неразобранные выше: они ждут человека, остальные — уже история.
+        return [.. items
+            .OrderBy(a => a.Status == AliasStatus.Proposed ? 0 : 1)
+            .ThenBy(a => a.AliasLabel, StringComparer.CurrentCulture)];
+    }
+
+    public async Task<ReconciliationAlias> Handle(ProposeAliasCommand cmd, CancellationToken ct)
+    {
+        if (string.Equals(cmd.AliasKey, cmd.CanonicalKey, StringComparison.Ordinal))
+            throw new InvalidOperationException("Позицию нельзя связать саму с собой.");
+
+        // Повторное предложение по тому же варианту — правка существующего: два разных канона у одного
+        // ключа сделали бы результат прогона зависящим от порядка выборки.
+        var existing = await FindByAliasKeyAsync(cmd.AliasKey, ct);
+
+        ReconciliationAlias alias;
+        if (existing is null)
+        {
+            alias = ReconciliationAlias.Propose(cmd.AliasKey, cmd.AliasLabel,
+                cmd.CanonicalKey, cmd.CanonicalLabel, cmd.Note, cmd.By);
+            if (cmd.Confirm) alias.Review(AliasStatus.Confirmed, cmd.Note, cmd.By);
+            await repo.AddAsync(alias, ct);
+        }
+        else
+        {
+            alias = existing;
+            alias.Review(cmd.Confirm ? AliasStatus.Confirmed : alias.Status, cmd.Note, cmd.By);
+            repo.Update(alias);
+        }
+
+        await repo.SaveChangesAsync(ct);
+        return alias;
+    }
+
+    public async Task<ReconciliationAlias> Handle(ReviewAliasCommand cmd, CancellationToken ct)
+    {
+        var alias = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
+        alias.Review(cmd.Status, cmd.Note, cmd.By);
+        repo.Update(alias);
+        await repo.SaveChangesAsync(ct);
+        return alias;
+    }
+
+    public async Task Handle(DeleteAliasCommand cmd, CancellationToken ct)
+    {
+        var alias = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
+        repo.Remove(alias);
+        await repo.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Два шага: <c>FindAsync</c> не отслеживает сущности, и правка копии столкнулась бы с
+    /// уже отслеживаемым экземпляром.</summary>
+    private async Task<ReconciliationAlias?> FindByAliasKeyAsync(string aliasKey, CancellationToken ct)
+    {
+        var id = (await repo.FindAsync(a => a.AliasKey == aliasKey, ct))
+            .Select(a => (Guid?)a.Id).FirstOrDefault();
+        return id is null ? null : await repo.GetByIdAsync(id.Value, ct);
+    }
+}

--- a/src/server/BHS.CRG.Domain/Reconciliation/ReconciliationAlias.cs
+++ b/src/server/BHS.CRG.Domain/Reconciliation/ReconciliationAlias.cs
@@ -1,0 +1,65 @@
+using BHS.CRG.Domain.Common;
+
+namespace BHS.CRG.Domain.Reconciliation;
+
+/// <summary>Кто и насколько уверенно утверждает, что две позиции — одно и то же.</summary>
+public enum AliasStatus
+{
+    /// <summary>Предложено (человеком или агентом), но не подтверждено. В сравнении НЕ участвует.</summary>
+    Proposed,
+
+    /// <summary>Подтверждено человеком — применяется при свёртке.</summary>
+    Confirmed,
+
+    /// <summary>Отклонено. Хранится, чтобы предложение не всплывало снова.</summary>
+    Rejected,
+}
+
+/// <summary>
+/// Алиас позиции (issue #446, фаза Ф2 из #414): утверждение, что два по-разному записанных
+/// наименования обозначают одно и то же. В ручном процессе это знание человека — «Hyperline CM-1U-ML»
+/// и «Органайзер СвязьСтройДеталь»; без него позиция даёт две находки-сироты.
+///
+/// Область общая, не привязанная к конкретной сверке: это утверждение о мире, а не свойство одного
+/// сравнения. Узнали один раз — применяется везде.
+///
+/// В сравнении участвуют ТОЛЬКО подтверждённые. Ограничение несущее: неподтверждённый алиас в пути
+/// сравнения и есть модель внутри арифметики — риск P1, ради которого Ф1 строился детерминированным.
+/// </summary>
+public class ReconciliationAlias : Entity
+{
+    /// <summary>Нормализованный ключ варианта — тот, что заменяем.</summary>
+    public string AliasKey { get; private set; } = null!;
+
+    /// <summary>Нормализованный ключ, к которому сводим.</summary>
+    public string CanonicalKey { get; private set; } = null!;
+
+    /// <summary>Наименования как их видит человек: голые нормализованные ключи в списке нечитаемы.</summary>
+    public string AliasLabel { get; private set; } = null!;
+    public string CanonicalLabel { get; private set; } = null!;
+
+    public AliasStatus Status { get; private set; } = AliasStatus.Proposed;
+    public string? Note { get; private set; }
+    public string? ProposedBy { get; private set; }
+    public string? ConfirmedBy { get; private set; }
+
+    private ReconciliationAlias() { }
+
+    public static ReconciliationAlias Propose(
+        string aliasKey, string aliasLabel, string canonicalKey, string canonicalLabel,
+        string? note, string? proposedBy)
+        => new()
+        {
+            AliasKey = aliasKey, AliasLabel = aliasLabel,
+            CanonicalKey = canonicalKey, CanonicalLabel = canonicalLabel,
+            Note = note, ProposedBy = proposedBy,
+        };
+
+    public void Review(AliasStatus status, string? note, string? confirmedBy)
+    {
+        Status = status;
+        if (note is not null) Note = note;
+        ConfirmedBy = confirmedBy;
+        TouchUpdatedAt();
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260726044446_ReconciliationAliases.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260726044446_ReconciliationAliases.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726044446_ReconciliationAliases")]
+    partial class ReconciliationAliases
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260726044446_ReconciliationAliases.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260726044446_ReconciliationAliases.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReconciliationAliases : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "reconciliation_aliases",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AliasKey = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    CanonicalKey = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    AliasLabel = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    CanonicalLabel = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Note = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    ProposedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ConfirmedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_reconciliation_aliases", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_reconciliation_aliases_AliasKey",
+                table: "reconciliation_aliases",
+                column: "AliasKey",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "reconciliation_aliases");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
@@ -52,6 +52,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options)
         => Set<BHS.CRG.Domain.Reconciliation.ReconciliationDecision>();
     public DbSet<BHS.CRG.Domain.Reconciliation.AgentObservation> AgentObservations
         => Set<BHS.CRG.Domain.Reconciliation.AgentObservation>();
+    public DbSet<BHS.CRG.Domain.Reconciliation.ReconciliationAlias> ReconciliationAliases
+        => Set<BHS.CRG.Domain.Reconciliation.ReconciliationAlias>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
     protected override void OnModelCreating(ModelBuilder builder)

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/ReconciliationConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/ReconciliationConfiguration.cs
@@ -95,3 +95,24 @@ public class AgentObservationConfiguration : IEntityTypeConfiguration<AgentObser
         b.HasIndex(e => new { e.Scope, e.ScopeId, e.Key }).IsUnique();
     }
 }
+
+public class ReconciliationAliasConfiguration : IEntityTypeConfiguration<ReconciliationAlias>
+{
+    public void Configure(EntityTypeBuilder<ReconciliationAlias> b)
+    {
+        b.ToTable("reconciliation_aliases");
+        b.HasKey(e => e.Id);
+        b.Property(e => e.AliasKey).HasMaxLength(1024).IsRequired();
+        b.Property(e => e.CanonicalKey).HasMaxLength(1024).IsRequired();
+        b.Property(e => e.AliasLabel).HasMaxLength(1024).IsRequired();
+        b.Property(e => e.CanonicalLabel).HasMaxLength(1024).IsRequired();
+        b.Property(e => e.Status).HasConversion<int>();
+        b.Property(e => e.Note).HasMaxLength(2048);
+        b.Property(e => e.ProposedBy).HasMaxLength(256);
+        b.Property(e => e.ConfirmedBy).HasMaxLength(256);
+
+        // Один вариант сводится ровно к одному канону: два разных канона у одного ключа сделали бы
+        // результат прогона зависящим от порядка выборки.
+        b.HasIndex(e => e.AliasKey).IsUnique();
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Reconciliation/AliasResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Reconciliation/AliasResolver.cs
@@ -1,0 +1,34 @@
+namespace BHS.CRG.Infrastructure.Reconciliation;
+
+/// <summary>
+/// Сведение ключа к каноническому по подтверждённым алиасам (issue #446).
+///
+/// Резолв транзитивный: человек неизбежно заведёт цепочку А→Б, а потом Б→В, и остановившись на первом
+/// шаге, мы получили бы две позиции там, где он ожидает одну. Цикл при этом не должен вешать прогон,
+/// поэтому обход помнит пройденное и на повторе останавливается.
+/// </summary>
+public sealed class AliasResolver
+{
+    private readonly IReadOnlyDictionary<string, string> _map;
+    private readonly Dictionary<string, string> _cache = new(StringComparer.Ordinal);
+
+    /// <param name="confirmed">Только ПОДТВЕРЖДЁННЫЕ пары «вариант → канон». Предложенный алиас в
+    /// сравнении участвовать не должен: это была бы модель внутри арифметики.</param>
+    public AliasResolver(IReadOnlyDictionary<string, string> confirmed) => _map = confirmed;
+
+    public static AliasResolver Empty { get; } = new(new Dictionary<string, string>(StringComparer.Ordinal));
+
+    public string Resolve(string key)
+    {
+        if (_map.Count == 0) return key;
+        if (_cache.TryGetValue(key, out var cached)) return cached;
+
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var current = key;
+        while (visited.Add(current) && _map.TryGetValue(current, out var next))
+            current = next;
+
+        _cache[key] = current;
+        return current;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Reconciliation/ReconciliationRunner.cs
+++ b/src/server/BHS.CRG.Infrastructure/Reconciliation/ReconciliationRunner.cs
@@ -41,8 +41,11 @@ public class ReconciliationRunner(
             var spec = definition.Spec.Deserialize<ReconciliationSpec>(Json)
                 ?? throw new InvalidOperationException("Спека сверки пуста или нечитаема.");
 
-            var left = await TotalsAsync(spec.Left, ct);
-            var right = await TotalsAsync(spec.Right, ct);
+            // Алиасы применяются на СВЁРТКЕ, до сравнения: иначе сопоставление ключей ничего не
+            // даст — количества так и останутся в двух разных позициях.
+            var aliases = await AliasesAsync(ct);
+            var left = await TotalsAsync(spec.Left, aliases, ct);
+            var right = await TotalsAsync(spec.Right, aliases, ct);
 
             var findings = Compare(run.Id, spec, left, right).ToList();
             db.AddRange(findings);
@@ -67,7 +70,28 @@ public class ReconciliationRunner(
     /// Строки источника после всей его обработки — тот же путь, которым их видит генерация. Иначе
     /// сверка судила бы о данных, отличных от попадающих в документ.
     /// </summary>
-    private async Task<SideTotals> TotalsAsync(ReconciliationSide side, CancellationToken ct)
+    /// <summary>
+    /// Только ПОДТВЕРЖДЁННЫЕ алиасы. Предложенный, но не подтверждённый, попав в путь сравнения, и
+    /// есть модель внутри арифметики — риск P1 из #414: отчёт начал бы меняться сам по себе.
+    /// </summary>
+    private async Task<AliasResolver> AliasesAsync(CancellationToken ct)
+    {
+        var confirmed = await db.Set<ReconciliationAlias>().AsNoTracking()
+            .Where(a => a.Status == AliasStatus.Confirmed)
+            .Select(a => new { a.AliasKey, a.CanonicalKey })
+            .ToListAsync(ct);
+
+        if (confirmed.Count == 0) return AliasResolver.Empty;
+
+        // Один вариант сводится ровно к одному канону: два разных канона у одного ключа сделали бы
+        // результат зависящим от порядка выборки.
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var a in confirmed) map.TryAdd(a.AliasKey, a.CanonicalKey);
+        return new AliasResolver(map);
+    }
+
+    private async Task<SideTotals> TotalsAsync(
+        ReconciliationSide side, AliasResolver aliases, CancellationToken ct)
     {
         var source = await db.DataSetSources.AsNoTracking().Include(s => s.File)
             .FirstOrDefaultAsync(s => s.Id == side.SourceId, ct)
@@ -82,8 +106,9 @@ public class ReconciliationRunner(
         for (var i = 0; i < rows.Count; i++)
         {
             var row = rows[i];
-            var key = ReconciliationKeys.Build(side.KeyColumns.Select(c => row.GetValueOrDefault(c)));
-            if (ReconciliationKeys.IsEmpty(key)) continue; // сопоставлять нечего — это шум, не находка
+            var rawKey = ReconciliationKeys.Build(side.KeyColumns.Select(c => row.GetValueOrDefault(c)));
+            if (ReconciliationKeys.IsEmpty(rawKey)) continue; // сопоставлять нечего — это шум, не находка
+            var key = aliases.Resolve(rawKey);
 
             // Отсутствие значения не то же самое, что ноль: незаполненная ячейка не делает позицию
             // нулевой, но и не отменяет её присутствия в документе.

--- a/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
+++ b/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
@@ -44,6 +44,7 @@ public class IntegrationTestFixture : WebApplicationFactory<Program>
         await db.Database.ExecuteSqlRawAsync(@"
             TRUNCATE TABLE
                 agent_observations,
+                reconciliation_aliases,
                 reconciliation_findings,
                 reconciliation_decisions,
                 reconciliation_runs,

--- a/src/server/BHS.CRG.Tests/Integration/ReconciliationRunnerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ReconciliationRunnerTests.cs
@@ -195,6 +195,68 @@ public class ReconciliationRunnerTests(IntegrationTestFixture fixture) : IAsyncL
     }
 
     /// <summary>Неудача обязана быть видимой: пустой журнал молча читался бы как «расхождений нет».</summary>
+    /// <summary>
+    /// Алиас сводит две по-разному названные позиции в одну и СКЛАДЫВАЕТ количества. Применяется на
+    /// свёртке: сопоставление ключей после сравнения ничего бы не дало.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmedAlias_MergesPositions_AndSumsQuantities()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        // Слева одна и та же позиция записана двумя именами, справа — одним.
+        var left = await SeedCsvAsync(scope, "Журнал",
+            """
+            Марка,Сечение,Кол
+            Органайзер СвязьСтройДеталь,1U,4
+            Hyperline CM-1U-ML,1U,6
+            """,
+            ["Марка", "Сечение", "Кол"]);
+        var right = await SeedCsvAsync(scope, "Реестр",
+            """
+            Марка,Сечение,Кол
+            Hyperline CM-1U-ML,1U,10
+            """,
+            ["Марка", "Сечение", "Кол"]);
+
+        var spec = new ReconciliationSpec(
+            new ReconciliationSide(left, ["Марка", "Сечение"], "Кол"),
+            new ReconciliationSide(right, ["Марка", "Сечение"], "Кол"),
+            new ComparisonRule(ComparisonOperator.Equal));
+        var definition = ReconciliationDefinition.Create("Органайзеры", CatalogScope.System, null,
+            JsonSerializer.SerializeToDocument(spec, Json));
+        db.Add(definition);
+        await db.SaveChangesAsync();
+
+        var runner = scope.ServiceProvider.GetRequiredService<IReconciliationRunner>();
+
+        // Без алиаса — две находки-сироты.
+        var before = await FindingsAsync(scope, (await runner.RunAsync(definition.Id)).Id);
+        Assert.Equal(2, before.Count);
+        Assert.Contains(before, f => f.Status == FindingStatus.MissingRight);
+
+        var variant = before.Single(f => f.Status == FindingStatus.MissingRight).Key;
+        var canonical = before.Single(f => f.Status != FindingStatus.MissingRight).Key;
+
+        // Предложенный, но НЕ подтверждённый алиас на сравнение влиять не должен: это была бы модель
+        // внутри арифметики (риск P1 в #414).
+        var alias = ReconciliationAlias.Propose(variant, "Органайзер", canonical, "Hyperline", null, "агент");
+        db.Add(alias);
+        await db.SaveChangesAsync();
+        Assert.Equal(2, (await FindingsAsync(scope, (await runner.RunAsync(definition.Id)).Id)).Count);
+
+        alias.Review(AliasStatus.Confirmed, "Одно и то же", "alex");
+        db.Update(alias);
+        await db.SaveChangesAsync();
+
+        var after = await FindingsAsync(scope, (await runner.RunAsync(definition.Id)).Id);
+        var merged = Assert.Single(after);
+        Assert.Equal(FindingStatus.Match, merged.Status);
+        Assert.Equal(10, merged.LeftValue);   // 4 + 6 сложились в одну позицию
+        Assert.Equal(10, merged.RightValue);
+    }
+
     [Fact]
     public async Task BrokenSpec_FailsRunVisibly_InsteadOfEmptyResult()
     {

--- a/src/server/BHS.CRG.Tests/Reconciliation/AliasResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Reconciliation/AliasResolverTests.cs
@@ -1,0 +1,50 @@
+using BHS.CRG.Infrastructure.Reconciliation;
+
+namespace BHS.CRG.Tests.Reconciliation;
+
+/// <summary>
+/// Сведение ключа по алиасам (issue #446). Ошибка здесь либо не сводит позиции, которые человек уже
+/// связал, либо вешает прогон на цикле.
+/// </summary>
+public class AliasResolverTests
+{
+    private static AliasResolver Of(params (string From, string To)[] pairs)
+        => new(pairs.ToDictionary(p => p.From, p => p.To, StringComparer.Ordinal));
+
+    [Fact]
+    public void UnknownKey_StaysAsIs() => Assert.Equal("а", Of(("б", "в")).Resolve("а"));
+
+    [Fact]
+    public void DirectAlias_IsApplied() => Assert.Equal("канон", Of(("вариант", "канон")).Resolve("вариант"));
+
+    /// <summary>
+    /// Человек неизбежно заведёт А→Б, а потом Б→В. Остановившись на первом шаге, мы дали бы две
+    /// позиции там, где он ожидает одну.
+    /// </summary>
+    [Fact]
+    public void Chain_IsResolvedTransitively()
+        => Assert.Equal("в", Of(("а", "б"), ("б", "в")).Resolve("а"));
+
+    /// <summary>Цикл — ошибка данных, но прогон он вешать не должен.</summary>
+    [Theory]
+    [InlineData("а")]
+    [InlineData("б")]
+    public void Cycle_DoesNotHang(string start)
+    {
+        var resolved = Of(("а", "б"), ("б", "а")).Resolve(start);
+        Assert.Contains(resolved, new[] { "а", "б" });
+    }
+
+    [Fact]
+    public void SelfCycle_DoesNotHang() => Assert.Equal("а", Of(("а", "а")).Resolve("а"));
+
+    [Fact]
+    public void Empty_IsPassthrough() => Assert.Equal("что угодно", AliasResolver.Empty.Resolve("что угодно"));
+
+    [Fact]
+    public void RepeatedResolve_IsStable()
+    {
+        var r = Of(("а", "б"), ("б", "в"));
+        Assert.Equal(r.Resolve("а"), r.Resolve("а"));
+    }
+}


### PR DESCRIPTION
Closes #446 · первая часть Ф2 из #414

Позиция, названная в двух документах по-разному, давала две находки-сироты: «нет слева» и «нет справа». В ручном процессе это разрешается знанием человека — «Hyperline CM-1U-ML» и «Органайзер СвязьСтройДеталь» суть одно и то же.

## Применяются только подтверждённые — и это несущее ограничение

Не удобство: предложенный, но не подтверждённый алиас, попавший в путь сравнения, и есть модель внутри арифметики — риск **P1**, ради которого весь Ф1 строился детерминированным. Отчёт начал бы меняться сам по себе.

Интеграционный тест проходит всю цепочку на одних данных:

```
без алиаса                      → 2 находки-сироты
алиас предложен, не подтверждён → по-прежнему 2 (модель в сравнение не пускаем)
алиас подтверждён               → 1 находка, слева 10 (4 + 6 сложились), справа 10, Совпадает
```

## Решения

**Применяется на свёртке, до сравнения.** После сравнения сопоставление ключей ничего бы не дало: количества так и остались бы в двух разных позициях.

**Резолв транзитивный.** Человек неизбежно заведёт А→Б, а следом Б→В; остановившись на первом шаге, мы дали бы две позиции там, где он ожидает одну. Цикл при этом прогон не вешает — обход помнит пройденное, и это проверено отдельно.

**Уникальность по ключу варианта.** Два разных канона у одного ключа сделали бы результат прогона зависящим от порядка выборки.

**Область общая**, не привязанная к сверке: алиас — утверждение о мире, а не свойство одного сравнения.

## В интерфейсе

Связывание прямо из списка находок: у несопоставленных позиций появляется выбор, отметил две — «Связать». Отдельный раздел «Алиасы позиций» со статусами «Применяется» / «Предложено» / «Отклонено».

Разрыв связи предупреждает прямо: «в следующем прогоне эти позиции снова разъедутся». Последствие проявится не сразу, и человек должен понимать, что делает.

## Вне этой части

Предложения алиасов от ИИ-агента через MCP и чтение находок сверки агентом — следующей частью. Здесь алиасы заводит человек, и структура под предложения уже есть (статус «Предложено», поле «кто предложил»).

## Проверка

- `dotnet test` — 656 зелёных (+9); `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём: раздел открывается, ошибок страницы нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
