### PR TITLE
feat(reconciliation): свод по нескольким источникам (#450)

### DIFF
--- a/src/client/src/features/reconciliations/ReconciliationEditor.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationEditor.tsx
@@ -6,10 +6,12 @@ import { Select, SelectItem } from '@/shared/ui/Select';
 import { useToast } from '@/shared/ui/Toast';
 import { useListDataSetFiles } from '@/shared/api/datasets';
 import type { DataSetSource } from '@/shared/api/types';
+import { Plus, Trash2 } from 'lucide-react';
 import {
   useCreateReconciliation, useUpdateReconciliation,
-  OPERATOR_LABELS,
-  type ComparisonOperator, type Reconciliation, type ReconciliationSide, type ToleranceKind,
+  OPERATOR_LABELS, sidePartsOf,
+  type ComparisonOperator, type Reconciliation, type ReconciliationSide, type SideSource,
+  type ToleranceKind,
 } from '@/shared/api/reconciliations';
 
 /**
@@ -20,7 +22,7 @@ import {
  * за реальное расхождение.
  */
 
-const EMPTY_SIDE: ReconciliationSide = { sourceId: '', keyColumns: [], valueColumn: '' };
+const EMPTY_PART: SideSource = { sourceId: '', keyColumns: [], valueColumn: '' };
 
 function columnsOf(source: DataSetSource | undefined): string[] {
   if (!source?.cachedSchema) return [];
@@ -34,39 +36,43 @@ function columnsOf(source: DataSetSource | undefined): string[] {
   }
 }
 
-function SideEditor({ title, side, onChange, sources }: {
-  title: string;
-  side: ReconciliationSide;
-  onChange: (s: ReconciliationSide) => void;
+function PartEditor({ part, onChange, onRemove, sources, index }: {
+  part: SideSource;
+  onChange: (p: SideSource) => void;
+  onRemove?: () => void;
   sources: { source: DataSetSource; fileName: string }[];
+  index: number;
 }) {
-  const current = sources.find(s => s.source.id === side.sourceId)?.source;
+  const current = sources.find(s => s.source.id === part.sourceId)?.source;
   const columns = columnsOf(current);
 
   function toggleKey(col: string) {
     // Порядок значим: стороны обязаны перечислять ключевые колонки согласованно, иначе ключи не сойдутся.
     onChange({
-      ...side,
-      keyColumns: side.keyColumns.includes(col)
-        ? side.keyColumns.filter(c => c !== col)
-        : [...side.keyColumns, col],
+      ...part,
+      keyColumns: part.keyColumns.includes(col)
+        ? part.keyColumns.filter(c => c !== col)
+        : [...part.keyColumns, col],
     });
   }
 
   return (
-    <div className="space-y-3 rounded-lg border border-stroke p-3">
-      <div className="text-xs font-semibold uppercase tracking-wide text-fg4">{title}</div>
+    <div className="space-y-2 rounded-md bg-muted/40 p-2">
+      <div className="flex items-center gap-2">
+        <Select value={part.sourceId} onValueChange={v => onChange({ ...EMPTY_PART, sourceId: v })}
+          placeholder="Источник данных" aria-label={`Источник ${index + 1}`} className="flex-1">
+          {sources.map(({ source, fileName }) => (
+            <SelectItem key={source.id} value={source.id}>{fileName} — {source.name}</SelectItem>
+          ))}
+        </Select>
+        {onRemove && (
+          <Button variant="text" size="sm" danger onClick={onRemove} aria-label="Убрать источник">
+            <Trash2 size={14} />
+          </Button>
+        )}
+      </div>
 
-      <Select value={side.sourceId} onValueChange={v => onChange({ ...EMPTY_SIDE, sourceId: v })}
-        placeholder="Источник данных" aria-label={`${title}: источник`}>
-        {sources.map(({ source, fileName }) => (
-          <SelectItem key={source.id} value={source.id}>
-            {fileName} — {source.name}
-          </SelectItem>
-        ))}
-      </Select>
-
-      {side.sourceId && columns.length === 0 && (
+      {part.sourceId && columns.length === 0 && (
         <p className="text-xs text-danger">У источника нет разобранной схемы — колонки не выбрать.</p>
       )}
 
@@ -74,17 +80,17 @@ function SideEditor({ title, side, onChange, sources }: {
         <>
           <div>
             <div className="text-xs text-fg3 mb-1">
-              Ключевые колонки {side.keyColumns.length > 0 && (
-                <span className="text-fg4">— порядок: {side.keyColumns.join(' + ')}</span>
+              Ключевые колонки {part.keyColumns.length > 0 && (
+                <span className="text-fg4">— порядок: {part.keyColumns.join(' + ')}</span>
               )}
             </div>
             <div className="flex flex-wrap gap-1">
               {columns.map(c => {
-                const on = side.keyColumns.includes(c);
+                const on = part.keyColumns.includes(c);
                 return (
                   <button key={c} type="button" onClick={() => toggleKey(c)}
                     className={`text-xs px-2 py-1 rounded-full transition-colors ${
-                      on ? 'bg-brand-subtle text-brand font-medium' : 'bg-muted text-fg3 hover:text-fg1'}`}>
+                      on ? 'bg-brand-subtle text-brand font-medium' : 'bg-base text-fg3 hover:text-fg1'}`}>
                     {c}
                   </button>
                 );
@@ -92,14 +98,41 @@ function SideEditor({ title, side, onChange, sources }: {
             </div>
           </div>
 
-          <div>
-            <div className="text-xs text-fg3 mb-1">Колонка количества (строки с одним ключом суммируются)</div>
-            <Select value={side.valueColumn} onValueChange={v => onChange({ ...side, valueColumn: v })}
-              placeholder="Выберите колонку" aria-label={`${title}: количество`}>
-              {columns.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
-            </Select>
-          </div>
+          <Select value={part.valueColumn} onValueChange={v => onChange({ ...part, valueColumn: v })}
+            placeholder="Колонка количества" aria-label={`Количество ${index + 1}`}>
+            {columns.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+          </Select>
         </>
+      )}
+    </div>
+  );
+}
+
+function SideEditor({ title, parts, onChange, sources }: {
+  title: string;
+  parts: SideSource[];
+  onChange: (p: SideSource[]) => void;
+  sources: { source: DataSetSource; fileName: string }[];
+}) {
+  return (
+    <div className="space-y-2 rounded-lg border border-stroke p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-fg4">{title}</span>
+        <Button variant="text" size="sm" onClick={() => onChange([...parts, EMPTY_PART])}>
+          <Plus size={14} /> Источник
+        </Button>
+      </div>
+
+      {parts.map((part, i) => (
+        <PartEditor key={i} part={part} index={i} sources={sources}
+          onChange={p => onChange(parts.map((x, xi) => xi === i ? p : x))}
+          onRemove={parts.length > 1 ? () => onChange(parts.filter((_, xi) => xi !== i)) : undefined} />
+      ))}
+
+      {parts.length > 1 && (
+        <p className="text-[11px] text-fg4">
+          Количества по одной позиции складываются по всем источникам стороны.
+        </p>
       )}
     </div>
   );
@@ -114,8 +147,10 @@ export function ReconciliationEditor({ existing, onClose }: {
   const update = useUpdateReconciliation();
 
   const [name, setName] = useState(existing?.name ?? '');
-  const [left, setLeft] = useState<ReconciliationSide>(existing?.spec.left ?? EMPTY_SIDE);
-  const [right, setRight] = useState<ReconciliationSide>(existing?.spec.right ?? EMPTY_SIDE);
+  const [left, setLeft] = useState<SideSource[]>(
+    existing ? sidePartsOf(existing.spec.left) : [EMPTY_PART]);
+  const [right, setRight] = useState<SideSource[]>(
+    existing ? sidePartsOf(existing.spec.right) : [EMPTY_PART]);
   const [operator, setOperator] = useState<ComparisonOperator>(
     existing?.spec.comparison.operator ?? 'GreaterOrEqual');
   const [tolerance, setTolerance] = useState(String(existing?.spec.comparison.tolerance ?? 0));
@@ -129,13 +164,16 @@ export function ReconciliationEditor({ existing, onClose }: {
     () => files.flatMap(f => (f.sources ?? []).map(s => ({ source: s, fileName: f.name }))),
     [files]);
 
-  const valid = name.trim() !== ''
-    && left.sourceId && left.valueColumn && left.keyColumns.length > 0
-    && right.sourceId && right.valueColumn && right.keyColumns.length > 0;
+  const complete = (parts: SideSource[]) =>
+    parts.length > 0 && parts.every(p => p.sourceId && p.valueColumn && p.keyColumns.length > 0);
+  const valid = name.trim() !== '' && complete(left) && complete(right);
 
   async function save() {
+    // Первый источник дублируется в поля стороны: их читают спеки прежней формы, и терять
+    // совместимость ради формы записи незачем.
+    const side = (parts: SideSource[]): ReconciliationSide => ({ ...parts[0], sources: parts });
     const spec = {
-      left, right,
+      left: side(left), right: side(right),
       comparison: { operator, tolerance: Number(tolerance) || 0, toleranceKind },
     };
     setBusy(true);
@@ -163,8 +201,8 @@ export function ReconciliationEditor({ existing, onClose }: {
           hint="Например: Кабель — проложено против реестра материалов" />
 
         <div className="grid grid-cols-2 gap-3">
-          <SideEditor title="Слева" side={left} onChange={setLeft} sources={sources} />
-          <SideEditor title="Справа" side={right} onChange={setRight} sources={sources} />
+          <SideEditor title="Слева" parts={left} onChange={setLeft} sources={sources} />
+          <SideEditor title="Справа" parts={right} onChange={setRight} sources={sources} />
         </div>
 
         <div className="rounded-lg border border-stroke p-3 space-y-3">

--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '@/shared/hooks/useAuth';
 import {
   useReconciliations, useReconciliationRuns, useFindings, useRunReconciliation,
   useDeleteReconciliation, useSetDecision, useRemoveDecision, downloadDiscrepancyReport,
-  useAliases, useCreateAlias, isUnmatched,
+  useAliases, useCreateAlias, isUnmatched, provenanceSummary,
   STATUS_LABELS, DECISION_LABELS, needsAttention, runSummary,
   type Finding, type ReconciliationRun,
 } from '@/shared/api/reconciliations';
@@ -83,8 +83,8 @@ function FindingRow({ f, onDecide, linkable, checked, onToggle }: {
       </div>
       <div className="flex items-center gap-3 mt-0.5 text-[11px] text-fg4">
         {/* Провенанс: без него находку нельзя проверить глазами по документу. */}
-        {left && <span>слева: {left.column}, строк {left.rows.length}</span>}
-        {right && <span>справа: {right.column}, строк {right.rows.length}</span>}
+        {provenanceSummary(left) && <span>слева: {provenanceSummary(left)}</span>}
+        {provenanceSummary(right) && <span>справа: {provenanceSummary(right)}</span>}
         {f.decision && (
           <span className="text-fg3">
             {DECISION_LABELS[f.decision.kind]}

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -15,13 +15,29 @@ export type FindingStatus = 'Match' | 'Mismatch' | 'MissingLeft' | 'MissingRight
 export type DecisionKind = 'Accepted' | 'Suppressed';
 export type RunStatus = 'Running' | 'Completed' | 'Failed';
 
-/** Одна сторона: источник и что из него брать. Строки с одним ключом суммируются. */
-export interface ReconciliationSide {
+/**
+ * Один источник в составе стороны. Колонки у каждого СВОИ: листы шкафов называют их по-разному, и
+ * требовать единообразия значило бы заставить править исходники ради сверки.
+ */
+export interface SideSource {
   sourceId: string;
   /** Колонки доменного ключа. Порядок значим — стороны обязаны перечислять их согласованно. */
   keyColumns: string[];
   valueColumn: string;
   labelColumn?: string | null;
+}
+
+/** Одна сторона: её источники. Строки с одним ключом суммируются по ВСЕМ источникам стороны. */
+export interface ReconciliationSide extends SideSource {
+  /** Свод по нескольким источникам (#450). Пусто — сторона одиночная, как в старых спеках. */
+  sources?: SideSource[] | null;
+}
+
+/** Источники стороны с учётом старой формы записи: спеки в БД её ещё используют. */
+export function sidePartsOf(side: ReconciliationSide): SideSource[] {
+  return side.sources && side.sources.length > 0
+    ? side.sources
+    : [{ sourceId: side.sourceId, keyColumns: side.keyColumns, valueColumn: side.valueColumn }];
 }
 
 export interface ComparisonRule {
@@ -75,6 +91,23 @@ export interface FindingSideProvenance {
   column: string;
   /** Номера строк источника, сложившихся в эту позицию. */
   rows: number[];
+  /** Все источники свода (#450). Пусто — находка записана до свода, читаем поля выше. */
+  parts?: { sourceId: string; column: string; rows: number[] }[] | null;
+}
+
+/**
+ * Сколько строк и из скольких источников собралась сторона. Свод из четырёх листов, показанный одним
+ * первым источником, был бы молча неполон.
+ */
+export function provenanceSummary(side: FindingSideProvenance | null): string | null {
+  if (!side) return null;
+  const parts = side.parts && side.parts.length > 0
+    ? side.parts
+    : [{ sourceId: side.sourceId, column: side.column, rows: side.rows }];
+  const rows = parts.reduce((n, p) => n + (p.rows?.length ?? 0), 0);
+  return parts.length > 1
+    ? `${parts.length} источника, строк ${rows}`
+    : `${parts[0].column}, строк ${rows}`;
 }
 
 export interface Finding {

--- a/src/server/BHS.CRG.Application/Reconciliation/DiscrepancyReport.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/DiscrepancyReport.cs
@@ -133,21 +133,35 @@ public static class DiscrepancyReport
             rows, preamble);
     }
 
-    /// <summary>Провенанс находки человеческим текстом: голый JSON в отчёте бесполезен.</summary>
+    /// <summary>
+    /// Провенанс находки человеческим текстом: голый JSON в отчёте бесполезен.
+    ///
+    /// Предпочитаем список частей: свод из четырёх листов, показанный одним первым источником, был бы
+    /// молча неполон — а провенанс существует ровно затем, чтобы находку можно было проверить глазами.
+    /// Прежняя форма читается для находок, записанных до #450.
+    /// </summary>
     private static string Provenance(JsonDocument provenance)
     {
         var parts = new List<string>();
-        foreach (var side in (string[])["left", "right"])
+        foreach (var (key, caption) in new[] { ("left", "слева"), ("right", "справа") })
         {
-            if (!provenance.RootElement.TryGetProperty(side, out var s)
-                || s.ValueKind != JsonValueKind.Object) continue;
+            if (!provenance.RootElement.TryGetProperty(key, out var side)
+                || side.ValueKind != JsonValueKind.Object) continue;
 
-            var column = s.TryGetProperty("column", out var c) ? c.GetString() : null;
-            var rows = s.TryGetProperty("rows", out var r) && r.ValueKind == JsonValueKind.Array
-                ? r.GetArrayLength() : 0;
-            parts.Add($"{(side == "left" ? "слева" : "справа")}: {column}, строк {rows}");
+            var described = side.TryGetProperty("parts", out var list) && list.ValueKind == JsonValueKind.Array
+                ? string.Join(", ", list.EnumerateArray().Select(Describe))
+                : Describe(side);
+            if (!string.IsNullOrWhiteSpace(described)) parts.Add($"{caption}: {described}");
         }
         return string.Join("; ", parts);
+    }
+
+    private static string Describe(JsonElement part)
+    {
+        var column = part.TryGetProperty("column", out var c) ? c.GetString() : null;
+        var rows = part.TryGetProperty("rows", out var r) && r.ValueKind == JsonValueKind.Array
+            ? r.GetArrayLength() : 0;
+        return $"{column}, строк {rows}";
     }
 
     /// <summary>Ссылки замечания человеческим текстом.</summary>

--- a/src/server/BHS.CRG.Application/Reconciliation/ReconciliationSpec.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ReconciliationSpec.cs
@@ -23,8 +23,29 @@ public enum ToleranceKind { Absolute, Percent }
 /// стороны обязаны перечислять их согласованно, иначе ключи не сойдутся.</param>
 /// <param name="ValueColumn">Колонка количества. Строки с одинаковым ключом суммируются: в кабельном
 /// журнале одна марка идёт десятком линий, и сравнивать надо итог по марке, а не отдельные строки.</param>
+/// <param name="Sources">Свод по нескольким источникам (issue #450): «сумма по четырём листам шкафов
+/// против сводной спецификации». Задан — <paramref name="SourceId"/> и колонки рядом игнорируются.</param>
 /// <param name="LabelColumn">Чем позицию назвать человеку. Пусто — берётся первая ключевая колонка.</param>
 public record ReconciliationSide(
+    Guid SourceId,
+    IReadOnlyList<string> KeyColumns,
+    string ValueColumn,
+    string? LabelColumn = null,
+    IReadOnlyList<SideSource>? Sources = null)
+{
+    /// <summary>
+    /// Источники стороны с их колонками. Пусто — сторона одиночная, как и была: спеки уже лежат в БД
+    /// со старым полем, и ломать их ради формы записи нельзя.
+    /// </summary>
+    public IReadOnlyList<SideSource> EffectiveSources =>
+        Sources is { Count: > 0 } ? Sources : [new SideSource(SourceId, KeyColumns, ValueColumn, LabelColumn)];
+}
+
+/// <summary>
+/// Один источник в составе стороны (issue #450). Колонки у каждого СВОИ: листы шкафов называют их
+/// по-разному, и требовать единообразия значило бы заставить пользователя править исходники ради сверки.
+/// </summary>
+public record SideSource(
     Guid SourceId,
     IReadOnlyList<string> KeyColumns,
     string ValueColumn,

--- a/src/server/BHS.CRG.Infrastructure/Reconciliation/ReconciliationRunner.cs
+++ b/src/server/BHS.CRG.Infrastructure/Reconciliation/ReconciliationRunner.cs
@@ -19,11 +19,12 @@ public class ReconciliationRunner(
 
     /// <summary>Сторона, сведённая к «ключ → итог»: значения строк с одним ключом просуммированы,
     /// номера исходных строк сохранены для провенанса.</summary>
+    /// <summary>Строки одного источника, попавшие в позицию: своей колонкой и своими номерами.</summary>
+    private sealed record PartRows(Guid SourceId, string ValueColumn, List<int> Rows);
+
     private sealed record SideTotals(
-        Guid SourceId,
-        string ValueColumn,
         Dictionary<string, double> Values,
-        Dictionary<string, List<int>> Rows,
+        Dictionary<string, List<PartRows>> Parts,
         Dictionary<string, string> Labels);
 
     public async Task<ReconciliationRun> RunAsync(Guid definitionId, CancellationToken ct = default)
@@ -90,43 +91,54 @@ public class ReconciliationRunner(
         return new AliasResolver(map);
     }
 
+    /// <summary>
+    /// Свод стороны: количества по одному ключу суммируются по ВСЕМ её источникам (issue #450) —
+    /// «сумма по четырём листам шкафов». У каждого источника свои колонки.
+    ///
+    /// Строки берутся после всей обработки источника — тем же путём, которым их видит генерация.
+    /// </summary>
     private async Task<SideTotals> TotalsAsync(
         ReconciliationSide side, AliasResolver aliases, CancellationToken ct)
     {
-        var source = await db.DataSetSources.AsNoTracking().Include(s => s.File)
-            .FirstOrDefaultAsync(s => s.Id == side.SourceId, ct)
-            ?? throw new InvalidOperationException($"Источник {side.SourceId} не найден.");
-
-        var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
-
         var values = new Dictionary<string, double>();
-        var rowNumbers = new Dictionary<string, List<int>>();
+        var parts = new Dictionary<string, List<PartRows>>();
         var labels = new Dictionary<string, string>();
 
-        for (var i = 0; i < rows.Count; i++)
+        foreach (var part in side.EffectiveSources)
         {
-            var row = rows[i];
-            var rawKey = ReconciliationKeys.Build(side.KeyColumns.Select(c => row.GetValueOrDefault(c)));
-            if (ReconciliationKeys.IsEmpty(rawKey)) continue; // сопоставлять нечего — это шум, не находка
-            var key = aliases.Resolve(rawKey);
+            var source = await db.DataSetSources.AsNoTracking().Include(s => s.File)
+                .FirstOrDefaultAsync(s => s.Id == part.SourceId, ct)
+                ?? throw new InvalidOperationException($"Источник {part.SourceId} не найден.");
 
-            // Отсутствие значения не то же самое, что ноль: незаполненная ячейка не делает позицию
-            // нулевой, но и не отменяет её присутствия в документе.
-            values[key] = values.GetValueOrDefault(key)
-                + (QuantityParser.Parse(row.GetValueOrDefault(side.ValueColumn)) ?? 0);
+            var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
 
-            if (!rowNumbers.TryGetValue(key, out var list)) rowNumbers[key] = list = [];
-            list.Add(i);
-
-            if (!labels.ContainsKey(key))
+            for (var i = 0; i < rows.Count; i++)
             {
-                var labelColumn = side.LabelColumn ?? side.KeyColumns.FirstOrDefault();
-                var label = labelColumn is null ? null : row.GetValueOrDefault(labelColumn);
-                labels[key] = string.IsNullOrWhiteSpace(label) ? key : label;
+                var row = rows[i];
+                var rawKey = ReconciliationKeys.Build(part.KeyColumns.Select(c => row.GetValueOrDefault(c)));
+                if (ReconciliationKeys.IsEmpty(rawKey)) continue; // сопоставлять нечего — это шум, не находка
+                var key = aliases.Resolve(rawKey);
+
+                // Отсутствие значения не то же самое, что ноль: незаполненная ячейка не делает позицию
+                // нулевой, но и не отменяет её присутствия в документе.
+                values[key] = values.GetValueOrDefault(key)
+                    + (QuantityParser.Parse(row.GetValueOrDefault(part.ValueColumn)) ?? 0);
+
+                if (!parts.TryGetValue(key, out var list)) parts[key] = list = [];
+                var slot = list.FirstOrDefault(p => p.SourceId == part.SourceId);
+                if (slot is null) list.Add(slot = new PartRows(part.SourceId, part.ValueColumn, []));
+                slot.Rows.Add(i);
+
+                if (!labels.ContainsKey(key))
+                {
+                    var labelColumn = part.LabelColumn ?? part.KeyColumns.FirstOrDefault();
+                    var label = labelColumn is null ? null : row.GetValueOrDefault(labelColumn);
+                    labels[key] = string.IsNullOrWhiteSpace(label) ? key : label;
+                }
             }
         }
 
-        return new SideTotals(source.Id, side.ValueColumn, values, rowNumbers, labels);
+        return new SideTotals(values, parts, labels);
     }
 
     private static IEnumerable<ReconciliationFinding> Compare(
@@ -170,8 +182,13 @@ public class ReconciliationRunner(
         };
     }
 
-    /// <summary>Файл, источник, колонка и номера строк по каждой стороне — то, что модель честно
-    /// может дать. До ячейки не дотягиваем и не обещаем (P3 в #414).</summary>
+    /// <summary>
+    /// Провенанс: по каждой стороне — все источники, из которых собралась позиция. Свод из четырёх
+    /// листов обязан назвать все четыре, иначе расхождение не проверить глазами, а это единственное,
+    /// ради чего провенанс существует.
+    ///
+    /// До ячейки не дотягиваем и не обещаем (P3 в #414): строки из PDF приходят от зрительной модели.
+    /// </summary>
     private static JsonDocument Provenance(string key, SideTotals left, SideTotals right)
         => JsonSerializer.SerializeToDocument(new
         {
@@ -180,7 +197,17 @@ public class ReconciliationRunner(
         }, Json);
 
     private static object? SideProvenance(string key, SideTotals side)
-        => side.Rows.TryGetValue(key, out var rows)
-            ? new { sourceId = side.SourceId, column = side.ValueColumn, rows }
-            : null;
+    {
+        if (!side.Parts.TryGetValue(key, out var parts) || parts.Count == 0) return null;
+
+        var list = parts.Select(p => new { sourceId = p.SourceId, column = p.ValueColumn, rows = p.Rows }).ToList();
+        // Одиночный источник пишем и прежней формой: её читают уже сохранённые находки, экран и отчёт.
+        return new
+        {
+            sourceId = parts[0].SourceId,
+            column = parts[0].ValueColumn,
+            rows = parts[0].Rows,
+            parts = list,
+        };
+    }
 }

--- a/src/server/BHS.CRG.Tests/Integration/ReconciliationRunnerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ReconciliationRunnerTests.cs
@@ -257,6 +257,94 @@ public class ReconciliationRunnerTests(IntegrationTestFixture fixture) : IAsyncL
         Assert.Equal(10, merged.RightValue);
     }
 
+    /// <summary>
+    /// Свод по нескольким источникам (issue #450) — «сумма по четырём листам шкафов против сводной».
+    /// У каждого источника СВОИ колонки: листы называют их по-разному, и требовать единообразия
+    /// значило бы заставить править исходники ради сверки.
+    /// </summary>
+    [Fact]
+    public async Task MultipleSources_AreSummedIntoOnePosition()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var sheet1 = await SeedCsvAsync(scope, "Шкаф 1", """
+            Марка,Кол
+            Автомат C16,3
+            """, ["Марка", "Кол"]);
+        var sheet2 = await SeedCsvAsync(scope, "Шкаф 2", """
+            Позиция,Штук
+            Автомат C16,5
+            """, ["Позиция", "Штук"]);
+        var summary = await SeedCsvAsync(scope, "Сводная", """
+            Марка,Кол
+            Автомат C16,8
+            """, ["Марка", "Кол"]);
+
+        var spec = new ReconciliationSpec(
+            new ReconciliationSide(Guid.Empty, [], "", null,
+            [
+                new SideSource(sheet1, ["Марка"], "Кол"),
+                new SideSource(sheet2, ["Позиция"], "Штук"),
+            ]),
+            new ReconciliationSide(summary, ["Марка"], "Кол"),
+            new ComparisonRule(ComparisonOperator.Equal));
+
+        var definition = ReconciliationDefinition.Create("Свод шкафов", CatalogScope.System, null,
+            JsonSerializer.SerializeToDocument(spec, Json));
+        db.Add(definition);
+        await db.SaveChangesAsync();
+
+        var run = await scope.ServiceProvider.GetRequiredService<IReconciliationRunner>()
+            .RunAsync(definition.Id);
+        Assert.Equal(ReconciliationRunStatus.Completed, run.Status);
+
+        var finding = Assert.Single(await FindingsAsync(scope, run.Id));
+        Assert.Equal(FindingStatus.Match, finding.Status);
+        Assert.Equal(8, finding.LeftValue); // 3 + 5 из двух листов
+        Assert.Equal(8, finding.RightValue);
+
+        // Позиция, собранная из двух листов, обязана назвать оба: иначе расхождение не проверить.
+        var parts = finding.Provenance.RootElement.GetProperty("left").GetProperty("parts");
+        Assert.Equal(2, parts.GetArrayLength());
+        Assert.Contains(parts.EnumerateArray(), p => p.GetProperty("column").GetString() == "Кол");
+        Assert.Contains(parts.EnumerateArray(), p => p.GetProperty("column").GetString() == "Штук");
+    }
+
+    /// <summary>Спеки уже лежат в БД с одиночным источником — ломать их ради формы записи нельзя.</summary>
+    [Fact]
+    public async Task LegacySingleSourceSpec_StillWorks()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var left = await SeedCsvAsync(scope, "Слева", """
+            Марка,Кол
+            А,5
+            """, ["Марка", "Кол"]);
+        var right = await SeedCsvAsync(scope, "Справа", """
+            Марка,Кол
+            А,5
+            """, ["Марка", "Кол"]);
+
+        // Спека В ТОЧНОСТИ прежней формы — без поля sources.
+        var raw = $$$"""
+            {"left":{"sourceId":"{{{left}}}","keyColumns":["Марка"],"valueColumn":"Кол"},
+             "right":{"sourceId":"{{{right}}}","keyColumns":["Марка"],"valueColumn":"Кол"},
+             "comparison":{"operator":"Equal","tolerance":0,"toleranceKind":"Absolute"}}
+            """;
+        var definition = ReconciliationDefinition.Create("Старая спека", CatalogScope.System, null,
+            JsonDocument.Parse(raw));
+        db.Add(definition);
+        await db.SaveChangesAsync();
+
+        var run = await scope.ServiceProvider.GetRequiredService<IReconciliationRunner>()
+            .RunAsync(definition.Id);
+
+        Assert.Equal(ReconciliationRunStatus.Completed, run.Status);
+        Assert.Equal(FindingStatus.Match, Assert.Single(await FindingsAsync(scope, run.Id)).Status);
+    }
+
     [Fact]
     public async Task BrokenSpec_FailsRunVisibly_InsteadOfEmptyResult()
     {


### PR DESCRIPTION
Closes #450 · последняя часть Ф3 из #414

Закрывает трудный кусок ручного процесса: **«сумма по четырём листам шкафов == сводная спецификация == реестр материалов»**. Сторона сверки была ровно одним источником, поэтому свод собрать было нечем.

## Живая проверка на реальных источниках

Свод двух списков против третьего:

```
свод: совпало=0 расхождений=130 нет слева=0 нет справа=1
пример: Автоматический выключатель дифференциальн…  слева=4  справа=2
части слева: [('Кол-во', 1), ('Кол-во', 1)]
```

Слева 4 — это 2 + 2 из двух источников; справа 2. Провенанс называет обе части.

## Решения

**У каждого источника свои колонки.** Листы шкафов называют их по-разному, и требовать единообразия значило бы заставить пользователя править исходники ради сверки. Тест это и проверяет: `Марка/Кол` и `Позиция/Штук` складываются в одну позицию.

**Совместимость.** Новое поле необязательное: пусто — сторона работает как раньше. Спеки уже лежат в БД со старым одиночным источником, ломать их ради формы записи нельзя. Отдельный тест гоняет спеку **в точности прежнего вида**, без поля `sources`.

**Провенанс перечисляет все источники позиции.** Свод из четырёх листов, показанный одним первым, был бы молча неполон — а провенанс существует ровно затем, чтобы находку можно было проверить глазами.

Читатели — экран и отчёт — понимают и прежнюю форму: уже записанные находки иначе стали бы непроверяемыми. Тот же приём, что с развёрнутыми ссылками замечаний в #442.

## В интерфейсе

В редакторе сверки у каждой стороны кнопка «Источник»: добавили второй — колонки выбираются отдельно для него. При двух и более подписано, что количества складываются.

## Проверка

- `dotnet test` — 662 зелёных (+2); `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём: свод суммирует, провенанс называет обе части. Пробная сверка за собой удалена.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
