### PR TITLE
fix(editor): проверять ограничения в строках таблиц и составных полях (#463)

### DIFF
--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -27,6 +27,7 @@ import { ContainerFieldBinding } from './ContainerFieldBinding';
 import {
   STATUS_LABELS, STATUS_COLORS,
   validateConstraint, isMissing, PrimitiveInput, FileField, ImageField,
+  collectConstraintViolations,
   DocRefField, DocArrayField, ArrayFieldEditor, ComplexFieldGroup, AutoFieldsSection,
   SCOPE_TIER, ancestorTypeIds, parseBaseRef, BaseInstanceChip, BaseCandidatePicker, type BaseCandidate,
 } from '../fields';
@@ -322,17 +323,16 @@ function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docType, ot
   async function handleSaveCore(): Promise<boolean> {
     setError('');
     // Формат/ограничения — блокируют (нельзя хранить мусор).
-    const constraintViolations: Record<string, string> = {};
-    for (const f of schemaFields) {
-      const def = getPrimitiveDef(f);
-      if (def) {
-        const err = validateConstraint(values[f.key], def);
-        if (err) constraintViolations[f.key] = err;
-      }
-    }
+    // По ВСЕМУ документу, включая строки таблиц и составные поля (#463). Раньше проверялся только
+    // верхний уровень — так в поле «Цело число» и оказался «3.3».
+    const constraintViolations = collectConstraintViolations(values, schemaFields, allDocTypes, primitiveTypes);
     if (Object.keys(constraintViolations).length > 0) {
       setConstraintErrors(constraintViolations);
-      setError('Исправьте ошибки формата в полях');
+      const nested = Object.keys(constraintViolations).filter(k => k.includes('.') || k.includes('['));
+      setError(nested.length > 0
+        // Адрес обязателен: нарушение внутри строки таблицы не видно, пока строку не откроешь.
+        ? `Исправьте ошибки формата: ${Object.entries(constraintViolations)[0][0]} — ${Object.values(constraintViolations)[0]}`
+        : 'Исправьте ошибки формата в полях');
       return false;
     }
     // Незаполненные обязательные не блокируют — но показываем маркеры (не «тихо»).

--- a/src/client/src/features/document-sets/fields/collectConstraintViolations.test.ts
+++ b/src/client/src/features/document-sets/fields/collectConstraintViolations.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { collectConstraintViolations } from './collectConstraintViolations';
+import type { DocumentType, PrimitiveTypeDef } from '@/shared/api/types';
+import type { SchemaField } from '@/shared/api/schema';
+
+/**
+ * Проверка ограничений по всему документу (issue #463). Раньше она вызывалась только для полей
+ * верхнего уровня — так в поле «Цело число» и оказался «3.3».
+ */
+
+const INT = 'int-type';
+const HIER = 'hier-type';
+const WORK = 'work-type';
+const ROUTE = 'route-type';
+
+const primitives = [
+  { id: INT, name: 'Цело число', code: 'Integer', baseType: 'number', constraints: { integer: true } },
+  { id: HIER, name: 'Иерархический номер', code: 'Hier', baseType: 'string',
+    constraints: { pattern: '^\\d+(?:\\.\\d+)*\\.?$' } },
+] as unknown as PrimitiveTypeDef[];
+
+const field = (key: string, type: string, typeId?: string): SchemaField =>
+  ({ key, type, typeId, title: key } as unknown as SchemaField);
+
+const docType = (id: string, fields: SchemaField[]): DocumentType =>
+  ({ id, name: id, schema: { fields }, parentId: null } as unknown as DocumentType);
+
+const types = [
+  docType(WORK, [field('ПорядковыйНомер', 'primitive', INT)]),
+  docType(ROUTE, [field('Длина', 'primitive', INT)]),
+];
+
+describe('collectConstraintViolations', () => {
+  it('ловит нарушение внутри строки таблицы — то, чего не видела прежняя проверка', () => {
+    const v = collectConstraintViolations(
+      { Работы: [{ ПорядковыйНомер: 1 }, { ПорядковыйНомер: 3.3 }] },
+      [field('Работы', 'array', WORK)], types, primitives);
+
+    // Адрес обязателен: без него нарушение внутри строки не найти, не открыв её.
+    expect(Object.keys(v)).toEqual(['Работы[1].ПорядковыйНомер']);
+    expect(v['Работы[1].ПорядковыйНомер']).toMatch(/целое/i);
+  });
+
+  it('ловит нарушение внутри составного поля', () => {
+    const v = collectConstraintViolations(
+      { Трасса: { Длина: 4.5 } },
+      [field('Трасса', 'complex', ROUTE)], types, primitives);
+
+    expect(Object.keys(v)).toEqual(['Трасса.Длина']);
+  });
+
+  it('проверяет и верхний уровень, как прежде', () => {
+    const v = collectConstraintViolations(
+      { Номер: 'не число' }, [field('Номер', 'primitive', INT)], types, primitives);
+    expect(Object.keys(v)).toEqual(['Номер']);
+  });
+
+  it('корректные значения молчат', () => {
+    const v = collectConstraintViolations(
+      { Работы: [{ ПорядковыйНомер: 10 }] },
+      [field('Работы', 'array', WORK)], types, primitives);
+    expect(v).toEqual({});
+  });
+
+  it('строковый паттерн: «3.10» проходит, «3,10» нет', () => {
+    const f = [field('Номер', 'primitive', HIER)];
+    expect(collectConstraintViolations({ Номер: '3.10' }, f, types, primitives)).toEqual({});
+    expect(Object.keys(collectConstraintViolations({ Номер: '3,10' }, f, types, primitives))).toEqual(['Номер']);
+  });
+
+  it('пустые значения не проверяются — незаполненность это не нарушение формата', () => {
+    expect(collectConstraintViolations({ Номер: null }, [field('Номер', 'primitive', INT)], types, primitives))
+      .toEqual({});
+  });
+
+  it('расчётные поля пропускаются: претензия к значению — претензия к выражению', () => {
+    const computed = { ...field('Номер', 'primitive', INT), computed: true } as SchemaField;
+    expect(collectConstraintViolations({ Номер: 'мусор' }, [computed], types, primitives)).toEqual({});
+  });
+
+  it('неизвестный тип строки таблицы не роняет обход', () => {
+    expect(collectConstraintViolations(
+      { Работы: [{ Что: 1 }] }, [field('Работы', 'array', 'нет-такого')], types, primitives)).toEqual({});
+  });
+});

--- a/src/client/src/features/document-sets/fields/collectConstraintViolations.ts
+++ b/src/client/src/features/document-sets/fields/collectConstraintViolations.ts
@@ -1,0 +1,79 @@
+import type { DocumentType, PrimitiveTypeDef } from '@/shared/api/types';
+import { resolveEffectiveFields, type SchemaField } from '@/shared/api/schema';
+import { validateConstraint } from './PrimitiveInput';
+
+/**
+ * Нарушения ограничений примитивов по ВСЕМУ документу, включая строки таблиц и составные поля
+ * (issue #463).
+ *
+ * Проверка существовала и работала, но вызывалась только для полей верхнего уровня: внутри строк
+ * таблицы контрол получал описание типа и рисовался правильно, а результат ввода не проверял никто.
+ * Так в поле «Цело число» и оказался «3.3».
+ *
+ * Ключ нарушения — путь вида `Работы[3].ПорядковыйНомер`: он и адресует место, и служит ключом для
+ * подсветки конкретного контрола.
+ */
+export function collectConstraintViolations(
+  values: Record<string, unknown>,
+  fields: SchemaField[],
+  allDocTypes: DocumentType[],
+  primitiveTypes: PrimitiveTypeDef[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  walk(values, fields, '', out, allDocTypes, primitiveTypes, 0);
+  return out;
+}
+
+/** Защита от патологически вложенных схем — та же, что у серверного сканера. */
+const MAX_DEPTH = 6;
+
+function walk(
+  obj: Record<string, unknown>,
+  fields: SchemaField[],
+  prefix: string,
+  out: Record<string, string>,
+  allDocTypes: DocumentType[],
+  primitiveTypes: PrimitiveTypeDef[],
+  depth: number,
+) {
+  if (depth >= MAX_DEPTH) return;
+
+  for (const f of fields) {
+    // Расчётное поле производное: претензия к его значению — претензия к выражению.
+    if (f.computed) continue;
+
+    const value = obj?.[f.key];
+    if (value == null) continue;
+    const path = prefix ? `${prefix}.${f.key}` : f.key;
+
+    if (f.type === 'array' && Array.isArray(value)) {
+      const inner = fieldsOf(f.typeId, allDocTypes);
+      if (inner.length === 0) continue;
+      value.forEach((row, i) => {
+        if (row && typeof row === 'object')
+          walk(row as Record<string, unknown>, inner, `${path}[${i}]`, out, allDocTypes, primitiveTypes, depth + 1);
+      });
+      continue;
+    }
+
+    if (f.type === 'complex' && typeof value === 'object' && !Array.isArray(value)) {
+      const inner = fieldsOf(f.typeId, allDocTypes);
+      if (inner.length > 0)
+        walk(value as Record<string, unknown>, inner, path, out, allDocTypes, primitiveTypes, depth + 1);
+      continue;
+    }
+
+    if (f.type !== 'primitive' || !f.typeId) continue;
+    const def = primitiveTypes.find(p => p.id === f.typeId);
+    if (!def) continue;
+
+    const err = validateConstraint(value, def);
+    if (err) out[path] = err;
+  }
+}
+
+function fieldsOf(typeId: string | null | undefined, allDocTypes: DocumentType[]): SchemaField[] {
+  if (!typeId) return [];
+  const t = allDocTypes.find(x => x.id === typeId);
+  return t ? resolveEffectiveFields(t, allDocTypes) : [];
+}

--- a/src/client/src/features/document-sets/fields/index.ts
+++ b/src/client/src/features/document-sets/fields/index.ts
@@ -2,6 +2,7 @@ export * from './constants';
 export * from './FileField';
 export * from './ImageField';
 export * from './PrimitiveInput';
+export * from './collectConstraintViolations';
 export * from './RefPickerModal';
 export * from './InstancePickerModal';
 export * from './DocRefCatalogPickerField';


### PR DESCRIPTION
Closes #463

Проверка ограничений была **написана и работала**: `validateConstraint` умеет и «Введите целое число», и min/max, и pattern, а сохранение блокирует невалидное. Но вызывалась она только для полей верхнего уровня — внутри строк таблицы контрол получал описание типа и рисовался правильно, а результат ввода не проверял никто.

Так в поле «Цело число» и оказался «3.3».

## Что сделано

Сбор нарушений вынесен в чистую функцию и обходит документ целиком — массивы и составные поля, — той же формы, что серверный сканер значений (#461).

Ключ нарушения — путь вида `Работы[3].ПорядковыйНомер`: он и адресует место, и служит ключом подсветки контрола. Сообщение об ошибке его называет: без адреса нарушение внутри строки не найти, не открыв её.

Расчётные поля пропускаются — их значение производное, претензия к нему это претензия к выражению.

## Главный риск и как проверен

Обход пошёл по **всем** строкам, и лишняя претензия заблокировала бы сохранение документа. Проверено живьём на двух самых больших таблицах комплекта:

```
Реестр материалов (152 строки): сохранение прошло
Кабельный журнал  (48 строк):   сохранение прошло
ошибки страницы: нет
```

## Граница

Клиент блокирует нарушения **формата** (ограничения примитива). Несоответствие JSON-типа — число там, где объявлена строка — ловит серверная проверка (#461): это разные вещи, и совмещать их в одном месте значило бы дублировать правила.

## Проверка

- `npx tsc -b --force` чисто; `npm test` — 167 зелёных (+8).
- Тесты покрывают нарушение в строке таблицы, в составном поле, на верхнем уровне, пустые значения, расчётные поля и неизвестный тип строки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
