### PR TITLE
feat(generation): проверка значений на соответствие объявленному типу (#461)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
@@ -16,6 +16,7 @@ public record ValidateInstanceResolutionQuery(Guid InstanceId) : IRequest<IReadO
 public class ValidateInstanceResolutionHandler(
     IRepository<DomainObject> instanceRepo,
     IRepository<DocumentType> docTypeRepo,
+    IRepository<Domain.Catalog.PrimitiveType> primitiveRepo,
     IEntityResolver entityResolver,
     IDataSetResolver dataSetResolver
 ) : IRequestHandler<ValidateInstanceResolutionQuery, IReadOnlyList<ResolutionDiagnostic>>
@@ -36,7 +37,14 @@ public class ValidateInstanceResolutionHandler(
         ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
         // Полнота обязательных (issue #296, фаза 0b) — та же проверка, что при генерации.
         var byId = (await docTypeRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
-        ResolutionScanner.ScanMissingRequired(context, DocumentTypeSchemaReader.EffectiveFields(instance.CompositeTypeId, byId), diagnostics);
+        var fields = DocumentTypeSchemaReader.EffectiveFields(instance.CompositeTypeId, byId);
+        ResolutionScanner.ScanMissingRequired(context, fields, diagnostics);
+
+        // Соответствие значений объявленному типу (issue #461) — предупреждениями: данные накоплены,
+        // и половина документов перестала бы выпускаться в тот же день.
+        var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+        ValueTypeScanner.Scan(context, fields, byId, primitives, diagnostics);
+
         return diagnostics;
     }
 }

--- a/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
@@ -1,0 +1,210 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Соответствие значений объявленному типу поля (issue #461).
+///
+/// Повод: поле «ПорядковыйНомер» объявлено примитивом «Цело число», а хранит иерархическую нумерацию
+/// «2.1», «3.4», «10». Восемнадцать значений строки, одно — дробное число; <c>validate_document</c>
+/// возвращал ноль ошибок и ноль предупреждений, потому что соответствие типу не проверялось вовсе.
+///
+/// Всё выдаётся ПРЕДУПРЕЖДЕНИЯМИ: данные накоплены, и половина документов перестала бы выпускаться в
+/// тот же день. Задача — показать расхождение, а не заблокировать работу; что чинить — объявление
+/// типа или данные — решает человек.
+/// </summary>
+public static class ValueTypeScanner
+{
+    /// <summary>Глубина обхода составных полей: защита от патологически вложенных схем.</summary>
+    private const int MaxDepth = 6;
+
+    public static void Scan(
+        GenerationContext ctx,
+        IReadOnlyList<SchemaFieldInfo> effectiveFields,
+        IReadOnlyDictionary<Guid, DocumentType> typesById,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        List<ResolutionDiagnostic> diagnostics)
+    {
+        foreach (var f in effectiveFields)
+        {
+            if (!ctx.Data.TryGetValue(f.Key, out var raw) || raw is not JsonElement value) continue;
+            Check(f.Key, f, value, typesById, primitivesById, diagnostics, depth: 0);
+        }
+    }
+
+    private static void Check(
+        string path, SchemaFieldInfo field, JsonElement value,
+        IReadOnlyDictionary<Guid, DocumentType> typesById,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        List<ResolutionDiagnostic> diagnostics, int depth)
+    {
+        // Расчётное поле производное: претензия к его значению — претензия к выражению (#368).
+        if (field.Computed) return;
+        if (value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined) return;
+        if (depth >= MaxDepth) return;
+
+        switch (field.Type)
+        {
+            case "array":
+                if (value.ValueKind != JsonValueKind.Array)
+                {
+                    Warn(diagnostics, path, $"Поле «{Title(field)}» — таблица, а хранится одиночное значение.");
+                    return;
+                }
+                var i = 0;
+                foreach (var item in value.EnumerateArray())
+                    CheckComposite($"{path}[{i++}]", field, item, typesById, primitivesById, diagnostics, depth);
+                return;
+
+            case "complex":
+                CheckComposite(path, field, value, typesById, primitivesById, diagnostics, depth);
+                return;
+
+            // Ссылки, файлы и картинки проверяет резолвер ссылок; здесь их трогать нечем.
+            case "doc-ref" or "doc-array" or "file" or "image":
+                return;
+
+            case "primitive":
+                CheckPrimitive(path, field, value, primitivesById, diagnostics);
+                return;
+
+            default:
+                CheckBase(path, field, value, field.Type, diagnostics);
+                return;
+        }
+    }
+
+    private static void CheckComposite(
+        string path, SchemaFieldInfo field, JsonElement value,
+        IReadOnlyDictionary<Guid, DocumentType> typesById,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        List<ResolutionDiagnostic> diagnostics, int depth)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+        {
+            Warn(diagnostics, path, $"Поле «{Title(field)}» — составное, а хранится простое значение.");
+            return;
+        }
+        if (field.TypeId is not { } typeId || !typesById.ContainsKey(typeId)) return;
+
+        // Именно здесь и живёт находка: верхнего уровня недостаточно, «ПорядковыйНомер» лежит внутри
+        // элементов массива «Работы».
+        foreach (var inner in DocumentTypeSchemaReader.EffectiveFields(typeId, typesById))
+        {
+            if (!value.TryGetProperty(inner.Key, out var innerValue)) continue;
+            Check($"{path}.{inner.Key}", inner, innerValue, typesById, primitivesById, diagnostics, depth + 1);
+        }
+    }
+
+    private static void CheckPrimitive(
+        string path, SchemaFieldInfo field, JsonElement value,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById, List<ResolutionDiagnostic> diagnostics)
+    {
+        if (field.TypeId is not { } id || !primitivesById.TryGetValue(id, out var primitive)) return;
+
+        if (!CheckBase(path, field, value, primitive.BaseType, diagnostics, primitive.Name)) return;
+        CheckConstraints(path, field, value, primitive, diagnostics);
+    }
+
+    /// <summary>Базовый тип. Возвращает false, если он уже не сошёлся — ограничения проверять незачем.</summary>
+    private static bool CheckBase(
+        string path, SchemaFieldInfo field, JsonElement value, string baseType,
+        List<ResolutionDiagnostic> diagnostics, string? typeName = null)
+    {
+        var actual = value.ValueKind switch
+        {
+            JsonValueKind.String => "строка",
+            JsonValueKind.Number => "число",
+            JsonValueKind.True or JsonValueKind.False => "логическое значение",
+            JsonValueKind.Array => "таблица",
+            JsonValueKind.Object => "составное значение",
+            _ => "пусто",
+        };
+
+        var ok = baseType switch
+        {
+            "number" => value.ValueKind == JsonValueKind.Number,
+            "bool" => value.ValueKind is JsonValueKind.True or JsonValueKind.False,
+            // Дата хранится строкой ISO — отдельная проверка разбора ниже, в ограничениях.
+            "string" or "date" or "enum" or "text" => value.ValueKind == JsonValueKind.String,
+            _ => true, // неизвестный вид — молчим, лучше промолчать, чем выдумать претензию
+        };
+
+        if (!ok)
+        {
+            var expected = typeName is null ? Expected(baseType) : $"{typeName} ({Expected(baseType)})";
+            Warn(diagnostics, path,
+                $"Поле «{Title(field)}»: ожидается {expected}, а хранится {actual}.");
+        }
+        return ok;
+    }
+
+    private static void CheckConstraints(
+        string path, SchemaFieldInfo field, JsonElement value, PrimitiveType primitive,
+        List<ResolutionDiagnostic> diagnostics)
+    {
+        var c = primitive.Constraints.RootElement;
+        if (c.ValueKind != JsonValueKind.Object) return;
+
+        double? Num(string name) => c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetDouble() : null;
+        string? Str(string name) => c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() : null;
+        var flag = c.TryGetProperty("integer", out var f) && f.ValueKind == JsonValueKind.True;
+
+        if (primitive.BaseType == "number" && value.TryGetDouble(out var n))
+        {
+            if (flag && Math.Abs(n - Math.Truncate(n)) > double.Epsilon)
+                Warn(diagnostics, path,
+                    $"Поле «{Title(field)}»: тип «{primitive.Name}» допускает только целые, а хранится {n.ToString(CultureInfo.InvariantCulture)}.");
+            if (Num("min") is { } min && n < min)
+                Warn(diagnostics, path, $"Поле «{Title(field)}»: значение меньше допустимого ({min}).");
+            if (Num("max") is { } max && n > max)
+                Warn(diagnostics, path, $"Поле «{Title(field)}»: значение больше допустимого ({max}).");
+        }
+
+        if (primitive.BaseType == "string" && value.GetString() is { } s)
+        {
+            if (Num("minLength") is { } minLen && s.Length < minLen)
+                Warn(diagnostics, path, $"Поле «{Title(field)}»: короче допустимого ({minLen} симв.).");
+            if (Num("maxLength") is { } maxLen && s.Length > maxLen)
+                Warn(diagnostics, path, $"Поле «{Title(field)}»: длиннее допустимого ({maxLen} симв.).");
+            if (Str("pattern") is { } pattern && !Matches(s, pattern))
+                Warn(diagnostics, path,
+                    Str("patternMessage") is { } msg && msg.Length > 0
+                        ? $"Поле «{Title(field)}»: {msg}"
+                        : $"Поле «{Title(field)}» не соответствует формату типа «{primitive.Name}».");
+        }
+
+        if (primitive.BaseType == "date" && value.GetString() is { } d && !DateTimeOffset.TryParse(
+                d, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out _))
+            Warn(diagnostics, path, $"Поле «{Title(field)}»: значение не разбирается как дата.");
+    }
+
+    /// <summary>Битый шаблон — ошибка НАСТРОЙКИ типа, а не данных: молча пропускаем значение, чтобы
+    /// не превратить одну опечатку администратора в предупреждение на каждой строке.</summary>
+    private static bool Matches(string value, string pattern)
+    {
+        try { return Regex.IsMatch(value, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(200)); }
+        catch (ArgumentException) { return true; }
+        catch (RegexMatchTimeoutException) { return true; }
+    }
+
+    private static string Expected(string baseType) => baseType switch
+    {
+        "number" => "число",
+        "date" => "дата",
+        "bool" => "логическое значение",
+        _ => "строка",
+    };
+
+    private static string Title(SchemaFieldInfo f) => f.Title ?? f.Key;
+
+    private static void Warn(List<ResolutionDiagnostic> diagnostics, string path, string message)
+        => diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Warning, path, message, "value-type"));
+}

--- a/src/server/BHS.CRG.Tests/Generation/ValueTypeScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ValueTypeScannerTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>
+/// Соответствие значений объявленному типу (issue #461). Повод — реальное поле «ПорядковыйНомер»:
+/// объявлено примитивом «Цело число», а хранит иерархическую нумерацию «2.1», «3.4», «10».
+/// Проверка молчала, и документ выпускался как ни в чём не бывало.
+/// </summary>
+public class ValueTypeScannerTests
+{
+    private static readonly Guid IntegerTypeId = Guid.NewGuid();
+    private static readonly Guid WorkTypeId = Guid.NewGuid();
+
+    private static PrimitiveType Integer() => Make<PrimitiveType>(
+        ("Name", "Цело число"), ("Code", "Integer"), ("BaseType", "number"),
+        ("Constraints", JsonDocument.Parse("""{"integer":true}""")), ("Id", IntegerTypeId));
+
+    private static T Make<T>(params (string Name, object Value)[] props) where T : class
+    {
+        var o = (T)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(T));
+        foreach (var (name, value) in props)
+        {
+            var p = typeof(T).GetProperty(name)
+                ?? throw new InvalidOperationException($"нет свойства {name}");
+            p.GetSetMethod(nonPublic: true)!.Invoke(o, [value]);
+        }
+        return o;
+    }
+
+    private static GenerationContext Context(string json)
+    {
+        var ctx = GenerationContext.FromJson(JsonDocument.Parse(json), JsonDocument.Parse("{}"));
+        return ctx;
+    }
+
+    private static List<ResolutionDiagnostic> ScanTopLevel(string json, params SchemaFieldInfo[] fields)
+    {
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ValueTypeScanner.Scan(Context(json), fields,
+            new Dictionary<Guid, DocumentType>(),
+            new Dictionary<Guid, PrimitiveType> { [IntegerTypeId] = Integer() },
+            diagnostics);
+        return diagnostics;
+    }
+
+    private static SchemaFieldInfo IntegerField(string key = "Номер") =>
+        new(key, "primitive", IntegerTypeId, "Порядковый номер");
+
+    [Fact]
+    public void StringWhereNumberDeclared_IsReported()
+    {
+        var d = Assert.Single(ScanTopLevel("""{"Номер":"2.1"}""", IntegerField()));
+        Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+        Assert.Equal("value-type", d.Code);
+        Assert.Contains("ожидается", d.Message);
+        Assert.Contains("хранится строка", d.Message);
+    }
+
+    /// <summary>Тот самый случай: базовый тип сошёлся, а ограничение «только целые» — нет.</summary>
+    [Fact]
+    public void FractionalWhereIntegerDeclared_IsReported()
+    {
+        var d = Assert.Single(ScanTopLevel("""{"Номер":3.3}""", IntegerField()));
+        Assert.Contains("только целые", d.Message);
+    }
+
+    [Fact]
+    public void ConformingValue_IsSilent()
+        => Assert.Empty(ScanTopLevel("""{"Номер":10}""", IntegerField()));
+
+    [Fact]
+    public void MissingValue_IsSilent()
+        => Assert.Empty(ScanTopLevel("""{}""", IntegerField()));
+
+    [Fact]
+    public void NullValue_IsSilent()
+        => Assert.Empty(ScanTopLevel("""{"Номер":null}""", IntegerField()));
+
+    /// <summary>Расчётное поле производное: претензия к его значению — претензия к выражению (#368).</summary>
+    [Fact]
+    public void ComputedField_IsSkipped()
+        => Assert.Empty(ScanTopLevel("""{"Номер":"строка"}""",
+            IntegerField() with { Computed = true, Expression = "1" }));
+
+    [Fact]
+    public void PlainNumberField_ChecksBaseType()
+    {
+        var d = Assert.Single(ScanTopLevel("""{"Кол":"пять"}""", new SchemaFieldInfo("Кол", "number", null, "Количество")));
+        Assert.Contains("ожидается число", d.Message);
+    }
+
+    [Fact]
+    public void TableFieldWithScalarValue_IsReported()
+    {
+        var d = Assert.Single(ScanTopLevel("""{"Работы":"текст"}""",
+            new SchemaFieldInfo("Работы", "array", WorkTypeId, "Работы")));
+        Assert.Contains("таблица", d.Message);
+    }
+
+    /// <summary>Ссылки и файлы проверяет резолвер ссылок — здесь их трогать нечем.</summary>
+    [Theory]
+    [InlineData("doc-ref")]
+    [InlineData("file")]
+    [InlineData("image")]
+    public void ReferenceLikeFields_AreSkipped(string type)
+        => Assert.Empty(ScanTopLevel("""{"П":123}""", new SchemaFieldInfo("П", type, null, "Поле")));
+
+    /// <summary>Битый шаблон — ошибка настройки типа, а не данных: одна опечатка администратора не
+    /// должна давать предупреждение на каждой строке.</summary>
+    [Fact]
+    public void BrokenPattern_DoesNotProduceNoise()
+    {
+        var typeId = Guid.NewGuid();
+        var broken = Make<PrimitiveType>(
+            ("Name", "Кривой"), ("Code", "Broken"), ("BaseType", "string"),
+            ("Constraints", JsonDocument.Parse("""{"pattern":"([unclosed"}""")), ("Id", typeId));
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ValueTypeScanner.Scan(Context("""{"П":"что угодно"}"""),
+            [new SchemaFieldInfo("П", "primitive", typeId, "Поле")],
+            new Dictionary<Guid, DocumentType>(),
+            new Dictionary<Guid, PrimitiveType> { [typeId] = broken },
+            diagnostics);
+
+        Assert.Empty(diagnostics);
+    }
+}


### PR DESCRIPTION
Closes #461

Найдено через замечание внешнего агента — но **корень оказался не тем, что он предположил**.

## Что на самом деле в данных

Поле `ПорядковыйНомер` объявлено примитивом **«Цело число»** (`baseType: number`, `constraints: {integer: true}`), а хранит иерархическую нумерацию: `"1"`, `"2.1"`, `"3.4"`, `"10"`.

Аномалия не в дробном `3.3`, как показалось агенту, а в **объявлении типа**: восемнадцать значений не соответствуют ему вовсе, девятнадцатое соответствует базовому типу, но нарушает ограничение «только целые».

`validate_document` при этом возвращал ноль ошибок и ноль предупреждений — соответствие значения объявленному типу не проверялось вообще.

## Что показывает теперь

```
РЕЕСТР РАБОТ: ошибок 0, предупреждений 20   (19 «не тот тип» + 1 «только целые»)
  Работы[0].ПорядковыйНомер   ожидается Цело число (число), а хранится строка
  Работы[11].ПорядковыйНомер  тип «Цело число» допускает только целые, а хранится 3.3
```

По комплекту целиком:

```
Титульный лист            0 / 2
АОСР                      0 / 4
1.Реестр работ            0 / 20
2.Реестр материалов       0 / 152
3.Реестр исполнительных   0 / 1
Кабельный журнал          0 / 96
```

Это не шум, а масштаб расхождения между схемой и данными, которого раньше не было видно.

## Границы

**Предупреждения, а не ошибки.** Данные накоплены; при ошибках половина документов перестала бы выпускаться в тот же день. Задача — перестать молчать, а не заблокировать работу. Что чинить — объявление типа или данные — решает человек.

**Обход внутрь составных и массивов** — именно там находка и живёт, верхнего уровня недостаточно.

**Расчётные поля пропускаются**: их значение производное, претензия к нему — претензия к выражению.

**Битый шаблон примитива пропускает значение**: это ошибка настройки типа, а не данных, и одна опечатка администратора не должна давать предупреждение на каждой строке.

## Проверка

- `dotnet test` — 687 зелёных (+12).
- Живьём: находка воспроизведена на том самом документе, оба вида расхождений различаются в тексте.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
