### PR TITLE
perf(common-data): списочные ответы без data-URI картинок (#520)

### DIFF
--- a/src/client/src/features/document-sets/catalog/CatalogResource.tsx
+++ b/src/client/src/features/document-sets/catalog/CatalogResource.tsx
@@ -6,7 +6,9 @@ import { Button } from '@/shared/ui/Button';
 import { SearchInput } from '@/shared/ui/SearchInput';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
-import { useListCommonData, useDeleteCommonDataEntry, useCommonDataForScope } from '@/shared/api/commonData';
+import {
+  useListCommonData, useDeleteCommonDataEntry, useCommonDataForScope, useCommonDataEntry,
+} from '@/shared/api/commonData';
 import type { CommonDataEntry, CatalogScope, DocumentType } from '@/shared/api/types';
 import { SCOPE_LABELS } from '@/shared/api/types';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
@@ -228,7 +230,7 @@ export function CatalogResource({ scope, scopeId, allDocTypes }: {
       </Modal>
       <Modal open={!!editEntry} onOpenChange={o => { if (!o) setEditEntry(null); }} title="Редактировать запись" wide flushBody>
         {editEntry && (
-          <CatalogEntryForm entry={editEntry} compositeTypes={compositeTypes} documentTypes={documentTypes}
+          <EditEntryForm id={editEntry.id} compositeTypes={compositeTypes} documentTypes={documentTypes}
             allDocTypes={allDocTypes} scope={scope} scopeId={scopeId} onClose={() => setEditEntry(null)} />
         )}
       </Modal>
@@ -259,6 +261,28 @@ function TypeNavItem({ icon, label, count, active, doc, muted, profile, onClick 
 
 /** Detail профиля уровня (issue #258): бейдж «уровень», объяснитель «данные во всех документах»,
  *  ключ доступа в шаблоне со «Скопировать», превью полей + «Редактировать» (открывает форму записи). */
+/**
+ * Редактирование записи — по ПОЛНОЙ записи из `/{id}`, а не по той, что пришла со списком
+ * (issue #520). Списочный ответ отдаётся без тяжёлой полезной нагрузки картинок, а форма засевает
+ * свои значения из `entry.data` и отправляет их обратно при сохранении: открой мы её на списочной
+ * копии — сохранение стёрло бы печати и факсимиле.
+ */
+function EditEntryForm({ id, onClose, ...rest }: {
+  id: string;
+  compositeTypes: DocumentType[];
+  documentTypes: DocumentType[];
+  allDocTypes: DocumentType[];
+  scope: CatalogScope;
+  scopeId: string | null;
+  onClose: () => void;
+}) {
+  const { data: entry, isLoading } = useCommonDataEntry(id);
+  if (isLoading || !entry) {
+    return <div className="p-8 text-center text-sm text-fg4">Загрузка записи…</div>;
+  }
+  return <CatalogEntryForm entry={entry} onClose={onClose} {...rest} />;
+}
+
 function ProfileDetail({ scope, type, object, templateKey, onEdit }: {
   scope: CatalogScope; type: DocumentType; object?: CommonDataEntry; templateKey: string; onEdit: () => void;
 }) {

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/CommonDataEndpoints.cs
@@ -23,7 +23,8 @@ public static class CommonDataEndpoints
                 _              => null,
             };
             return Results.Ok((await m.Send(new ListCommonDataEntriesQuery(parsedScope, scopeId, typeId)))
-                .Select(CommonDataEntryDto.From));
+                .Select(CommonDataEntryDto.From)
+                .Select(Elide));
         });
 
         // Resolve all relevant entries for a document set (full hierarchy)
@@ -31,7 +32,7 @@ public static class CommonDataEndpoints
         {
             try
             {
-                return Results.Ok(await m.Send(new ResolveCommonDataForSetQuery(setId, typeId)));
+                return Results.Ok((await m.Send(new ResolveCommonDataForSetQuery(setId, typeId))).Select(Elide));
             }
             catch (KeyNotFoundException ex) { return Results.NotFound(ex.Message); }
         });
@@ -48,13 +49,14 @@ public static class CommonDataEndpoints
                 _              => null,
             };
             if (parsed is null) return Results.BadRequest($"Unknown scope '{scope}'.");
-            return Results.Ok(await m.Send(new ResolveCommonDataForScopeQuery(parsed.Value, scopeId, typeId)));
+            return Results.Ok((await m.Send(new ResolveCommonDataForScopeQuery(parsed.Value, scopeId, typeId)))
+                .Select(Elide));
         });
 
+        // По идентификатору — ПОЛНАЯ запись, без отсечения: этот путь кормит редактор (issue #520).
         g.MapGet("/{id:guid}", async (Guid id, IMediator m) =>
         {
-            var all = await m.Send(new ListCommonDataEntriesQuery());
-            var entry = all.FirstOrDefault(e => e.Id == id);
+            var entry = await m.Send(new GetCommonDataEntryQuery(id));
             return entry is null ? Results.NotFound() : Results.Ok(CommonDataEntryDto.From(entry));
         });
 
@@ -90,6 +92,17 @@ public static class CommonDataEndpoints
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
     }
+
+    /// <summary>
+    /// Списочный ответ без тяжёлой полезной нагрузки (issue #520). Вызывается ЯВНО в трёх списочных
+    /// местах и никогда внутри <see cref="CommonDataEntryDto.From"/>: тот обслуживает и чтение одной
+    /// записи, и ответы POST/PUT — отсечение там молча обрезало бы редактор и round-trip записи.
+    /// </summary>
+    private static CommonDataEntryDto Elide(CommonDataEntryDto dto) =>
+        dto with { Data = HeavyLeafElision.WithoutHeavyLeaves(dto.Data) };
+
+    private static CommonDataEntryWithScope Elide(CommonDataEntryWithScope entry) =>
+        entry with { Data = HeavyLeafElision.WithoutHeavyLeaves(entry.Data) };
 
     record CreateRequest(string DisplayName, Guid CompositeTypeId, string Data, string Scope, Guid? ScopeId, string[]? Aliases);
     record UpdateRequest(string DisplayName, string Data, string[]? Aliases);

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -141,6 +141,16 @@ public record UpdateCommonDataEntryCommand(Guid Id, string DisplayName, JsonDocu
 
 public record DeleteCommonDataEntryCommand(Guid Id) : IRequest;
 
+/// <summary>
+/// Одна запись общих данных по идентификатору (issue #520).
+///
+/// Раньше эндпоинт <c>/{id}</c> звал список без фильтров и искал нужную запись в памяти — то есть
+/// вычитывал весь каталог (у нас это мегабайты картинок) ради одной записи. С отсечением тяжёлых
+/// листьев в списке такой обходной путь стал бы вдобавок НЕВЕРНЫМ: по нему пришла бы обрезанная
+/// запись, а этот эндпоинт кормит редактор.
+/// </summary>
+public record GetCommonDataEntryQuery(Guid Id) : IRequest<DomainObject?>;
+
 public record ListCommonDataEntriesQuery(
     CatalogScope? Scope = null,
     Guid? ScopeId = null,

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -740,6 +740,7 @@ public class CommonDataHandlers(
     IRequestHandler<UpdateCommonDataEntryCommand, DomainObject>,
     IRequestHandler<DeleteCommonDataEntryCommand>,
     IRequestHandler<ListCommonDataEntriesQuery, IReadOnlyList<DomainObject>>,
+    IRequestHandler<GetCommonDataEntryQuery, DomainObject?>,
     IRequestHandler<ResolveCommonDataForSetQuery, IReadOnlyList<CommonDataEntryWithScope>>,
     IRequestHandler<ResolveCommonDataForScopeQuery, IReadOnlyList<CommonDataEntryWithScope>>
 {
@@ -783,6 +784,9 @@ public class CommonDataHandlers(
         repo.Remove(entry);
         await repo.SaveChangesAsync(ct);
     }
+
+    public async Task<DomainObject?> Handle(GetCommonDataEntryQuery q, CancellationToken ct)
+        => await repo.GetByIdAsync(q.Id, ct);
 
     public async Task<IReadOnlyList<DomainObject>> Handle(ListCommonDataEntriesQuery q, CancellationToken ct)
     {

--- a/src/server/BHS.CRG.Application/Documents/HeavyLeafElision.cs
+++ b/src/server/BHS.CRG.Application/Documents/HeavyLeafElision.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace BHS.CRG.Application.Documents;
+
+/// <summary>
+/// Вырезание тяжёлой полезной нагрузки из СПИСОЧНЫХ ответов (issue #520).
+///
+/// Зачем: <c>GET /api/common-data</c> отдавал 5,43 МБ, из них 99,6 % — base64 картинок, при том что
+/// список при отрисовке сам отбрасывает объекты (<c>typeof v !== 'object'</c>) и показывает только
+/// скаляры. То есть провод грузили тем, что клиент осознанно не показывает.
+///
+/// Почему не «просто не отдавать Data»: по ключам записи считается покрытие базовым экземпляром
+/// (<c>Object.keys(entry.data)</c>) — без них поля, приходящие наследованием, начали бы требовать
+/// заполнения вручную. Это было бы тихим изменением наследования, а не экономией трафика. Поэтому
+/// форма и КЛЮЧИ сохраняются, вырезается только сама data-URI; опции картинки (width/height/align/
+/// fit) остаются — они лёгкие и по ним строится подпись.
+///
+/// Применять ТОЛЬКО в списочных местах и никогда в <c>CommonDataEntryDto.From</c>: тот обслуживает и
+/// чтение одной записи, и ответы POST/PUT — там отсечение молча обрезало бы редактор и round-trip.
+/// </summary>
+public static class HeavyLeafElision
+{
+    /// <summary>Маркер вырезанного значения. Не «пустая строка» и не отсутствие ключа — по нему видно, что данные есть, но не отданы.</summary>
+    public const string ElidedMarker = "$elided";
+
+    /// <summary>Значение маркера для картинки.</summary>
+    public const string ImageKind = "image";
+
+    private const string DataUriPrefix = "data:image";
+
+    /// <summary>
+    /// Копия документа без data-URI картинок. Возвращает ТОТ ЖЕ экземпляр, если резать нечего —
+    /// подавляющее большинство записей картинок не имеет, и платить за них копированием незачем.
+    /// </summary>
+    public static JsonDocument WithoutHeavyLeaves(JsonDocument data)
+    {
+        var node = JsonNode.Parse(data.RootElement.GetRawText());
+        if (node is null || !Elide(node)) return data;
+        return JsonDocument.Parse(node.ToJsonString());
+    }
+
+    /// <summary>Обходит дерево, заменяя тяжёлые листья. true — что-то вырезано.</summary>
+    private static bool Elide(JsonNode node)
+    {
+        var changed = false;
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var key in obj.Select(kv => kv.Key).ToList())
+                {
+                    var child = obj[key];
+                    if (IsDataUri(child))
+                    {
+                        // Голая строка (легаси-форма значения) — заменяем маркером-объектом: опций у
+                        // неё нет, а форма объекта совпадает с той, что получится из {src, ...}.
+                        obj[key] = new JsonObject { [ElidedMarker] = ImageKind };
+                        changed = true;
+                    }
+                    else if (child is JsonObject inner && IsDataUri(inner["src"]))
+                    {
+                        inner.Remove("src");
+                        inner[ElidedMarker] = ImageKind;   // опции остаются на месте
+                        changed = true;
+                    }
+                    else if (child is not null && Elide(child))
+                    {
+                        changed = true;
+                    }
+                }
+                break;
+
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                {
+                    var item = arr[i];
+                    if (IsDataUri(item))
+                    {
+                        arr[i] = new JsonObject { [ElidedMarker] = ImageKind };
+                        changed = true;
+                    }
+                    else if (item is not null && Elide(item))
+                    {
+                        changed = true;
+                    }
+                }
+                break;
+        }
+        return changed;
+    }
+
+    private static bool IsDataUri(JsonNode? node) =>
+        node is JsonValue v
+        && v.TryGetValue<string>(out var s)
+        && s.StartsWith(DataUriPrefix, StringComparison.Ordinal);
+}

--- a/src/server/BHS.CRG.Tests/Documents/HeavyLeafElisionTests.cs
+++ b/src/server/BHS.CRG.Tests/Documents/HeavyLeafElisionTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using BHS.CRG.Application.Documents;
+
+namespace BHS.CRG.Tests.Documents;
+
+/// <summary>
+/// Отсечение тяжёлых листьев в списочных ответах (issue #520). Главное требование — не потерять
+/// КЛЮЧИ: по ним считается покрытие базовым экземпляром, и без них поля начали бы требовать
+/// заполнения вручную.
+///
+/// Проверяем структуру, а не подстроки: <c>JsonNode.ToJsonString()</c> экранирует кириллицу
+/// (<c>П</c>), и сравнение по тексту падало бы на ровном месте, ничего не говоря о поведении.
+/// </summary>
+public class HeavyLeafElisionTests
+{
+    private static JsonElement Elide(string json) =>
+        HeavyLeafElision.WithoutHeavyLeaves(JsonDocument.Parse(json)).RootElement;
+
+    private static bool IsElided(JsonElement el) =>
+        el.ValueKind == JsonValueKind.Object
+        && el.TryGetProperty(HeavyLeafElision.ElidedMarker, out var m)
+        && m.GetString() == HeavyLeafElision.ImageKind;
+
+    [Fact]
+    public void KeepsKeyAndOptions_DropsPayload()
+    {
+        var root = Elide("""
+            {"Печать":{"src":"data:image/png;base64,iVBORw0KGgo=","width":"4cm","align":"center"}}
+            """);
+
+        var stamp = root.GetProperty("Печать");           // ключ на месте
+        Assert.True(IsElided(stamp));
+        Assert.False(stamp.TryGetProperty("src", out _)); // полезной нагрузки нет
+        Assert.Equal("4cm", stamp.GetProperty("width").GetString());
+        Assert.Equal("center", stamp.GetProperty("align").GetString());
+    }
+
+    /// <summary>Легаси-форма значения — голая строка data-URI; ключ обязан уцелеть так же.</summary>
+    [Fact]
+    public void LegacyBareStringIsElidedToo()
+    {
+        var root = Elide("""{"Факсимиле":"data:image/png;base64,iVBORw0KGgo="}""");
+        Assert.True(IsElided(root.GetProperty("Факсимиле")));
+    }
+
+    [Fact]
+    public void FindsImagesInNestedObjectsAndArrays()
+    {
+        var root = Elide("""
+            {"Орг":{"Скан":{"src":"data:image/png;base64,AAAA"}},
+             "Материалы":[{"Фото":{"src":"data:image/jpeg;base64,BBBB"}}]}
+            """);
+
+        Assert.True(IsElided(root.GetProperty("Орг").GetProperty("Скан")));
+        Assert.True(IsElided(root.GetProperty("Материалы")[0].GetProperty("Фото")));
+    }
+
+    /// <summary>Скаляры — то, ради чего список и грузит Data, — не трогаем.</summary>
+    [Fact]
+    public void ScalarsUntouched()
+    {
+        const string json = """{"ИНН":"7701234567","Дом":12,"Активна":true,"_baseRef":"abc"}""";
+        var root = Elide(json);
+        Assert.Equal("7701234567", root.GetProperty("ИНН").GetString());
+        Assert.Equal(12, root.GetProperty("Дом").GetInt32());
+        Assert.True(root.GetProperty("Активна").GetBoolean());
+        Assert.Equal("abc", root.GetProperty("_baseRef").GetString());
+    }
+
+    /// <summary>
+    /// Резать нечего — возвращаем ТОТ ЖЕ экземпляр: картинок нет у подавляющего большинства записей,
+    /// и платить за них копированием документа незачем.
+    /// </summary>
+    [Fact]
+    public void ReturnsSameInstanceWhenNothingToElide()
+    {
+        var doc = JsonDocument.Parse("""{"ИНН":"7701234567"}""");
+        Assert.Same(doc, HeavyLeafElision.WithoutHeavyLeaves(doc));
+    }
+
+    /// <summary>Ссылка на файл-вложение живёт в блобе, а не в JSON — её трогать не за что.</summary>
+    [Fact]
+    public void FileAttachmentNodeUntouched()
+    {
+        var root = Elide("""{"Файл":{"$type":"file","blobPath":"attachments/x.pdf","fileName":"x.pdf"}}""");
+        var file = root.GetProperty("Файл");
+        Assert.Equal("file", file.GetProperty("$type").GetString());
+        Assert.Equal("attachments/x.pdf", file.GetProperty("blobPath").GetString());
+        Assert.False(IsElided(file));
+    }
+}


### PR DESCRIPTION
Closes #520. Шаг 1 эпика #518.

> **Оговорка о ветке.** Первый коммит по недосмотру ушёл прямо в master (`dd9f2db`); он отменён коммитом-обратом `77112b1`, а работа перенесена сюда. Историю master не переписывал — отмена добавлена сверху.

## Что было

`GET /api/common-data` отдавал **5,43 МБ, из них 99,6 % base64**, при том что список при отрисовке сам отбрасывает объекты (`typeof v !== 'object'`) и показывает только скаляры.

## Что стало

| | до | после |
|---|---|---|
| `GET /api/common-data` | 5,43 МБ | **0,03 МБ**, base64 ноль |
| `GET /api/common-data/for-set/{id}` | 5,70 МБ | 0,03 МБ |
| `GET /api/common-data/{id}` (редактор) | — | полные 2,67 МБ, как и должно |

## Как

Не «просто не отдавать `Data`»: по ключам записи считается покрытие базовым экземпляром (`Object.keys(entry.data)` в `RequisitesTab.tsx:172`) — без них поля, приходящие наследованием, начали бы требовать заполнения вручную. Поэтому форма и **ключи** сохраняются, вырезается только сама data-URI; опции картинки (`width`/`height`/`align`/`fit`) остаются.

Отсечение вызывается **явно** в трёх списочных местах и никогда внутри `CommonDataEntryDto.From` — тот обслуживает и чтение одной записи, и ответы POST/PUT.

## Фронт пришлось тронуть, вопреки первоначальной оценке

Форма редактирования засевалась записью **из списка** (`setEditEntry(entry)` → `values = entry.data`) и отправляла эти значения при сохранении. С отсечением открытие и сохранение записи **стёрло бы печать**. Теперь модалка грузит полную запись по id.

Заодно `/{id}` переписан на настоящий by-id запрос: он звал список без фильтров и искал в памяти, то есть вычитывал весь каталог ради одной записи, а с отсечением стал бы ещё и неверным — именно он кормит редактор.

## Проверка на живых данных

| | |
|---|---|
| Список | 5,43 МБ → 0,03 МБ, base64 ноль, ключи «Печать» и «Логотип» на месте |
| Ответ по id | несёт полные 2,67 МБ |
| Модалка редактирования | один запрос по id, обе картинки показаны (7 КБ и 2726 КБ) |
| Открыть и сохранить запись без изменений | `Data` в базе побайтово та же (MD5 совпал) |

791 backend-тест (+6 на отсечение: ключи и опции сохраняются, легаси-строка, вложенность и массивы, скаляры нетронуты, тот же экземпляр когда резать нечего, узел файла-вложения не трогается) и 261 frontend. Ошибка eslint в `CatalogResource.tsx` — та же, что на master (проверил на чистом дереве).

🤖 Generated with [Claude Code](https://claude.com/claude-code)