### PR TITLE
feat(templates): создание файла библиотеки с строки-папки, с подстановкой пути (#479)

### DIFF
--- a/src/client/src/features/templates/UserLibFileList.tsx
+++ b/src/client/src/features/templates/UserLibFileList.tsx
@@ -23,7 +23,8 @@ export function UserLibFileList({
   dirty: Set<string>;
   check: UserLibCheck | null;
   onSelect: (path: string) => void;
-  onCreate: () => void;
+  /** Создать файл; аргумент — папка, в которой создаём (пусто = корень дерева). */
+  onCreate: (folder?: string) => void;
   onRename: (path: string) => void;
   onDelete: (path: string) => void;
 }) {
@@ -46,7 +47,7 @@ export function UserLibFileList({
 
       <div className="flex items-center justify-between pr-2">
         <NavSection label="Файлы библиотеки" />
-        <button type="button" onClick={onCreate} title="Создать файл"
+        <button type="button" onClick={() => onCreate()} title="Создать файл"
           className="h-6 w-6 inline-flex items-center justify-center rounded text-fg3 hover:text-fg1 hover:bg-muted transition-colors">
           <Plus size={14} />
         </button>
@@ -57,9 +58,19 @@ export function UserLibFileList({
           Пока всё в одном файле. Создайте файл, чтобы вынести часть функций.
         </p>
       ) : rows.map(row => row.kind === 'folder' ? (
-        <div key={`d:${row.path}`} className="flex items-center gap-1.5 py-1 text-xs text-fg4"
+        /* «+» на папке — то же правило, что у заголовка секции, уровнем ниже: «создать в этом
+           контейнере». Кебаб был бы хуже — единственный пункт под безликим глифом и лишний клик.
+           Это ускоритель, а не единственный путь: создание через шапку секции остаётся. */
+        <div key={`d:${row.path}`} className="group/dir flex items-center gap-1.5 py-1 pr-2 text-xs text-fg4"
           style={{ paddingLeft: `${0.75 + row.depth}rem` }}>
-          <Folder size={12} className="shrink-0" />{row.label}
+          <Folder size={12} className="shrink-0" />
+          <span className="truncate flex-1">{row.label}</span>
+          <button type="button" onClick={() => onCreate(row.path)} title={`Создать файл в «${row.path}»`}
+            className="h-5 w-5 shrink-0 inline-flex items-center justify-center rounded text-fg4
+                       hover:text-fg1 hover:bg-muted opacity-0 group-hover/dir:opacity-100
+                       focus-visible:opacity-100 transition-colors">
+            <Plus size={12} />
+          </button>
         </div>
       ) : (
         <FileRow

--- a/src/client/src/features/templates/UserLibPanel.tsx
+++ b/src/client/src/features/templates/UserLibPanel.tsx
@@ -168,7 +168,7 @@ export function UserLibPanel() {
         <UserLibFileList
           files={files} selected={selected} dirty={dirty} check={check}
           onSelect={setSelected}
-          onCreate={() => setPathDialog({ mode: 'create', path: '' })}
+          onCreate={folder => setPathDialog({ mode: 'create', path: folder ? `${folder}/` : '' })}
           onRename={p => setPathDialog({ mode: 'rename', path: p })}
           onDelete={p => setDeleting(p)}
         />

--- a/src/client/src/features/templates/UserLibPathDialog.tsx
+++ b/src/client/src/features/templates/UserLibPathDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { validatePath } from './userLibTree';
@@ -22,6 +22,23 @@ export function UserLibPathDialog({
   const [path, setPath] = useState(initialPath);
   const [touched, setTouched] = useState(false);
   const error = validatePath(path, existing, mode === 'rename' ? initialPath : undefined);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Курсор в КОНЕЦ, без выделения (issue #479). Обычный автофокус выделяет содержимое целиком, и
+  // подставленный префикс «gost/21.613/» стёрся бы первым же нажатием — то есть ровно та опечатка,
+  // от которой подстановка и должна избавлять.
+  //
+  // Через кадр, а не в самом эффекте: ловушка фокуса модалки Radix расставляет фокус в СВОЁМ
+  // эффекте, и поставленный раньше просто перехватывается — проверено, поле оставалось без фокуса.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   return (
     <Modal open onOpenChange={o => { if (!o) onCancel(); }} title={mode === 'create' ? 'Новый файл библиотеки' : 'Изменить путь'}>
@@ -31,7 +48,7 @@ export function UserLibPathDialog({
             Путь внутри <code className="font-mono">userlib/</code>
           </label>
           <input
-            id="userlib-path" autoFocus value={path}
+            id="userlib-path" ref={inputRef} value={path}
             onChange={e => { setPath(e.target.value); setTouched(true); }}
             onKeyDown={e => { if (e.key === 'Enter' && !error) onSubmit(path.trim().replace(/\\/g, '/')); }}
             placeholder="gost/forms/f3.typ"


### PR DESCRIPTION
Closes #479

При глубине вроде `gost/21.613/` префикс приходилось набирать руками на каждый новый файл. Теперь у строки-папки есть «+», а диалог открывается с подставленным путём.

## Решения (разобрано с Дизайнером)

**«+», а не кебаб.** «+» и «⋮» — не два жеста для одного действия, а два разных смысла, и оба в списке уже работают: «+» у заголовка секции = «создать в этом контейнере», «⋮» у файла = «действия над этим предметом». Папка есть контейнер ровно как секция, тот же знак на ней — то же правило уровнем ниже. Кебаб содержал бы единственный пункт: лишний клик под безликим глифом. Видимость по hover укладывается в сложившееся правило «действия строки — по hover, действие контейнера-заголовка — всегда»; создание через шапку секции остаётся, так что «+» на папке — ускоритель, а не единственный путь.

*(Здесь я ошибался и признаю: предлагал кебаб ради единообразия с файловыми строками.)*

**Поле редактируемое, а не с неизменяемой приставкой.** Диалог общий для создания и переименования и стоит на инварианте «переименование = перемещение = правка одной строки». Приставка защищала бы от опечатки, которая до сохранения, видна глазом и чинится backspace'ом, а отняла бы обычный сценарий «создать в другой папке, стоя на этой».

**Курсор в конец без выделения.** Обычный автофокус выделяет содержимое целиком — подставленный префикс стёрся бы первым же нажатием, то есть автофокус сам создавал бы ту ошибку, от которой подстановка избавляет.

**Клик по строке-папке по-прежнему без действия.** В этом списке у клика единственный смысл — «открыть в редакторе»; открытие модалки по клику сделало бы так, что одинаковые с виду строки делают несопоставимые вещи.

## Что поймала живая проверка

Первая версия ставила фокус прямо в эффекте — поле оставалось **без фокуса**: ловушка фокуса модалки Radix расставляет фокус в своём эффекте и перехватывает поставленный раньше. Проверка показала `focused: false` при верном курсоре. Исправлено переносом в `requestAnimationFrame`.

## Вне объёма

**Переименование и удаление папки — не сейчас, и это не вкусовщина**: папочные операции несовместимы с отказом от автоправки чужих импортов (принято в #473). Смысл того решения держится на том, что человек чинит по одному месту за раз и видит каждое; N сломанных импортов одним списком необозримы. Посильное переименование папки уже есть — «Изменить путь» на каждом файле. Условие пересмотра: брать папочные операции только вместе с автоперезаписью импортов.

## Проверка

На рабочей структуре пользователя (`gost/21.101`, `gost/21.608`, `gost/21.613`, `utils.typ`): 4 папки получили кнопку с верными подписями («Создать файл в «gost/21.613»»), диалог открылся с `gost/21.613/`, курсор в позиции 12 без выделения, поле в фокусе; дописанное имя создало файл в нужной папке.

212 фронтенд-тестов зелёные, `tsc -b` чистый. База не тронута — файл создавался только в интерфейсе и не сохранялся.

🤖 Generated with [Claude Code](https://claude.com/claude-code)