### PR TITLE
feat(reconciliation): уведомление о существенных замечаниях агента (#457)

### DIFF
--- a/src/server/BHS.CRG.Application/Reconciliation/ObservationCommands.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ObservationCommands.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Notifications;
+using BHS.CRG.Domain.Notifications;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Reconciliation;
 using MediatR;
@@ -24,7 +26,11 @@ public record ReviewObservationCommand(Guid Id, ObservationStatus Status, string
 
 public record DeleteObservationCommand(Guid Id) : IRequest;
 
-public class ObservationHandlers(IRepository<AgentObservation> repo) :
+public class ObservationHandlers(
+    IRepository<AgentObservation> repo,
+    IRepository<Domain.Documents.DocumentSet> sets,
+    IRepository<Domain.Documents.Section> sections,
+    INotificationService notifications) :
     IRequestHandler<ListObservationsQuery, IReadOnlyList<AgentObservation>>,
     IRequestHandler<ReportObservationCommand, AgentObservation>,
     IRequestHandler<ReviewObservationCommand, AgentObservation>,
@@ -49,6 +55,7 @@ public class ObservationHandlers(IRepository<AgentObservation> repo) :
         var existing = await FindByKeyAsync(cmd.Scope, cmd.ScopeId, cmd.Key, ct);
 
         AgentObservation observation;
+        var isNew = existing is null;
         if (existing is null)
         {
             observation = AgentObservation.Create(cmd.Scope, cmd.ScopeId, cmd.Key, cmd.Title,
@@ -63,6 +70,14 @@ public class ObservationHandlers(IRepository<AgentObservation> repo) :
         }
 
         await repo.SaveChangesAsync(ct);
+
+        // Уведомляем только о НОВОМ и только о существенном (#457). Повтор с тем же ключом — это
+        // обновление уже известного утверждения, и звонить о нём значит наказывать агента за
+        // повторный анализ, ради которого стабильный ключ и вводился. Замечания рангом ниже видны
+        // счётчиками; колокольчик — про «пришло что-то важное».
+        if (isNew && cmd.Severity == ObservationSeverity.Error)
+            await NotifyAsync(observation, ct);
+
         return observation;
     }
 
@@ -80,6 +95,36 @@ public class ObservationHandlers(IRepository<AgentObservation> repo) :
         var observation = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException();
         repo.Remove(observation);
         await repo.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Уведомление общесистемное, без адресата: замечание относится к КОМПЛЕКТУ, а не к тому, от чьего
+    /// имени работал агент, — увидеть его должен тот, кто ведёт комплект.
+    /// </summary>
+    private async Task NotifyAsync(AgentObservation o, CancellationToken ct)
+    {
+        var link = await SetLinkAsync(o, ct);
+        await notifications.PublishAsync(
+            NotificationSeverity.Warning,
+            "Внешний анализ: замечание",
+            o.Title,
+            source: "Сверка",
+            userId: null,
+            linkUrl: link,
+            linkLabel: link is null ? null : "Открыть проблемы комплекта",
+            ct: ct);
+    }
+
+    /// <summary>Ссылка ведёт в панель проблем комплекта; без стройки маршрут не собрать, поэтому
+    /// поднимаемся по цепочке. Не собралась — уведомление всё равно нужно, просто без ссылки.</summary>
+    private async Task<string?> SetLinkAsync(AgentObservation o, CancellationToken ct)
+    {
+        if (o.Scope != CatalogScope.Set || o.ScopeId is not { } setId) return null;
+        var set = await sets.GetByIdAsync(setId, ct);
+        if (set is null) return null;
+        var section = await sections.GetByIdAsync(set.SectionId, ct);
+        return section is null ? null
+            : $"/document-sets/{section.ConstructionId}/sets/{setId}/issues";
     }
 
     /// <summary>Поиск по естественному ключу в два шага: <c>FindAsync</c> репозитория не отслеживает

--- a/src/server/BHS.CRG.Tests/Integration/AgentObservationsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/AgentObservationsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using BHS.CRG.Api.Mcp;
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Notifications;
 using BHS.CRG.Application.Reconciliation;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Reconciliation;
@@ -138,6 +139,36 @@ public class AgentObservationsTests(IntegrationTestFixture fixture) : IAsyncLife
             SetId, "текстом", "Ссылка обычным текстом", refs, CancellationToken.None);
 
         Assert.Equal(JsonValueKind.String, reported.References.ValueKind);
+    }
+
+    /// <summary>
+    /// Колокольчик — про «пришло что-то важное». Повтор с тем же ключом звонить не должен: это
+    /// обновление известного утверждения, и звонок наказывал бы агента за повторный анализ, ради
+    /// которого стабильный ключ и вводился (#457).
+    /// </summary>
+    [Fact]
+    public async Task Notification_OnlyForNewAndSevere()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var notifications = scope.ServiceProvider.GetRequiredService<INotificationService>();
+        var tools = Tools(scope);
+        var user = Guid.NewGuid();
+
+        async Task<int> CountAsync() =>
+            (await notifications.GetAsync(user)).Count(n => n.Source == "Сверка");
+
+        await tools.ReportObservationAsync(SetId, "мелочь", "Внимание", Refs(),
+            CancellationToken.None, severity: "Warning");
+        Assert.Equal(0, await CountAsync()); // рангом ниже — только счётчики
+
+        await tools.ReportObservationAsync(SetId, "важное", "Существенное расхождение", Refs(),
+            CancellationToken.None, severity: "Error");
+        Assert.Equal(1, await CountAsync());
+
+        await tools.ReportObservationAsync(SetId, "важное", "Существенное расхождение (уточнено)",
+            Refs(), CancellationToken.None, severity: "Error");
+        Assert.Equal(1, await CountAsync());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #457

Агент записал тринадцать замечаний — а узнали вы об этом, только когда спросили. Счётчики в иерархии показывают **состояние**, но требуют зайти и посмотреть; о **появлении** нового они не говорят.

## Живая проверка

```
уведомлений «Сверка»: было 0, стало 1
  [Warning] «Внешний анализ: замечание» → Проба уведомления
  ссылка: /document-sets/66b75946-…/sets/e9d618fb-…/issues
после ПОВТОРА: 1 — верно, не зазвонило
```

## Три ограничения, и все по делу

**Только новое.** Повторное сообщение с тем же ключом — обновление уже известного утверждения. Звонок о нём наказывал бы агента за повторный анализ, ради которого стабильный ключ и вводился.

**Только существенное.** Замечания уровня «внимание» и «к сведению» видны счётчиками; колокольчик — про «пришло что-то важное», и тринадцать звонков подряд превратили бы его в шум, от которого отписываются.

**Без адресата, общесистемное.** Замечание относится к комплекту, а не к тому, от чьего имени работал агент: увидеть его должен тот, кто ведёт комплект.

Ссылка ведёт прямо в панель проблем и собирается через стройку — без неё маршрут не построить. Не собралась (осиротевший комплект) — уведомление всё равно уходит, просто без ссылки.

## Проверка

- `dotnet test` — 671 зелёный (+1).
- Живьём через MCP: новое существенное звонит, повтор молчит, ссылка ведёт куда надо. Пробное замечание за собой удалено.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
