### PR TITLE
feat(reconciliation): замечания на документе (#456)

### DIFF
--- a/src/client/src/features/document-sets/editor/DocumentObservations.tsx
+++ b/src/client/src/features/document-sets/editor/DocumentObservations.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Bot } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { Modal } from '@/shared/ui/Modal';
+import { EmptyState } from '@/shared/ui/EmptyState';
+import {
+  useObservations, SEVERITY_LABELS, OBSERVATION_STATUS_LABELS, isUnreviewed,
+} from '@/shared/api/observations';
+
+/**
+ * Замечания, упоминающие этот документ (issue #456).
+ *
+ * Заголовок — «упоминающие», а не «ошибки документа»: агент пишет `documentIds` как «документы,
+ * которых утверждение касается», и назвать это ошибкой документа значило бы приписать ему вину,
+ * которой в данных нет.
+ *
+ * Находок сверки здесь нет намеренно: связь находки с документом идёт через привязку источника и
+ * слабее, чем выглядит — «расхождение в этом документе» было бы неправдой.
+ */
+export function DocumentObservationsChip({ setId, documentId }: {
+  setId: string;
+  documentId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const { data: all = [] } = useObservations(setId);
+
+  const mine = all.filter(o => (o.references.documentIds ?? []).includes(documentId));
+  if (mine.length === 0) return null;
+
+  const unreviewed = mine.filter(isUnreviewed).length;
+
+  return (
+    <>
+      <Button variant="text" size="sm" icon={<Bot size={15} />} onClick={() => setOpen(true)}
+        className="shrink-0" title="Замечания внешнего анализа, упоминающие этот документ">
+        <span className="hidden sm:inline">Замечания</span>
+        {unreviewed > 0 && (
+          <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-warning-subtle text-warning">
+            {unreviewed}
+          </span>
+        )}
+      </Button>
+
+      <Modal open={open} onOpenChange={setOpen} wide title="Замечания, упоминающие этот документ">
+        <div className="space-y-3">
+          {/* Происхождение рядом с данными: это утверждения, а не результат проверки системы. */}
+          <p className="text-[11px] text-fg4">
+            Утверждения внешнего ИИ-агента. Система их не проверяла; разбирать — на странице комплекта.
+          </p>
+
+          {mine.length === 0 && <EmptyState icon={<Bot size={28} />} title="Замечаний нет" />}
+
+          {mine.map(o => (
+            <div key={o.id} className={`px-3 py-2 border border-stroke rounded-lg ${
+              isUnreviewed(o) ? '' : 'opacity-60'}`}>
+              <div className="flex items-start gap-2">
+                <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 mt-0.5 ${
+                  o.severity === 'Error' ? 'bg-warning-subtle text-warning' : 'bg-muted text-fg3'}`}>
+                  {SEVERITY_LABELS[o.severity]}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-fg1">{o.title}</div>
+                  {o.detail && <p className="text-xs text-fg3 mt-0.5 whitespace-pre-wrap">{o.detail}</p>}
+                  {o.reviewNote && (
+                    <p className="text-[11px] text-fg3 mt-1">
+                      {OBSERVATION_STATUS_LABELS[o.status]}: {o.reviewNote}
+                    </p>
+                  )}
+                </div>
+                <span className="text-[11px] text-fg4 shrink-0">{OBSERVATION_STATUS_LABELS[o.status]}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -4,6 +4,7 @@ import { Markdown } from '@/shared/ui/Markdown';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useEmailDocument } from '@/shared/api/documentSets';
 import { EmailSendDialog } from '../EmailSendDialog';
+import { DocumentObservationsChip } from './DocumentObservations';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
 import {
@@ -1127,6 +1128,9 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           <span className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${STATUS_COLORS[instance.status] ?? 'bg-brand-subtle text-brand'}`}>
             {STATUS_LABELS[instance.status] ?? instance.status}
           </span>
+          {/* Замечания внешнего анализа, упоминающие ЭТОТ документ (issue #456). Находок сверки
+              здесь нет: их связь с документом слабее, чем выглядит. */}
+          <DocumentObservationsChip setId={instance.documentSetId} documentId={instance.id} />
           {/* Источники данных (issue #296, фаза 3): пакетные операции уровня документа — обзор
               привязок, «Проверить данные», «Из шаблона». Точечная привязка — на самих полях. */}
           <Button variant="text" size="sm" icon={<Database size={15} />} onClick={() => setDataSourcesOpen(true)}


### PR DESCRIPTION
Closes #456

Последний из согласованных с Дизайнером заходов. Открыв документ, человек не видел, что о нём говорит внешний анализ.

Чип «Замечания» в шапке документа рядом со статусом, по образцу «Источников данных»; в модалке — список. **Чипа нет вовсе, если замечаний нет**: пустая кнопка — шум.

## Формулировка — не мелочь

Заголовок: «Замечания, **упоминающие** этот документ», а не «ошибки документа». Агент пишет `documentIds` как «документы, которых утверждение касается»; назвать это ошибкой документа значило бы приписать ему вину, которой в данных нет.

Оговорка о происхождении стоит рядом со списком: «утверждения внешнего ИИ-агента, система их не проверяла».

## Чего здесь нет

**Находок сверки.** Их связь с документом идёт через привязку источника и слабее, чем выглядит — «расхождение в этом документе» было бы неправдой. Это ровно тот вопрос, который откладывали до живой работы; пока он остаётся открытым.

**Разбора.** Он остаётся на комплекте: документ показывает, не дублируя действие в двух местах.

## Проверка

- `npx tsc -b --force` чисто; `npm test` — 159.
- Живьём на «250701.ЭОМ-1.2.Реестр материалов»: чип со счётчиком `3`, модалка с тремя относящимися замечаниями, ошибок страницы нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
