### PR TITLE
feat(templates): библиотека Typst становится деревом файлов — backend (#473)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -192,6 +192,14 @@ public static class GenerationEndpoints
                     await WriteEntry(zip, "data.json", dataJson);
                     await WriteEntry(zip, "typeblocks.typ", typeBlocks);
                     await WriteEntry(zip, "userlib.typ", userLib);
+
+                    // Дерево библиотеки (issue #473) — той же раскладкой, что при генерации: точка
+                    // входа реэкспортирует эти файлы, и без них внешняя компиляция упадёт на первом
+                    // же вложенном импорте.
+                    foreach (var libFile in bundle.UserLibFiles)
+                        await WriteEntry(zip,
+                            $"{BHS.CRG.Application.Templates.UserLibPath.FolderName}/{libFile.Path}",
+                            libFile.Content);
                     if (fontsDirDbg is not null)
                         await WriteEntry(zip, "README.txt",
                             "У шаблона есть шрифтовые ассеты — компилируйте с --font-path:\r\n\r\n" +

--- a/src/server/BHS.CRG.Api/Endpoints/Templates/TypstUserLibEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Templates/TypstUserLibEndpoints.cs
@@ -1,6 +1,6 @@
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Templates;
 using BHS.CRG.Domain.Documents;
-using Microsoft.EntityFrameworkCore;
 
 namespace BHS.CRG.Api.Endpoints.Templates;
 
@@ -10,31 +10,133 @@ public static class TypstUserLibEndpoints
     {
         var g = app.MapGroup("/api/typst-userlib").RequireAuthorization("Admin");
 
-        g.MapGet("/", async (IRepository<TypstUserLib> repo, CancellationToken ct) =>
+        g.MapGet("/", async (IUserLibProvider provider, CancellationToken ct) =>
         {
-            var all = await repo.GetAllAsync(ct);
-            var lib = all.FirstOrDefault();
-            return Results.Ok(new { content = lib?.Content ?? string.Empty });
+            var snapshot = await provider.GetAsync(ct);
+            return Results.Ok(new
+            {
+                content = snapshot.Entrypoint,
+                files = snapshot.Files.Select(f => new { path = f.Path, content = f.Content }),
+            });
         });
 
-        g.MapPut("/", async (SaveTypstUserLibRequest req, IRepository<TypstUserLib> repo, CancellationToken ct) =>
+        // Сохранение — ВСЕГО дерева разом (issue #473). Пофайловое сохранение позволило бы
+        // зафиксировать половину рефакторинга: правка «util/text.typ» и правка зовущего её
+        // «gost/f3.typ» обязаны лечь вместе, иначе между двумя запросами библиотека не собирается —
+        // а её импортирует каждый шаблон.
+        //
+        // `files: null` означает «дерево не трогать» и оставлено осознанно: так продолжает работать
+        // клиент, который шлёт только точку входа.
+        g.MapPut("/", async (SaveTypstUserLibRequest req, IRepository<TypstUserLib> libRepo,
+            IRepository<TypstUserLibFile> fileRepo, IUserLibProvider provider,
+            IUserLibChecker checker, CancellationToken ct) =>
         {
-            var all = await repo.GetAllAsync(ct);
-            var lib = all.FirstOrDefault();
+            if (req.Files is { } incoming)
+            {
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                var normalized = new List<UserLibFile>(incoming.Count);
+                foreach (var f in incoming)
+                {
+                    if (!UserLibPath.TryNormalize(f.Path, out var path, out var error))
+                        return Results.BadRequest(new { error = $"«{f.Path}»: {error}" });
+                    if (!seen.Add(path))
+                        return Results.BadRequest(new { error = $"Путь «{path}» встречается дважды." });
+                    normalized.Add(new UserLibFile(path, f.Content ?? string.Empty));
+                }
+
+                // Пути, различающиеся только регистром, на Linux — разные файлы, на Windows — один.
+                // Разойтись это может уже в продакшене, поэтому отказываем сразу.
+                var caseClash = normalized.GroupBy(f => f.Path, StringComparer.OrdinalIgnoreCase)
+                    .FirstOrDefault(x => x.Count() > 1);
+                if (caseClash is not null)
+                    return Results.BadRequest(new
+                    {
+                        error = $"Пути различаются только регистром: {string.Join(", ", caseClash.Select(f => f.Path))}.",
+                    });
+
+                await ApplyTreeAsync(fileRepo, normalized, ct);
+            }
+
+            var lib = (await libRepo.GetAllAsync(ct)).FirstOrDefault();
             if (lib is null)
             {
                 lib = TypstUserLib.Create(req.Content);
-                await repo.AddAsync(lib, ct);
+                await libRepo.AddAsync(lib, ct);
             }
             else
             {
                 lib.UpdateContent(req.Content);
-                repo.Update(lib);
+                libRepo.Update(lib);
             }
-            await repo.SaveChangesAsync(ct);
-            return Results.Ok(new { content = lib.Content });
+            await libRepo.SaveChangesAsync(ct);
+
+            // Проверка не блокирует сохранение: инвариант «сохранение = черновик», и на середине
+            // рефакторинга работу надо дать отложить. Результат возвращаем, чтобы состояние
+            // «библиотека не собирается» было видно сразу, а не при следующей генерации.
+            var snapshot = await provider.GetAsync(ct);
+            UserLibCheckResult check;
+            try
+            {
+                check = await checker.CheckAsync(snapshot.Entrypoint, snapshot.Files, ct);
+            }
+            catch (Exception ex)
+            {
+                // Недоступный Typst CLI — не повод потерять сохранение; честно говорим, что не проверили.
+                check = new UserLibCheckResult(
+                    [new UserLibError(UserLibAnalysis.EntrypointName, 0, 0,
+                        $"Проверить библиотеку не удалось: {ex.Message}")],
+                    UserLibAnalysis.Warnings(snapshot.Entrypoint, snapshot.Files));
+            }
+
+            return Results.Ok(new
+            {
+                content = snapshot.Entrypoint,
+                files = snapshot.Files.Select(f => new { path = f.Path, content = f.Content }),
+                check = new
+                {
+                    ok = check.Ok,
+                    errors = check.Errors.Select(e => new { path = e.Path, line = e.Line, column = e.Column, message = e.Message }),
+                    warnings = check.Warnings.Select(w => new { path = w.Path, message = w.Message }),
+                },
+            });
         });
+    }
+
+    /// <summary>
+    /// Приведение дерева в БД к присланному состоянию. Существующие файлы обновляются на месте, а не
+    /// удаляются и создаются заново — иначе на каждом сохранении терялись бы <c>CreatedAt</c> и
+    /// идентификаторы, по которым файл узнаётся между сохранениями.
+    /// </summary>
+    private static async Task ApplyTreeAsync(
+        IRepository<TypstUserLibFile> fileRepo, IReadOnlyList<UserLibFile> desired, CancellationToken ct)
+    {
+        var existing = (await fileRepo.GetAllAsync(ct)).ToDictionary(f => f.Path, StringComparer.Ordinal);
+        var desiredPaths = desired.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var file in desired)
+        {
+            if (existing.TryGetValue(file.Path, out var row))
+            {
+                if (!string.Equals(row.Content, file.Content, StringComparison.Ordinal))
+                {
+                    row.Update(file.Content);
+                    fileRepo.Update(row);
+                }
+            }
+            else
+            {
+                await fileRepo.AddAsync(TypstUserLibFile.Create(file.Path, file.Content), ct);
+            }
+        }
+
+        foreach (var (path, row) in existing)
+            if (!desiredPaths.Contains(path))
+                fileRepo.Remove(row);
+
+        await fileRepo.SaveChangesAsync(ct);
     }
 }
 
-record SaveTypstUserLibRequest(string Content);
+record UserLibFileRequest(string Path, string? Content);
+
+record SaveTypstUserLibRequest(string Content, IReadOnlyList<UserLibFileRequest>? Files = null);

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -209,6 +209,7 @@ builder.Services.AddScoped<IRepository<BHS.CRG.Domain.Reconciliation.Reconciliat
     Repository<BHS.CRG.Domain.Reconciliation.ReconciliationAlias>>();
 builder.Services.AddScoped<IRepository<DocumentSetOutput>, Repository<DocumentSetOutput>>();
 builder.Services.AddScoped<IRepository<TypstUserLib>, Repository<TypstUserLib>>();
+builder.Services.AddScoped<IRepository<TypstUserLibFile>, Repository<TypstUserLibFile>>();
 builder.Services.AddScoped<IRepository<QualityDocument>, Repository<QualityDocument>>();
 builder.Services.AddScoped<IRepository<MaterialQualityLink>, Repository<MaterialQualityLink>>();
 
@@ -300,6 +301,10 @@ builder.Services.AddHttpClient<IFileUrlFetcher, HttpFileUrlFetcher>()
 builder.Services.AddSingleton<TypstGenerator>();
 builder.Services.AddSingleton<IDocumentGeneratorFactory, DocumentGeneratorFactory>();
 builder.Services.AddSingleton<ITypstSyntaxChecker, TypstSyntaxChecker>();
+builder.Services.AddSingleton<BHS.CRG.Application.Templates.IUserLibChecker, UserLibChecker>();
+// Единая точка чтения библиотеки (issue #473) — раньше три места читали её каждое по-своему.
+builder.Services.AddScoped<BHS.CRG.Application.Templates.IUserLibProvider,
+    BHS.CRG.Application.Templates.UserLibProvider>();
 
 // ── DataSets ──────────────────────────────────────────────────────────────────
 builder.Services.AddSingleton<IDataSetParser, CsvDataSetParser>();

--- a/src/server/BHS.CRG.Application/Backup/BackupModels.cs
+++ b/src/server/BHS.CRG.Application/Backup/BackupModels.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 
 namespace BHS.CRG.Application.Backup;
 
@@ -16,6 +16,7 @@ public record BackupManifest(
     BackupEnumType[]? EnumTypes = null,
     BackupTemplateAsset[]? TemplateAssets = null,
     BackupTypstUserLib? TypstUserLib = null,
+    IReadOnlyList<BackupTypstUserLibFile>? TypstUserLibFiles = null,
     BackupRecognitionProfile[]? RecognitionProfiles = null);
 
 public record BackupPrimitiveType(
@@ -59,6 +60,12 @@ public record BackupTemplateAsset(
 // Общая Typst-библиотека (userlib.typ) — синглтон, подмешивается при компиляции всех шаблонов.
 public record BackupTypstUserLib(string Content, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
 
+// Файл дерева библиотеки (issue #473). Добавлено АДДИТИВНО, без подъёма версии схемы: иначе
+// копии предыдущей версии перестали бы восстанавливаться (конвенция #403). Старый бэкап просто
+// не несёт этой секции — дерево останется пустым, а точка входа восстановится как раньше.
+public record BackupTypstUserLibFile(
+    Guid Id, string Path, string Content, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
 // Профиль распознавания (issue #406) — параметры к хардкод-промптам. Конфигурация, влияющая на
 // извлекаемые данные, поэтому в бэкапе. Встроенные несут Code (ключ ре-сидинга) и IsModified:
 // восстановленный правленый профиль не должен быть затёрт сидингом на целевой системе.
@@ -87,5 +94,6 @@ public record RestoreReport(
     int TemplateAssetsCreated = 0,
     int TemplateAssetsUpdated = 0,
     bool TypstUserLibRestored = false,
+    int TypstUserLibFilesRestored = 0,
     int RecognitionProfilesCreated = 0,
     int RecognitionProfilesUpdated = 0);

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Notifications;
@@ -18,7 +18,7 @@ public class GenerateDocumentHandler(
     IRepository<Template> templateRepo,
     IRepository<DocumentType> docTypeRepo,
     IRepository<Domain.Catalog.PrimitiveType> primitiveRepo,
-    IRepository<TypstUserLib> userLibRepo,
+    IUserLibProvider userLib,
     IEntityResolver entityResolver,
     IDataSetResolver dataSetResolver,
     IQualityLinkResolver qualityLinkResolver,
@@ -108,15 +108,18 @@ public class GenerateDocumentHandler(
 
             string? typeBlocksContent = null;
             string? userLibContent = null;
+            IReadOnlyList<UserLibFile>? userLibFiles = null;
             if (cmd.Format == OutputFormat.Pdf)
             {
                 var preamble = TypstPreambleBuilder.Build(allDocTypes);
                 if (!string.IsNullOrEmpty(preamble))
                     typeBlocksContent = preamble;
 
-                var lib = (await userLibRepo.GetAllAsync(ct)).FirstOrDefault();
-                if (lib is not null && !string.IsNullOrWhiteSpace(lib.Content))
-                    userLibContent = lib.Content;
+                var snapshot = await userLib.GetAsync(ct);
+                if (!string.IsNullOrWhiteSpace(snapshot.Entrypoint))
+                    userLibContent = snapshot.Entrypoint;
+                if (snapshot.Files.Count > 0)
+                    userLibFiles = snapshot.Files;
             }
 
             var ext = cmd.Format == OutputFormat.Pdf ? "pdf" : "docx";
@@ -141,7 +144,7 @@ public class GenerateDocumentHandler(
                 var generator = generatorFactory.Create(cmd.Format);
                 var request = new GenerationRequest(template.Content, cmd.Format, context,
                     TypeBlocksContent: typeBlocksContent, UserLibContent: userLibContent,
-                    TemplateAssets: templateAssets);
+                    TemplateAssets: templateAssets, UserLibFiles: userLibFiles);
                 var bytes = await generator.GenerateAsync(request, ct);
 
                 // Обратная запись метаданных — только с ПЕРВОГО файла (репрезентативно: число листов и т.п.).

--- a/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
+++ b/src/server/BHS.CRG.Application/Generation/GetGenerationDebugBundle.cs
@@ -1,4 +1,4 @@
-using System.Text.Encodings.Web;
+﻿using System.Text.Encodings.Web;
 using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Templates;
@@ -20,7 +20,10 @@ public record GenerationDebugBundle(
     string DataJson,
     string TypeBlocks,
     string UserLib,
-    ResolvedTemplateAssets TemplateAssets);
+    ResolvedTemplateAssets TemplateAssets,
+    // Дерево библиотеки (issue #473). Без него бандл ломается на первом же вложенном импорте —
+    // точка входа реэкспортирует файлы, которых в пакете бы не оказалось.
+    IReadOnlyList<UserLibFile> UserLibFiles);
 
 public record GetGenerationDebugBundleQuery(Guid InstanceId) : IRequest<GenerationDebugBundle?>;
 
@@ -28,7 +31,7 @@ public class GetGenerationDebugBundleHandler(
     IRepository<DomainObject> instanceRepo,
     IRepository<Template> templateRepo,
     IRepository<DocumentType> docTypeRepo,
-    IRepository<TypstUserLib> userLibRepo,
+    IUserLibProvider userLib,
     IEntityResolver entityResolver,
     IDataSetResolver dataSetResolver,
     IQualityLinkResolver qualityLinkResolver,
@@ -79,10 +82,10 @@ public class GetGenerationDebugBundleHandler(
         var dataJson = JsonSerializer.Serialize(context.Data, JsonOpts);
         var typeBlocks = TypstPreambleBuilder.Build(allDocTypes);
 
-        var allLibs = await userLibRepo.GetAllAsync(ct);
-        var userLib = allLibs.FirstOrDefault()?.Content ?? "";
+        var libSnapshot = await userLib.GetAsync(ct);
 
         var templateAssets = await templateAssetResolver.ResolveAsync(template.Id, instance.CompositeTypeId, ct);
-        return new GenerationDebugBundle(template.Content, dataJson, typeBlocks, userLib, templateAssets);
+        return new GenerationDebugBundle(template.Content, dataJson, typeBlocks,
+            libSnapshot.Entrypoint, templateAssets, libSnapshot.Files);
     }
 }

--- a/src/server/BHS.CRG.Application/Generation/IDocumentGenerator.cs
+++ b/src/server/BHS.CRG.Application/Generation/IDocumentGenerator.cs
@@ -14,5 +14,7 @@ public record GenerationRequest(
     GenerationContext Context,
     string? TypeBlocksContent = null,
     string? UserLibContent = null,
-    ResolvedTemplateAssets? TemplateAssets = null
+    ResolvedTemplateAssets? TemplateAssets = null,
+    // Дерево библиотеки (issue #473) — материализуется в подпапку userlib/ рядом с точкой входа.
+    IReadOnlyList<UserLibFile>? UserLibFiles = null
 );

--- a/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
+++ b/src/server/BHS.CRG.Application/Generation/PreviewDocument.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Application.Templates;
@@ -35,7 +35,7 @@ public class PreviewDocumentHandler(
     IRepository<DomainObject> instanceRepo,
     IRepository<Template> templateRepo,
     IRepository<DocumentType> docTypeRepo,
-    IRepository<TypstUserLib> userLibRepo,
+    IUserLibProvider userLib,
     IEntityResolver entityResolver,
     IDataSetResolver dataSetResolver,
     IQualityLinkResolver qualityLinkResolver,
@@ -93,8 +93,7 @@ public class PreviewDocumentHandler(
             TypeStamper.Stamp(context, instance.CompositeTypeId, allDocTypes.ToDictionary(t => t.Id));
 
             var preamble = TypstPreambleBuilder.Build(allDocTypes);
-            var lib = (await userLibRepo.GetAllAsync(ct)).FirstOrDefault();
-            var userLib = lib is not null && !string.IsNullOrWhiteSpace(lib.Content) ? lib.Content : null;
+            var libSnapshot = await userLib.GetAsync(ct);
 
             context.Set("params", TemplateParams.Effective(template.Parameters,
                 TemplateParams.OverridesForTemplate(instance.TemplateParams, template.Id)));
@@ -103,8 +102,9 @@ public class PreviewDocumentHandler(
             var generator = generatorFactory.Create(OutputFormat.Pdf);
             var request = new GenerationRequest(template.Content, OutputFormat.Pdf, context,
                 TypeBlocksContent: string.IsNullOrEmpty(preamble) ? null : preamble,
-                UserLibContent: userLib,
-                TemplateAssets: assets);
+                UserLibContent: string.IsNullOrWhiteSpace(libSnapshot.Entrypoint) ? null : libSnapshot.Entrypoint,
+                TemplateAssets: assets,
+                UserLibFiles: libSnapshot.Files.Count > 0 ? libSnapshot.Files : null);
             var bytes = await generator.GenerateAsync(request, ct);
             return PreviewDocumentResult.Ok(bytes);
         }

--- a/src/server/BHS.CRG.Application/Templates/IUserLibChecker.cs
+++ b/src/server/BHS.CRG.Application/Templates/IUserLibChecker.cs
@@ -1,0 +1,34 @@
+namespace BHS.CRG.Application.Templates;
+
+/// <summary>
+/// Ошибка компиляции библиотеки с указанием ФАЙЛА — в дереве ошибка может прилететь откуда угодно,
+/// в том числе из файла, который сейчас не открыт.
+/// </summary>
+/// <param name="Path">Путь от <c>userlib/</c>, либо <c>userlib.typ</c> для точки входа.</param>
+public record UserLibError(string Path, int Line, int Column, string Message);
+
+/// <summary>
+/// Итог проверки библиотеки. Ошибки означают, что библиотека НЕ собирается — а её импортирует каждый
+/// шаблон, поэтому встанет генерация всех документов. Предупреждения собираться не мешают.
+/// </summary>
+/// <remarks>
+/// Проверка компилирует зонд, который лишь ИМПОРТИРУЕТ точку входа: ловятся синтаксис и битые пути
+/// импортов, но НЕ поведение — шаблон, зовущий функцию с изменившейся сигнатурой, проверку пройдёт и
+/// упадёт при генерации. Поэтому состояние называется «библиотека собирается», а не «шаблоны
+/// работают»: второе было бы обещанием, которого проверка не даёт.
+/// </remarks>
+public record UserLibCheckResult(
+    IReadOnlyList<UserLibError> Errors,
+    IReadOnlyList<UserLibWarning> Warnings)
+{
+    public bool Ok => Errors.Count == 0;
+
+    public static UserLibCheckResult Empty => new([], []);
+}
+
+/// <summary>Проверка дерева библиотеки: компиляция зонда + разбор дерева без Typst.</summary>
+public interface IUserLibChecker
+{
+    Task<UserLibCheckResult> CheckAsync(
+        string entrypointContent, IReadOnlyList<UserLibFile> files, CancellationToken ct);
+}

--- a/src/server/BHS.CRG.Application/Templates/UserLibAnalysis.cs
+++ b/src/server/BHS.CRG.Application/Templates/UserLibAnalysis.cs
@@ -1,0 +1,151 @@
+using System.Text.RegularExpressions;
+
+namespace BHS.CRG.Application.Templates;
+
+/// <summary>Файл дерева библиотеки в виде, пригодном для анализа и материализации.</summary>
+public record UserLibFile(string Path, string Content);
+
+/// <summary>Замечание к библиотеке, не мешающее ей собраться, но почти наверняка означающее ошибку.</summary>
+/// <param name="Path">Файл, к которому относится (пустой — общее).</param>
+public record UserLibWarning(string Path, string Message);
+
+/// <summary>
+/// Разбор дерева библиотеки БЕЗ запуска Typst (issue #473).
+///
+/// Ловит два режима отказа, которые создало само разрезание одного файла на много и которые
+/// компилятор не считает ошибками:
+///
+/// 1. <b>Файл не подключён.</b> Пользователь создаёт «util/text.typ», забывает дописать реэкспорт в
+///    точку входа — и функции просто не появляются в шаблонах. Ошибки нет: файл валиден, он никому
+///    не нужен. Самый неприятный вид отказа — молчаливый.
+/// 2. <b>Одноимённые объявления в разных файлах.</b> Проверено на Typst 0.15.1: при двух
+///    <c>#import ...: *</c> с одинаковым именем побеждает последний импорт, БЕЗ предупреждения. В
+///    одном файле два одинаковых <c>#let</c> видно глазом, в двадцати — нет.
+/// </summary>
+public static class UserLibAnalysis
+{
+    /// <summary>Имя точки входа — то же, что видит шаблон.</summary>
+    public const string EntrypointName = "userlib.typ";
+
+    // #import "путь": ... — путь в двойных кавычках. Пакетные координаты («@ns/name:1.0.0») сюда не
+    // подходят и не должны: дерево локальное.
+    private static readonly Regex ImportRe =
+        new(@"#import\s+""([^""]+)""", RegexOptions.Compiled);
+
+    // Объявления верхнего уровня: строка начинается с #let/#show-независимого let. Вложенные let
+    // (внутри тела функции) наружу не экспортируются, поэтому берём только неотступленные.
+    private static readonly Regex TopLevelLetRe =
+        new(@"(?m)^#let\s+([\p{L}\p{N}_][\p{L}\p{N}_-]*)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Пути, достижимые из точки входа по цепочке импортов. Пути в результате — относительные от
+    /// <c>userlib/</c>, как и у самих файлов.
+    /// </summary>
+    public static HashSet<string> ReachableFrom(string entrypointContent, IReadOnlyList<UserLibFile> files)
+    {
+        var byPath = files.ToDictionary(f => f.Path, StringComparer.Ordinal);
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+
+        // Точка входа лежит в КОРНЕ временной папки, а дерево — в подпапке userlib/, поэтому её
+        // импорты пишутся как «userlib/gost/f3.typ». У файлов дерева база — их собственная папка,
+        // и для файла в корне дерева она ПУСТАЯ — отличать её от точки входа по пустой строке
+        // нельзя: так «a.typ», импортирующий соседний «b.typ», переставал резолвиться.
+        var queue = new Queue<(string? BaseDir, string Content)>();
+        queue.Enqueue((null, entrypointContent));
+        var entryImportsPrefix = UserLibPath.FolderName + "/";
+
+        while (queue.Count > 0)
+        {
+            var (baseDir, content) = queue.Dequeue();
+            foreach (Match m in ImportRe.Matches(content))
+            {
+                var raw = m.Groups[1].Value.Replace('\\', '/');
+                if (raw.StartsWith('@')) continue;   // координата пакета — не наш файл
+
+                string? target;
+                if (baseDir is null)
+                {
+                    // из точки входа: интересуют только ссылки внутрь дерева
+                    if (!raw.StartsWith(entryImportsPrefix, StringComparison.Ordinal)) continue;
+                    target = raw[entryImportsPrefix.Length..];
+                }
+                else
+                {
+                    target = ResolveRelative(baseDir, raw);
+                }
+
+                if (target is null || !byPath.TryGetValue(target, out var file)) continue;
+                if (!reachable.Add(target)) continue;   // уже обошли — заодно и защита от цикла
+
+                var dir = target.Contains('/') ? target[..target.LastIndexOf('/')] : string.Empty;
+                queue.Enqueue((dir, file.Content));
+            }
+        }
+
+        return reachable;
+    }
+
+    /// <summary>Разрешение относительного пути «../../util/text.typ» от папки файла.</summary>
+    private static string? ResolveRelative(string baseDir, string raw)
+    {
+        var parts = new List<string>(baseDir.Length == 0 ? [] : baseDir.Split('/'));
+        foreach (var segment in raw.Split('/'))
+        {
+            switch (segment)
+            {
+                case "" or ".":
+                    break;
+                case "..":
+                    if (parts.Count == 0) return null;   // ушли выше дерева — такого файла у нас нет
+                    parts.RemoveAt(parts.Count - 1);
+                    break;
+                default:
+                    parts.Add(segment);
+                    break;
+            }
+        }
+        return parts.Count == 0 ? null : string.Join('/', parts);
+    }
+
+    /// <summary>Имена, объявленные в файле на верхнем уровне (то, что уходит наружу при <c>: *</c>).</summary>
+    public static IReadOnlyList<string> TopLevelNames(string content) =>
+        TopLevelLetRe.Matches(content).Select(m => m.Groups[1].Value).Distinct(StringComparer.Ordinal).ToList();
+
+    /// <summary>
+    /// Замечания по дереву: неподключённые файлы и одноимённые объявления. Порядок устойчив —
+    /// список показывается пользователю и не должен «прыгать» между сохранениями.
+    /// </summary>
+    public static IReadOnlyList<UserLibWarning> Warnings(
+        string entrypointContent, IReadOnlyList<UserLibFile> files)
+    {
+        var warnings = new List<UserLibWarning>();
+        var reachable = ReachableFrom(entrypointContent, files);
+
+        foreach (var file in files.OrderBy(f => f.Path, StringComparer.Ordinal))
+            if (!reachable.Contains(file.Path))
+                warnings.Add(new UserLibWarning(file.Path,
+                    $"Файл не подключён: из «{EntrypointName}» до него нет цепочки импортов, его функции в шаблонах не появятся."));
+
+        // Дубликаты ищем только среди подключённых: неподключённый файл ни с кем не конфликтует,
+        // а сообщение о нём уже есть выше.
+        var declarations = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var file in files.Where(f => reachable.Contains(f.Path)).OrderBy(f => f.Path, StringComparer.Ordinal))
+            foreach (var name in TopLevelNames(file.Content))
+                (declarations.TryGetValue(name, out var list) ? list : declarations[name] = []).Add(file.Path);
+
+        foreach (var (name, paths) in declarations.Where(d => d.Value.Count > 1).OrderBy(d => d.Key, StringComparer.Ordinal))
+            foreach (var path in paths)
+                warnings.Add(new UserLibWarning(path,
+                    $"«{name}» объявлено ещё в: {string.Join(", ", paths.Where(p => p != path))}. "
+                    + "Typst молча возьмёт объявление из файла, импортированного последним."));
+
+        return warnings;
+    }
+
+    /// <summary>
+    /// Строка реэкспорта для только что созданного файла — чтобы он не остался молча неподключённым.
+    /// Путь пишется от корня временной папки, как его видит точка входа.
+    /// </summary>
+    public static string ReExportLine(string path) =>
+        $"#import \"{UserLibPath.FolderName}/{path}\": *";
+}

--- a/src/server/BHS.CRG.Application/Templates/UserLibPath.cs
+++ b/src/server/BHS.CRG.Application/Templates/UserLibPath.cs
@@ -1,0 +1,121 @@
+using System.Globalization;
+
+namespace BHS.CRG.Application.Templates;
+
+/// <summary>
+/// Путь файла внутри дерева библиотеки (issue #473) — относительный, от папки <c>userlib/</c>.
+///
+/// Путь приходит от пользователя и превращается в путь на диске при материализации во временную
+/// папку генерации, поэтому проверка тут не про удобство, а про то, чтобы запись не ушла за пределы
+/// <c>userlib/</c>. Логика чистая и лежит в Application — её проверяют тесты, а не живая генерация.
+/// </summary>
+public static class UserLibPath
+{
+    /// <summary>Расширение единственного допустимого вида файлов: библиотека — это Typst-код.</summary>
+    public const string Extension = ".typ";
+
+    /// <summary>Имя папки дерева во временной папке генерации и внутри отладочного бандла.</summary>
+    public const string FolderName = "userlib";
+
+    private const int MaxLength = 200;
+    private const int MaxSegments = 10;
+
+    // Windows не создаст файл с этими символами, а часть из них к тому же меняет смысл пути.
+    private static readonly char[] Forbidden = ['<', '>', ':', '"', '|', '?', '*'];
+
+    // Зарезервированные имена устройств Windows: файл «CON.typ» не создастся, причём молча и с
+    // невнятной ошибкой ввода-вывода уже во время генерации.
+    private static readonly HashSet<string> ReservedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    };
+
+    /// <summary>
+    /// Нормализованный путь либо причина отказа. Нормализация — только разделители и лишние пробелы
+    /// по краям: менять сам путь молча нельзя, иначе пользователь сохранит одно, а импортировать
+    /// придётся другое.
+    /// </summary>
+    public static bool TryNormalize(string? raw, out string normalized, out string? error)
+    {
+        normalized = string.Empty;
+        error = null;
+
+        var path = (raw ?? string.Empty).Replace('\\', '/').Trim();
+        if (path.Length == 0) { error = "Путь пустой."; return false; }
+        if (path.Length > MaxLength) { error = $"Путь длиннее {MaxLength} символов."; return false; }
+        if (path.StartsWith('/')) { error = "Путь должен быть относительным — без ведущего «/»."; return false; }
+
+        var segments = path.Split('/');
+        if (segments.Length > MaxSegments) { error = $"Слишком глубокая вложенность (больше {MaxSegments} уровней)."; return false; }
+
+        foreach (var segment in segments)
+        {
+            if (segment.Length == 0) { error = "Пустой сегмент пути (двойной «/» или «/» в конце)."; return false; }
+            if (segment is "." or "..") { error = "Сегменты «.» и «..» запрещены."; return false; }
+            if (segment != segment.Trim()) { error = $"Сегмент «{segment}» начинается или заканчивается пробелом."; return false; }
+            if (segment.EndsWith('.')) { error = $"Сегмент «{segment}» заканчивается точкой."; return false; }
+            if (segment.Any(char.IsControl)) { error = "Управляющие символы в пути запрещены."; return false; }
+            if (segment.IndexOfAny(Forbidden) >= 0)
+            {
+                error = $"Сегмент «{segment}» содержит запрещённый символ (из {string.Join(' ', Forbidden)}).";
+                return false;
+            }
+            var withoutExt = Path.GetFileNameWithoutExtension(segment);
+            if (ReservedNames.Contains(withoutExt))
+            {
+                error = $"«{withoutExt}» — зарезервированное имя Windows, файл с таким именем не создастся.";
+                return false;
+            }
+        }
+
+        if (!path.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"Файл библиотеки должен иметь расширение «{Extension}».";
+            return false;
+        }
+        if (Path.GetFileNameWithoutExtension(segments[^1]).Length == 0)
+        {
+            error = "Имя файла пустое.";
+            return false;
+        }
+
+        normalized = path;
+        return true;
+    }
+
+    /// <summary>Нормализованный путь или исключение — для мест, где отказ уже отсеян валидацией.</summary>
+    public static string Normalize(string raw) =>
+        TryNormalize(raw, out var normalized, out var error)
+            ? normalized
+            : throw new ArgumentException(error, nameof(raw));
+
+    /// <summary>
+    /// Сравнение путей. Регистр учитываем: Linux в контейнере различает «Gost/» и «gost/», и импорт,
+    /// написанный по одному написанию, на другом сломается — расхождение проявилось бы только в
+    /// продакшене.
+    /// </summary>
+    public static bool AreEqual(string a, string b) => string.Equals(a, b, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Путь <paramref name="path"/> лежит внутри папки <paramref name="folder"/> — для переименования
+    /// и удаления папки целиком (папки отдельной сущности не имеют, они подразумеваются путями).
+    /// </summary>
+    public static bool IsInFolder(string path, string folder)
+    {
+        var prefix = folder.EndsWith('/') ? folder : folder + "/";
+        return path.StartsWith(prefix, StringComparison.Ordinal);
+    }
+
+    /// <summary>Части пути для отображения деревом: «gost/forms/f3.typ» → [gost, forms, f3.typ].</summary>
+    public static string[] Segments(string path) => path.Split('/');
+
+    /// <summary>Проверка, что имя не отличается от другого только регистром — предупредить до записи.</summary>
+    public static bool DiffersOnlyByCase(string a, string b) =>
+        !AreEqual(a, b) && string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Человеческая сортировка дерева: сначала по папкам, внутри — по имени.</summary>
+    public static int Compare(string a, string b) =>
+        string.Compare(a, b, CultureInfo.GetCultureInfo("ru-RU"), CompareOptions.StringSort);
+}

--- a/src/server/BHS.CRG.Application/Templates/UserLibProvider.cs
+++ b/src/server/BHS.CRG.Application/Templates/UserLibProvider.cs
@@ -1,0 +1,39 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Templates;
+
+/// <summary>Библиотека целиком: точка входа плюс дерево.</summary>
+public record UserLibSnapshot(string Entrypoint, IReadOnlyList<UserLibFile> Files)
+{
+    public static UserLibSnapshot Empty => new(string.Empty, []);
+
+    /// <summary>Пустая библиотека — плейсхолдер вместо неё писать не нужно, это делает материализатор.</summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Entrypoint) && Files.Count == 0;
+}
+
+/// <summary>
+/// Единая точка чтения библиотеки. До issue #473 три места (генерация, предпросмотр, отладочный
+/// бандл) читали её каждое своим <c>GetAllAsync().FirstOrDefault()</c>; с появлением дерева такое
+/// расхождение означало бы, что где-то файл подмешивается, а где-то нет — и разница вылезала бы
+/// только в PDF.
+/// </summary>
+public interface IUserLibProvider
+{
+    Task<UserLibSnapshot> GetAsync(CancellationToken ct = default);
+}
+
+public class UserLibProvider(
+    IRepository<TypstUserLib> libRepo, IRepository<TypstUserLibFile> fileRepo) : IUserLibProvider
+{
+    public async Task<UserLibSnapshot> GetAsync(CancellationToken ct = default)
+    {
+        var lib = (await libRepo.GetAllAsync(ct)).FirstOrDefault();
+        var files = (await fileRepo.GetAllAsync(ct))
+            .OrderBy(f => f.Path, StringComparer.Ordinal)
+            .Select(f => new UserLibFile(f.Path, f.Content))
+            .ToList();
+
+        return new UserLibSnapshot(lib?.Content ?? string.Empty, files);
+    }
+}

--- a/src/server/BHS.CRG.Domain/Documents/TypstUserLibFile.cs
+++ b/src/server/BHS.CRG.Domain/Documents/TypstUserLibFile.cs
@@ -1,0 +1,29 @@
+using BHS.CRG.Domain.Common;
+
+namespace BHS.CRG.Domain.Documents;
+
+/// <summary>
+/// Файл дерева библиотеки Typst (issue #473). Путь — относительный, от папки <c>userlib/</c>
+/// («gost/forms/f3.typ»); отдельной сущности у папок нет — папка существует ровно постольку,
+/// поскольку в ней лежит файл, а пустая папка в Typst бессмысленна.
+///
+/// Точка входа <c>userlib.typ</c> сюда НЕ входит: она осталась в <see cref="TypstUserLib"/>, чтобы
+/// уже выпущенные шаблоны с дословным <c>#import "userlib.typ": *</c> (#353) продолжали работать
+/// без переписывания истории.
+/// </summary>
+public class TypstUserLibFile : Entity
+{
+    public string Path { get; private set; } = string.Empty;
+    public string Content { get; private set; } = string.Empty;
+
+    private TypstUserLibFile() { }
+
+    public static TypstUserLibFile Create(string path, string content)
+        => new() { Path = path, Content = content };
+
+    public void Update(string content) { Content = content; TouchUpdatedAt(); }
+
+    public static TypstUserLibFile Restore(
+        Guid id, string path, string content, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        => new() { Id = id, Path = path, Content = content, CreatedAt = createdAt, UpdatedAt = updatedAt };
+}

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -70,6 +70,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         var enumTypes = await db.EnumTypes.AsNoTracking().ToListAsync(ct);
         var templateAssets = await db.TemplateAssets.AsNoTracking().ToListAsync(ct);
         var userLib = await db.TypstUserLibs.AsNoTracking().FirstOrDefaultAsync(ct);
+        var userLibFiles = await db.TypstUserLibFiles.AsNoTracking().OrderBy(f => f.Path).ToListAsync(ct);
         var recognitionProfiles = await db.RecognitionProfiles.AsNoTracking().ToListAsync(ct);
 
         return new BackupManifest(
@@ -104,6 +105,9 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
                 a.CreatedAt, a.UpdatedAt)).ToArray(),
             TypstUserLib: userLib is null ? null
                 : new BackupTypstUserLib(userLib.Content, userLib.CreatedAt, userLib.UpdatedAt),
+            TypstUserLibFiles: userLibFiles
+                .Select(f => new BackupTypstUserLibFile(f.Id, f.Path, f.Content, f.CreatedAt, f.UpdatedAt))
+                .ToList(),
             RecognitionProfiles: recognitionProfiles.Select(p => new BackupRecognitionProfile(
                 p.Id, p.Name, p.Code, p.Kind.ToString(),
                 p.Fields.RootElement.Clone(), p.Shape?.RootElement.Clone(),
@@ -177,6 +181,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             await RestoreTemplatesAsync(manifest.Templates, stats, warnings, ct);
             await RestoreTemplateAssetsAsync(manifest.TemplateAssets ?? [], stats, warnings, ct);
             await RestoreTypstUserLibAsync(manifest.TypstUserLib, stats, ct);
+            await RestoreTypstUserLibFilesAsync(manifest.TypstUserLibFiles, stats, ct);
             await RestoreCatalogEntitiesAsync(manifest.CatalogEntities, stats, warnings, ct);
             await RestoreCommonDataEntriesAsync(manifest.CommonDataEntries, stats, warnings, ct);
             await tx.CommitAsync(ct);
@@ -190,6 +195,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
                 stats.EnumTypesCreated, stats.EnumTypesUpdated,
                 stats.TemplateAssetsCreated, stats.TemplateAssetsUpdated,
                 stats.TypstUserLibRestored,
+                stats.TypstUserLibFilesRestored,
                 stats.RecognitionProfilesCreated, stats.RecognitionProfilesUpdated);
         }
         catch (Exception ex)
@@ -388,6 +394,27 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         stats.TypstUserLibRestored = true;
     }
 
+    /// <summary>
+    /// Дерево библиотеки (issue #473). Восстановление ЗАМЕЩАЮЩЕЕ: дерево — единое целое, и оставить
+    /// на целевой системе файлы, которых в копии нет, значит собрать библиотеку, которой никогда не
+    /// существовало (лишний файл переопределил бы одноимённую функцию молча).
+    /// </summary>
+    private async Task RestoreTypstUserLibFilesAsync(
+        IReadOnlyList<BackupTypstUserLibFile>? items, RestoreStats stats, CancellationToken ct)
+    {
+        if (items is null) return; // бэкап предыдущей версии — секции просто нет, дерево не трогаем
+
+        var existing = await db.TypstUserLibFiles.ToListAsync(ct);
+        db.TypstUserLibFiles.RemoveRange(existing);
+        foreach (var item in items)
+            db.TypstUserLibFiles.Add(TypstUserLibFile.Restore(
+                item.Id, item.Path, item.Content, item.CreatedAt, item.UpdatedAt));
+
+        await db.SaveChangesAsync(ct);
+        db.ChangeTracker.Clear();
+        stats.TypstUserLibFilesRestored = items.Count;
+    }
+
     private async Task RestoreDocumentTypesAsync(
         BackupDocumentType[] items, RestoreStats stats, List<string> warnings, CancellationToken ct)
     {
@@ -506,6 +533,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         public int TemplatesCreated, TemplatesUpdated;
         public int TemplateAssetsCreated, TemplateAssetsUpdated;
         public bool TypstUserLibRestored;
+        public int TypstUserLibFilesRestored;
         public int CatalogEntitiesCreated, CatalogEntitiesUpdated;
         public int CommonDataEntriesCreated, CommonDataEntriesUpdated;
     }

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
@@ -69,11 +69,11 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
             if (!File.Exists(typeBlocksPath))
                 throw new InvalidOperationException($"Failed to write {TypeBlocksFileName} to {tmpDir}");
 
-            // userlib.typ — пользовательские вспомогательные функции; всегда присутствует в tmpDir
-            var userLibContent = string.IsNullOrEmpty(request.UserLibContent)
-                ? "// user typst library is empty"
-                : request.UserLibContent;
-            await File.WriteAllTextAsync(Path.Combine(tmpDir, UserLibFileName), userLibContent, Encoding.UTF8, ct);
+            // userlib.typ — точка входа пользовательской библиотеки; всегда присутствует в tmpDir.
+            // Рядом раскладывается дерево userlib/ (issue #473), структуру которого задаёт пользователь;
+            // точка входа реэкспортирует его, поэтому шаблон с дословным `#import "userlib.typ": *`
+            // (#353) видит всё вложенное и переписывать историю шаблонов не нужно.
+            await UserLibMaterializer.WriteAsync(tmpDir, request.UserLibContent, request.UserLibFiles, ct);
 
             // Ассеты шаблона (issue #62) — уже свёрнутые по приоритету Template>DocumentType>System
             // резолвером (ITemplateAssetResolver). Картинки — в assets/ по стабильному Name (шаблон

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstShortDiagnostics.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstShortDiagnostics.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>Строка вывода Typst в формате <c>--diagnostic-format short</c>.</summary>
+public record TypstShortDiagnostic(string File, int Line, int Column, string Severity, string Message);
+
+/// <summary>
+/// Разбор коротких диагностик Typst CLI: <c>путь:строка:колонка: severity: сообщение</c>.
+///
+/// Вынесено из <see cref="TypstSyntaxChecker"/>, где шаблон был прибит к одному имени файла
+/// (<c>typeblocks\.typ</c>). Для дерева библиотеки (issue #473) ошибка приходит из произвольного
+/// файла, и такой шаблон дал бы худший вид отказа — ТИХИЙ ЗЕЛЁНЫЙ: ошибок «нет», потому что не
+/// совпал путь.
+/// </summary>
+public static partial class TypstShortDiagnostics
+{
+    // Путь — всё до «:строка:колонка:». Разделитель может быть и «/», и «\» (Windows), поэтому
+    // забираем путь жадно до последней подходящей пары чисел в строке.
+    [GeneratedRegex(@"^(?<file>.+?):(?<line>\d+):(?<col>\d+):\s*(?<sev>error|warning):\s*(?<msg>.*)$",
+        RegexOptions.Multiline)]
+    private static partial Regex ShortDiagRe { get; }
+
+    public static IReadOnlyList<TypstShortDiagnostic> Parse(string? stderr)
+    {
+        if (string.IsNullOrEmpty(stderr)) return [];
+        var result = new List<TypstShortDiagnostic>();
+        foreach (Match m in ShortDiagRe.Matches(stderr))
+            result.Add(new TypstShortDiagnostic(
+                Normalize(m.Groups["file"].Value),
+                int.Parse(m.Groups["line"].Value),
+                int.Parse(m.Groups["col"].Value),
+                m.Groups["sev"].Value,
+                m.Groups["msg"].Value.Trim()));
+        return result;
+    }
+
+    /// <summary>
+    /// Путь из диагностики — в вид, которым оперирует приложение: разделители «/», без префикса
+    /// временной папки (Typst печатает путь так, как получил его от нас — относительно
+    /// рабочей папки процесса).
+    /// </summary>
+    private static string Normalize(string file)
+    {
+        var path = file.Replace('\\', '/').Trim();
+        return path.StartsWith("./", StringComparison.Ordinal) ? path[2..] : path;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstSyntaxChecker.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstSyntaxChecker.cs
@@ -17,9 +17,7 @@ public class TypstSyntaxChecker : ITypstSyntaxChecker
     private static readonly string TypstPath =
         Environment.GetEnvironmentVariable("TYPST_PATH") ?? "typst";
 
-    // Короткий формат диагностики: путь:строка:колонка: severity: сообщение.
-    private static readonly Regex ShortDiag =
-        new(@"typeblocks\.typ:(\d+):(\d+):\s*(error|warning):\s*(.*)", RegexOptions.Compiled);
+    private const string FileName = "typeblocks.typ";
 
     public async Task<IReadOnlyList<TypstSyntaxError>> CheckAsync(string typeBlocksContent, CancellationToken ct)
     {
@@ -53,12 +51,13 @@ public class TypstSyntaxChecker : ITypstSyntaxChecker
             await process.WaitForExitAsync(ct);
             var stderr = await stderrTask;
 
-            var errors = new List<TypstSyntaxError>();
-            foreach (Match m in ShortDiag.Matches(stderr))
-                if (m.Groups[3].Value == "error")
-                    errors.Add(new TypstSyntaxError(
-                        int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value), m.Groups[4].Value.Trim()));
-            return errors;
+            // Разбор общий с проверкой библиотеки (issue #473); отбор по имени файла — здесь, а не в
+            // самом шаблоне: координаты этого контракта заявлены ВНУТРИ typeblocks.typ, и ошибка из
+            // harness'а с чужими номерами строк уехала бы по line-map не туда.
+            return TypstShortDiagnostics.Parse(stderr)
+                .Where(d => d.Severity == "error" && d.File.EndsWith(FileName, StringComparison.Ordinal))
+                .Select(d => new TypstSyntaxError(d.Line, d.Column, d.Message))
+                .ToList();
         }
         finally
         {

--- a/src/server/BHS.CRG.Infrastructure/Generation/UserLibChecker.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/UserLibChecker.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using System.Text;
+using BHS.CRG.Application.Templates;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Проверка дерева библиотеки Typst (issue #473): раскладываем точку входа и дерево ровно так же, как
+/// при генерации, и компилируем зонд, который лишь ИМПОРТИРУЕТ точку входа.
+///
+/// Зачем вообще: библиотеку импортирует КАЖДЫЙ шаблон, поэтому один сломанный файл останавливает
+/// генерацию всех документов. Проверка на сохранении переводит это из «узнаем при следующей
+/// генерации» в «видно сразу».
+///
+/// Чего проверка НЕ делает: тела функций — замыкания, они не вызываются, поэтому ловятся синтаксис и
+/// битые пути импортов, но не поведение. Формулировать результат как «библиотека собирается», не как
+/// «шаблоны работают».
+/// </summary>
+public class UserLibChecker : IUserLibChecker
+{
+    private static readonly string TypstPath =
+        Environment.GetEnvironmentVariable("TYPST_PATH") ?? "typst";
+
+    public async Task<UserLibCheckResult> CheckAsync(
+        string entrypointContent, IReadOnlyList<UserLibFile> files, CancellationToken ct)
+    {
+        // Разбор дерева не зависит от компилятора и обязан отработать, даже если CLI недоступен.
+        var warnings = UserLibAnalysis.Warnings(entrypointContent, files);
+
+        var tmp = Path.Combine(Path.GetTempPath(), "userlib-check-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            await UserLibMaterializer.WriteAsync(tmp, entrypointContent, files, ct);
+
+            // Зонд импортирует точку входа так же, как это делает шаблон. Строка текста — чтобы у
+            // документа была страница и Typst не ругался на пустой вывод.
+            await File.WriteAllTextAsync(Path.Combine(tmp, "check.typ"),
+                $"#import \"{UserLibAnalysis.EntrypointName}\": *\nx\n", Encoding.UTF8, ct);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = TypstPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tmp,
+            };
+            foreach (var a in new[] { "compile", "check.typ", "out.pdf", "--diagnostic-format", "short", "--root", tmp })
+                psi.ArgumentList.Add(a);
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Не удалось запустить Typst CLI");
+
+            var stderrTask = process.StandardError.ReadToEndAsync(ct);
+            await process.WaitForExitAsync(ct);
+            var stderr = await stderrTask;
+
+            var errors = TypstShortDiagnostics.Parse(stderr)
+                .Where(d => d.Severity == "error")
+                .Select(d => new UserLibError(ToLibPath(d.File), d.Line, d.Column, d.Message))
+                // Ошибки самого зонда пользователю не показать — он его не писал и не увидит.
+                .Where(e => e.Path != "check.typ")
+                .ToList();
+
+            return new UserLibCheckResult(errors, warnings);
+        }
+        finally
+        {
+            try { Directory.Delete(tmp, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Путь из диагностики — в путь, которым оперирует интерфейс: точка входа как есть, файлы дерева
+    /// без префикса <c>userlib/</c> (префикс постоянный и ничего не сообщает).
+    /// </summary>
+    private static string ToLibPath(string file)
+    {
+        var prefix = UserLibPath.FolderName + "/";
+        var idx = file.IndexOf(prefix, StringComparison.Ordinal);
+        if (idx >= 0) return file[(idx + prefix.Length)..];
+        return file.EndsWith(UserLibAnalysis.EntrypointName, StringComparison.Ordinal)
+            ? UserLibAnalysis.EntrypointName
+            : file;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/UserLibMaterializer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/UserLibMaterializer.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using BHS.CRG.Application.Templates;
+
+namespace BHS.CRG.Infrastructure.Generation;
+
+/// <summary>
+/// Раскладка библиотеки на диск (issue #473) — единая точка для генерации, проверки при сохранении и
+/// отладочного бандла. Раскладка обязана совпадать во всех трёх: расхождение означало бы, что
+/// проверка зелёная там, где генерация падает.
+///
+/// <code>
+/// &lt;dir&gt;/userlib.typ        — точка входа; её импортирует шаблон (#353, дословно)
+/// &lt;dir&gt;/userlib/...        — дерево, структуру которого задаёт пользователь
+/// </code>
+/// </summary>
+public static class UserLibMaterializer
+{
+    /// <summary>Плейсхолдер пустой библиотеки — файл обязан существовать, иначе импорт в шаблоне не резолвится.</summary>
+    public const string EmptyEntrypoint = "// user typst library is empty";
+
+    public static async Task WriteAsync(
+        string dir, string? entrypointContent, IReadOnlyList<UserLibFile>? files, CancellationToken ct = default)
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, UserLibAnalysis.EntrypointName),
+            string.IsNullOrEmpty(entrypointContent) ? EmptyEntrypoint : entrypointContent,
+            Encoding.UTF8, ct);
+
+        if (files is null || files.Count == 0) return;
+
+        var root = Path.Combine(dir, UserLibPath.FolderName);
+        Directory.CreateDirectory(root);
+        var rootFull = Path.GetFullPath(root);
+
+        foreach (var file in files)
+        {
+            var target = Path.GetFullPath(Path.Combine(root, file.Path.Replace('/', Path.DirectorySeparatorChar)));
+
+            // Путь проверяется при сохранении, но записи мог наделать и восстановленный бэкап из
+            // другой (в том числе более старой) инсталляции. Запись за пределы дерева — не та
+            // ошибка, которую стоит ловить один раз.
+            if (!target.StartsWith(rootFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                throw new InvalidOperationException(
+                    $"Путь файла библиотеки «{file.Path}» выходит за пределы папки {UserLibPath.FolderName}/.");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            await File.WriteAllTextAsync(target, file.Content, Encoding.UTF8, ct);
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260727123456_AddTypstUserLibFiles.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260727123456_AddTypstUserLibFiles.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727123456_AddTypstUserLibFiles")]
+    partial class AddTypstUserLibFiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260727123456_AddTypstUserLibFiles.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260727123456_AddTypstUserLibFiles.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTypstUserLibFiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "typst_user_lib_files",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Path = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Content = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_typst_user_lib_files", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_typst_user_lib_files_Path",
+                table: "typst_user_lib_files",
+                column: "Path",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "typst_user_lib_files");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
@@ -32,6 +32,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options)
     public DbSet<DocumentSetOutput> DocumentSetOutputs => Set<DocumentSetOutput>();
     public DbSet<Subscription> Subscriptions => Set<Subscription>();
     public DbSet<TypstUserLib> TypstUserLibs => Set<TypstUserLib>();
+    public DbSet<TypstUserLibFile> TypstUserLibFiles => Set<TypstUserLibFile>();
     public DbSet<DataSetFile> DataSetFiles => Set<DataSetFile>();
     public DbSet<DataSetSource> DataSetSources => Set<DataSetSource>();
     public DbSet<DataSetBinding> DataSetBindings => Set<DataSetBinding>();

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/TypstUserLibFileConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/TypstUserLibFileConfiguration.cs
@@ -1,0 +1,20 @@
+using BHS.CRG.Domain.Documents;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BHS.CRG.Infrastructure.Persistence.Configurations;
+
+public class TypstUserLibFileConfiguration : IEntityTypeConfiguration<TypstUserLibFile>
+{
+    public void Configure(EntityTypeBuilder<TypstUserLibFile> b)
+    {
+        b.ToTable("typst_user_lib_files");
+        b.HasKey(e => e.Id);
+        b.Property(e => e.Path).IsRequired().HasMaxLength(200);
+        b.Property(e => e.Content).IsRequired();
+
+        // Путь — это то, чем файл адресуется в импортах; два файла с одним путём означали бы, что
+        // при материализации один молча затрёт другой.
+        b.HasIndex(e => e.Path).IsUnique();
+    }
+}

--- a/src/server/BHS.CRG.Tests/Templates/UserLibAnalysisTests.cs
+++ b/src/server/BHS.CRG.Tests/Templates/UserLibAnalysisTests.cs
@@ -1,0 +1,107 @@
+using BHS.CRG.Application.Templates;
+
+namespace BHS.CRG.Tests.Templates;
+
+/// <summary>
+/// Разбор дерева библиотеки (issue #473). Ловит два режима отказа, созданных самим разрезанием одного
+/// файла на много, — оба МОЛЧАЛИВЫЕ: компилятор их ошибками не считает.
+/// </summary>
+public class UserLibAnalysisTests
+{
+    private static UserLibFile F(string path, string content) => new(path, content);
+
+    [Fact]
+    public void ReachesFilesThroughEntrypoint()
+    {
+        var files = new[] { F("gost/f3.typ", "#let place-f3() = []") };
+        var reachable = UserLibAnalysis.ReachableFrom("#import \"userlib/gost/f3.typ\": *", files);
+        Assert.Equal(["gost/f3.typ"], reachable);
+    }
+
+    /// <summary>Цепочка: точка входа → файл → его относительный импорт. Так устроена реальная библиотека.</summary>
+    [Fact]
+    public void ReachesTransitively_ThroughRelativeImports()
+    {
+        var files = new[]
+        {
+            F("gost/forms/f3.typ", "#import \"../../util/text.typ\": capitalize-first\n#let place-f3() = []"),
+            F("util/text.typ", "#let capitalize-first(s) = s"),
+        };
+        var reachable = UserLibAnalysis.ReachableFrom("#import \"userlib/gost/forms/f3.typ\": *", files);
+        Assert.Equal(["gost/forms/f3.typ", "util/text.typ"], reachable.OrderBy(x => x));
+    }
+
+    /// <summary>
+    /// Самый неприятный отказ: файл валиден, просто никем не импортирован — функции молча не появятся
+    /// в шаблонах, и ошибки не будет.
+    /// </summary>
+    [Fact]
+    public void UnreachableFile_IsReported()
+    {
+        var warnings = UserLibAnalysis.Warnings("// пусто", [F("util/text.typ", "#let x() = []")]);
+        var w = Assert.Single(warnings);
+        Assert.Equal("util/text.typ", w.Path);
+        Assert.Contains("не подключён", w.Message);
+    }
+
+    /// <summary>
+    /// Проверено на Typst 0.15.1: при двух <c>import: *</c> с одинаковым именем побеждает последний,
+    /// БЕЗ предупреждения. В одном файле дубль видно глазом, в двадцати — нет.
+    /// </summary>
+    [Fact]
+    public void DuplicateNames_AcrossFiles_AreReported()
+    {
+        var files = new[] { F("a.typ", "#let f() = []"), F("b.typ", "#let f() = []") };
+        var entry = "#import \"userlib/a.typ\": *\n#import \"userlib/b.typ\": *";
+
+        var duplicates = UserLibAnalysis.Warnings(entry, files).Where(w => w.Message.Contains("объявлено ещё")).ToList();
+
+        Assert.Equal(2, duplicates.Count);   // сказать надо на обеих строках — иначе ищи вторую сам
+        Assert.All(duplicates, d => Assert.Contains("«f»", d.Message));
+    }
+
+    /// <summary>Неподключённый файл ни с кем не конфликтует — про него уже сказано отдельно.</summary>
+    [Fact]
+    public void DuplicateWithUnreachableFile_IsNotReportedAsDuplicate()
+    {
+        var files = new[] { F("a.typ", "#let f() = []"), F("orphan.typ", "#let f() = []") };
+        var warnings = UserLibAnalysis.Warnings("#import \"userlib/a.typ\": *", files);
+        Assert.DoesNotContain(warnings, w => w.Message.Contains("объявлено ещё"));
+    }
+
+    [Fact]
+    public void ConformingTree_IsSilent()
+    {
+        var files = new[] { F("gost/f3.typ", "#let place-f3() = []") };
+        Assert.Empty(UserLibAnalysis.Warnings("#import \"userlib/gost/f3.typ\": *", files));
+    }
+
+    /// <summary>Взаимный импорт не должен зациклить обход.</summary>
+    [Fact]
+    public void ImportCycle_DoesNotHang()
+    {
+        var files = new[]
+        {
+            F("a.typ", "#import \"b.typ\": *"),
+            F("b.typ", "#import \"a.typ\": *"),
+        };
+        var reachable = UserLibAnalysis.ReachableFrom("#import \"userlib/a.typ\": *", files);
+        Assert.Equal(["a.typ", "b.typ"], reachable.OrderBy(x => x));
+    }
+
+    /// <summary>Вложенные объявления наружу не экспортируются — считать их дублями нельзя.</summary>
+    [Fact]
+    public void OnlyTopLevelDeclarations_Count()
+    {
+        var names = UserLibAnalysis.TopLevelNames("#let outer() = {\n  let inner = 1\n  inner\n}");
+        Assert.Equal(["outer"], names);
+    }
+
+    [Fact]
+    public void PackageImports_AreIgnored()
+        => Assert.Empty(UserLibAnalysis.ReachableFrom("#import \"@preview/cetz:0.3.1\": *", []));
+
+    [Fact]
+    public void ReExportLine_PointsAtTheFileFromEntrypoint()
+        => Assert.Equal("#import \"userlib/gost/f3.typ\": *", UserLibAnalysis.ReExportLine("gost/f3.typ"));
+}

--- a/src/server/BHS.CRG.Tests/Templates/UserLibMaterializerTests.cs
+++ b/src/server/BHS.CRG.Tests/Templates/UserLibMaterializerTests.cs
@@ -1,0 +1,56 @@
+﻿using BHS.CRG.Application.Templates;
+using BHS.CRG.Infrastructure.Generation;
+
+namespace BHS.CRG.Tests.Templates;
+
+/// <summary>
+/// Раскладка библиотеки на диск (issue #473). Она общая для генерации, проверки при сохранении и
+/// отладочного бандла — расхождение означало бы «проверка зелёная, генерация падает».
+/// </summary>
+public class UserLibMaterializerTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "userlib-mat-" + Guid.NewGuid().ToString("N"));
+
+    public UserLibMaterializerTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task EntrypointIsAtRoot_TreeIsInSubfolder()
+    {
+        await UserLibMaterializer.WriteAsync(_dir, "#import \"userlib/gost/f3.typ\": *",
+            [new UserLibFile("gost/f3.typ", "#let place-f3() = []")]);
+
+        // Именно так это видит шаблон: `#import "userlib.typ"` в корне (#353, дословно).
+        Assert.True(File.Exists(Path.Combine(_dir, "userlib.typ")));
+        Assert.True(File.Exists(Path.Combine(_dir, "userlib", "gost", "f3.typ")));
+    }
+
+    /// <summary>Файл обязан существовать всегда: иначе `#import "userlib.typ"` в шаблоне не резолвится.</summary>
+    [Fact]
+    public async Task EmptyLibrary_StillWritesEntrypoint()
+    {
+        await UserLibMaterializer.WriteAsync(_dir, null, null);
+        Assert.Equal(UserLibMaterializer.EmptyEntrypoint,
+            (await File.ReadAllTextAsync(Path.Combine(_dir, "userlib.typ"))).Trim());
+    }
+
+    /// <summary>
+    /// Путь проверяется при сохранении, но записи мог наделать восстановленный бэкап из другой
+    /// инсталляции. Запись за пределы дерева — не та ошибка, которую ловят один раз.
+    /// </summary>
+    [Fact]
+    public async Task PathEscapingTheTree_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            UserLibMaterializer.WriteAsync(_dir, "x",
+                [new UserLibFile("../../evil.typ", "#let boom() = []")]));
+
+        Assert.Contains("выходит за пределы", ex.Message);
+        Assert.False(File.Exists(Path.Combine(Path.GetDirectoryName(_dir)!, "evil.typ")));
+    }
+}

--- a/src/server/BHS.CRG.Tests/Templates/UserLibPathTests.cs
+++ b/src/server/BHS.CRG.Tests/Templates/UserLibPathTests.cs
@@ -1,0 +1,93 @@
+using BHS.CRG.Application.Templates;
+
+namespace BHS.CRG.Tests.Templates;
+
+/// <summary>
+/// Проверка путей файлов библиотеки (issue #473). Путь приходит от пользователя и превращается в путь
+/// на диске, поэтому цена ошибки — запись за пределы папки генерации, а не кривое имя.
+/// </summary>
+public class UserLibPathTests
+{
+    private static string? ErrorFor(string? raw)
+    {
+        UserLibPath.TryNormalize(raw, out _, out var error);
+        return error;
+    }
+
+    private static string Ok(string raw)
+    {
+        Assert.True(UserLibPath.TryNormalize(raw, out var normalized, out var error), error);
+        return normalized;
+    }
+
+    [Theory]
+    [InlineData("f3.typ")]
+    [InlineData("gost/forms/f3.typ")]
+    [InlineData("util/текст.typ")]              // кириллица в именах — обычное дело у этого пользователя
+    [InlineData("gost/forms/f-3_v2.typ")]
+    public void ValidPaths_Pass(string path) => Assert.Equal(path, Ok(path));
+
+    [Fact]
+    public void Backslashes_AreNormalized() => Assert.Equal("gost/forms/f3.typ", Ok(@"gost\forms\f3.typ"));
+
+    /// <summary>Главное, ради чего вся проверка: выход за пределы дерева.</summary>
+    [Theory]
+    [InlineData("../userlib.typ")]
+    [InlineData("gost/../../data.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("gost/./f3.typ")]
+    public void EscapeAttempts_AreRejected(string path) => Assert.NotNull(ErrorFor(path));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("gost//f3.typ")]
+    [InlineData("gost/")]
+    public void EmptyOrMalformed_AreRejected(string path) => Assert.NotNull(ErrorFor(path));
+
+    /// <summary>Библиотека — это Typst-код; всё прочее в дереве только сбивало бы с толку.</summary>
+    [Theory]
+    [InlineData("gost/f3.txt")]
+    [InlineData("gost/f3")]
+    [InlineData("gost/.typ")]
+    public void NonTypstFiles_AreRejected(string path) => Assert.NotNull(ErrorFor(path));
+
+    /// <summary>Файл «CON.typ» на Windows не создастся — и упало бы это уже во время генерации.</summary>
+    [Theory]
+    [InlineData("CON.typ")]
+    [InlineData("gost/nul.typ")]
+    [InlineData("COM1.typ")]
+    public void WindowsReservedNames_AreRejected(string path) => Assert.NotNull(ErrorFor(path));
+
+    [Theory]
+    [InlineData("go:st/f3.typ")]
+    [InlineData("gost/f?3.typ")]
+    [InlineData("gost/f|3.typ")]
+    public void ForbiddenCharacters_AreRejected(string path) => Assert.NotNull(ErrorFor(path));
+
+    [Fact]
+    public void TooDeep_IsRejected()
+        => Assert.NotNull(ErrorFor(string.Join('/', Enumerable.Repeat("a", 11)) + ".typ"));
+
+    [Fact]
+    public void TooLong_IsRejected() => Assert.NotNull(ErrorFor(new string('a', 250) + ".typ"));
+
+    /// <summary>
+    /// Регистр значим: Linux в контейнере различает «Gost/» и «gost/», и импорт, написанный по одному
+    /// написанию, сломался бы только в продакшене.
+    /// </summary>
+    [Fact]
+    public void CaseIsSignificant()
+    {
+        Assert.False(UserLibPath.AreEqual("Gost/f3.typ", "gost/f3.typ"));
+        Assert.True(UserLibPath.DiffersOnlyByCase("Gost/f3.typ", "gost/f3.typ"));
+    }
+
+    [Fact]
+    public void IsInFolder_MatchesOnlyWholeSegments()
+    {
+        Assert.True(UserLibPath.IsInFolder("gost/forms/f3.typ", "gost"));
+        Assert.True(UserLibPath.IsInFolder("gost/forms/f3.typ", "gost/forms"));
+        Assert.False(UserLibPath.IsInFolder("gostx/f3.typ", "gost"));
+    }
+}


### PR DESCRIPTION
Backend по #473. UI — следующим PR, по разбору Дизайнера.

## Что меняется

`userlib` перестаёт быть одной колонкой TEXT. Раскладка временной папки генерации:

```
<tmp>/
  template.typ      шаблон, дословно (#353)
  userlib.typ       точка входа — как и раньше; реэкспортирует вложенное
  userlib/          дерево, структуру задаёт пользователь
      gost/forms/f3.typ
      util/text.typ
  systemlib.typ  typeblocks.typ  data.json  assets/  fonts/
```

**Обратная совместимость полная**: шаблоны с дословным `#import "userlib.typ": *` видят вложенное транзитивно. Изоляция дерева в подпапке снимает вопрос коллизий со служебными именами — пользовательские пути в них физически не попадают, резервировать имена не нужно.

## Ключевые решения

**Сохранение — всего дерева разом.** Пофайловое позволило бы зафиксировать половину рефакторинга: правка `util/text.typ` и правка зовущего её `gost/f3.typ` обязаны лечь вместе, иначе между двумя запросами библиотека не собирается, а её импортирует каждый шаблон. `files: null` означает «дерево не трогать» — так продолжает работать клиент, шлющий только точку входа.

**Проверка не блокирует сохранение** (инвариант «сохранение = черновик», работу надо дать отложить на середине рефакторинга), но возвращает результат: узнавать о неработающей библиотеке при следующей генерации поздно.

**Два молчаливых отказа, созданных самим разрезанием** — ловим разбором дерева без Typst:
- *файл не подключён* — валиден, но цепочки импортов от точки входа до него нет, функций в шаблонах не будет, ошибки не будет тоже;
- *одноимённые объявления в разных файлах* — проверено на Typst 0.15.1: при двух `import: *` побеждает последний, **без предупреждения**. В одном файле дубль видно глазом, в двадцати нет.

**Единая точка чтения.** Генерация, предпросмотр и отладочный бандл читали библиотеку каждый своим `GetAllAsync().FirstOrDefault()`; с деревом расхождение вылезало бы только в PDF.

**Бандл несёт дерево** — без него внешняя отладка падала бы на первом вложенном импорте.

## Попутно исправлено

Регекс диагностики в `TypstSyntaxChecker.cs:22` был прибит к `typeblocks\.typ`. Для дерева это дало бы худший вид отказа — **тихий зелёный**: «ошибок нет», потому что не совпал путь. Разбор вынесен в `TypstShortDiagnostics`, отбор по имени файла остался у вызывающего (координаты typeblocks заявлены внутри файла, и чужие номера строк уехали бы по line-map не туда).

## Миграция и бэкап

Миграция только создаёт таблицу — существующие данные не трогаются. Бэкап расширен **аддитивно, без подъёма версии схемы** (#403): старая копия просто не несёт секции, дерево останется пустым. Восстановление дерева замещающее — оставить на целевой системе файлы, которых в копии нет, значит собрать библиотеку, которой никогда не существовало.

## Проверка

739 тестов зелёные (40 новых: пути, разбор дерева, раскладка). Тест на цикл импортов поймал настоящую ошибку — файл в корне `userlib/` не мог импортировать соседа, потому что я отличал точку входа от корня дерева по пустому пути.

Живьём на реальной базе:

| Проверка | Результат |
|---|---|
| Миграция при старте | применилась |
| Дерево с относительным импортом между файлами | сохранилось, `ok=true` |
| Битый файл | ошибка с верным файлом и строкой: `gost/forms/f-test.typ:2 unclosed delimiter` |
| Неподключённый файл | предупреждение |
| Путь `../evil.typ` | `400`, «Сегменты «.» и «..» запрещены» |
| Генерация PDF | «Реестр работ» и «Реестр материалов» собрались |
| Отладочный бандл | содержит `userlib/gost/forms/f-test.typ`, `userlib/util/text.typ` |

Тестовое дерево из базы удалено, библиотека пользователя восстановлена байт в байт (6641 символ, 271 строка, 15 функций).

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)