### PR TITLE
feat(reconciliation): маркеры проблем на разделах и стройках (#454)

### DIFF
--- a/src/client/src/features/document-sets/DocumentSetsPage.tsx
+++ b/src/client/src/features/document-sets/DocumentSetsPage.tsx
@@ -20,7 +20,7 @@ import { MoveDocumentDialog } from './MoveDocumentDialog';
 import { CatalogResource } from './catalog/CatalogResource';
 import { DataSetsResource } from '@/features/datasets/DataSetsResource';
 import { SetProblemsPanel } from './SetProblemsPanel';
-import { useRelatedProblems } from '@/shared/api/reconciliations';
+import { useRelatedProblems, useProblemSummary, problemOf } from '@/shared/api/reconciliations';
 import { SubscribersResource } from './SubscribersResource';
 import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
@@ -494,11 +494,13 @@ function SetDetail() {
 type SectionPanel = 'catalog' | 'datasets' | 'subscribers';
 
 function SectionDetail() {
+
   const { constructionId, sectionId, panel } = useParams<{ constructionId: string; sectionId: string; panel?: string }>();
   const navigate = useNavigate();
   const activePanel: SectionPanel = (['datasets', 'subscribers'].includes(panel ?? '') ? panel : 'catalog') as SectionPanel;
   const { data: construction, isLoading } = useGetConstruction(constructionId!);
   const { data: docTypes = [] } = useListDocumentTypes();
+  const { data: problems } = useProblemSummary('Section', sectionId);
 
   const [addSetOpen, setAddSetOpen] = useState(false);
   const [newSetName, setNewSetName] = useState('');
@@ -550,10 +552,14 @@ function SectionDetail() {
     <div className="flex-1 overflow-y-auto px-2 pb-3 pt-2 space-y-0.5">
       <NavSection label="Комплекты" />
       {section.documentSets.length === 0 && <p className="px-3 py-1.5 text-xs text-fg4">Нет комплектов</p>}
-      {section.documentSets.map(ds => (
-        <NavItem key={ds.id} icon={<FolderOpen size={17} />} label={ds.name} count={ds.documentCount ?? 0} chevron
-          onClick={() => navigate(`/document-sets/${constructionId}/sets/${ds.id}`)} />
-      ))}
+      {section.documentSets.map(ds => {
+        const p = problemOf(problems, ds.id);
+        return (
+          <NavItem key={ds.id} icon={<FolderOpen size={17} />} label={ds.name} count={ds.documentCount ?? 0} chevron
+            alert={p?.needsAttention} alertDanger={p?.hasArithmeticProblems}
+            onClick={() => navigate(`/document-sets/${constructionId}/sets/${ds.id}`)} />
+        );
+      })}
       <button type="button" onClick={() => setAddSetOpen(true)}
         className="w-full flex items-center gap-2.5 px-3 h-9 rounded-full text-left text-sm text-brand hover:bg-brand-subtle transition-colors">
         <Plus size={16} className="shrink-0" /> Добавить комплект
@@ -659,11 +665,13 @@ function SectionDetail() {
 type ConstructionPanel = 'catalog' | 'datasets' | 'subscribers';
 
 function ConstructionDetail() {
+
   const { constructionId, panel } = useParams<{ constructionId: string; panel?: string }>();
   const navigate = useNavigate();
   const activePanel: ConstructionPanel = (['datasets', 'subscribers'].includes(panel ?? '') ? panel : 'catalog') as ConstructionPanel;
   const { data: construction, isLoading } = useGetConstruction(constructionId!);
   const { data: docTypes = [] } = useListDocumentTypes();
+  const { data: problems } = useProblemSummary('Construction', constructionId);
   const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [newSectionName, setNewSectionName] = useState('');
   const [sectionError, setSectionError] = useState('');
@@ -704,10 +712,14 @@ function ConstructionDetail() {
     <div className="flex-1 overflow-y-auto px-2 pb-3 pt-2 space-y-0.5">
       <NavSection label="Разделы" />
       {construction.sections.length === 0 && <p className="px-3 py-1.5 text-xs text-fg4">Нет разделов</p>}
-      {construction.sections.map(s => (
-        <NavItem key={s.id} icon={<Layers size={17} />} label={s.name} count={s.documentSets.length} chevron
-          onClick={() => navigate(`/document-sets/${constructionId}/sections/${s.id}`)} />
-      ))}
+      {construction.sections.map(s => {
+        const p = problemOf(problems, s.id);
+        return (
+          <NavItem key={s.id} icon={<Layers size={17} />} label={s.name} count={s.documentSets.length} chevron
+            alert={p?.needsAttention} alertDanger={p?.hasArithmeticProblems}
+            onClick={() => navigate(`/document-sets/${constructionId}/sections/${s.id}`)} />
+        );
+      })}
       <button type="button" onClick={() => setAddSectionOpen(true)}
         className="w-full flex items-center gap-2.5 px-3 h-9 rounded-full text-left text-sm text-brand hover:bg-brand-subtle transition-colors">
         <Plus size={16} className="shrink-0" /> Добавить раздел
@@ -872,12 +884,14 @@ function DocumentSearchPanel() {
 // ─── Constructions list ───────────────────────────────────────────────────────
 
 function ConstructionsList() {
+
   const navigate = useNavigate();
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState('');
   const [createError, setCreateError] = useState('');
 
   const { data: constructions = [], isLoading } = useListConstructions();
+  const { data: problems } = useProblemSummary('System');
   const createMutation = useCreateConstruction();
   const deleteMutation = useDeleteConstruction();
   const renameMutation = useRenameConstruction();
@@ -950,6 +964,12 @@ function ConstructionsList() {
                 <div className="flex items-center gap-4 text-xs text-fg4">
                   <span>{ruCount(c.sections.length, 'раздел', 'раздела', 'разделов')}</span>
                   <span>{ruCount(setsCount, 'комплект', 'комплекта', 'комплектов')}</span>
+                  {/* Строкой, а не пилюлей: красные пилюли на карточках дают «ёлку» раньше всего. */}
+                  {(problemOf(problems, c.id)?.needsAttention ?? 0) > 0 && (
+                    <span className="text-warning">
+                      требует разбора: {problemOf(problems, c.id)!.needsAttention}
+                    </span>
+                  )}
                 </div>
                 {c.sections.length > 0 && (
                   <div className="flex flex-wrap gap-1.5">

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -240,6 +240,37 @@ export function useRelatedProblems(scope: 'Construction' | 'Section' | 'Set', sc
   });
 }
 
+/** Счётчик проблем одного объекта иерархии. */
+export interface ProblemCount {
+  scopeId: string;
+  needsAttention: number;
+  hasArithmeticProblems: boolean;
+}
+
+/** Свой уровень + разбивка по детям: страница обходится ОДНИМ запросом (#454). */
+export interface ProblemSummary {
+  needsAttention: number;
+  hasArithmeticProblems: boolean;
+  children: ProblemCount[];
+}
+
+export function useProblemSummary(
+  scope: 'System' | 'Construction' | 'Section' | 'Set', scopeId?: string,
+) {
+  return useQuery({
+    queryKey: [...KEY, 'summary', scope, scopeId ?? null],
+    enabled: scope === 'System' || !!scopeId,
+    queryFn: async () => (await apiClient.get<ProblemSummary>('/reconciliations/summary', {
+      params: { scope, scopeId },
+    })).data,
+  });
+}
+
+/** Счётчик ребёнка по идентификатору — маркер рисуется только когда есть что разбирать. */
+export function problemOf(summary: ProblemSummary | undefined, scopeId: string): ProblemCount | undefined {
+  return summary?.children.find(c => c.scopeId === scopeId);
+}
+
 // ─── Алиасы позиций (#446) ────────────────────────────────────────────────────
 
 export type AliasStatus = 'Proposed' | 'Confirmed' | 'Rejected';

--- a/src/client/src/shared/ui/ListDetailShell.tsx
+++ b/src/client/src/shared/ui/ListDetailShell.tsx
@@ -73,8 +73,14 @@ export function NavSection({ label }: { label: string }) {
  * `chevron` — «ребёнок» (уводит вглубь/роут): счётчик перед chevron, НИКОГДА не подсвечивается;
  * без `chevron` — ресурс/контент уровня (меняет detail на месте): тональный бейдж-счётчик, подсветка при active.
  */
-export function NavItem({ icon, label, count, active, chevron, onClick }: {
+export function NavItem({ icon, label, count, active, chevron, onClick, alert, alertDanger }: {
   icon: ReactNode; label: string; count?: number; active?: boolean; chevron?: boolean; onClick: () => void;
+  /** Сколько проблем ждёт разбора ниже по иерархии. Ноль/пусто — маркер не рисуется: он существует,
+   *  чтобы отличать «есть что разобрать» от «пусто», а нарисованный ноль этой задачи не решает. */
+  alert?: number;
+  /** Расхождение, посчитанное СИСТЕМОЙ. Красный зарезервирован за арифметикой: двести утверждений
+   *  агента — не то же самое, что одно расхождение в числах. */
+  alertDanger?: boolean;
 }) {
   const highlight = active && !chevron;
   return (
@@ -83,6 +89,13 @@ export function NavItem({ icon, label, count, active, chevron, onClick }: {
         highlight ? 'bg-brand-subtle text-brand-hover font-medium' : 'text-fg2 hover:bg-muted'}`}>
       <span className={`shrink-0 ${highlight ? 'text-brand-hover' : 'text-fg4'}`}>{icon}</span>
       <span className="flex-1 truncate text-sm">{label}</span>
+      {alert != null && alert > 0 && (
+        <span title={`Требует разбора: ${alert}`}
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${
+            alertDanger ? 'bg-danger-subtle text-danger' : 'bg-warning-subtle text-warning'}`}>
+          {alert > 99 ? '99+' : alert}
+        </span>
+      )}
       {chevron ? (
         <>
           {count != null && <span className="text-xs text-fg4 shrink-0">{count}</span>}

--- a/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Reconciliation/ReconciliationEndpoints.cs
@@ -119,6 +119,16 @@ public static class ReconciliationEndpoints
             return Results.Ok(ToDto(await m.Send(new GetRelatedProblemsQuery(s, scopeId))));
         });
 
+        // Счётчики для маркеров: свой уровень + разбивка по детям одним ответом (#454).
+        user.MapGet("/summary", async (string scope, Guid? scopeId, IMediator m) =>
+        {
+            if (!Enum.TryParse<CatalogScope>(scope, true, out var s))
+                return Results.BadRequest(new { error = $"Неизвестная область: «{scope}»." });
+            if (s != CatalogScope.System && scopeId is null)
+                return Results.BadRequest(new { error = "Для этой области нужен scopeId." });
+            return Results.Ok(ToDto(await m.Send(new GetProblemSummaryQuery(s, scopeId))));
+        });
+
         // ── Отчёт ───────────────────────────────────────────────────────────────
 
         // Отчёт собирается по КОМПЛЕКТУ, а не по сверке: наружу уходит один файл про комплект, как и
@@ -196,6 +206,13 @@ public static class ReconciliationEndpoints
     /// <summary>Решение адресуется ключом позиции, а не идентификатором находки: находка живёт один
     /// прогон, решение обязано пережить любое их число.</summary>
     private record DecisionReq(string Key, string Kind, string? Note);
+
+    private static object ToDto(ProblemSummary p) => new
+    {
+        p.NeedsAttention,
+        p.HasArithmeticProblems,
+        children = p.Children.Select(c => new { c.ScopeId, c.NeedsAttention, c.HasArithmeticProblems }),
+    };
 
     private static object ToDto(RelatedProblems p) => new
     {

--- a/src/server/BHS.CRG.Application/Reconciliation/ProblemAttribution.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ProblemAttribution.cs
@@ -34,6 +34,19 @@ public record RelatedReconciliation(Guid Id, string Name, int UnresolvedFindings
 
 public record GetRelatedProblemsQuery(CatalogScope Scope, Guid ScopeId) : IRequest<RelatedProblems>;
 
+/// <param name="NeedsAttention">Сколько ждёт разбора человеком на этом уровне и ниже.</param>
+/// <param name="HasArithmeticProblems">Есть ли расхождение, посчитанное системой (а не заявленное агентом).</param>
+public record ProblemCount(Guid ScopeId, int NeedsAttention, bool HasArithmeticProblems);
+
+/// <param name="Children">Разбивка по непосредственным детям уровня: разделы у стройки, комплекты у
+/// раздела, стройки у System. Отдаём вместе со своим счётчиком, чтобы страница обходилась ОДНИМ
+/// запросом — иначе раздел с десятью комплектами сделал бы десять.</param>
+public record ProblemSummary(
+    int NeedsAttention, bool HasArithmeticProblems, IReadOnlyList<ProblemCount> Children);
+
+/// <param name="ScopeId">Пусто при <c>System</c>: детьми тогда становятся все стройки.</param>
+public record GetProblemSummaryQuery(CatalogScope Scope, Guid? ScopeId) : IRequest<ProblemSummary>;
+
 /// <summary>
 /// Какие сверки относятся к уровню иерархии (issue #452).
 ///

--- a/src/server/BHS.CRG.Application/Reconciliation/ProblemSummaryHandler.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ProblemSummaryHandler.cs
@@ -1,0 +1,61 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Catalog;
+using MediatR;
+
+namespace BHS.CRG.Application.Reconciliation;
+
+/// <summary>
+/// Счётчики проблем для маркеров навигации (issue #454).
+///
+/// Отдаёт свой уровень И разбивку по непосредственным детям одним ответом: маркер нужен именно на
+/// пунктах, ведущих вниз, и запрос-на-ребёнка превратил бы страницу раздела с десятью комплектами в
+/// десять обращений.
+/// </summary>
+public class ProblemSummaryHandler(
+    IMediator mediator,
+    IRepository<Domain.Documents.Construction> constructions,
+    IRepository<Domain.Documents.Section> sections,
+    IRepository<Domain.Documents.DocumentSet> sets)
+    : IRequestHandler<GetProblemSummaryQuery, ProblemSummary>
+{
+    public async Task<ProblemSummary> Handle(GetProblemSummaryQuery q, CancellationToken ct)
+    {
+        var children = await ChildrenOfAsync(q.Scope, q.ScopeId, ct);
+
+        var counts = new List<ProblemCount>();
+        foreach (var (childScope, childId) in children)
+        {
+            var p = await mediator.Send(new GetRelatedProblemsQuery(childScope, childId), ct);
+            // Нулевой маркер не рисуется, поэтому и в ответе его нет: он существует, чтобы отличать
+            // «есть что разобрать» от «пусто», а нарисованный ноль этой задачи не решает.
+            if (p.NeedsAttention > 0)
+                counts.Add(new ProblemCount(childId, p.NeedsAttention, p.HasArithmeticProblems));
+        }
+
+        // Для System своего уровня нет — он сумма всех строек.
+        if (q.Scope == CatalogScope.System || q.ScopeId is not { } selfId)
+            return new ProblemSummary(
+                counts.Sum(c => c.NeedsAttention), counts.Any(c => c.HasArithmeticProblems), counts);
+
+        var self = await mediator.Send(new GetRelatedProblemsQuery(q.Scope, selfId), ct);
+        return new ProblemSummary(self.NeedsAttention, self.HasArithmeticProblems, counts);
+    }
+
+    private async Task<IReadOnlyList<(CatalogScope Scope, Guid Id)>> ChildrenOfAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct) => scope switch
+    {
+        CatalogScope.System => [.. (await constructions.GetAllAsync(ct))
+            .Select(c => (CatalogScope.Construction, c.Id))],
+
+        CatalogScope.Construction when scopeId is { } id => [.. (await sections.FindAsync(
+            s => s.ConstructionId == id, ct)).Select(s => (CatalogScope.Section, s.Id))],
+
+        CatalogScope.Section when scopeId is { } id => [.. (await sets.FindAsync(
+            s => s.SectionId == id, ct)).Select(s => (CatalogScope.Set, s.Id))],
+
+        // У комплекта детей в этой оси нет: документы проблемами не помечаются — связь находки с
+        // документом слабее, чем выглядит, и маркер на нём читался бы как «ошибка в документе».
+        _ => [],
+    };
+}

--- a/src/server/BHS.CRG.Tests/Integration/ProblemAttributionTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ProblemAttributionTests.cs
@@ -205,6 +205,40 @@ public class ProblemAttributionTests(IntegrationTestFixture fixture) : IAsyncLif
         Assert.Equal(0, (await m.Send(new GetRelatedProblemsQuery(CatalogScope.Construction, other))).NeedsAttention);
     }
 
+    /// <summary>
+    /// Свод для маркеров: свой уровень И разбивка по детям одним ответом. Запрос-на-ребёнка
+    /// превратил бы страницу раздела с десятью комплектами в десять обращений.
+    /// </summary>
+    [Fact]
+    public async Task Summary_CarriesChildrenBreakdown()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var (c, section, set) = await SeedHierarchyAsync(m);
+        var quiet = await m.Send(new CreateDocumentSetCommand(section, "Тихий комплект"));
+
+        db.Add(AgentObservation.Create(CatalogScope.Set, set, "k", "Замечание", null,
+            ObservationSeverity.Warning, JsonDocument.Parse("""{"note":"x"}"""), "агент"));
+        await db.SaveChangesAsync();
+
+        var atSection = await m.Send(new GetProblemSummaryQuery(CatalogScope.Section, section));
+        Assert.Equal(1, atSection.NeedsAttention);
+        Assert.Equal(set, Assert.Single(atSection.Children).ScopeId);
+        // Нулевой маркер не рисуется, поэтому и в ответе его нет.
+        Assert.DoesNotContain(atSection.Children, x => x.ScopeId == quiet.Id);
+
+        var atConstruction = await m.Send(new GetProblemSummaryQuery(CatalogScope.Construction, c));
+        Assert.Equal(section, Assert.Single(atConstruction.Children).ScopeId);
+
+        // Красный зарезервирован за арифметикой: утверждение агента её не заменяет.
+        Assert.False(atConstruction.HasArithmeticProblems);
+
+        var atSystem = await m.Send(new GetProblemSummaryQuery(CatalogScope.System, null));
+        Assert.Equal(c, Assert.Single(atSystem.Children).ScopeId);
+        Assert.Equal(1, atSystem.NeedsAttention);
+    }
+
     /// <summary>Счётчик обязан обнуляться действиями человека — иначе он не сигнал, а украшение.</summary>
     [Fact]
     public async Task NeedsAttention_CountsOnlyUnreviewed()


### PR DESCRIPTION
Closes #454

Панель проблем живёт на комплекте (#453), но, стоя на стройке или разделе, человек не видел, в какой комплект идти.

## Живая проверка

```
система: 13 | строек с проблемами: 1
стройка ДНС ЕЦДМ: 13 | разделов с проблемами: 1
  ОВиК: 0 | комплектов с проблемами 0
  ЭОМ: 13 | комплектов с проблемами 1
  CC: 0 | комплектов с проблемами 0
```

На скриншоте стройки маркер `13` стоит ровно на разделе ЭОМ; ОВиК и СС чисты.

## Решения

**Один запрос на страницу.** Эндпоинт отдаёт свой уровень **и** разбивку по непосредственным детям — запрос-на-ребёнка превратил бы раздел с десятью комплектами в десять обращений.

**Красный зарезервирован за арифметикой системы.** Есть неразобранная находка — красный; двести неразобранных утверждений агента без расхождений — жёлтый. Иначе цвет перестаёт что-либо значить, а утверждение агента получает вес результата проверки.

**Нулевой счётчик не рисуется**, и в ответе его нет: маркер существует, чтобы отличать «есть что разобрать» от «пусто», а нарисованный ноль этой задачи не решает.

**На списке строек — строкой, а не пилюлей:** красные пилюли на карточках дают «ёлку» раньше всех остальных мест.

**У комплекта детей в этой оси нет.** Документы маркерами не помечаются: связь находки с документом слабее, чем выглядит, и маркер на документе читался бы как «ошибка в документе».

## Проверка

- `dotnet test` — 670 зелёных (+1); `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём: маркеры на всех трёх уровнях верны, ошибок страницы нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
