### PR TITLE
feat(reconciliation): проблемы сверки на странице комплекта (#452)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, useNavigate, useParams, useSearchParams, Link } from 're
 import {
   Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy, FolderInput, FolderOutput,
   ArrowUp, ArrowDown, Layers, Building2, FileText, Search, X, Mail, Database, Table2, Users,
+  AlertTriangle,
 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
@@ -18,6 +19,8 @@ import { CopyDocumentDialog } from './CopyDocumentDialog';
 import { MoveDocumentDialog } from './MoveDocumentDialog';
 import { CatalogResource } from './catalog/CatalogResource';
 import { DataSetsResource } from '@/features/datasets/DataSetsResource';
+import { SetProblemsPanel } from './SetProblemsPanel';
+import { useRelatedProblems } from '@/shared/api/reconciliations';
 import { SubscribersResource } from './SubscribersResource';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -42,16 +45,17 @@ import { useAuth } from '@/shared/hooks/useAuth';
 
 // ─── Set detail (documents) ───────────────────────────────────────────────────
 
-type SetPanel = 'documents' | 'catalog' | 'datasets' | 'subscribers';
+type SetPanel = 'documents' | 'catalog' | 'datasets' | 'subscribers' | 'issues';
 
 function SetDetail() {
   const { constructionId, setId, panel } = useParams<{ constructionId: string; setId: string; panel?: string }>();
   const navigate = useNavigate();
-  const activePanel: SetPanel = (['catalog', 'datasets', 'subscribers'].includes(panel ?? '') ? panel : 'documents') as SetPanel;
+  const activePanel: SetPanel = (['catalog', 'datasets', 'subscribers', 'issues'].includes(panel ?? '') ? panel : 'documents') as SetPanel;
   const { data: set, isLoading } = useGetDocumentSet(setId);
   const { data: construction } = useGetConstruction(constructionId!);
   const { data: allConstructions = [] } = useListConstructions();
   const { data: availableInstances = [] } = useGetAvailableInstances(setId);
+  const { data: problems } = useRelatedProblems('Set', setId);
   const { data: docTypes = [] } = useListDocumentTypes();
   const [addDocOpen, setAddDocOpen] = useState(false);
   const [editInstance, setEditInstance] = useState<DocumentInstance | null>(null);
@@ -199,6 +203,10 @@ function SetDetail() {
       <NavItem icon={<Database size={17} />} label="Каталог" active={activePanel === 'catalog'} onClick={() => goPanel('catalog')} />
       <NavItem icon={<Table2 size={17} />} label="Наборы данных" active={activePanel === 'datasets'} onClick={() => goPanel('datasets')} />
       <NavItem icon={<Users size={17} />} label="Подписчики" active={activePanel === 'subscribers'} onClick={() => goPanel('subscribers')} />
+      {/* Проблемы живут здесь, а не в разделе «Сверка»: комплект — тот уровень, где их разбирают. */}
+      <NavItem icon={<AlertTriangle size={17} />} label="Проблемы"
+        count={problems?.needsAttention || undefined}
+        active={activePanel === 'issues'} onClick={() => goPanel('issues')} />
     </div>
   );
 
@@ -354,6 +362,9 @@ function SetDetail() {
         ? <CatalogResource scope="Set" scopeId={setId ?? null} allDocTypes={docTypes} />
         : activePanel === 'datasets'
         ? <DataSetsResource scope="Set" scopeId={setId} />
+        : activePanel === 'issues'
+        ? <SetProblemsPanel setId={setId!} setName={set.name}
+            documentNames={new Map(set.instances.map(i => [i.id, i.name ?? '(без имени)']))} />
         : <div className="mx-auto max-w-5xl">
             {activePanel === 'documents' ? documentsContent
               : <SubscribersResource scope="Set" scopeId={setId!} />}

--- a/src/client/src/features/document-sets/SetProblemsPanel.tsx
+++ b/src/client/src/features/document-sets/SetProblemsPanel.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { Play, FileSpreadsheet, AlertTriangle, Bot, Scale } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { EmptyState } from '@/shared/ui/EmptyState';
+import { useToast } from '@/shared/ui/Toast';
+import {
+  useRelatedProblems, useRunReconciliation, useFindings,
+  downloadDiscrepancyReport, STATUS_LABELS, DECISION_LABELS, provenanceSummary, needsAttention,
+  type Finding,
+} from '@/shared/api/reconciliations';
+import { useObservations, SEVERITY_LABELS, OBSERVATION_STATUS_LABELS, isUnreviewed } from '@/shared/api/observations';
+
+/**
+ * Проблемы комплекта (issue #452) — дом подсистемы сверки в иерархии.
+ *
+ * Две подписанные секции, а НЕ общий список и не табы: находка сверки — результат арифметики
+ * системы, замечание — утверждение внешнего агента. Смешать их значило бы выдать одно за другое.
+ */
+
+function num(v: number | null): string {
+  return v == null ? '—' : String(Math.round(v * 1000) / 1000);
+}
+
+function FindingLine({ f }: { f: Finding }) {
+  const open = needsAttention(f);
+  return (
+    <div className={`px-3 py-2 border-b border-stroke text-sm ${open ? '' : 'opacity-60'}`}>
+      <div className="flex items-center gap-2">
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${
+          f.status === 'Match' ? 'text-fg4' : open ? 'bg-danger-subtle text-danger' : 'bg-muted text-fg3'}`}>
+          {f.resolved ? 'Устранено' : STATUS_LABELS[f.status]}
+        </span>
+        <span className="flex-1 truncate text-fg1" title={f.label}>{f.label}</span>
+        <span className="tabular-nums text-fg2 shrink-0">
+          {num(f.leftValue)} <span className="text-fg4">/</span> {num(f.rightValue)}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 mt-0.5 text-[11px] text-fg4">
+        {provenanceSummary(f.provenance.left) && <span>слева: {provenanceSummary(f.provenance.left)}</span>}
+        {provenanceSummary(f.provenance.right) && <span>справа: {provenanceSummary(f.provenance.right)}</span>}
+        {f.decision && <span className="text-fg3">{DECISION_LABELS[f.decision.kind]}</span>}
+      </div>
+    </div>
+  );
+}
+
+function ReconciliationBlock({ id, name, unresolved }: {
+  id: string; name: string; unresolved: number;
+}) {
+  const { data: findings = [] } = useFindings(id);
+  const run = useRunReconciliation();
+  const toast = useToast();
+  const [onlyOpen, setOnlyOpen] = useState(true);
+
+  const shown = onlyOpen ? findings.filter(needsAttention) : findings;
+
+  return (
+    <div className="border border-stroke rounded-lg overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 bg-muted/40">
+        <Scale size={14} className="text-fg4 shrink-0" />
+        <span className="flex-1 truncate text-sm font-medium text-fg1">{name}</span>
+        <button type="button" onClick={() => setOnlyOpen(v => !v)}
+          className={`text-[11px] px-2 py-0.5 rounded-full transition-colors ${
+            onlyOpen ? 'bg-brand-subtle text-brand font-medium' : 'text-fg3 hover:bg-base'}`}>
+          не разобрано: {unresolved}
+        </button>
+        <Button variant="text" size="sm" loading={run.isPending}
+          onClick={async () => {
+            const r = await run.mutateAsync(id);
+            if (r.status === 'Failed') toast.error(r.error ?? 'Прогон не выполнен');
+            else toast.success('Пересчитано');
+          }}>
+          <Play size={13} /> Прогнать
+        </Button>
+      </div>
+      {shown.length === 0
+        ? <p className="px-3 py-2 text-xs text-fg4">{onlyOpen ? 'Всё разобрано.' : 'Находок нет.'}</p>
+        : shown.map(f => <FindingLine key={f.id} f={f} />)}
+    </div>
+  );
+}
+
+export function SetProblemsPanel({ setId, setName, documentNames }: {
+  setId: string;
+  setName: string;
+  /** Имена документов комплекта: в ссылках замечаний иначе стоят нечитаемые идентификаторы. */
+  documentNames: Map<string, string>;
+}) {
+  const { data: problems } = useRelatedProblems('Set', setId);
+  const { data: observations = [] } = useObservations(setId);
+  const toast = useToast();
+  const [busy, setBusy] = useState(false);
+
+  const open = observations.filter(isUnreviewed);
+
+  return (
+    <div className="flex-1 min-w-0 overflow-y-auto p-4 space-y-5">
+      <div className="flex items-center gap-2">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-fg2">
+            {problems && problems.needsAttention > 0
+              ? <>Требует разбора: <b className="text-fg1">{problems.needsAttention}</b>
+                  <span className="text-fg4"> — {problems.unresolvedFindings} по сверке,
+                  {' '}{problems.unreviewedObservations} замечаний анализа</span></>
+              : 'Всё разобрано.'}
+          </p>
+        </div>
+        <Button variant="outlined" size="sm" loading={busy}
+          onClick={async () => {
+            setBusy(true);
+            try {
+              await downloadDiscrepancyReport(setId, setName);
+              toast.success('Отчёт выгружен');
+            } catch { toast.error('Не удалось выгрузить отчёт'); }
+            finally { setBusy(false); }
+          }}>
+          <FileSpreadsheet size={14} /> Отчёт
+        </Button>
+      </div>
+
+      {/* ── Арифметика системы ──────────────────────────────────────────────── */}
+      <section className="space-y-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-fg4">Находки сверки</h3>
+        {problems?.reconciliations.length
+          ? problems.reconciliations.map(r => (
+              <ReconciliationBlock key={r.id} id={r.id} name={r.name} unresolved={r.unresolvedFindings} />
+            ))
+          : (
+            <p className="text-sm text-fg4">
+              К этому комплекту сверки не относятся. Сверка привязывается к уровню через области
+              своих источников данных.
+            </p>
+          )}
+      </section>
+
+      {/* ── Утверждения агента ──────────────────────────────────────────────── */}
+      <section className="space-y-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-fg4 flex items-center gap-1.5">
+          <Bot size={13} /> Замечания анализа
+        </h3>
+        {/* Происхождение обязано быть видно рядом с данными: это утверждения, а не результат системы. */}
+        <p className="text-[11px] text-fg4 -mt-1">
+          Утверждения внешнего ИИ-агента. Система их не проверяла.
+        </p>
+
+        {observations.length === 0 && (
+          <EmptyState icon={<AlertTriangle size={28} />} title="Замечаний нет"
+            description="Здесь появятся находки внешнего агента, если попросить его записать их в журнал." />
+        )}
+
+        {observations.map(o => (
+          <div key={o.id} className={`px-3 py-2 border border-stroke rounded-lg ${
+            isUnreviewed(o) ? '' : 'opacity-60'}`}>
+            <div className="flex items-start gap-2">
+              <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 mt-0.5 ${
+                o.severity === 'Error' ? 'bg-warning-subtle text-warning' : 'bg-muted text-fg3'}`}>
+                {SEVERITY_LABELS[o.severity]}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm text-fg1">{o.title}</div>
+                {o.detail && <p className="text-xs text-fg3 mt-0.5 line-clamp-2">{o.detail}</p>}
+                {/* Имена документов, а не идентификаторы: «документ 77de9193» человеку ничего не говорит. */}
+                {(o.references.documentIds ?? []).length > 0 && (
+                  <p className="text-[11px] text-fg4 mt-1">
+                    {(o.references.documentIds ?? [])
+                      .map(id => documentNames.get(id) ?? `документ ${id.slice(0, 8)}`)
+                      .join(' · ')}
+                  </p>
+                )}
+              </div>
+              <span className="text-[11px] text-fg4 shrink-0">{OBSERVATION_STATUS_LABELS[o.status]}</span>
+            </div>
+          </div>
+        ))}
+
+        {observations.length > 0 && open.length === 0 && (
+          <p className="text-xs text-fg4">Всё разобрано. Разбирать замечания — в разделе «Сверка».</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -210,6 +210,36 @@ export function useRemoveDecision() {
   });
 }
 
+// ─── Связанные проблемы уровня (#452) ─────────────────────────────────────────
+
+/** Сверка, относящаяся к уровню иерархии, с числом НЕразобранных находок. */
+export interface RelatedReconciliation {
+  id: string;
+  name: string;
+  unresolvedFindings: number;
+  lastRunAt: string | null;
+}
+
+export interface RelatedProblems {
+  /** Что показывать в счётчике: только неразобранное — бейдж обязан обнуляться действиями человека. */
+  needsAttention: number;
+  unresolvedFindings: number;
+  unreviewedObservations: number;
+  /** Есть ли расхождение, посчитанное САМОЙ системой: красный цвет зарезервирован за арифметикой. */
+  hasArithmeticProblems: boolean;
+  reconciliations: RelatedReconciliation[];
+}
+
+export function useRelatedProblems(scope: 'Construction' | 'Section' | 'Set', scopeId: string | undefined) {
+  return useQuery({
+    queryKey: [...KEY, 'related', scope, scopeId ?? null],
+    enabled: !!scopeId,
+    queryFn: async () => (await apiClient.get<RelatedProblems>('/reconciliations/related', {
+      params: { scope, scopeId },
+    })).data,
+  });
+}
+
 // ─── Алиасы позиций (#446) ────────────────────────────────────────────────────
 
 export type AliasStatus = 'Proposed' | 'Confirmed' | 'Rejected';

--- a/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
@@ -110,19 +110,35 @@ public static class ReconciliationEndpoints
             catch (KeyNotFoundException) { return Results.NotFound(); }
         });
 
+        // ── Связанные проблемы уровня ───────────────────────────────────────────
+
+        user.MapGet("/related", async (string scope, Guid scopeId, IMediator m) =>
+        {
+            if (!Enum.TryParse<CatalogScope>(scope, true, out var s) || s == CatalogScope.System)
+                return Results.BadRequest(new { error = "Ожидается Construction, Section или Set." });
+            return Results.Ok(ToDto(await m.Send(new GetRelatedProblemsQuery(s, scopeId))));
+        });
+
         // ── Отчёт ───────────────────────────────────────────────────────────────
 
         // Отчёт собирается по КОМПЛЕКТУ, а не по сверке: наружу уходит один файл про комплект, как и
         // тот, что сегодня ведут руками. Сверок на комплекте может быть несколько.
         user.MapGet("/report/{setId:guid}", async (
-            Guid setId, string? format, IMediator m, IDomainSnapshotService domain, CancellationToken ct) =>
+            Guid setId, string? format, IMediator m, IDomainSnapshotService domain,
+            IProblemAttribution attribution, CancellationToken ct) =>
         {
             var set = await domain.GetDocumentSetAsync(setId, ct);
             if (set is null) return Results.NotFound();
 
             var sheets = new List<SpreadsheetExporter.Sheet>();
 
-            foreach (var definition in await m.Send(new ListReconciliationsQuery(null, null), ct))
+            // Только сверки, относящиеся к этому комплекту (#452). Раньше сюда шли ВСЕ сверки
+            // системы, и отчёт «по комплекту» мог содержать листы про чужие данные.
+            var related = await attribution.ReconciliationIdsForAsync(CatalogScope.Set, setId, ct);
+            var definitions = (await m.Send(new ListReconciliationsQuery(null, null), ct))
+                .Where(d => related.Contains(d.Id));
+
+            foreach (var definition in definitions)
             {
                 var runs = await m.Send(new ListReconciliationRunsQuery(definition.Id, 1), ct);
                 var findings = await m.Send(new ListFindingsQuery(definition.Id), ct);
@@ -136,7 +152,8 @@ public static class ReconciliationEndpoints
             // Комплект без сверок: пустой лист с шапкой, а не ошибка — «расхождений нет» тоже
             // результат, и его тоже показывают заказчику.
             if (sheets.Count == 1)
-                sheets.Insert(0, ToSheet(DiscrepancyReport.Findings("Сверок не настроено", null, [])));
+                sheets.Insert(0, ToSheet(DiscrepancyReport.Findings(
+                    "К этому комплекту сверки не относятся", null, [])));
 
             var fmt = SpreadsheetExporter.ParseFormat(format);
             if (fmt == SpreadsheetFormat.Csv)
@@ -179,6 +196,20 @@ public static class ReconciliationEndpoints
     /// <summary>Решение адресуется ключом позиции, а не идентификатором находки: находка живёт один
     /// прогон, решение обязано пережить любое их число.</summary>
     private record DecisionReq(string Key, string Kind, string? Note);
+
+    private static object ToDto(RelatedProblems p) => new
+    {
+        p.NeedsAttention,
+        p.UnresolvedFindings,
+        p.UnreviewedObservations,
+        // Красный цвет зарезервирован за арифметикой системы: двести утверждений агента — это не то
+        // же самое, что одно расхождение в числах.
+        p.HasArithmeticProblems,
+        reconciliations = p.Reconciliations.Select(r => new
+        {
+            r.Id, r.Name, r.UnresolvedFindings, r.LastRunAt,
+        }),
+    };
 
     private static object ToDto(ReconciliationAlias a) => new
     {

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -253,6 +253,8 @@ builder.Services.AddScoped<IEntityResolver, EntityResolver>();
 // Сверка на непротиворечивость (issue #431): арифметику считает код, ИИ в пути сравнения нет.
 builder.Services.AddScoped<BHS.CRG.Application.Reconciliation.IReconciliationRunner,
     BHS.CRG.Infrastructure.Reconciliation.ReconciliationRunner>();
+builder.Services.AddScoped<BHS.CRG.Application.Reconciliation.IProblemAttribution,
+    BHS.CRG.Infrastructure.Reconciliation.ProblemAttributionService>();
 builder.Services.AddScoped<BHS.CRG.Application.Documents.ILevelProfileService, BHS.CRG.Infrastructure.Generation.LevelProfileService>();
 builder.Services.AddScoped<IMetadataExtractor, MetadataExtractor>();
 builder.Services.AddScoped<IDataSetResolver, DataSetResolver>();

--- a/src/server/BHS.CRG.Application/Reconciliation/ProblemAttribution.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ProblemAttribution.cs
@@ -1,0 +1,70 @@
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Reconciliation;
+using MediatR;
+
+namespace BHS.CRG.Application.Reconciliation;
+
+/// <summary>Уровень иерархии, для которого спрашивают проблемы.</summary>
+/// <param name="Scope">Construction / Section / Set.</param>
+public record ProblemScope(CatalogScope Scope, Guid ScopeId);
+
+/// <param name="Reconciliations">Сверки, относящиеся к уровню, с числом НЕРАЗОБРАННЫХ находок.</param>
+/// <param name="UnresolvedFindings">Сумма по сверкам: находки без решения человека.</param>
+/// <param name="UnreviewedObservations">Замечания агента, ждущие разбора.</param>
+public record RelatedProblems(
+    IReadOnlyList<RelatedReconciliation> Reconciliations,
+    int UnresolvedFindings,
+    int UnreviewedObservations)
+{
+    /// <summary>
+    /// Что показывать в счётчике. Считаем только НЕРАЗОБРАННОЕ: бейдж обязан обнуляться действиями
+    /// человека, иначе он перестаёт быть сигналом и становится украшением.
+    /// </summary>
+    public int NeedsAttention => UnresolvedFindings + UnreviewedObservations;
+
+    /// <summary>
+    /// Есть ли расхождение, посчитанное САМОЙ системой. Красный цвет зарезервирован за арифметикой:
+    /// двести неразобранных утверждений агента — это не то же самое, что одно расхождение в числах.
+    /// </summary>
+    public bool HasArithmeticProblems => UnresolvedFindings > 0;
+}
+
+/// <param name="UnresolvedFindings">Находки без решения человека: расхождение либо отсутствие пары.</param>
+public record RelatedReconciliation(Guid Id, string Name, int UnresolvedFindings, DateTimeOffset? LastRunAt);
+
+public record GetRelatedProblemsQuery(CatalogScope Scope, Guid ScopeId) : IRequest<RelatedProblems>;
+
+/// <summary>
+/// Какие сверки относятся к уровню иерархии (issue #452).
+///
+/// Принадлежность — свойство СПЕКИ, а не находок: спека называет источники, и связь достраивается
+/// пакетными запросами. Перебирать прогоны и находки ради счётчика не нужно.
+///
+/// Две оси, ОБЪЕДИНЕНИЕ:
+///  • область файла набора, которому принадлежит источник;
+///  • область объектов, привязанных к источнику через DataSetBinding (документ потребляет эти строки).
+///
+/// Правило «самый узкий scope» отвергнуто сознательно: сверка над источниками разных уровней
+/// досталась бы одному комплекту и исчезла бы с раздела, хотя касается обоих.
+///
+/// System-область связи НЕ даёт: сверка над общесистемным файлом иначе загорелась бы на каждом
+/// комплекте и обесценила бы счётчики за вечер. Не привязавшаяся никуда сверка остаётся «общей» —
+/// см. <see cref="IProblemAttribution.GlobalReconciliationsAsync"/>, тихо исчезнуть она не должна.
+/// </summary>
+public interface IProblemAttribution
+{
+    /// <summary>Идентификаторы сверок, относящихся к уровню.</summary>
+    Task<IReadOnlyList<Guid>> ReconciliationIdsForAsync(
+        CatalogScope scope, Guid scopeId, CancellationToken ct = default);
+
+    /// <summary>Сверки, не привязавшиеся ни к одному уровню, — общие для системы.</summary>
+    Task<IReadOnlyList<Guid>> GlobalReconciliationsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Комплекты, лежащие под уровнем (для самого комплекта — он сам). Нужны, чтобы свести вверх
+    /// замечания: они адресованы комплекту, и на стройке без свода счётчик показал бы ноль при
+    /// тринадцати неразобранных этажом ниже.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> SetIdsUnderAsync(
+        CatalogScope scope, Guid scopeId, CancellationToken ct = default);
+}

--- a/src/server/BHS.CRG.Application/Reconciliation/RelatedProblemsHandler.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/RelatedProblemsHandler.cs
@@ -1,0 +1,57 @@
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Reconciliation;
+using MediatR;
+
+namespace BHS.CRG.Application.Reconciliation;
+
+/// <summary>
+/// Проблемы, относящиеся к уровню иерархии (issue #452).
+///
+/// Находки и замечания сводятся ТОЛЬКО в этой проекции чтения, но не в хранении: находка —
+/// пересчитываемый снимок арифметики, замечание — персистированное утверждение агента. Слить их в
+/// одну сущность значило бы вернуть смешение, запрещённое дизайном сверки (#414).
+/// </summary>
+public class RelatedProblemsHandler(
+    IProblemAttribution attribution,
+    IMediator mediator) : IRequestHandler<GetRelatedProblemsQuery, RelatedProblems>
+{
+    public async Task<RelatedProblems> Handle(GetRelatedProblemsQuery q, CancellationToken ct)
+    {
+        var ids = await attribution.ReconciliationIdsForAsync(q.Scope, q.ScopeId, ct);
+
+        var definitions = (await mediator.Send(new ListReconciliationsQuery(null, null), ct))
+            .Where(d => ids.Contains(d.Id))
+            .ToList();
+
+        var related = new List<RelatedReconciliation>();
+        var unresolved = 0;
+
+        foreach (var d in definitions)
+        {
+            // Агрегаты прогона тут не годятся: они не знают о решениях человека, а бейдж обязан
+            // обнуляться его действиями.
+            var findings = await mediator.Send(new ListFindingsQuery(d.Id), ct);
+            var open = findings.Count(f => f.Finding.Status != FindingStatus.Match && f.Decision is null);
+            unresolved += open;
+
+            var runs = await mediator.Send(new ListReconciliationRunsQuery(d.Id, 1), ct);
+            related.Add(new RelatedReconciliation(d.Id, d.Name, open, runs.FirstOrDefault()?.StartedAt));
+        }
+
+        // Замечания адресованы КОМПЛЕКТУ, поэтому выше их надо сводить: без свода на стройке
+        // счётчик показал бы ноль при тринадцати неразобранных этажом ниже.
+        //
+        // ScopeChain для этого не годится: он отвечает «видно ли отсюда», и System-запись
+        // засчиталась бы каждому уровню.
+        var sets = await attribution.SetIdsUnderAsync(q.Scope, q.ScopeId, ct);
+        var observations = 0;
+        foreach (var setId in sets)
+            observations += (await mediator.Send(
+                new ListObservationsQuery(CatalogScope.Set, setId, ObservationStatus.New), ct)).Count;
+
+        return new RelatedProblems(
+            [.. related.OrderByDescending(r => r.UnresolvedFindings).ThenBy(r => r.Name)],
+            unresolved,
+            observations);
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Reconciliation/ProblemAttributionService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Reconciliation/ProblemAttributionService.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using BHS.CRG.Application.Reconciliation;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Reconciliation;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.Reconciliation;
+
+/// <inheritdoc />
+public class ProblemAttributionService(AppDbContext db) : IProblemAttribution
+{
+    /// <summary>Уровни, на которых сверка проявляется: (область, идентификатор).</summary>
+    private sealed record Attribution(Guid DefinitionId, CatalogScope Scope, Guid ScopeId);
+
+    /// <summary>
+    /// Полный граф «сверка → уровни» за несколько пакетных запросов, независимо от числа прогонов и
+    /// находок. Мемоизация на запрос: страница спрашивает атрибуцию несколько раз подряд.
+    /// </summary>
+    private List<Attribution>? _cache;
+
+    private async Task<List<Attribution>> GraphAsync(CancellationToken ct)
+    {
+        if (_cache is not null) return _cache;
+
+        var definitions = await db.Set<ReconciliationDefinition>().AsNoTracking()
+            .Select(d => new { d.Id, Spec = d.Spec })
+            .ToListAsync(ct);
+        if (definitions.Count == 0) return _cache = [];
+
+        // 1) Источники каждой спеки.
+        var sourcesByDefinition = new Dictionary<Guid, HashSet<Guid>>();
+        foreach (var d in definitions)
+        {
+            var ids = SourceIdsOf(d.Spec);
+            if (ids.Count > 0) sourcesByDefinition[d.Id] = ids;
+        }
+        var allSources = sourcesByDefinition.Values.SelectMany(x => x).Distinct().ToList();
+        if (allSources.Count == 0) return _cache = [];
+
+        // 2) Ось «география файла»: где лежит набор, которому принадлежит источник.
+        var fileScopes = await db.DataSetSources.AsNoTracking()
+            .Where(s => allSources.Contains(s.Id))
+            .Select(s => new { s.Id, s.File!.Scope, s.File.ScopeId })
+            .ToListAsync(ct);
+
+        // 3) Ось «потребители»: объекты, привязанные к источнику, — документ реально ест эти строки.
+        var bindings = await db.DataSetBindings.AsNoTracking()
+            .Where(b => allSources.Contains(b.SourceId))
+            .Select(b => new { b.SourceId, b.OwnerId })
+            .ToListAsync(ct);
+
+        var ownerIds = bindings.Select(b => b.OwnerId).Distinct().ToList();
+        var ownerScopes = ownerIds.Count == 0
+            ? []
+            : await db.DomainObjects.AsNoTracking()
+                .Where(o => ownerIds.Contains(o.Id))
+                .Select(o => new { o.Id, o.ScopeLevel, o.ScopeId })
+                .ToListAsync(ct);
+
+        var scopeByOwner = ownerScopes.ToDictionary(o => o.Id, o => (o.ScopeLevel, o.ScopeId));
+        var placesBySource = new Dictionary<Guid, HashSet<(CatalogScope, Guid)>>();
+
+        void Place(Guid sourceId, CatalogScope scope, Guid? scopeId)
+        {
+            // System связи не даёт: иначе сверка над общесистемным файлом загорелась бы везде.
+            if (scope == CatalogScope.System || scopeId is not { } id) return;
+            if (!placesBySource.TryGetValue(sourceId, out var set))
+                placesBySource[sourceId] = set = [];
+            set.Add((scope, id));
+        }
+
+        foreach (var f in fileScopes) Place(f.Id, f.Scope, f.ScopeId);
+        foreach (var b in bindings)
+            if (scopeByOwner.TryGetValue(b.OwnerId, out var s)) Place(b.SourceId, s.ScopeLevel, s.ScopeId);
+
+        // 4) Разворачиваем вверх: проблема комплекта видна и на его разделе, и на стройке.
+        var setIds = placesBySource.Values.SelectMany(x => x)
+            .Where(p => p.Item1 == CatalogScope.Set).Select(p => p.Item2).Distinct().ToList();
+        var sectionIds = placesBySource.Values.SelectMany(x => x)
+            .Where(p => p.Item1 == CatalogScope.Section).Select(p => p.Item2).Distinct().ToList();
+
+        var setParents = await db.DocumentSets.AsNoTracking()
+            .Where(s => setIds.Contains(s.Id))
+            .Select(s => new { s.Id, s.SectionId })
+            .ToListAsync(ct);
+        var allSections = sectionIds.Concat(setParents.Select(s => s.SectionId)).Distinct().ToList();
+        var sectionParents = await db.Sections.AsNoTracking()
+            .Where(s => allSections.Contains(s.Id))
+            .Select(s => new { s.Id, s.ConstructionId })
+            .ToListAsync(ct);
+
+        var sectionOfSet = setParents.ToDictionary(s => s.Id, s => s.SectionId);
+        var constructionOfSection = sectionParents.ToDictionary(s => s.Id, s => s.ConstructionId);
+
+        var result = new List<Attribution>();
+        foreach (var (definitionId, sources) in sourcesByDefinition)
+        {
+            var places = new HashSet<(CatalogScope Scope, Guid Id)>();
+            foreach (var sourceId in sources)
+                if (placesBySource.TryGetValue(sourceId, out var p))
+                    foreach (var x in p) places.Add(x);
+
+            foreach (var (scope, id) in places.ToList())
+            {
+                if (scope == CatalogScope.Set && sectionOfSet.TryGetValue(id, out var sectionId))
+                {
+                    places.Add((CatalogScope.Section, sectionId));
+                    if (constructionOfSection.TryGetValue(sectionId, out var c))
+                        places.Add((CatalogScope.Construction, c));
+                }
+                else if (scope == CatalogScope.Section && constructionOfSection.TryGetValue(id, out var c2))
+                {
+                    places.Add((CatalogScope.Construction, c2));
+                }
+            }
+
+            foreach (var (scope, id) in places) result.Add(new Attribution(definitionId, scope, id));
+        }
+
+        return _cache = result;
+    }
+
+    public async Task<IReadOnlyList<Guid>> ReconciliationIdsForAsync(
+        CatalogScope scope, Guid scopeId, CancellationToken ct = default)
+        => [.. (await GraphAsync(ct))
+            .Where(a => a.Scope == scope && a.ScopeId == scopeId)
+            .Select(a => a.DefinitionId)
+            .Distinct()];
+
+    public async Task<IReadOnlyList<Guid>> GlobalReconciliationsAsync(CancellationToken ct = default)
+    {
+        var attributed = (await GraphAsync(ct)).Select(a => a.DefinitionId).ToHashSet();
+        var all = await db.Set<ReconciliationDefinition>().AsNoTracking().Select(d => d.Id).ToListAsync(ct);
+        return [.. all.Where(id => !attributed.Contains(id))];
+    }
+
+    public async Task<IReadOnlyList<Guid>> SetIdsUnderAsync(
+        CatalogScope scope, Guid scopeId, CancellationToken ct = default) => scope switch
+    {
+        CatalogScope.Set => [scopeId],
+        CatalogScope.Section => await db.DocumentSets.AsNoTracking()
+            .Where(s => s.SectionId == scopeId).Select(s => s.Id).ToListAsync(ct),
+        CatalogScope.Construction => await db.DocumentSets.AsNoTracking()
+            .Where(s => db.Sections.Any(sec => sec.Id == s.SectionId && sec.ConstructionId == scopeId))
+            .Select(s => s.Id).ToListAsync(ct),
+        _ => [],
+    };
+
+    /// <summary>
+    /// Источники спеки, включая свод по нескольким (#450). Спека — свободный jsonb, поэтому читаем
+    /// терпимо: сломанная спека не должна ронять весь экран проблем.
+    /// </summary>
+    private static HashSet<Guid> SourceIdsOf(JsonDocument spec)
+    {
+        var ids = new HashSet<Guid>();
+        if (spec.RootElement.ValueKind != JsonValueKind.Object) return ids;
+
+        foreach (var sideName in (string[])["left", "right"])
+        {
+            if (!spec.RootElement.TryGetProperty(sideName, out var side)
+                || side.ValueKind != JsonValueKind.Object) continue;
+
+            Add(side);
+            if (side.TryGetProperty("sources", out var list) && list.ValueKind == JsonValueKind.Array)
+                foreach (var part in list.EnumerateArray()) Add(part);
+        }
+        return ids;
+
+        void Add(JsonElement e)
+        {
+            if (e.ValueKind == JsonValueKind.Object
+                && e.TryGetProperty("sourceId", out var s)
+                && s.ValueKind == JsonValueKind.String
+                && Guid.TryParse(s.GetString(), out var id)
+                && id != Guid.Empty)
+                ids.Add(id);
+        }
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/ProblemAttributionTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ProblemAttributionTests.cs
@@ -1,0 +1,231 @@
+using System.Text;
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Reconciliation;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Reconciliation;
+using BHS.CRG.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Какие сверки относятся к уровню иерархии (issue #452). Ошибка здесь либо прячет проблему от
+/// человека, либо зажигает счётчик там, где проблемы нет, — второе обесценивает бейджи быстрее.
+/// </summary>
+[Collection("Integration")]
+public class ProblemAttributionTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IProblemAttribution Attribution(IServiceScope s) =>
+        s.ServiceProvider.GetRequiredService<IProblemAttribution>();
+
+    private static async Task<Guid> SeedSourceAsync(
+        IServiceScope scope, string name, CatalogScope fileScope, Guid? scopeId)
+    {
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var blob = scope.ServiceProvider.GetRequiredService<IBlobStorage>();
+        var path = await blob.UploadAsync($"{Guid.NewGuid():N}.csv",
+            new MemoryStream(Encoding.UTF8.GetBytes("Марка,Кол\nА,1")), "text/csv");
+
+        var file = DataSetFile.Create(name, DataSetFormat.Csv, path, fileScope, scopeId);
+        var schema = JsonSerializer.Serialize(new[] { new { name = "Марка", sampleValues = new[] { "" } } });
+        var source = file.AddSource(name, "default", schema, 1);
+        db.DataSetFiles.Add(file);
+        db.DataSetSources.Add(source);
+        await db.SaveChangesAsync();
+        return source.Id;
+    }
+
+    private static async Task<Guid> SeedDefinitionAsync(IServiceScope scope, string name, params Guid[] sourceIds)
+    {
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var spec = new ReconciliationSpec(
+            new ReconciliationSide(sourceIds[0], ["Марка"], "Кол"),
+            new ReconciliationSide(sourceIds[^1], ["Марка"], "Кол"),
+            new ComparisonRule(ComparisonOperator.Equal));
+        var d = ReconciliationDefinition.Create(name, CatalogScope.System, null,
+            JsonSerializer.SerializeToDocument(spec, ReconciliationSpecJson.Options));
+        db.Add(d);
+        await db.SaveChangesAsync();
+        return d.Id;
+    }
+
+    private static async Task<(Guid constructionId, Guid sectionId, Guid setId)> SeedHierarchyAsync(IMediator m)
+    {
+        var c = await m.Send(new CreateConstructionCommand("ДНС Сити", Guid.NewGuid()));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, "ЭОМ-1"));
+        return (c.Id, s.Id, set.Id);
+    }
+
+    /// <summary>Проблема комплекта видна и на его разделе, и на стройке: иначе, стоя на стройке,
+    /// человек не узнает, что где-то внизу расхождение.</summary>
+    [Fact]
+    public async Task SetLevelSource_RollsUpToSectionAndConstruction()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var (c, section, set) = await SeedHierarchyAsync(scope.ServiceProvider.GetRequiredService<IMediator>());
+
+        var source = await SeedSourceAsync(scope, "Журнал", CatalogScope.Set, set);
+        var definition = await SeedDefinitionAsync(scope, "Кабель", source);
+
+        var a = Attribution(scope);
+        Assert.Contains(definition, await a.ReconciliationIdsForAsync(CatalogScope.Set, set));
+        Assert.Contains(definition, await a.ReconciliationIdsForAsync(CatalogScope.Section, section));
+        Assert.Contains(definition, await a.ReconciliationIdsForAsync(CatalogScope.Construction, c));
+    }
+
+    /// <summary>
+    /// Объединение осей, а НЕ «самый узкий scope»: сверка над источниками разных уровней касается
+    /// обоих, и исчезнув с раздела, она обманула бы человека.
+    /// </summary>
+    [Fact]
+    public async Task SourcesOnDifferentLevels_AttachToBoth()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (_, section, set) = await SeedHierarchyAsync(m);
+        var (_, otherSection, _) = await SeedHierarchyAsync(m);
+
+        var onSet = await SeedSourceAsync(scope, "Комплектный", CatalogScope.Set, set);
+        var onOtherSection = await SeedSourceAsync(scope, "Разделный", CatalogScope.Section, otherSection);
+        var definition = await SeedDefinitionAsync(scope, "Смешанная", onSet, onOtherSection);
+
+        var a = Attribution(scope);
+        Assert.Contains(definition, await a.ReconciliationIdsForAsync(CatalogScope.Set, set));
+        Assert.Contains(definition, await a.ReconciliationIdsForAsync(CatalogScope.Section, section));
+        Assert.Contains(definition, await a.ReconciliationIdsForAsync(CatalogScope.Section, otherSection));
+    }
+
+    /// <summary>
+    /// System-источник связи НЕ даёт: иначе сверка над общесистемным файлом загорелась бы на КАЖДОМ
+    /// комплекте и обесценила бы счётчики за вечер. Такая сверка остаётся «общей», а не пропадает.
+    /// </summary>
+    [Fact]
+    public async Task SystemLevelSource_DoesNotLightUpEverySet()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (c, section, set) = await SeedHierarchyAsync(m);
+
+        var source = await SeedSourceAsync(scope, "Общий справочник", CatalogScope.System, null);
+        var definition = await SeedDefinitionAsync(scope, "Общая", source);
+
+        var a = Attribution(scope);
+        Assert.DoesNotContain(definition, await a.ReconciliationIdsForAsync(CatalogScope.Set, set));
+        Assert.DoesNotContain(definition, await a.ReconciliationIdsForAsync(CatalogScope.Section, section));
+        Assert.DoesNotContain(definition, await a.ReconciliationIdsForAsync(CatalogScope.Construction, c));
+
+        // Тихо исчезнуть со всех экранов она не должна.
+        Assert.Contains(definition, await a.GlobalReconciliationsAsync());
+    }
+
+    /// <summary>
+    /// Вторая ось: документ, привязанный к источнику, реально потребляет эти строки — значит сверка
+    /// над источником относится к его комплекту, даже если файл лежит выше.
+    /// </summary>
+    [Fact]
+    public async Task BoundDocument_AttachesReconciliationToItsSet()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var (_, _, set) = await SeedHierarchyAsync(m);
+
+        var type = await m.Send(new CreateDocumentTypeCommand(
+            "Акт", $"ACT_{Guid.NewGuid():N}"[..12], DocumentTypeKind.Document, null,
+            JsonDocument.Parse("""{"fields":[]}""")));
+        var doc = await m.Send(new AddDocumentToSetCommand(set, type.Id));
+
+        // Файл лежит на уровне System — по одной лишь географии сверка не досталась бы комплекту.
+        var source = await SeedSourceAsync(scope, "Общий", CatalogScope.System, null);
+        db.DataSetBindings.Add(DataSetBinding.For(doc.Id, source, "Материалы", "{}"));
+        await db.SaveChangesAsync();
+
+        var definition = await SeedDefinitionAsync(scope, "По привязке", source);
+
+        Assert.Contains(definition, await Attribution(scope).ReconciliationIdsForAsync(CatalogScope.Set, set));
+    }
+
+    [Fact]
+    public async Task MultiSourceSpec_CountsAllItsSources()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var (_, _, set) = await SeedHierarchyAsync(m);
+
+        var a1 = await SeedSourceAsync(scope, "Шкаф 1", CatalogScope.System, null);
+        var a2 = await SeedSourceAsync(scope, "Шкаф 2", CatalogScope.Set, set);
+        var right = await SeedSourceAsync(scope, "Сводная", CatalogScope.System, null);
+
+        // Свод (#450): второй источник лежит на комплекте — сверка обязана к нему привязаться.
+        var spec = new ReconciliationSpec(
+            new ReconciliationSide(a1, ["Марка"], "Кол", null,
+                [new SideSource(a1, ["Марка"], "Кол"), new SideSource(a2, ["Марка"], "Кол")]),
+            new ReconciliationSide(right, ["Марка"], "Кол"),
+            new ComparisonRule(ComparisonOperator.Equal));
+        var d = ReconciliationDefinition.Create("Свод", CatalogScope.System, null,
+            JsonSerializer.SerializeToDocument(spec, ReconciliationSpecJson.Options));
+        db.Add(d);
+        await db.SaveChangesAsync();
+
+        Assert.Contains(d.Id, await Attribution(scope).ReconciliationIdsForAsync(CatalogScope.Set, set));
+    }
+
+    /// <summary>
+    /// Замечания адресованы комплекту, поэтому выше их надо СВОДИТЬ: иначе, стоя на стройке, человек
+    /// видел бы ноль при тринадцати неразобранных этажом ниже. Найдено живой проверкой, не рассуждением.
+    /// </summary>
+    [Fact]
+    public async Task Observations_RollUpToSectionAndConstruction()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var (c, section, set) = await SeedHierarchyAsync(m);
+
+        db.Add(AgentObservation.Create(CatalogScope.Set, set, "k", "Замечание", null,
+            ObservationSeverity.Warning, JsonDocument.Parse("""{"note":"x"}"""), "агент"));
+        await db.SaveChangesAsync();
+
+        Assert.Equal(1, (await m.Send(new GetRelatedProblemsQuery(CatalogScope.Set, set))).NeedsAttention);
+        Assert.Equal(1, (await m.Send(new GetRelatedProblemsQuery(CatalogScope.Section, section))).NeedsAttention);
+        Assert.Equal(1, (await m.Send(new GetRelatedProblemsQuery(CatalogScope.Construction, c))).NeedsAttention);
+
+        // Соседняя стройка чужие замечания не показывает.
+        var (other, _, _) = await SeedHierarchyAsync(m);
+        Assert.Equal(0, (await m.Send(new GetRelatedProblemsQuery(CatalogScope.Construction, other))).NeedsAttention);
+    }
+
+    /// <summary>Счётчик обязан обнуляться действиями человека — иначе он не сигнал, а украшение.</summary>
+    [Fact]
+    public async Task NeedsAttention_CountsOnlyUnreviewed()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var (_, _, set) = await SeedHierarchyAsync(m);
+
+        var observation = AgentObservation.Create(CatalogScope.Set, set, "k", "Замечание", null,
+            ObservationSeverity.Warning, JsonDocument.Parse("""{"note":"x"}"""), "агент");
+        db.Add(observation);
+        await db.SaveChangesAsync();
+
+        var before = await m.Send(new GetRelatedProblemsQuery(CatalogScope.Set, set));
+        Assert.Equal(1, before.NeedsAttention);
+        // Красный — только за арифметику системы; утверждение агента её не заменяет.
+        Assert.False(before.HasArithmeticProblems);
+
+        await m.Send(new ReviewObservationCommand(observation.Id, ObservationStatus.Rejected, "не ошибка", "alex"));
+
+        Assert.Equal(0, (await m.Send(new GetRelatedProblemsQuery(CatalogScope.Set, set))).NeedsAttention);
+    }
+}


### PR DESCRIPTION
Closes #452

Разобрано с Дизайнером и Архитектором (разделы в `_designer-report.md` §34 и `_architect-report.md`). Первый заход из согласованных.

## Починен существующий дефект

Отчёт «по комплекту» брал **все** сверки системы: `ListReconciliationsQuery(null, null)`, а `setId` влиял только на лист замечаний и имя файла. Вопрос «какие сверки относятся к комплекту» уже был задан — и отвечен неверно.

Вторая половина того же корня: селектор комплекта в шапке раздела «Сверка» вставал на первый комплект списка, а не на тот, о котором экран. Жмёшь «Отчёт» — почти пустой файл без предупреждения. Кнопка переехала на страницу комплекта, где комплект известен из маршрута.

## Атрибуция — свойство спеки, а не находок

Спека называет источники, дальше связь достраивается пакетными запросами; перебирать прогоны и находки ради счётчика не нужно.

Две оси, **объединение**: область файла набора **и** область объектов, привязанных к источнику через `DataSetBinding` — документ реально потребляет эти строки.

Правило «самый узкий scope» отвергнуто: сверка над источниками разных уровней досталась бы одному комплекту и исчезла бы с раздела, хотя касается обоих. `System`-область связи не даёт — иначе общесистемная сверка загорелась бы на каждом комплекте и обесценила бы счётчики за вечер; не привязавшаяся никуда остаётся «общей» и не пропадает с глаз.

## Что живая проверка нашла, а тесты — нет

Замечания адресованы комплекту. Без свода вверх стройка показывала **0** при тринадцати неразобранных этажом ниже:

```
СТРОЙКА ДНС ЕЦДМ: 13
  раздел ОВиК: 0
    Комплект ОВиК-1: требует разбора 0 (сверок 0)
  раздел ЭОМ: 13
    250701.ЭОМ-1: требует разбора 13 (сверок 1)
  раздел CC: 0
```

Свод добавлен, тест на него тоже. Соседняя стройка чужие замечания не показывает.

## Панель

Две подписанные секции, а не общий список и не табы: находка — арифметика системы, замечание — утверждение агента. Происхождение написано рядом с данными.

В счётчик только **неразобранное**: бейдж обязан обнуляться действиями человека, поэтому агрегаты прогона не годятся — они о решениях не знают.

Ссылки замечаний показывают имена документов («250701.ЭОМ-1.2.Реестр материалов») вместо «документ 77de9193».

## Вне этого захода

Маркеры на разделах и стройках, чип на документе, сортировка панели. Отдельно отложен вопрос, показывать ли находки на уровне документа: связь через `DataSetBinding` существует, но она слабее, чем выглядит.

## Проверка

- `dotnet test` — 669 зелёных (+7); `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём: панель на 250701.ЭОМ-1 показывает 13, свод по уровням верен, ошибок страницы нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
