### PR TITLE
fix(dev): MinIO по IPv4 — первая генерация после рестарта занимала 20+ секунд (#484)

### DIFF
--- a/src/server/BHS.CRG.Api/appsettings.json
+++ b/src/server/BHS.CRG.Api/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ConnectionStrings": {
     "Postgres": "Host=localhost;Port=5432;Database=bhs_crg;Username=postgres;Password=xxsystem"
   },

--- a/src/server/BHS.CRG.Api/appsettings.json
+++ b/src/server/BHS.CRG.Api/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "ConnectionStrings": {
     "Postgres": "Host=localhost;Port=5432;Database=bhs_crg;Username=postgres;Password=xxsystem"
   },
@@ -52,7 +52,7 @@
     "AccessTokenMinutes": 60
   },
   "BlobStorage": {
-    "Endpoint": "localhost:9000",
+    "Endpoint": "127.0.0.1:9000",
     "AccessKey": "minioadmin",
     "SecretKey": "minioadmin",
     "Bucket": "bhs-crg",

--- a/src/server/BHS.CRG.Infrastructure/Storage/BlobStorage.cs
+++ b/src/server/BHS.CRG.Infrastructure/Storage/BlobStorage.cs
@@ -72,7 +72,14 @@ public class MinIOBlobStorage(IMinioClient minio, BlobStorageOptions options) : 
 
 public class BlobStorageOptions
 {
-    public string Endpoint { get; set; } = "localhost:9000";
+    /// <summary>
+    /// Именно IPv4-литерал, а не «localhost» (issue #484): на Windows localhost резолвится сначала
+    /// в IPv6, где порт-прокси Docker Desktop не слушает и при этом МОЛЧИТ вместо отказа —
+    /// первое обращение к хранилищу висело 21 секунду до таймаута TCP. В контейнере адрес всё
+    /// равно задаётся переменной окружения (minio:9000), а этот дефолт страхует конфигурации,
+    /// где секция BlobStorage не заполнена.
+    /// </summary>
+    public string Endpoint { get; set; } = "127.0.0.1:9000";
     public string AccessKey { get; set; } = "minioadmin";
     public string SecretKey { get; set; } = "minioadmin";
     public string Bucket { get; set; } = "bhs-crg";


### PR DESCRIPTION
Closes #484

Изменение — один адрес в `appsettings.json`. Стоит того, чтобы прочитать почему.

## Симптом

Первый вызов генерации или предпросмотра после запуска API — 20–25 секунд, последующие — три. Наблюдалось дважды независимо.

## Как сужал

Каждый раз перезапуск API и смена ПЕРВОГО вызова:

| Первый вызов | Время | Вывод |
|---|---|---|
| Список строек (EF) | 365 мс, второй 13 мс | EF ни при чём |
| `validate-typst-blocks` (только Typst) | 576 мс | Typst ни при чём |
| `debug-bundle` (резолверы + блобы) | **24 400 мс** | цена здесь |
| `download` PDF (чистый MinIO) | **21 383 мс**, второй **17 мс** | вот оно |

Release-сборка проблему не снимала (11.6 с против 16.3 с) — значит не прогрев JIT.

## Причина

Эндпоинт был `localhost:9000`. На Windows `localhost` резолвится **сначала в IPv6**, а порт-прокси Docker Desktop слушает только IPv4 и при этом **молчит, а не отвергает** — соединение висит до таймаута TCP:

```
IPv4 127.0.0.1:9000   соединился за     19 мс
IPv6 [::1]:9000       TimeoutError через 21 034 мс
```

21 034 против наблюдаемых 21 383 — совпадение до сотен миллисекунд.

Проверены соседи: PostgreSQL слушает и на IPv6 (0 мс), Ollama отвергает за 2 с. Ловушка только у MinIO — именно из-за молчания прокси.

## Результат

| | До | После |
|---|---|---|
| Первое обращение к MinIO | 21 383 мс | **268 мс** |
| Первый предпросмотр | 11 579 мс | **1 114 мс** |
| Первая генерация | 23 125 мс | **3 769 мс** |

## Продакшена не касается

`deploy/docker-compose.yml:84` задаёт `minio:9000` — имя сервиса в сети Docker, IPv6-ловушки нет. Проблема девелоперская, но платил её каждый разработчик при каждом рестарте.

## Побочное наблюдение

Установившееся время генерации — около **3 секунд**. Это уже не холодный старт; под голым спиннером терпимо, но замечание Дизайнера про фазы генерации остаётся в силе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)