### PR TITLE
fix(catalog): проверять ограничения при сохранении записи каталога (#469)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -30,7 +30,7 @@ import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
   PrimitiveInput, FileField, ImageField, AutoFieldsSection,
   BaseInstanceChip, SCOPE_TIER, type BaseCandidate,
-  SectionRail, collectConstraintViolations,
+  SectionRail, collectConstraintViolations, describeViolationPath, violationRootKey,
 } from '../fields';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 
@@ -307,9 +307,14 @@ export function CatalogEntryForm({
     const violations = collectConstraintViolations(values, effectiveFields, allDocTypes, primitiveTypes);
     const firstBad = Object.entries(violations)[0];
     if (firstBad) {
+      const [path, message] = firstBad;
       setConstraintErrors(violations);
-      // Адрес обязателен: нарушение внутри вложенного объекта не видно, пока его не раскроешь.
-      setError(`${firstBad[0]} — ${firstBad[1]}`);
+      // Технический путь адресует точно, но читателю не говорит ничего: ключей он не видел, а поле
+      // может лежать в свёрнутой группе. Показываем заголовки и сразу раскрываем группу с прокруткой —
+      // иначе «сохранить нельзя» превращается в поиск вслепую.
+      setError(`${describeViolationPath(path, effectiveFields, allDocTypes)} — ${message}`);
+      const section = sections.find(s => s.fields.some(f => f.key === violationRootKey(path)));
+      if (section) goToSection(section.key);
       return;
     }
 
@@ -657,6 +662,10 @@ export function CatalogEntryForm({
                     ? <ChevronUp size={13} className="text-fg4 shrink-0" />
                     : <ChevronDown size={13} className="text-fg4 shrink-0" />}
                   <span className="text-xs font-semibold uppercase tracking-wide text-fg2 flex-1">{section.title}</span>
+                  {/* Метка на заголовке: свёрнутая группа иначе прячет причину отказа. */}
+                  {section.fields.some(f => Object.keys(constraintErrors).some(k => violationRootKey(k) === f.key)) && (
+                    <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" title="Есть ошибка формата" />
+                  )}
                   <span className="text-xs text-fg4">{section.fields.length} п.</span>
                 </button>
                 {isExpanded && <div className="px-3 py-3">{renderFields(section.fields)}</div>}

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -30,7 +30,7 @@ import {
   SCOPE_COLORS, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField,
   PrimitiveInput, FileField, ImageField, AutoFieldsSection,
   BaseInstanceChip, SCOPE_TIER, type BaseCandidate,
-  SectionRail,
+  SectionRail, collectConstraintViolations,
 } from '../fields';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 
@@ -104,6 +104,9 @@ export function CatalogEntryForm({
   const [typeId, setTypeId] = useState(entry?.compositeTypeId ?? '');
   const [pickerOpen, setPickerOpen] = useState(false);
   const [values, setValues] = useState<Record<string, unknown>>(() => entry?.data ?? {});
+  // Нарушения ограничений по путям («ЮридическийАдрес.Web»); сбрасываются при правке значения,
+  // иначе претензия висела бы на исправленном поле.
+  const [constraintErrors, setConstraintErrors] = useState<Record<string, string>>({});
   const [error, setError] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [recognizing, setRecognizing] = useState(false);
@@ -251,6 +254,13 @@ export function CatalogEntryForm({
       if (val === undefined) { const n = { ...p }; delete n[key]; return n; }
       return { ...p, [key]: val };
     });
+    // Претензия к прежнему значению больше не актуальна: следующая проверка на сохранении рассудит.
+    setConstraintErrors(prev => {
+      if (!Object.keys(prev).some(k => k === key || k.startsWith(`${key}.`) || k.startsWith(`${key}[`)))
+        return prev;
+      return Object.fromEntries(Object.entries(prev)
+        .filter(([k]) => k !== key && !k.startsWith(`${key}.`) && !k.startsWith(`${key}[`)));
+    });
   }
   function toggleGroup(key: string) {
     setExpandedGroups(prev => { const n = new Set(prev); n.has(key) ? n.delete(key) : n.add(key); return n; });
@@ -289,6 +299,20 @@ export function CatalogEntryForm({
     e.preventDefault();
     setError('');
     if (!displayName.trim() || !typeId) { setError('Укажите название и тип'); return; }
+
+    // Ограничения примитивов проверялись только в редакторе ДОКУМЕНТОВ (#463); записи каталога
+    // сохранялись без единой проверки, и невалидное значение всплывало позже — уже на документе,
+    // куда запись подмешивается по ссылке. Тот же сбор, что и там: вторая реализация правил
+    // разошлась бы с первой.
+    const violations = collectConstraintViolations(values, effectiveFields, allDocTypes, primitiveTypes);
+    const firstBad = Object.entries(violations)[0];
+    if (firstBad) {
+      setConstraintErrors(violations);
+      // Адрес обязателен: нарушение внутри вложенного объекта не видно, пока его не раскроешь.
+      setError(`${firstBad[0]} — ${firstBad[1]}`);
+      return;
+    }
+
     try {
       if (entry) {
         await updateMutation.mutateAsync({ id: entry.id, displayName, data: JSON.stringify(values), aliases });
@@ -434,9 +458,15 @@ export function CatalogEntryForm({
                   <FileField value={val} onChange={v => setValue(field.key, v)} />
                 </div>
               ) : (
-                <PrimitiveInput field={field} value={val} label={field.title}
-                  hint={getPrimitiveDef(field)?.name} onChange={v => setValue(field.key, v)} invalid={false}
-                  primitiveTypeDef={getPrimitiveDef(field)} enumTypeDef={getEnumDef(field)} />
+                <>
+                  <PrimitiveInput field={field} value={val} label={field.title}
+                    hint={getPrimitiveDef(field)?.name} onChange={v => setValue(field.key, v)}
+                    invalid={!!constraintErrors[field.key]}
+                    primitiveTypeDef={getPrimitiveDef(field)} enumTypeDef={getEnumDef(field)} />
+                  {constraintErrors[field.key] && (
+                    <p className="text-xs text-danger mt-0.5">{constraintErrors[field.key]}</p>
+                  )}
+                </>
               )}
             </div>
           );

--- a/src/client/src/features/document-sets/fields/collectConstraintViolations.test.ts
+++ b/src/client/src/features/document-sets/fields/collectConstraintViolations.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { collectConstraintViolations } from './collectConstraintViolations';
+import {
+  collectConstraintViolations, describeViolationPath, violationRootKey,
+} from './collectConstraintViolations';
 import type { DocumentType, PrimitiveTypeDef } from '@/shared/api/types';
 import type { SchemaField } from '@/shared/api/schema';
 
@@ -81,5 +83,43 @@ describe('collectConstraintViolations', () => {
   it('неизвестный тип строки таблицы не роняет обход', () => {
     expect(collectConstraintViolations(
       { Работы: [{ Что: 1 }] }, [field('Работы', 'array', 'нет-такого')], types, primitives)).toEqual({});
+  });
+});
+
+/**
+ * Технический путь адресует точно, но читателю не говорит ничего: ключей он не видел, а поле может
+ * лежать в свёрнутой группе (#469).
+ */
+describe('describeViolationPath', () => {
+  const ADDR = 'addr-type';
+  const withAddr = [
+    docType(ADDR, [field('Web', 'primitive', HIER)]),
+    ...types,
+  ];
+  const fields = [
+    { ...field('ЮридическийАдрес', 'complex', ADDR), title: 'Юридический адрес' } as SchemaField,
+    { ...field('Работы', 'array', WORK), title: 'Работы' } as SchemaField,
+  ];
+
+  it('переводит путь в заголовки', () => {
+    expect(describeViolationPath('ЮридическийАдрес.Web', fields, withAddr))
+      .toBe('Юридический адрес → Web');
+  });
+
+  it('строку таблицы нумерует с единицы — как её видит человек', () => {
+    expect(describeViolationPath('Работы[2].ПорядковыйНомер', fields, withAddr))
+      .toBe('Работы №3 → ПорядковыйНомер');
+  });
+
+  it('неизвестный ключ отдаёт как есть, а не теряет', () => {
+    expect(describeViolationPath('НетТакого', fields, withAddr)).toBe('НетТакого');
+  });
+});
+
+describe('violationRootKey', () => {
+  it('корень пути — поле, по которому ищется группа формы', () => {
+    expect(violationRootKey('ЮридическийАдрес.Web')).toBe('ЮридическийАдрес');
+    expect(violationRootKey('Работы[2].Номер')).toBe('Работы');
+    expect(violationRootKey('Номер')).toBe('Номер');
   });
 });

--- a/src/client/src/features/document-sets/fields/collectConstraintViolations.ts
+++ b/src/client/src/features/document-sets/fields/collectConstraintViolations.ts
@@ -77,3 +77,38 @@ function fieldsOf(typeId: string | null | undefined, allDocTypes: DocumentType[]
   const t = allDocTypes.find(x => x.id === typeId);
   return t ? resolveEffectiveFields(t, allDocTypes) : [];
 }
+
+/**
+ * Путь нарушения человеческими названиями: «Адреса → Юридический адрес → Сайт» вместо
+ * «ЮридическийАдрес.Web».
+ *
+ * Технический путь адресует место точно, но читателю не говорит ничего: ключи он не видел никогда, а
+ * поле может лежать в свёрнутой группе. Заголовки — то, что у него перед глазами.
+ */
+export function describeViolationPath(
+  path: string,
+  fields: SchemaField[],
+  allDocTypes: DocumentType[],
+): string {
+  const parts: string[] = [];
+  let current = fields;
+
+  for (const segment of path.split('.')) {
+    // Индекс строки таблицы показываем номером, а не нулевой базой: в форме строки нумеруются с единицы.
+    const m = /^(.+?)\[(\d+)\]$/.exec(segment);
+    const key = m ? m[1] : segment;
+    const f = current.find(x => x.key === key);
+    if (!f) { parts.push(key); break; }
+
+    parts.push(m ? `${f.title ?? key} №${Number(m[2]) + 1}` : (f.title ?? key));
+    current = fieldsOf(f.typeId, allDocTypes);
+    if (current.length === 0) break;
+  }
+
+  return parts.join(' → ');
+}
+
+/** Корневое поле нарушения — по нему находится группа формы, которую надо раскрыть. */
+export function violationRootKey(path: string): string {
+  return path.split(/[.[]/)[0];
+}


### PR DESCRIPTION
Closes #469

Найдено сразу после #463: в поле `web` организации «ООО "Инвест Строй"» можно было ввести что угодно.

**Я закрыл одну из двух форм ввода.** Фикс #463 подключил проверку к редактору документов; записи каталога редактируются другим компонентом, и там валидации не было вовсе — `handleSubmit` проверял «укажите название и тип» и сразу сохранял.

```
редактор документов   → проверка есть (после #463, включая строки таблиц)
редактор каталога     → проверки не было вовсе
```

Нарушение при этом всё-таки было видно — но позже и в другом месте: серверная проверка #461 ловит его, когда запись подмешивается в документ по ссылке. Отсюда и были те предупреждения про «web» в АОСР и титульном листе. Система знала, а сказать в момент ввода не могла.

## Живая проверка на той самой записи

```
заблокировано с адресом: ЮридическийАдрес.Web — Введите корректный адрес сайта
ошибки страницы: нет
```

Значение `dnsdevelopment.ru` не проходит паттерн типа `SiteURL`, который требует схему (`https://…`).

## Решения

**Тот же сбор нарушений, что в документах.** Вторая реализация правил разошлась бы с первой.

**Сообщение называет путь** (`ЮридическийАдрес.Web`): нарушение внутри вложенного объекта не видно, пока его не раскроешь.

**Претензия снимается при правке значения** — иначе висела бы на исправленном поле.

## Риск и мера

Данные накоплены, и блокировка могла бы не дать сохранить запись, которую просто открыли и закрыли. Перед включением посчитано по рабочей базе: **из 33 записей нарушение ровно у одной** — той самой. Блокировать безопасно.

## Проверка

- `npx tsc -b --force` чисто; `npm test` — 167.
- Живьём: запись с некорректным адресом не сохраняется, сообщение называет поле.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
