### PR TITLE
feat(templates): дерево файлов библиотеки Typst — UI (#473)

### DIFF
--- a/src/client/src/features/templates/UserLibFileList.tsx
+++ b/src/client/src/features/templates/UserLibFileList.tsx
@@ -1,0 +1,107 @@
+import { FileCode, Folder, LogIn, Plus, AlertCircle, AlertTriangle } from 'lucide-react';
+import { NavSection } from '@/shared/ui/ListDetailShell';
+import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
+import { buildRows, ENTRYPOINT } from './userLibTree';
+import type { UserLibFile, UserLibCheck } from '@/shared/api/typstUserLib';
+
+/**
+ * Список файлов библиотеки (issue #473).
+ *
+ * ПЛОСКИЙ список с отступом, а не сворачиваемое дерево: смысл разрезания одного файла на много —
+ * видеть инвентарь целиком, и свёрнутые папки воссоздали бы ровно ту проблему, которую мы решаем.
+ *
+ * Точка входа — отдельной секцией, а не бейджем на общей строке: особость позицией объясняет себя до
+ * первого касания, а украшение на обычной строке porождает вопрос «почему у неё нет „Удалить“».
+ * Пунктов удаления/переименования у неё просто НЕТ, а не задизейблены.
+ */
+export function UserLibFileList({
+  files, selected, dirty, check, onSelect, onCreate, onRename, onDelete,
+}: {
+  files: UserLibFile[];
+  selected: string;
+  /** Пути с несохранёнными правками — точка-маркер, как на вкладках редактора. */
+  dirty: Set<string>;
+  check: UserLibCheck | null;
+  onSelect: (path: string) => void;
+  onCreate: () => void;
+  onRename: (path: string) => void;
+  onDelete: (path: string) => void;
+}) {
+  const rows = buildRows(files);
+  const errorsBy = new Map<string, number>();
+  const warningsBy = new Map<string, number>();
+  for (const e of check?.errors ?? []) errorsBy.set(e.path, (errorsBy.get(e.path) ?? 0) + 1);
+  for (const w of check?.warnings ?? []) warningsBy.set(w.path, (warningsBy.get(w.path) ?? 0) + 1);
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto pb-2">
+      <NavSection label="Точка входа" />
+      <FileRow
+        label={ENTRYPOINT} depth={0} icon={<LogIn size={13} />}
+        active={selected === ENTRYPOINT} dirty={dirty.has(ENTRYPOINT)}
+        errors={errorsBy.get(ENTRYPOINT) ?? 0} warnings={warningsBy.get(ENTRYPOINT) ?? 0}
+        title="Подключает всё, что ниже"
+        onClick={() => onSelect(ENTRYPOINT)}
+      />
+
+      <div className="flex items-center justify-between pr-2">
+        <NavSection label="Файлы библиотеки" />
+        <button type="button" onClick={onCreate} title="Создать файл"
+          className="h-6 w-6 inline-flex items-center justify-center rounded text-fg3 hover:text-fg1 hover:bg-muted transition-colors">
+          <Plus size={14} />
+        </button>
+      </div>
+
+      {files.length === 0 ? (
+        <p className="px-3 py-2 text-xs text-fg4">
+          Пока всё в одном файле. Создайте файл, чтобы вынести часть функций.
+        </p>
+      ) : rows.map(row => row.kind === 'folder' ? (
+        <div key={`d:${row.path}`} className="flex items-center gap-1.5 py-1 text-xs text-fg4"
+          style={{ paddingLeft: `${0.75 + row.depth}rem` }}>
+          <Folder size={12} className="shrink-0" />{row.label}
+        </div>
+      ) : (
+        <FileRow
+          key={row.path} label={row.label} depth={row.depth} icon={<FileCode size={13} />}
+          active={selected === row.path} dirty={dirty.has(row.path)}
+          errors={errorsBy.get(row.path) ?? 0} warnings={warningsBy.get(row.path) ?? 0}
+          title={row.path}
+          onClick={() => onSelect(row.path)}
+          actions={
+            <RowActionsMenu actions={[
+              { key: 'rename', label: 'Изменить путь', onSelect: () => onRename(row.path) },
+              { key: 'delete', label: 'Удалить', onSelect: () => onDelete(row.path), danger: true },
+            ]} />
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+function FileRow({ label, depth, icon, active, dirty, errors, warnings, title, onClick, actions }: {
+  label: string; depth: number; icon: React.ReactNode; active: boolean; dirty: boolean;
+  errors: number; warnings: number; title?: string; onClick: () => void; actions?: React.ReactNode;
+}) {
+  return (
+    <div className={`group flex items-center gap-1 pr-1.5 ${active ? 'bg-brand-subtle' : 'hover:bg-muted'}`}>
+      <button type="button" onClick={onClick} title={title} aria-current={active ? 'true' : undefined}
+        className="flex-1 min-w-0 flex items-center gap-1.5 py-1.5 text-left text-sm"
+        style={{ paddingLeft: `${0.75 + depth}rem` }}>
+        <span className={`shrink-0 ${active ? 'text-brand' : 'text-fg3'}`}>{icon}</span>
+        <span className={`truncate ${active ? 'text-fg1 font-medium' : 'text-fg2'}`}>{label}</span>
+        {/* Ошибка может прилететь из файла, который сейчас закрыт — бейдж на его строке
+            единственное место, где её видно. */}
+        {errors > 0 && (
+          <span title={`Ошибок: ${errors}`} className="shrink-0 text-danger"><AlertCircle size={12} /></span>
+        )}
+        {errors === 0 && warnings > 0 && (
+          <span title={`Замечаний: ${warnings}`} className="shrink-0 text-warning"><AlertTriangle size={12} /></span>
+        )}
+        {dirty && <span title="Не сохранено" className="shrink-0 h-1.5 w-1.5 rounded-full bg-fg3" />}
+      </button>
+      {actions && <span className="shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100">{actions}</span>}
+    </div>
+  );
+}

--- a/src/client/src/features/templates/UserLibPanel.tsx
+++ b/src/client/src/features/templates/UserLibPanel.tsx
@@ -1,121 +1,287 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Editor from '@monaco-editor/react';
 import type * as monacoEditor from 'monaco-editor';
 import { registerTypstLanguage } from '@/shared/ui/typstLanguage';
 import { useTheme } from '@/shared/ui/ThemeProvider';
 import { useUserLibCompletion } from '@/shared/ui/typstUserLibCompletion';
 import { Button } from '@/shared/ui/Button';
-import { Save } from 'lucide-react';
-import { useTypstUserLib, useSaveTypstUserLib } from '@/shared/api/typstUserLib';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { Save, AlertCircle, AlertTriangle } from 'lucide-react';
+import {
+  useTypstUserLib, useSaveTypstUserLib,
+  type UserLibFile, type UserLibCheck,
+} from '@/shared/api/typstUserLib';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
-// ─── User Typst library panel ─────────────────────────────────────────────────
+import { UserLibFileList } from './UserLibFileList';
+import { UserLibPathDialog } from './UserLibPathDialog';
+import {
+  ENTRYPOINT, withReExport, withoutReExport, renameReExport, referencingFiles,
+} from './userLibTree';
+
+// ─── User Typst library: точка входа + дерево файлов (issue #473) ─────────────
+
+/** Пустое дерево модульной константой: инлайновый `[]` — новая ссылка на каждый рендер (#305). */
+const NO_FILES: UserLibFile[] = [];
 
 export function UserLibPanel() {
   const { resolvedTheme } = useTheme();
   useUserLibCompletion();
-  const { data: serverContent = '', isLoading } = useTypstUserLib();
+  const { data, isLoading } = useTypstUserLib();
   const saveMutation = useSaveTypstUserLib();
-  const [content, setContent] = useState('');
+
+  const [entry, setEntry] = useState('');
+  const [files, setFiles] = useState<UserLibFile[]>(NO_FILES);
+  const [selected, setSelected] = useState(ENTRYPOINT);
+  const [check, setCheck] = useState<UserLibCheck | null>(null);
   const [savedMsg, setSavedMsg] = useState(false);
   const [error, setError] = useState('');
+  const [pathDialog, setPathDialog] = useState<{ mode: 'create' | 'rename'; path: string } | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
   const editorRef = useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
-  // Библиотека — это список функций; развёрнутой она читается как простыня, и нужную приходится
-  // искать прокруткой. Сворачиваем ОДИН раз при первой загрузке: повтор на каждое изменение
-  // схлопывал бы блок прямо во время правки.
   const foldedOnce = useRef(false);
 
-  useEffect(() => { setContent(serverContent); }, [serverContent]);
+  const serverEntry = data?.content ?? '';
+  const serverFiles = data?.files ?? NO_FILES;
 
-  async function handleSave() {
+  useEffect(() => { setEntry(serverEntry); setFiles(serverFiles); }, [serverEntry, serverFiles]);
+
+  // Несохранённые файлы — точка-маркер на строке, идиома вкладок редактора.
+  const dirty = useMemo(() => {
+    const set = new Set<string>();
+    if (entry !== serverEntry) set.add(ENTRYPOINT);
+    const byPath = new Map(serverFiles.map(f => [f.path, f.content]));
+    for (const f of files) if (byPath.get(f.path) !== f.content) set.add(f.path);
+    for (const f of serverFiles) if (!files.some(x => x.path === f.path)) set.add(f.path);
+    return set;
+  }, [entry, files, serverEntry, serverFiles]);
+
+  const isDirty = dirty.size > 0;
+  const currentContent = selected === ENTRYPOINT
+    ? entry
+    : files.find(f => f.path === selected)?.content ?? '';
+
+  function updateCurrent(value: string) {
+    if (selected === ENTRYPOINT) setEntry(value);
+    else setFiles(prev => prev.map(f => (f.path === selected ? { ...f, content: value } : f)));
+  }
+
+  /**
+   * Сохранение — ВСЕГО дерева разом. Пофайлового нет намеренно: правка файла и правка зовущего его
+   * файла обязаны лечь вместе, иначе между двумя запросами библиотека не собирается, а её читает
+   * генерация каждого документа.
+   */
+  const handleSave = useCallback(async () => {
     setError('');
     try {
-      await saveMutation.mutateAsync(content);
+      const res = await saveMutation.mutateAsync({ content: entry, files });
+      setCheck(res.check);
       setSavedMsg(true);
       setTimeout(() => setSavedMsg(false), 2000);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Ошибка сохранения');
     }
-  }
+  }, [entry, files, saveMutation]);
 
-  // Ctrl+S — тем же способом, что в редакторе шаблонов: перехват на окне в фазе capture, чтобы
-  // опередить браузерное «Сохранить страницу», и по e.code, потому что на русской раскладке
-  // e.key даёт «ы». Команду Monaco НЕ регистрируем: она сработала бы вторым, параллельным
-  // сохранением (обработчик окна делает preventDefault, но не stopPropagation).
-  const handleSaveRef = useRef(handleSave);
-  handleSaveRef.current = handleSave;
+  // Ctrl+S — перехват на окне в фазе capture, чтобы опередить браузерное «Сохранить страницу», и по
+  // e.code, потому что на русской раскладке e.key даёт «ы». Команду Monaco НЕ регистрируем: она
+  // сработала бы вторым, параллельным сохранением.
+  const saveRef = useRef(handleSave);
+  saveRef.current = handleSave;
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if ((e.ctrlKey || e.metaKey) && e.code === 'KeyS') {
         e.preventDefault();
-        if (editorRef.current?.hasTextFocus()) void handleSaveRef.current();
+        if (editorRef.current?.hasTextFocus()) void saveRef.current();
       }
     }
     window.addEventListener('keydown', onKeyDown, { capture: true });
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true });
   }, []);
 
-  /**
-   * Свернуть тела функций, оставив видимыми объявления. Именно foldLevel1, а не foldAll: последний
-   * схлопнул бы и вложенные блоки, а нужен как раз перечень сигнатур.
-   *
-   * Область свёртки Monaco считает после разбора модели, поэтому запускаем следующим тиком — сразу
-   * после монтирования сворачивать ещё нечего.
-   */
-  function foldFunctions() {
-    if (foldedOnce.current || !editorRef.current || !serverContent.trim()) return;
+  // Уход со страницы с несохранённым деревом — единственное место, где предупреждаем: переключение
+  // между файлами это навигация внутри правки, а не коммит, и диалог на нём быстро обесценился бы.
+  useEffect(() => {
+    if (!isDirty) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => { e.preventDefault(); };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [isDirty]);
+
+  // Библиотека читается как список функций; развёрнутой она простыня. Сворачиваем один раз при
+  // первой загрузке — повтор схлопывал бы блок прямо во время правки.
+  const foldFunctions = useCallback(() => {
+    if (foldedOnce.current || !editorRef.current || !serverEntry.trim()) return;
     foldedOnce.current = true;
-    const editor = editorRef.current;
-    setTimeout(() => editor.getAction('editor.foldLevel1')?.run(), 0);
+    const ed = editorRef.current;
+    setTimeout(() => ed.getAction('editor.foldLevel1')?.run(), 0);
+  }, [serverEntry]);
+  useEffect(() => { foldFunctions(); }, [foldFunctions]);
+
+  /** Ошибка в открытом файле — маркерами Monaco: там, где она есть. */
+  useEffect(() => {
+    const monaco = (window as unknown as { monaco?: typeof monacoEditor }).monaco;
+    const model = editorRef.current?.getModel();
+    if (!monaco || !model) return;
+    const mine = (check?.errors ?? []).filter(e => e.path === selected);
+    monaco.editor.setModelMarkers(model, 'userlib', mine.map(e => ({
+      severity: monaco.MarkerSeverity.Error,
+      message: e.message,
+      startLineNumber: Math.max(1, e.line), startColumn: Math.max(1, e.column),
+      endLineNumber: Math.max(1, e.line), endColumn: Math.max(1, e.column) + 1,
+    })));
+  }, [check, selected]);
+
+  function handleCreate(path: string) {
+    setFiles(prev => [...prev, { path, content: `// ${path}\n` }]);
+    // Реэкспорт дописываем сами: иначе самый частый отказ — молчаливый, файл валиден, но не
+    // подключён, и его функции просто не появляются в шаблонах.
+    setEntry(prev => withReExport(prev, path));
+    setSelected(path);
   }
 
-  // Монтирование и приход содержимого не упорядочены — пробуем на обоих.
-  useEffect(foldFunctions, [serverContent]);
+  function handleRename(from: string, to: string) {
+    setFiles(prev => prev.map(f => (f.path === from ? { ...f, path: to } : f)));
+    setEntry(prev => renameReExport(prev, from, to));
+    if (selected === from) setSelected(to);
+  }
+
+  function handleDelete(path: string) {
+    setFiles(prev => prev.filter(f => f.path !== path));
+    setEntry(prev => withoutReExport(prev, path));
+    if (selected === path) setSelected(ENTRYPOINT);
+    setDeleting(null);
+  }
 
   if (isLoading) {
     return <div className="flex-1 flex items-center justify-center text-fg4 text-sm">Загрузка...</div>;
   }
 
+  const errors = check?.errors ?? [];
+  const warnings = check?.warnings ?? [];
+
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-surface gap-3">
-        <p className="text-xs text-fg3">
-          Доступен в каждом шаблоне через{' '}
-          <code className="font-mono bg-muted px-1.5 py-0.5 rounded text-fg2">#import "userlib.typ": *</code>
-        </p>
-        <div className="flex items-center gap-2">
-          {savedMsg && <span className="text-xs text-success">Сохранено</span>}
-          {error && <span className="text-xs text-danger max-w-xs truncate">{error}</span>}
-          <Button variant="filled" size="sm" onClick={handleSave} loading={saveMutation.isPending}
-            icon={<Save size={12} />}>
-            {saveMutation.isPending ? 'Сохранение…' : 'Сохранить'}
-          </Button>
+    <div className="flex h-full min-h-0">
+      <aside className="w-72 shrink-0 border-r border-stroke flex flex-col bg-base">
+        <UserLibFileList
+          files={files} selected={selected} dirty={dirty} check={check}
+          onSelect={setSelected}
+          onCreate={() => setPathDialog({ mode: 'create', path: '' })}
+          onRename={p => setPathDialog({ mode: 'rename', path: p })}
+          onDelete={p => setDeleting(p)}
+        />
+        <TemplateAssetsPanel scope="System" scopeId={null} title="Системные ассеты" />
+      </aside>
+
+      <div className="flex-1 min-w-0 flex flex-col">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-surface gap-3">
+          <p className="text-xs text-fg3 truncate">
+            {selected === ENTRYPOINT ? (
+              <>Доступен в каждом шаблоне через{' '}
+                <code className="font-mono bg-muted px-1.5 py-0.5 rounded text-fg2">#import "userlib.typ": *</code>
+              </>
+            ) : (
+              <>Файл библиотеки — <code className="font-mono bg-muted px-1.5 py-0.5 rounded text-fg2">userlib/{selected}</code></>
+            )}
+          </p>
+          <div className="flex items-center gap-2 shrink-0">
+            {savedMsg && !isDirty && <span className="text-xs text-success">Сохранено</span>}
+            {error && <span className="text-xs text-danger max-w-xs truncate">{error}</span>}
+            {isDirty && <span className="text-xs text-fg3">Изменено: {dirty.size}</span>}
+            <Button variant="filled" size="sm" onClick={handleSave} loading={saveMutation.isPending}
+              icon={<Save size={12} />}>
+              {saveMutation.isPending ? 'Сохранение…' : 'Сохранить всё'}
+            </Button>
+          </div>
+        </div>
+
+        {/* Постоянное состояние, а не всплывающее сообщение: пока библиотека не собирается, стоит
+            генерация ВСЕХ документов, и больше этого нигде не видно. Зелёной строки на каждое
+            сохранение нет — «всё хорошо» каждый раз это шум. */}
+        {errors.length > 0 && (
+          <div className="px-4 py-2 bg-danger-subtle border-b border-stroke flex items-start gap-2">
+            <AlertCircle size={14} className="text-danger shrink-0 mt-0.5" />
+            <div className="min-w-0 text-xs">
+              <p className="text-danger font-medium">Библиотека не собирается — генерация документов не пройдёт.</p>
+              {errors.slice(0, 3).map((e, i) => (
+                <button key={i} type="button" onClick={() => setSelected(e.path)}
+                  className="block text-left text-fg2 hover:text-fg1 hover:underline">
+                  {e.path}:{e.line} — {e.message}
+                </button>
+              ))}
+              {errors.length > 3 && <p className="text-fg3">…и ещё {errors.length - 3}</p>}
+            </div>
+          </div>
+        )}
+        {errors.length === 0 && warnings.length > 0 && (
+          <div className="px-4 py-2 bg-warning-subtle border-b border-stroke flex items-start gap-2">
+            <AlertTriangle size={14} className="text-warning shrink-0 mt-0.5" />
+            <div className="min-w-0 text-xs">
+              {warnings.slice(0, 3).map((w, i) => (
+                <button key={i} type="button" onClick={() => setSelected(w.path)}
+                  className="block text-left text-fg2 hover:text-fg1 hover:underline">
+                  {w.path} — {w.message}
+                </button>
+              ))}
+              {warnings.length > 3 && <p className="text-fg3">…и ещё {warnings.length - 3}</p>}
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <Editor
+            key={selected}
+            height="100%"
+            defaultLanguage="typst"
+            theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
+            value={currentContent}
+            onChange={val => updateCurrent(val ?? '')}
+            beforeMount={registerTypstLanguage}
+            onMount={ed => { editorRef.current = ed; foldFunctions(); }}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              fontFamily: "'Cascadia Code', 'Fira Code', Consolas, monospace",
+              wordWrap: 'on',
+              lineNumbers: 'on',
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              tabSize: 2,
+              renderWhitespace: 'boundary',
+            }}
+          />
         </div>
       </div>
-      <div className="flex-1 overflow-hidden">
-        <Editor
-          height="100%"
-          defaultLanguage="typst"
-          theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
-          value={content}
-          onChange={(val) => setContent(val ?? '')}
-          beforeMount={registerTypstLanguage}
-          onMount={editor => { editorRef.current = editor; foldFunctions(); }}
-          options={{
-            minimap: { enabled: false },
-            fontSize: 13,
-            fontFamily: "'Cascadia Code', 'Fira Code', Consolas, monospace",
-            wordWrap: 'on',
-            lineNumbers: 'on',
-            scrollBeyondLastLine: false,
-            automaticLayout: true,
-            tabSize: 2,
-            renderWhitespace: 'boundary',
+
+      {pathDialog && (
+        <UserLibPathDialog
+          mode={pathDialog.mode}
+          initialPath={pathDialog.path}
+          existing={files.map(f => f.path)}
+          referencing={pathDialog.mode === 'rename' ? referencingFiles(files, pathDialog.path) : []}
+          onCancel={() => setPathDialog(null)}
+          onSubmit={path => {
+            if (pathDialog.mode === 'create') handleCreate(path);
+            else handleRename(pathDialog.path, path);
+            setPathDialog(null);
           }}
         />
-      </div>
-      {/* Ассеты шаблонов (issue #62) — системный уровень, общий для всех шаблонов */}
-      <TemplateAssetsPanel scope="System" scopeId={null} title="Системные ассеты" />
+      )}
+
+      <ConfirmDialog
+        open={deleting != null}
+        onOpenChange={open => { if (!open) setDeleting(null); }}
+        title={`Удалить «${deleting ?? ''}»?`}
+        description={
+          deleting && referencingFiles(files, deleting).length > 0
+            ? `На файл ссылаются: ${referencingFiles(files, deleting).join(', ')}. `
+              + 'Пока импорт не убран, генерация ВСЕХ документов не пройдёт — библиотеку читает каждый шаблон.'
+            : 'Строка подключения в точке входа будет убрана вместе с файлом. '
+              + 'Изменение вступит в силу после сохранения.'
+        }
+        confirmLabel="Удалить"
+        onConfirm={() => { if (deleting) handleDelete(deleting); }}
+      />
     </div>
   );
 }
-

--- a/src/client/src/features/templates/UserLibPathDialog.tsx
+++ b/src/client/src/features/templates/UserLibPathDialog.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Modal } from '@/shared/ui/Modal';
+import { Button } from '@/shared/ui/Button';
+import { validatePath } from './userLibTree';
+
+/**
+ * Путь файла библиотеки (issue #473). Создание и переименование — одна форма: и то и другое суть
+ * присвоение новой строки, а отдельной команды «создать папку» нет — папка возникает из «/» в пути,
+ * пустая папка в Typst бессмысленна.
+ */
+export function UserLibPathDialog({
+  mode, initialPath, existing, referencing, onSubmit, onCancel,
+}: {
+  mode: 'create' | 'rename';
+  initialPath: string;
+  existing: string[];
+  /** Файлы, ссылающиеся на переименовываемый — их импорты сломаются. */
+  referencing: string[];
+  onSubmit: (path: string) => void;
+  onCancel: () => void;
+}) {
+  const [path, setPath] = useState(initialPath);
+  const [touched, setTouched] = useState(false);
+  const error = validatePath(path, existing, mode === 'rename' ? initialPath : undefined);
+
+  return (
+    <Modal open onOpenChange={o => { if (!o) onCancel(); }} title={mode === 'create' ? 'Новый файл библиотеки' : 'Изменить путь'}>
+      <div className="space-y-3">
+        <div>
+          <label htmlFor="userlib-path" className="block text-xs text-fg3 mb-1">
+            Путь внутри <code className="font-mono">userlib/</code>
+          </label>
+          <input
+            id="userlib-path" autoFocus value={path}
+            onChange={e => { setPath(e.target.value); setTouched(true); }}
+            onKeyDown={e => { if (e.key === 'Enter' && !error) onSubmit(path.trim().replace(/\\/g, '/')); }}
+            placeholder="gost/forms/f3.typ"
+            className="w-full h-8 px-2.5 text-sm font-mono rounded-md border border-stroke bg-surface text-fg1
+                       outline-none focus:ring-2 focus:ring-brand/40"
+          />
+          <p className="mt-1 text-xs text-fg4">
+            Папки создаются сами из «/» в пути. Файл подключится к точке входа автоматически.
+          </p>
+          {touched && error && <p className="mt-1 text-xs text-danger">{error}</p>}
+        </div>
+
+        {/* Автоматически переписывать чужие импорты не беремся: это текстовая трансформация
+            пользовательского кода, ошибиться в ней тоньше, чем не делать. Говорим поимённо. */}
+        {mode === 'rename' && referencing.length > 0 && (
+          <p className="text-xs text-warning">
+            На этот файл ссылаются: {referencing.join(', ')}. Импорты в них придётся поправить вручную.
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <Button variant="text" size="sm" onClick={onCancel}>Отмена</Button>
+          <Button variant="filled" size="sm" disabled={!!error}
+            onClick={() => onSubmit(path.trim().replace(/\\/g, '/'))}>
+            {mode === 'create' ? 'Создать' : 'Изменить'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/client/src/features/templates/userLibTree.test.ts
+++ b/src/client/src/features/templates/userLibTree.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildRows, withReExport, withoutReExport, renameReExport,
+  referencingFiles, resolveRelative, validatePath, reExportLine,
+} from './userLibTree';
+import type { UserLibFile } from '@/shared/api/typstUserLib';
+
+const f = (path: string, content = ''): UserLibFile => ({ path, content });
+
+describe('buildRows', () => {
+  it('раскладывает папки заголовками, файлы — с отступом', () => {
+    const rows = buildRows([f('gost/forms/f3.typ'), f('util/text.typ'), f('root.typ')]);
+    expect(rows.map(r => `${r.kind}:${r.label}:${r.depth}`)).toEqual([
+      'file:root.typ:0',
+      'folder:gost:0', 'folder:forms:1', 'file:f3.typ:2',
+      'folder:util:0', 'file:text.typ:1',
+    ]);
+  });
+
+  it('не повторяет общий сегмент соседних папок', () => {
+    const rows = buildRows([f('gost/forms/f3.typ'), f('gost/tables/t1.typ')]);
+    expect(rows.filter(r => r.kind === 'folder').map(r => r.path))
+      .toEqual(['gost', 'gost/forms', 'gost/tables']);
+  });
+
+  it('порядок устойчив — строки не прыгают между сохранениями', () => {
+    const a = buildRows([f('b.typ'), f('a.typ')]).map(r => r.path);
+    const b = buildRows([f('a.typ'), f('b.typ')]).map(r => r.path);
+    expect(a).toEqual(b);
+  });
+});
+
+/**
+ * Самый частый отказ при разрезании — молчаливый: файл валиден, но не подключён, и его функции
+ * просто не появляются в шаблонах. Поэтому строку реэкспорта дописываем сами.
+ */
+describe('реэкспорт в точке входа', () => {
+  it('дописывает строку при создании файла', () => {
+    expect(withReExport('#let get(p) = none', 'gost/f3.typ'))
+      .toBe('#let get(p) = none\n#import "userlib/gost/f3.typ": *\n');
+  });
+
+  it('не дублирует уже имеющуюся строку', () => {
+    const once = withReExport('', 'a.typ');
+    expect(withReExport(once, 'a.typ')).toBe(once);
+  });
+
+  it('убирает строку при удалении файла — иначе останется битый импорт', () => {
+    const entry = withReExport('#let x = 1', 'a.typ');
+    expect(withoutReExport(entry, 'a.typ')).not.toContain(reExportLine('a.typ'));
+  });
+
+  it('переписывает строку при смене пути', () => {
+    const entry = withReExport('', 'a.typ');
+    const renamed = renameReExport(entry, 'a.typ', 'util/a.typ');
+    expect(renamed).toContain(reExportLine('util/a.typ'));
+    expect(renamed).not.toContain(reExportLine('a.typ'));
+  });
+
+  it('файл без реэкспорта при переименовании его получает', () => {
+    expect(renameReExport('#let x = 1', 'a.typ', 'b.typ')).toContain(reExportLine('b.typ'));
+  });
+});
+
+describe('resolveRelative', () => {
+  it('поднимается по «..» от папки файла', () =>
+    expect(resolveRelative('gost/forms', '../../util/text.typ')).toBe('util/text.typ'));
+
+  it('файл в корне дерева адресует соседа без префикса', () =>
+    expect(resolveRelative('', 'b.typ')).toBe('b.typ'));
+
+  it('выход выше дерева — не наш файл', () =>
+    expect(resolveRelative('gost', '../../../data.json')).toBeNull());
+});
+
+/** Перед удалением надо сказать поимённо, что сломается, — автоправку чужого кода не делаем. */
+describe('referencingFiles', () => {
+  it('находит ссылающихся по относительному импорту', () => {
+    const files = [
+      f('gost/forms/f3.typ', '#import "../../util/text.typ": shout'),
+      f('util/text.typ', '#let shout(s) = upper(s)'),
+    ];
+    expect(referencingFiles(files, 'util/text.typ')).toEqual(['gost/forms/f3.typ']);
+  });
+
+  it('координаты пакетов не считаются ссылкой на файл', () => {
+    const files = [f('a.typ', '#import "@preview/cetz:0.3.1": canvas')];
+    expect(referencingFiles(files, 'cetz')).toEqual([]);
+  });
+
+  it('никто не ссылается — пусто', () =>
+    expect(referencingFiles([f('a.typ', ''), f('b.typ', '')], 'a.typ')).toEqual([]));
+});
+
+describe('validatePath', () => {
+  it.each([
+    ['', 'пустой'],
+    ['/abs.typ', 'абсолютный'],
+    ['a.txt', 'не .typ'],
+    ['../a.typ', 'выход наружу'],
+    ['a//b.typ', 'пустой сегмент'],
+  ])('отклоняет %s (%s)', (path) => expect(validatePath(path, [])).not.toBeNull());
+
+  it('принимает обычный путь', () => expect(validatePath('gost/forms/f3.typ', [])).toBeNull());
+
+  it('ловит дубль пути', () => expect(validatePath('a.typ', ['a.typ'])).not.toBeNull());
+
+  /** На Linux это разные файлы, на Windows — один; разошлось бы только в продакшене. */
+  it('ловит расхождение только по регистру', () =>
+    expect(validatePath('A.typ', ['a.typ'])).not.toBeNull());
+
+  it('переименование файла в себя же не считается дублем', () =>
+    expect(validatePath('a.typ', ['a.typ'], 'a.typ')).toBeNull());
+});

--- a/src/client/src/features/templates/userLibTree.ts
+++ b/src/client/src/features/templates/userLibTree.ts
@@ -1,0 +1,157 @@
+import type { UserLibFile } from '@/shared/api/typstUserLib';
+
+/** Имя папки дерева — фиксировано; из точки входа файлы адресуются через неё. */
+export const USERLIB_FOLDER = 'userlib';
+/** Точка входа. Лежит в корне, а не в дереве: её импортирует шаблон дословно (#353). */
+export const ENTRYPOINT = 'userlib.typ';
+
+/**
+ * Строка списка файлов (issue #473). Список ПЛОСКИЙ, с отступом по глубине, а не сворачиваемое
+ * дерево: смысл разрезания одного файла на много — видеть инвентарь целиком, а свёрнутые папки
+ * воссоздали бы ровно ту проблему, которую мы решаем, этажом выше.
+ */
+export interface TreeRow {
+  kind: 'folder' | 'file';
+  /** Для файла — полный путь («gost/forms/f3.typ»), для папки — путь папки («gost/forms»). */
+  path: string;
+  /** Что показать: имя файла или последний сегмент папки. */
+  label: string;
+  depth: number;
+}
+
+/**
+ * Плоский список строк для отрисовки: папки-заголовки в позиции, файлы с отступом.
+ * Порядок устойчивый (по пути), иначе строки прыгали бы между сохранениями.
+ */
+export function buildRows(files: UserLibFile[]): TreeRow[] {
+  // Файлы корня — первыми, папки следом: сортировка по одному лишь пути ставила бы «root.typ»
+  // между содержимым «gost/» и «util/», и корневой файл терялся бы среди чужих отступов.
+  const depthOf = (p: string) => (p.includes('/') ? 1 : 0);
+  const sorted = [...files].sort((a, b) =>
+    depthOf(a.path) - depthOf(b.path) || a.path.localeCompare(b.path, 'ru'));
+  const rows: TreeRow[] = [];
+  let lastFolder = '';
+
+  for (const file of sorted) {
+    const cut = file.path.lastIndexOf('/');
+    const folder = cut < 0 ? '' : file.path.slice(0, cut);
+
+    if (folder !== lastFolder) {
+      // Заголовки только для НОВЫХ сегментов: переход «gost/forms» → «gost/tables» не должен
+      // повторять «gost».
+      const parts = folder ? folder.split('/') : [];
+      const lastParts = lastFolder ? lastFolder.split('/') : [];
+      let common = 0;
+      while (common < parts.length && common < lastParts.length && parts[common] === lastParts[common]) common++;
+      for (let i = common; i < parts.length; i++)
+        rows.push({ kind: 'folder', path: parts.slice(0, i + 1).join('/'), label: parts[i], depth: i });
+      lastFolder = folder;
+    }
+
+    rows.push({
+      kind: 'file',
+      path: file.path,
+      label: file.path.slice(cut + 1),
+      depth: folder ? folder.split('/').length : 0,
+    });
+  }
+
+  return rows;
+}
+
+/** Строка реэкспорта — та же, что дописывает сервер в своих подсказках. */
+export function reExportLine(path: string): string {
+  return `#import "${USERLIB_FOLDER}/${path}": *`;
+}
+
+/**
+ * Точка входа с дописанной строкой реэкспорта.
+ *
+ * Дописываем при создании файла, потому что иначе самый частый отказ — МОЛЧАЛИВЫЙ: файл валиден,
+ * просто не подключён, ошибки нет, а функций в шаблонах не появляется.
+ */
+export function withReExport(entrypoint: string, path: string): string {
+  const line = reExportLine(path);
+  if (entrypoint.includes(line)) return entrypoint;
+  const body = entrypoint.replace(/\s*$/, '');
+  return body.length === 0 ? `${line}\n` : `${body}\n${line}\n`;
+}
+
+/** Убрать строку реэкспорта — при удалении файла, иначе останется битый импорт. */
+export function withoutReExport(entrypoint: string, path: string): string {
+  const line = reExportLine(path);
+  return entrypoint
+    .split('\n')
+    .filter(l => l.trim() !== line)
+    .join('\n');
+}
+
+/** Переписать строку реэкспорта при смене пути файла. */
+export function renameReExport(entrypoint: string, from: string, to: string): string {
+  const before = reExportLine(from);
+  return entrypoint.includes(before)
+    ? entrypoint.split('\n').map(l => (l.trim() === before ? l.replace(before, reExportLine(to)) : l)).join('\n')
+    : withReExport(entrypoint, to);
+}
+
+/**
+ * Файлы, ссылающиеся на данный относительным импортом — чтобы перед удалением или сменой пути
+ * сказать поимённо, что сломается. Автоматически переписывать чужие импорты не беремся: это
+ * текстовая трансформация пользовательского кода, ошибиться в ней тоньше, чем не делать.
+ */
+export function referencingFiles(files: UserLibFile[], target: string): string[] {
+  const result: string[] = [];
+  for (const file of files) {
+    if (file.path === target) continue;
+    const dir = file.path.includes('/') ? file.path.slice(0, file.path.lastIndexOf('/')) : '';
+    for (const raw of importPaths(file.content)) {
+      if (resolveRelative(dir, raw) === target) { result.push(file.path); break; }
+    }
+  }
+  return result;
+}
+
+/** Пути из `#import "…"`; координаты пакетов (`@ns/name`) — не наши файлы. */
+function importPaths(content: string): string[] {
+  const out: string[] = [];
+  const re = /#import\s+"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const raw = m[1].replace(/\\/g, '/');
+    if (!raw.startsWith('@')) out.push(raw);
+  }
+  return out;
+}
+
+/** Разрешение «../../util/text.typ» от папки файла. Возвращает null, если путь уходит выше дерева. */
+export function resolveRelative(baseDir: string, raw: string): string | null {
+  const parts = baseDir ? baseDir.split('/') : [];
+  for (const segment of raw.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      if (parts.length === 0) return null;
+      parts.pop();
+    } else {
+      parts.push(segment);
+    }
+  }
+  return parts.length === 0 ? null : parts.join('/');
+}
+
+/**
+ * Проверка пути на стороне клиента — зеркало серверной (`UserLibPath`), чтобы отказ приходил до
+ * запроса. Сервер проверяет всё равно: это подсказка, а не защита.
+ */
+export function validatePath(path: string, existing: string[], selfPath?: string): string | null {
+  const trimmed = path.trim().replace(/\\/g, '/');
+  if (!trimmed) return 'Укажите путь.';
+  if (trimmed.startsWith('/')) return 'Путь должен быть относительным — без ведущего «/».';
+  if (!trimmed.toLowerCase().endsWith('.typ')) return 'Файл библиотеки должен иметь расширение «.typ».';
+  if (trimmed.split('/').some(s => s === '' || s === '.' || s === '..'))
+    return 'Пустые сегменты и «.»/«..» в пути запрещены.';
+  if (existing.some(p => p === trimmed && p !== selfPath)) return 'Такой файл уже есть.';
+  // Регистр значим на Linux и не значим на Windows — расхождение вылезло бы только в продакшене.
+  if (existing.some(p => p.toLowerCase() === trimmed.toLowerCase() && p !== trimmed && p !== selfPath))
+    return 'Уже есть файл, отличающийся только регистром.';
+  return null;
+}

--- a/src/client/src/shared/api/typstUserLib.ts
+++ b/src/client/src/shared/api/typstUserLib.ts
@@ -3,12 +3,34 @@ import { apiClient } from './client';
 
 const QK = ['typst-userlib'] as const;
 
+/** Файл дерева библиотеки (issue #473). Путь — относительный, от папки `userlib/`. */
+export interface UserLibFile { path: string; content: string; }
+
+export interface UserLibError { path: string; line: number; column: number; message: string; }
+export interface UserLibWarning { path: string; message: string; }
+
+/**
+ * Итог проверки на сервере. `ok: false` означает, что библиотека НЕ собирается — а её импортирует
+ * каждый шаблон, поэтому встала генерация всех документов.
+ *
+ * Проверка компилирует зонд, который лишь импортирует точку входа: ловятся синтаксис и битые пути
+ * импортов, но НЕ поведение. Поэтому состояние называется «библиотека собирается», а не «шаблоны
+ * работают» — второе было бы обещанием, которого проверка не даёт.
+ */
+export interface UserLibCheck {
+  ok: boolean;
+  errors: UserLibError[];
+  warnings: UserLibWarning[];
+}
+
+export interface UserLibState { content: string; files: UserLibFile[]; }
+
 export function useTypstUserLib() {
   return useQuery({
     queryKey: QK,
     queryFn: async () => {
-      const r = await apiClient.get<{ content: string }>('/typst-userlib');
-      return r.data.content;
+      const r = await apiClient.get<UserLibState>('/typst-userlib');
+      return { content: r.data.content, files: r.data.files ?? [] } satisfies UserLibState;
     },
   });
 }
@@ -25,12 +47,17 @@ export function useSystemTypstLib() {
   });
 }
 
+/**
+ * Сохранение библиотеки ЦЕЛИКОМ (issue #473). Пофайлового сохранения нет намеренно: правка файла и
+ * правка зовущего его файла обязаны лечь вместе, иначе между двумя запросами библиотека не
+ * собирается — а её читает генерация каждого документа.
+ */
 export function useSaveTypstUserLib() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (content: string) => {
-      const r = await apiClient.put<{ content: string }>('/typst-userlib', { content });
-      return r.data.content;
+    mutationFn: async (state: UserLibState) => {
+      const r = await apiClient.put<UserLibState & { check: UserLibCheck }>('/typst-userlib', state);
+      return r.data;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: QK }),
   });

--- a/src/client/src/shared/ui/typstUserLibCompletion.ts
+++ b/src/client/src/shared/ui/typstUserLibCompletion.ts
@@ -7,22 +7,30 @@ import { useTypstUserLib } from '@/shared/api/typstUserLib';
  * (шаблоны, Typst-блоки типов, сам userlib). Зеркалит паттерн `it.`-провайдера: модульный список
  * обновляется хуком из загруженного userlib, провайдер регистрируется один раз и читает его лениво.
  */
-interface UserLibDef { name: string; params: string; isFunction: boolean; }
+interface UserLibDef { name: string; params: string; isFunction: boolean; source: string; }
 
 let _defs: UserLibDef[] = [];
 let _registered = false;
 
-/** Парсит `#let name(params) = …` (функция) и `#let name = …` (значение) из содержимого userlib.typ. */
-export function setUserLibDefs(content: string): void {
+/**
+ * Парсит `#let name(params) = …` (функция) и `#let name = …` (значение) из точки входа И файлов
+ * дерева (issue #473). Источник запоминаем: подсказка «из какого файла функция» — единственное, что
+ * отвечает на вопрос «где её править», когда файлов два десятка.
+ */
+export function setUserLibDefs(entrypoint: string, files: { path: string; content: string }[] = []): void {
   const defs: UserLibDef[] = [];
   const seen = new Set<string>();
   // Имя — Typst-идентификатор (буквы/цифры/_/-), опциональные (params) → функция.
   const re = /#let\s+([\p{L}_][\p{L}\p{N}_-]*)\s*(\(([^)]*)\))?/gu;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(content)) !== null) {
-    if (seen.has(m[1])) continue;
-    seen.add(m[1]);
-    defs.push({ name: m[1], params: m[3] ?? '', isFunction: m[2] != null });
+
+  for (const { path, content } of [{ path: 'userlib.typ', content: entrypoint }, ...files]) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content)) !== null) {
+      if (seen.has(m[1])) continue;
+      seen.add(m[1]);
+      defs.push({ name: m[1], params: m[3] ?? '', isFunction: m[2] != null, source: path });
+    }
   }
   _defs = defs;
 }
@@ -64,7 +72,7 @@ export function registerUserLibCompletion(monaco: typeof Monaco): void {
             ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
             : undefined,
           range,
-          detail: 'userlib.typ',
+          detail: d.source,
           documentation: d.isFunction ? `#let ${d.name}(${d.params}) = …` : `#let ${d.name} = …`,
         })),
       };
@@ -75,5 +83,5 @@ export function registerUserLibCompletion(monaco: typeof Monaco): void {
 /** Хук: подтягивает userlib.typ и обновляет список автокомплита. Вызывать в компонентах-хостах Typst-редакторов. */
 export function useUserLibCompletion(): void {
   const { data } = useTypstUserLib();
-  useEffect(() => { setUserLibDefs(data ?? ''); }, [data]);
+  useEffect(() => { setUserLibDefs(data?.content ?? '', data?.files ?? []); }, [data]);
 }


### PR DESCRIPTION
Фронтенд к #473 (backend — #474, слит). Разбор Дизайнера (§36 + §35.9) применён.

## Что появилось

Вкладка «Общие функции Typst» — колонка файлов слева от редактора:

```
ТОЧКА ВХОДА
  userlib.typ
ФАЙЛЫ БИБЛИОТЕКИ                    +
  📁 gost
    📁 forms
      f-ui.typ ⚠
```

## Решения и почему

**Плоский список с отступом, не сворачиваемое дерево.** Смысл разрезания одного файла на много — видеть инвентарь целиком; свёрнутые папки воссоздали бы ровно ту проблему, которую мы решаем (#471), этажом выше. Отдельного примитива-дерева не заводил: на двух десятках строк состояние раскрытия, drop-таргеты и `aria-tree` не окупаются.

**Точка входа — секцией, а не бейджем.** Особость позицией объясняет себя до первого касания. Пунктов «Переименовать»/«Удалить» у неё *нет*, а не задизейблены: disabled провоцирует «как включить».

**Сохранение всего дерева одной кнопкой; переключение файлов ничего не спрашивает.** Не удобство, а семантика: правка `util/text.typ` и правка зовущего её `gost/f3.typ` обязаны лечь вместе, иначе фиксируется половина рефакторинга — неработающая библиотека, которую читает генерация каждого документа. Диалог на каждом переключении быстро обесценился бы: заглянуть в соседний файл — навигация внутри правки, а не коммит. Предупреждение только при уходе со страницы. Автосохранения нет — оно фиксировало бы сломанные промежуточные состояния.

**Автоподключение файла.** При создании строка реэкспорта дописывается в точку входа, при удалении убирается, при смене пути переписывается. Без этого самый частый отказ был бы **молчаливым**: файл валиден, просто не подключён, ошибки нет, функций в шаблонах не появляется.

**Показ поломки.** Ошибка в открытом файле — маркерами Monaco; в закрытом — бейджем на его строке (иначе её негде увидеть). Пока библиотека не собирается — постоянная красная строка со ссылками на виновников: последствие глобально и больше нигде не видно. Зелёной строки на каждое сохранение нет, «всё хорошо» каждый раз это шум.

**Чужие импорты не переписываем** при переименовании и удалении — называем ссылающиеся файлы поимённо. Автоправка пользовательского кода ошибается тоньше, чем её отсутствие (строковые формы, `*` против именованных, вхождения в комментариях).

**Автодополнение** разбирает дерево целиком, в `detail` — файл-источник вместо постоянного `userlib.typ`: когда файлов два десятка, это единственное, что отвечает на «где её править».

## Отступление от разбора Дизайнера

Он предлагал `ListDetailShell`. Не взял: страница уже несёт собственную шапку с вкладками, и shell добавил бы вторую. Использую раскладку соседней вкладки (колонка + detail) и `NavSection` из того же модуля — намерение сохранено, дублирования шапки нет.

## Проверка

Живьём на реальной библиотеке (15 функций, 271 строка):

| Шаг | Результат |
|---|---|
| Создание `gost/forms/f-ui.typ` | файл и папки появились в списке |
| Автоподключение | «Изменено: 2» — файл и точка входа |
| Сломанное содержимое → Сохранить | красная строка: `gost/forms/f-ui.typ:1 — expected semicolon or line break`, бейдж на строке файла |
| Починка → Сохранить | строка ушла |

`tsc -b` чистый, 194 фронтенд-теста зелёные (23 новых на чистых хелперах: раскладка строк, реэкспорт, разрешение относительных путей, поиск ссылающихся, валидация пути). Тест поймал, что сортировка по одному лишь пути ставила корневой файл между содержимым папок.

Библиотека пользователя после проверок восстановлена байт в байт (6641 символ, CRLF на месте).

Part of #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)