### PR TITLE
feat: картинки переезжают в блоб-хранилище (#522)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -33,6 +33,7 @@ import {
   SectionRail, collectConstraintViolations, describeViolationPath, violationRootKey,
 } from '../fields';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { useUploadsInFlight } from '@/shared/ui/uploadsInFlight';
 
 // Отчёт «Проверить связки» (issue #99): статус каждого @@ref-поля.
 const CHECK_STATUS: Record<string, { label: string; cls: string }> = {
@@ -112,6 +113,9 @@ export function CatalogEntryForm({
   const [recognizing, setRecognizing] = useState(false);
   const [showAllProxyFields, setShowAllProxyFields] = useState(false); // прокси: раскрыть все поля для переопределения (issue #89)
   const [pendingBase, setPendingBase] = useState<BaseCandidate | null>(null); // подтверждение замены основы
+  // Пока картинка едет в хранилище, значение поля ещё не проставлено — сохранив сейчас, человек
+  // потерял бы её молча: на экране она уже видна (issue #522).
+  const uploading = useUploadsInFlight();
   const createMutation = useCreateCommonDataEntry();
   const updateMutation = useUpdateCommonDataEntry();
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
@@ -681,7 +685,8 @@ export function CatalogEntryForm({
       </div>
       <div className="shrink-0 px-6 py-3 border-t border-stroke flex justify-end gap-2">
         <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
-        <Button type="submit" variant="filled" loading={isPending} disabled={isPending || recognizing}>
+        <Button type="submit" variant="filled" loading={isPending} disabled={isPending || recognizing || uploading}
+          title={uploading ? "Дождитесь загрузки изображения" : undefined}>
           {isPending ? 'Сохранение…' : entry ? 'Сохранить' : 'Создать'}
         </Button>
       </div>

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -15,6 +15,7 @@ import { containsRef } from './brokenRefs';
 import { BrokenCountBadge } from './BrokenCountBadge';
 import { RequisitesTab } from './RequisitesTab';
 import { GenerationTab } from './GenerationTab';
+import { useUploadsInFlight } from '@/shared/ui/uploadsInFlight';
 
 // ── Редактор экземпляра документа: оболочка вкладок ──────────────────────────
 // Сами вкладки вынесены по файлам (#490).
@@ -82,6 +83,8 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
   const [switching, setSwitching] = useState(false);
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
+  // Картинка ещё едет в хранилище — сохранять рано: значение поля появится только после (issue #522).
+  const uploading = useUploadsInFlight();
   // Актуальная функция сохранения активной редактируемой вкладки.
   const saveRef = useRef<(() => Promise<boolean>) | null>(null);
   // «Основа» (issue #223): состояние-зеркало базы для chip шапки — источник правды `_baseRef` живёт в
@@ -200,10 +203,12 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           {editable && (
             <div className="flex items-center gap-2 shrink-0">
               {savedFlash && <span className="text-sm text-success hidden sm:inline">Сохранено</span>}
-              <Button variant="text" onClick={() => void doSave()} disabled={saving}>
+              <Button variant="text" onClick={() => void doSave()} disabled={saving || uploading}
+                title={uploading ? "Дождитесь загрузки изображения" : undefined}>
                 {saving ? 'Сохранение…' : 'Сохранить'}
               </Button>
-              <Button variant="filled" onClick={() => void doSaveAndClose()} loading={saving} title="Ctrl+Enter">
+              <Button variant="filled" onClick={() => void doSaveAndClose()} loading={saving} disabled={uploading}
+                title={uploading ? 'Дождитесь загрузки изображения' : 'Ctrl+Enter'}>
                 Сохранить и закрыть
               </Button>
             </div>

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -147,7 +147,10 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
     setTab(next);
     setPendingTab(null);
   }
+  // Тот же запрет, что у кнопок и горячей клавиши: диалог «есть несохранённое» при переключении
+  // вкладки сохранял бы документ без ещё не доехавшей картинки (issue #532).
   async function saveThenSwitch() {
+    if (uploading) return;
     if (!pendingTab) return;
     setSwitching(true);
     try {
@@ -161,7 +164,9 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
     <div className="flex flex-col min-h-0 flex-1"
       onKeyDown={e => {
         // Ctrl/⌘+Enter — сохранить и закрыть (issue #107 F7); работает из любого поля вкладки реквизитов.
-        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && editable && !saving) {
+        // uploading — не косметика: горячая клавиша объявлена в подсказке самой кнопки, и без
+        // проверки она сохраняла бы документ БЕЗ картинки, пока та ещё едет (issue #532).
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && editable && !saving && !uploading) {
           e.preventDefault();
           void doSaveAndClose();
         }

--- a/src/client/src/features/document-sets/fields/ImageField.tsx
+++ b/src/client/src/features/document-sets/fields/ImageField.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
-import { Image as ImageIcon, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
-import { formatBytes } from '@/shared/api/attachments';
-import type { ImageValue } from '@/shared/api/schema';
+import { useEffect, useState } from 'react';
+import { Image as ImageIcon, Trash2, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { formatBytes, uploadImage, loadAttachmentObjectUrl } from '@/shared/api/attachments';
+import { beginUpload, endUpload } from '@/shared/ui/uploadsInFlight';
+import { apiError } from '@/shared/utils/apiError';
+import type { ImageValue, ImageBlobValue, ImageOptions } from '@/shared/api/schema';
 
 /**
  * Предел размера картинки (issue #521). Значение поля лежит data-URI прямо в реквизитах, своего
@@ -33,11 +35,19 @@ const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
  * (голая data-URI строка) читается как `{ src }` без размера.
  */
 export function ImageField({ value, onChange }: {
-  value: unknown; onChange: (val: ImageValue | null) => void;
+  value: unknown; onChange: (val: ImageValue | ImageBlobValue | null) => void;
 }) {
   const [sizeOpen, setSizeOpen] = useState(false);
   const [error, setError] = useState('');
+  /** Локальное превью выбранного файла — показывается СРАЗУ, пока байты едут в хранилище. */
+  const [pending, setPending] = useState<string | null>(null);
   const img = normalize(value);
+  const shownSrc = useImageSrc(img, pending);
+  // Превью держим ровно до того мига, как картинка поехала из хранилища: дальше это лишняя копия
+  // в памяти (у печати — мегабайты) и повод показывать не то, что на самом деле сохранено.
+  useEffect(() => {
+    if (pending && shownSrc && shownSrc !== pending) setPending(null);
+  }, [pending, shownSrc]);
   const hasSize = !!(img && (img.width || img.height || img.align || img.fit));
 
   /**
@@ -56,25 +66,47 @@ export function ImageField({ value, onChange }: {
     const tooBig = checkImageSize(file.size);
     if (tooBig) { setError(tooBig); return; }
 
+    // Тип проверяем по прочитанному, как и раньше (issue #519): accept — только фильтр диалога.
+    // Читаем ради проверки и локального превью; в значение уходит ссылка на блоб, а не байты.
     const reader = new FileReader();
     reader.onerror = () => setError(`Не удалось прочитать файл «${file.name}».`);
     reader.onload = () => {
       const checked = checkImageResult(reader.result, file.name);
       if ('error' in checked) { setError(checked.error); return; }
-      onChange({ ...(img ?? {}), src: checked.src });
+      setPending(checked.src);   // видно немедленно, ещё до загрузки
+      void upload(file);
     };
     reader.readAsDataURL(file);
   }
 
-  const patch = (p: Partial<ImageValue>) => {
+  /**
+   * Байты уезжают в хранилище, в значении остаётся ссылка (issue #522). Опции размера переносим со
+   * старого значения — смена картинки не должна сбрасывать заданную ширину и выравнивание.
+   */
+  async function upload(file: File) {
+    beginUpload();
+    try {
+      const node = await uploadImage(file);
+      const opts: ImageOptions = img ?? {};
+      onChange({ ...node, ...opts });
+    } catch (e) {
+      // Превью убираем: иначе человек уверен, что картинка на месте, а её нет (issue #522).
+      setPending(null);
+      setError(apiError(e, 'Не удалось загрузить изображение'));
+    } finally {
+      endUpload();
+    }
+  }
+
+  const patch = (p: ImageOptions) => {
     if (!img) return;
-    const next: ImageValue = { ...img, ...p };
+    const next = { ...img, ...p };
     // Пустые строки в опциях убираем, чтобы значение не тащило пустышки.
     (['width', 'height', 'align', 'fit'] as const).forEach(k => { if (!next[k]) delete next[k]; });
     onChange(next);
   };
 
-  if (!img) {
+  if (!img && !pending) {
     return (
       <>
         <label className="flex flex-col items-center justify-center gap-2 border-2 border-dashed border-stroke-strong rounded-lg py-6 cursor-pointer hover:border-brand hover:bg-brand-subtle transition-colors">
@@ -93,23 +125,32 @@ export function ImageField({ value, onChange }: {
 
   return (
     <div className="space-y-2">
-      <div className="border border-stroke rounded-lg overflow-hidden bg-base flex items-center justify-center p-2 max-h-52">
-        <img src={img.src} alt="" className="max-h-48 max-w-full object-contain" />
+      {/* Пока байты едут — показываем ЛОКАЛЬНОЕ превью с индикатором в углу, а не пустую рамку:
+          файл уже в браузере, и ждать нечего (issue #522). */}
+      <div className="relative border border-stroke rounded-lg overflow-hidden bg-base flex items-center justify-center p-2 max-h-52">
+        {shownSrc
+          ? <img src={shownSrc} alt="" className="max-h-48 max-w-full object-contain" />
+          : <span className="py-8 text-xs text-fg4">Загрузка изображения…</span>}
+        {pending && (
+          <span className="absolute top-1.5 right-1.5 rounded bg-surface/90 p-1" title="Загружается в хранилище">
+            <Loader2 size={13} className="animate-spin text-brand" />
+          </span>
+        )}
       </div>
 
       <div className="flex items-center gap-4">
-        <button type="button" onClick={() => onChange(null)}
+        <button type="button" onClick={() => { setPending(null); onChange(null); }}
           className="flex items-center gap-1.5 text-xs text-danger hover:text-danger transition-colors">
           <Trash2 size={12} /> Удалить изображение
         </button>
-        <button type="button" onClick={() => setSizeOpen(o => !o)}
+        <button type="button" onClick={() => setSizeOpen(o => !o)} disabled={!img}
           className="flex items-center gap-1 text-xs text-fg3 hover:text-fg1 transition-colors">
           {sizeOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
           Размер и выравнивание{!sizeOpen && hasSize ? ' ·' : ''}
         </button>
       </div>
 
-      {sizeOpen && (
+      {sizeOpen && img && (
         <div className="flex flex-wrap items-center gap-2 pl-1">
           <input value={img.width ?? ''} onChange={e => patch({ width: e.target.value })}
             placeholder="ширина (напр. 4cm)"
@@ -174,12 +215,54 @@ export function checkImageResult(result: unknown, fileName: string): { src: stri
   return { src: result };
 }
 
-/** Приводит значение к объекту {src, ...} или null. Понимает легаси-строку data-URI. */
-function normalize(value: unknown): ImageValue | null {
+/**
+ * Приводит значение к объекту или null. Понимает три формы: голую строку data-URI (легаси), объект
+ * `{src: data-URI, …}` и ссылку на блоб `{$type:"image", blobPath, …}` (issue #522).
+ *
+ * Читать старые формы не перестанем никогда: восстановление бэкапа заново впрыскивает их, а архивы
+ * восстановимы неограниченно долго.
+ */
+function normalize(value: unknown): ImageValue | ImageBlobValue | null {
   if (typeof value === 'string') return value.startsWith('data:image') ? { src: value } : null;
   if (value && typeof value === 'object') {
-    const src = (value as { src?: unknown }).src;
-    if (typeof src === 'string' && src.startsWith('data:image')) return value as ImageValue;
+    const o = value as Record<string, unknown>;
+    if (o['$type'] === 'image' && typeof o.blobPath === 'string' && o.blobPath) return value as ImageBlobValue;
+    if (typeof o.src === 'string' && o.src.startsWith('data:image')) return value as ImageValue;
   }
   return null;
+}
+
+/** Ссылка на блоб? Форма значения после переезда (issue #522). */
+function isBlobValue(v: ImageValue | ImageBlobValue | null): v is ImageBlobValue {
+  return !!v && '$type' in v && v.$type === 'image';
+}
+
+/**
+ * Что показать: локальное превью (пока байты едут), сама data-URI (старая форма) либо скачанный из
+ * хранилища объект-URL (новая). Блоб тянем один раз на путь и освобождаем URL при смене.
+ */
+function useImageSrc(value: ImageValue | ImageBlobValue | null, pending: string | null): string | null {
+  const blobPath = isBlobValue(value) ? value.blobPath : null;
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!blobPath) { setBlobUrl(null); return; }
+    let cancelled = false;
+    let url: string | null = null;
+    loadAttachmentObjectUrl(blobPath)
+      .then(res => {
+        if (cancelled) { URL.revokeObjectURL(res.url); return; }
+        url = res.url;
+        setBlobUrl(res.url);
+      })
+      .catch(() => { if (!cancelled) setBlobUrl(null); });
+    return () => { cancelled = true; if (url) URL.revokeObjectURL(url); };
+  }, [blobPath]);
+
+  // Порядок важен: как только картинка приехала ИЗ ХРАНИЛИЩА, показываем её, а не локальное превью.
+  // Иначе поле до конца жизни показывало бы копию из памяти, и «а читается ли блоб» никто бы не
+  // проверил — узнали бы при генерации документа.
+  if (isBlobValue(value)) return blobUrl ?? pending;
+  if (pending) return pending;
+  return value?.src ?? null;
 }

--- a/src/client/src/features/document-sets/fields/ImageField.tsx
+++ b/src/client/src/features/document-sets/fields/ImageField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Image as ImageIcon, Trash2, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
 import { formatBytes, uploadImage, loadAttachmentObjectUrl } from '@/shared/api/attachments';
 import { beginUpload, endUpload } from '@/shared/ui/uploadsInFlight';
@@ -41,6 +41,12 @@ export function ImageField({ value, onChange }: {
   const [error, setError] = useState('');
   /** Локальное превью выбранного файла — показывается СРАЗУ, пока байты едут в хранилище. */
   const [pending, setPending] = useState<string | null>(null);
+  /**
+   * Номер актуального выбора (issue #532). Загрузка асинхронна, а поле за это время могут очистить
+   * или выбрать другой файл: без маркера удалённая картинка «воскресала» бы, когда доедет запоздавший
+   * ответ, а из двух загрузок побеждала бы та, что ответила последней, — не та, что выбрана последней.
+   */
+  const pick = useRef(0);
   const img = normalize(value);
   const shownSrc = useImageSrc(img, pending);
   // Превью держим ровно до того мига, как картинка поехала из хранилища: дальше это лишняя копия
@@ -61,20 +67,27 @@ export function ImageField({ value, onChange }: {
     e.target.value = '';   // сбрасываем всегда, иначе повторный выбор того же файла не сработает
     if (!file) return;
     setError('');
+    const mine = ++pick.current;
 
     // Размер проверяем ДО чтения: незачем гонять FileReader по файлу, который всё равно отвергнем.
     const tooBig = checkImageSize(file.size);
     if (tooBig) { setError(tooBig); return; }
 
+    // Счётчик занятости включаем с МОМЕНТА ВЫБОРА, а не после чтения (issue #532): чтение файла на
+    // 10 МБ занимает заметное время, и до его конца кнопка сохранения оставалась бы активной при
+    // ещё пустом значении.
+    beginUpload();
+
     // Тип проверяем по прочитанному, как и раньше (issue #519): accept — только фильтр диалога.
     // Читаем ради проверки и локального превью; в значение уходит ссылка на блоб, а не байты.
     const reader = new FileReader();
-    reader.onerror = () => setError(`Не удалось прочитать файл «${file.name}».`);
+    reader.onerror = () => { endUpload(); setError(`Не удалось прочитать файл «${file.name}».`); };
     reader.onload = () => {
       const checked = checkImageResult(reader.result, file.name);
-      if ('error' in checked) { setError(checked.error); return; }
+      if ('error' in checked) { endUpload(); setError(checked.error); return; }
+      if (pick.current !== mine) { endUpload(); return; }   // выбор уже сменился, пока читали
       setPending(checked.src);   // видно немедленно, ещё до загрузки
-      void upload(file);
+      void upload(file, mine);
     };
     reader.readAsDataURL(file);
   }
@@ -83,13 +96,16 @@ export function ImageField({ value, onChange }: {
    * Байты уезжают в хранилище, в значении остаётся ссылка (issue #522). Опции размера переносим со
    * старого значения — смена картинки не должна сбрасывать заданную ширину и выравнивание.
    */
-  async function upload(file: File) {
-    beginUpload();
+  async function upload(file: File, mine: number) {
     try {
       const node = await uploadImage(file);
+      // Запоздавший ответ не должен ни воскрешать удалённую картинку, ни перебивать более свежий
+      // выбор: значение меняем, только если это всё ещё ТОТ выбор (issue #532).
+      if (pick.current !== mine) return;
       const opts: ImageOptions = img ?? {};
       onChange({ ...node, ...opts });
     } catch (e) {
+      if (pick.current !== mine) return;
       // Превью убираем: иначе человек уверен, что картинка на месте, а её нет (issue #522).
       setPending(null);
       setError(apiError(e, 'Не удалось загрузить изображение'));
@@ -139,7 +155,7 @@ export function ImageField({ value, onChange }: {
       </div>
 
       <div className="flex items-center gap-4">
-        <button type="button" onClick={() => { setPending(null); onChange(null); }}
+        <button type="button" onClick={() => { pick.current++; setPending(null); onChange(null); }}
           className="flex items-center gap-1.5 text-xs text-danger hover:text-danger transition-colors">
           <Trash2 size={12} /> Удалить изображение
         </button>

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -15,6 +15,7 @@ import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import {
   PrimitiveInput, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField, ImageField, FileField,
 } from '@/features/document-sets/fields';
+import { useUploadsInFlight } from '@/shared/ui/uploadsInFlight';
 
 /** Разворачивает поля типа в плоские «листья» (путь через точку) для распознавания. */
 export function flattenLeaves(fields: SchemaField[], allDocTypes: DocumentType[], prefix = '', depth = 0): RecognitionFieldReq[] {
@@ -69,6 +70,9 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
   );
   const [uploading, setUploading] = useState(false);
   const [recognizing, setRecognizing] = useState(false);
+  // Картинка поля ещё едет в хранилище — сохранять рано: значение появится только после (issue #522).
+  // Своё `uploading` выше — про скан документа качества, это разные загрузки.
+  const imageUploading = useUploadsInFlight();
   const [error, setError] = useState('');
 
   const create = useCreateQualityDoc();
@@ -221,7 +225,8 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
 
       {error && <p className="text-sm text-danger">{error}</p>}
       <div className="flex items-center gap-2 pt-1">
-        <Button variant="filled" onClick={handleSave} loading={busy} disabled={busy || recognizing || !typeId}>
+        <Button variant="filled" onClick={handleSave} loading={busy}
+          disabled={busy || recognizing || uploading || imageUploading || !typeId} title={imageUploading ? "Дождитесь загрузки изображения" : undefined}>
           {busy ? 'Сохранение…' : isEdit ? 'Сохранить' : 'Создать'}
         </Button>
         <Button variant="text" onClick={onCancel}>Отмена</Button>

--- a/src/client/src/shared/api/attachments.ts
+++ b/src/client/src/shared/api/attachments.ts
@@ -46,6 +46,23 @@ export async function uploadAttachment(file: File): Promise<FileAttachment> {
   return { $type: 'file', ...data };
 }
 
+/**
+ * Загрузка картинки поля-изображения (issue #522). Эндпоинт тот же, что у вложений, а форма значения
+ * другая: `$type: "image"` вместо `"file"`.
+ *
+ * Дискриминатор обязан отличаться: узел вложения материализуется другим путём и несёт другой контракт
+ * (`fileName`/`mimeType`/`pageCount`), тогда как картинке нужны `width`/`align`/`fit`. Свести их
+ * значило бы сломать хелпер `img()` во всех шаблонах.
+ */
+export async function uploadImage(file: File): Promise<{
+  $type: 'image'; blobPath: string; fileName: string; mimeType: string;
+}> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const { data } = await apiClient.post<Omit<FileAttachment, '$type'>>('/attachments', formData);
+  return { $type: 'image', blobPath: data.blobPath, fileName: data.fileName, mimeType: data.mimeType };
+}
+
 export async function uploadPrintForm(
   file: File,
   setId: string,

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -36,6 +36,21 @@ export interface ImageValue extends ImageOptions {
   src: string;
 }
 
+/**
+ * Значение поля-картинки, лежащей в блоб-хранилище (issue #522). Новая форма записи; читать data-URI
+ * (`ImageValue`) при этом не перестаём никогда — восстановление бэкапа заново впрыскивает старую
+ * форму, а архивы восстановимы неограниченно долго.
+ *
+ * Дискриминатор `"image"`, не `"file"`: узел вложения (`FileAttachment`) обслуживается другим путём
+ * и несёт другой контракт — свести их значило бы отнять у картинки опции размера.
+ */
+export interface ImageBlobValue extends ImageOptions {
+  $type: 'image';
+  blobPath: string;
+  fileName: string;
+  mimeType: string;
+}
+
 export interface FieldGroup {
   key: string;
   title: string;

--- a/src/client/src/shared/ui/uploadsInFlight.ts
+++ b/src/client/src/shared/ui/uploadsInFlight.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Счётчик незавершённых загрузок файлов (issue #522).
+ *
+ * Зачем не проп: поле-картинка живёт в четырёх местах, и в одном из них — внутри вложенных
+ * составных полей и строк массива (`ComplexFields`). Протаскивать «я занято» через всю эту глубину
+ * значило бы менять сигнатуры на каждом уровне ради одного логического бита.
+ *
+ * Зачем вообще: значение поля появляется только ПОСЛЕ загрузки. Сохрани пользователь форму раньше —
+ * документ уедет без картинки, и человек об этом не узнает: он ведь её уже видит (показывается
+ * локальное превью). Поэтому кнопка сохранения на время загрузки гаснет.
+ */
+let inFlight = 0;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export function beginUpload(): void {
+  inFlight += 1;
+  emit();
+}
+
+export function endUpload(): void {
+  inFlight = Math.max(0, inFlight - 1);
+  emit();
+}
+
+/** true, пока хоть одна загрузка не закончилась. */
+export function useUploadsInFlight(): boolean {
+  return useSyncExternalStore(
+    listener => { listeners.add(listener); return () => listeners.delete(listener); },
+    () => inFlight > 0,
+    () => false,   // на сервере рендерить нечего — загрузок там не бывает
+  );
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Generation/GenerationEndpoints.cs
@@ -129,8 +129,8 @@ public static class GenerationEndpoints
                     WriteIndented = true,
                     Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 };
-                dataJson = BHS.CRG.Infrastructure.Generation.TypstImageMaterializer
-                    .MaterializeJson(bundle.DataJson, tmpDir, "assets", prettyOpts);
+                dataJson = await BHS.CRG.Infrastructure.Generation.TypstImageMaterializer
+                    .MaterializeJsonAsync(bundle.DataJson, tmpDir, blob, "assets", prettyOpts, ct);
 
                 // Вложения ({$type:"file"}) скачиваем в те же assets/ (att_N) — bundle воспроизводит ВХОД
                 // для внешнего `typst compile`. blob-доступ на сервере есть; так внешний Typst найдёт файлы.

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -1,0 +1,28 @@
+using BHS.CRG.Infrastructure.Maintenance;
+
+namespace BHS.CRG.Api.Endpoints.Maintenance;
+
+/// <summary>
+/// Разовые действия обслуживания — только администратор (issue #522).
+///
+/// Отдельно от EF-миграций осознанно: те применяются на старте приложения, когда блоб-хранилище
+/// может быть недоступно, и получилось бы падающее или наполовину сконвертированное приложение.
+/// Здесь момент выбирает человек и видит отчёт.
+/// </summary>
+public static class MaintenanceEndpoints
+{
+    public static void MapMaintenanceEndpoints(this IEndpointRouteBuilder app)
+    {
+        var g = app.MapGroup("/api/maintenance").RequireAuthorization("Admin");
+
+        // dryRun=true (по умолчанию) — только посчитать: сколько записей и картинок переедет и
+        // сколько байт освободится в JSONB. Пересчёт безопасен и повторяем.
+        g.MapPost("/images/migrate", async (
+            ImageBlobMigration migration, bool? dryRun, CancellationToken ct) =>
+        {
+            var isDryRun = dryRun ?? true;
+            var report = await migration.RunAsync(isDryRun, ct);
+            return Results.Ok(new { report.Objects, report.Images, report.Bytes, dryRun = isDryRun });
+        });
+    }
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -22,7 +22,7 @@ public static class MaintenanceEndpoints
         {
             var isDryRun = dryRun ?? true;
             var report = await migration.RunAsync(isDryRun, ct);
-            return Results.Ok(new { report.Objects, report.Images, report.Bytes, dryRun = isDryRun });
+            return Results.Ok(new { report.Objects, report.Images, report.Bytes, report.Failed, dryRun = isDryRun });
         });
     }
 }

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -6,6 +6,7 @@ using BHS.CRG.Api.Endpoints.Account;
 using BHS.CRG.Api.Endpoints.Attachments;
 using BHS.CRG.Api.Endpoints.Auth;
 using BHS.CRG.Api.Endpoints.Backup;
+using BHS.CRG.Api.Endpoints.Maintenance;
 using BHS.CRG.Api.Endpoints.Catalog;
 using BHS.CRG.Api.Endpoints.Recognition;
 using BHS.CRG.Api.Endpoints.DataSets;
@@ -225,6 +226,7 @@ builder.Services.AddScoped<IRepository<MaterialQualityLink>, Repository<Material
 
 // ── Backup ────────────────────────────────────────────────────────────────────
 builder.Services.AddScoped<BackupService>();
+builder.Services.AddScoped<BHS.CRG.Infrastructure.Maintenance.ImageBlobMigration>();
 
 // ── Снимок данных для внешних потребителей + MCP (issue #415) ─────────────────
 builder.Services.AddScoped<BHS.CRG.Application.DataSnapshots.IDataSnapshotService,
@@ -435,6 +437,7 @@ app.MapAuthEndpoints();
 app.MapAccountEndpoints();
 app.MapUserEndpoints();
 app.MapBackupEndpoints();
+app.MapMaintenanceEndpoints();
 app.MapCatalogEndpoints();
 app.MapPrimitiveTypeEndpoints();
 app.MapEnumTypeEndpoints();

--- a/src/server/BHS.CRG.Infrastructure/Generation/ImageValues.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/ImageValues.cs
@@ -3,11 +3,18 @@ using System.Text.Json.Nodes;
 namespace BHS.CRG.Infrastructure.Generation;
 
 /// <summary>
-/// Общие правила распознавания значений полей-изображений (issue #246). Значение бывает двух форм:
+/// Общие правила распознавания значений полей-изображений (issue #246). Значение бывает трёх форм:
 ///  • голая data-URI строка (<c>data:image/...;base64,...</c>) — легаси / только что загруженная картинка;
 ///  • объект <c>{ src: data-URI, width?, height?, align?, fit? }</c> — размер/выравнивание задаются в
-///    инстансе (перенесены из схемы типа). Служебные ключи размера — те же, что прежде брались из схемы.
-/// Обе формы понимают и материализатор Typst, и разовая миграция размеров.
+///    инстансе (перенесены из схемы типа). Служебные ключи размера — те же, что прежде брались из схемы;
+///  • объект <c>{ $type:"image", blobPath, width?, ... }</c> — картинка живёт в блоб-хранилище (issue #522).
+/// Все формы понимают и материализатор Typst, и разовая миграция размеров.
+/// <para>
+/// Читать data-URI мы не перестанем НИКОГДА, даже после переезда: восстановление бэкапа заново
+/// впрыскивает старую форму, а архивы восстановимы неограниченно долго — срок был бы объявлен, но не
+/// обеспечен. Проект уже принимал это решение дважды (легаси-строка здесь же, легаси-<c>options</c>
+/// в <c>EnumType</c>).
+/// </para>
 /// </summary>
 public static class ImageValues
 {
@@ -18,6 +25,21 @@ public static class ImageValues
         s is not null
         && s.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)
         && s.Contains(";base64,", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Дискриминатор узла-картинки в блоб-хранилище. Не <c>"file"</c> — тот занят вложениями.</summary>
+    public const string BlobTypeMarker = "image";
+
+    /// <summary>
+    /// Узел-ссылка на блоб: <c>{ $type:"image", blobPath }</c> (issue #522). Возвращает путь блоба.
+    /// </summary>
+    public static bool TryGetImageBlobPath(JsonObject obj, out string blobPath)
+    {
+        blobPath = "";
+        if (obj["$type"]?.GetValue<string>() != BlobTypeMarker) return false;
+        if (obj["blobPath"] is not JsonValue v || !v.TryGetValue<string>(out var p) || p.Length == 0) return false;
+        blobPath = p;
+        return true;
+    }
 
     /// <summary>Объект-значение картинки: есть строковый <c>src</c> с data-URI. Возвращает сам src.</summary>
     public static bool TryGetImageObjectSrc(JsonObject obj, out string src)

--- a/src/server/BHS.CRG.Infrastructure/Generation/ImageValues.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/ImageValues.cs
@@ -35,7 +35,12 @@ public static class ImageValues
     public static bool TryGetImageBlobPath(JsonObject obj, out string blobPath)
     {
         blobPath = "";
-        if (obj["$type"]?.GetValue<string>() != BlobTypeMarker) return false;
+        // TryGetValue, а не GetValue: этот разбор идёт по ВСЕМУ контексту генерации, включая данные
+        // наборов и плагинов, а там «$type» может оказаться числом или объектом — GetValue бросил бы
+        // InvalidOperationException и уронил генерацию PDF вместо того, чтобы пропустить чужой узел
+        // (issue #532).
+        if (obj["$type"] is not JsonValue t || !t.TryGetValue<string>(out var marker) || marker != BlobTypeMarker)
+            return false;
         if (obj["blobPath"] is not JsonValue v || !v.TryGetValue<string>(out var p) || p.Length == 0) return false;
         blobPath = p;
         return true;

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstGenerator.cs
@@ -31,7 +31,7 @@ public class TypstGenerator(IBlobStorage blob) : IDocumentGenerator
             // Поля-изображения (data-URI) декодируем в файлы assets/ и подставляем пути,
             // чтобы шаблон мог обращаться к ним через image(it.Поле). Размер/выравнивание — из самого
             // значения-объекта {src, width, ...} (issue #246).
-            var dataJson = TypstImageMaterializer.Materialize(request.Context.Data, tmpDir);
+            var dataJson = await TypstImageMaterializer.MaterializeAsync(request.Context.Data, tmpDir, blob, ct: ct);
 
             // Поля-вложения ({$type:"file"}) скачиваем из blob-хранилища в assets/ и подставляем путь+
             // pageCount, чтобы шаблон вставлял их через image(it.Поле.src[, page: n]) — в т.ч. страницы PDF.

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstImageMaterializer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstImageMaterializer.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Generation;
 
 namespace BHS.CRG.Infrastructure.Generation;
@@ -15,55 +16,68 @@ namespace BHS.CRG.Infrastructure.Generation;
 /// опций нет. Раньше опции задавались в схеме типа и подмешивались по имени поля.
 /// </para>
 /// В шаблоне такое поле используется через хелпер <c>img(it.Поле)</c> (или <c>image(it.Поле.src)</c>).
+/// <para>
+/// С issue #522 значение бывает ещё и ссылкой на блоб — <c>{ $type:"image", blobPath, width?, ... }</c>.
+/// Байты тогда берутся из хранилища, а не из строки; на выходе форма та же, и шаблоны об этом не знают.
+/// Дискриминатор именно <c>"image"</c>, а не <c>"file"</c>: узел вложения обслуживает
+/// <see cref="TypstFileMaterializer"/>, и его контракт (<c>fileName/mimeType/pageCount</c>) другой —
+/// свести их значило бы отнять у поля-картинки <c>width/align/fit</c> и сломать <c>img()</c>.
+/// </para>
 /// </summary>
 public static class TypstImageMaterializer
 {
     /// <summary>
     /// Возвращает JSON для data.json, попутно записав изображения в <paramref name="targetDir"/>/<paramref name="assetsSubdir"/>.
     /// </summary>
-    public static string Materialize(IReadOnlyDictionary<string, object?> data, string targetDir,
-        string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null)
-        => MaterializeNode(JsonSerializer.SerializeToNode(data) ?? new JsonObject(), targetDir, assetsSubdir, outputOptions);
+    public static Task<string> MaterializeAsync(IReadOnlyDictionary<string, object?> data, string targetDir,
+        IBlobStorage? blob = null, string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null,
+        CancellationToken ct = default)
+        => MaterializeNodeAsync(JsonSerializer.SerializeToNode(data) ?? new JsonObject(),
+            targetDir, blob, assetsSubdir, outputOptions, ct);
 
     /// <summary>То же, но на входе готовый JSON-текст (для отладочного комплекта).</summary>
-    public static string MaterializeJson(string json, string targetDir,
-        string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null)
-        => MaterializeNode(JsonNode.Parse(json) ?? new JsonObject(), targetDir, assetsSubdir, outputOptions);
+    public static Task<string> MaterializeJsonAsync(string json, string targetDir,
+        IBlobStorage? blob = null, string assetsSubdir = "assets", JsonSerializerOptions? outputOptions = null,
+        CancellationToken ct = default)
+        => MaterializeNodeAsync(JsonNode.Parse(json) ?? new JsonObject(),
+            targetDir, blob, assetsSubdir, outputOptions, ct);
 
-    private static string MaterializeNode(JsonNode root, string targetDir, string assetsSubdir,
-        JsonSerializerOptions? outputOptions)
+    private static async Task<string> MaterializeNodeAsync(JsonNode root, string targetDir, IBlobStorage? blob,
+        string assetsSubdir, JsonSerializerOptions? outputOptions, CancellationToken ct)
     {
-        var ctx = new Context(Path.Combine(targetDir, assetsSubdir), assetsSubdir);
-        Walk(root, ctx);
+        var ctx = new Context(Path.Combine(targetDir, assetsSubdir), assetsSubdir, blob);
+        await WalkAsync(root, ctx, ct);
         return outputOptions is null ? root.ToJsonString() : root.ToJsonString(outputOptions);
     }
 
-    private sealed class Context(string assetsDir, string assetsSubdir)
+    private sealed class Context(string assetsDir, string assetsSubdir, IBlobStorage? blob)
     {
         public string AssetsDir { get; } = assetsDir;
         public string AssetsSubdir { get; } = assetsSubdir;
+        /// <summary>Хранилище для узлов-ссылок; null — их просто не будет чем прочитать (тесты без блобов).</summary>
+        public IBlobStorage? Blob { get; } = blob;
         public int Count;
     }
 
-    private static void Walk(JsonNode? node, Context ctx)
+    private static async Task WalkAsync(JsonNode? node, Context ctx, CancellationToken ct)
     {
         switch (node)
         {
             case JsonObject obj:
                 foreach (var key in obj.Select(kv => kv.Key).ToList())
-                    Replace(ctx, v => obj[key] = v, obj[key]);
+                    await ReplaceAsync(ctx, v => obj[key] = v, obj[key], ct);
                 break;
             case JsonArray arr:
                 for (var i = 0; i < arr.Count; i++)
                 {
                     var idx = i;
-                    Replace(ctx, v => arr[idx] = v, arr[idx]);
+                    await ReplaceAsync(ctx, v => arr[idx] = v, arr[idx], ct);
                 }
                 break;
         }
     }
 
-    private static void Replace(Context ctx, Action<JsonNode?> set, JsonNode? child)
+    private static async Task ReplaceAsync(Context ctx, Action<JsonNode?> set, JsonNode? child, CancellationToken ct)
     {
         // Голая data-URI строка (легаси / только что загруженная) — без размера.
         if (child is JsonValue val && val.TryGetValue<string>(out var s) && ImageValues.IsDataImage(s))
@@ -72,6 +86,14 @@ public static class TypstImageMaterializer
             if (path is not null) set(BuildImageNode(path, null));
             return;
         }
+        // Ссылка на блоб {$type:"image", blobPath, width?, ...} — issue #522. Байты берём из
+        // хранилища; форма на выходе та же, что и у data-URI, поэтому шаблоны не различают.
+        if (child is JsonObject blobNode && ImageValues.TryGetImageBlobPath(blobNode, out var blobPath))
+        {
+            var path = await WriteBlobImageAsync(blobPath, ctx, ct);
+            if (path is not null) set(BuildImageNode(path, blobNode));
+            return; // не спускаемся внутрь — это лист-значение
+        }
         // Объект-значение картинки {src, width, ...} — размер из него самого (issue #246).
         if (child is JsonObject obj && ImageValues.TryGetImageObjectSrc(obj, out var src))
         {
@@ -79,7 +101,34 @@ public static class TypstImageMaterializer
             if (path is not null) set(BuildImageNode(path, obj));
             return; // не спускаемся внутрь — это лист-значение
         }
-        Walk(child, ctx);
+        await WalkAsync(child, ctx, ct);
+    }
+
+    /// <summary>
+    /// Байты картинки из блоб-хранилища в файл каталога компиляции (issue #522). Хранилища нет или
+    /// блоб не читается — узел оставляем как есть: генерация не должна падать целиком из-за одной
+    /// картинки, а пустой src в шаблоне даст понятную ошибку Typst с именем файла.
+    /// </summary>
+    private static async Task<string?> WriteBlobImageAsync(string blobPath, Context ctx, CancellationToken ct)
+    {
+        if (ctx.Blob is null) return null;
+        try
+        {
+            await using var stream = await ctx.Blob.DownloadAsync(blobPath, ct);
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms, ct);
+
+            Directory.CreateDirectory(ctx.AssetsDir);
+            var ext = Path.GetExtension(blobPath).TrimStart('.');
+            if (ext.Length == 0) ext = "png";
+            var name = $"img_{ctx.Count++}.{ext}";
+            await File.WriteAllBytesAsync(Path.Combine(ctx.AssetsDir, name), ms.ToArray(), ct);
+            return AssetPath.FromRoot(ctx.AssetsSubdir, name);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 
     // Изображение отдаём объектом {src, width, height, align, fit}; размерные ключи — из значения-объекта

--- a/src/server/BHS.CRG.Infrastructure/Generation/TypstImageMaterializer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/TypstImageMaterializer.cs
@@ -90,7 +90,8 @@ public static class TypstImageMaterializer
         // хранилища; форма на выходе та же, что и у data-URI, поэтому шаблоны не различают.
         if (child is JsonObject blobNode && ImageValues.TryGetImageBlobPath(blobNode, out var blobPath))
         {
-            var path = await WriteBlobImageAsync(blobPath, ctx, ct);
+            var mime = blobNode["mimeType"] is JsonValue mv && mv.TryGetValue<string>(out var m) ? m : null;
+            var path = await WriteBlobImageAsync(blobPath, mime, ctx, ct);
             if (path is not null) set(BuildImageNode(path, blobNode));
             return; // не спускаемся внутрь — это лист-значение
         }
@@ -109,7 +110,8 @@ public static class TypstImageMaterializer
     /// блоб не читается — узел оставляем как есть: генерация не должна падать целиком из-за одной
     /// картинки, а пустой src в шаблоне даст понятную ошибку Typst с именем файла.
     /// </summary>
-    private static async Task<string?> WriteBlobImageAsync(string blobPath, Context ctx, CancellationToken ct)
+    private static async Task<string?> WriteBlobImageAsync(
+        string blobPath, string? mimeType, Context ctx, CancellationToken ct)
     {
         if (ctx.Blob is null) return null;
         try
@@ -119,11 +121,19 @@ public static class TypstImageMaterializer
             await stream.CopyToAsync(ms, ct);
 
             Directory.CreateDirectory(ctx.AssetsDir);
-            var ext = Path.GetExtension(blobPath).TrimStart('.');
+            // Расширение — из ЗАЯВЛЕННОГО типа, а путь блоба только запасной вариант (issue #532):
+            // путь может оканчиваться чем угодно, а Typst выбирает декодер по расширению файла.
+            // «bin» из ExtFor означает «тип незнакомый» — тогда решает путь блоба, и лишь затем png.
+            var byMime = mimeType is null ? "bin" : ExtFor(mimeType);
+            var ext = byMime != "bin" ? byMime : Path.GetExtension(blobPath).TrimStart('.');
             if (ext.Length == 0) ext = "png";
             var name = $"img_{ctx.Count++}.{ext}";
             await File.WriteAllBytesAsync(Path.Combine(ctx.AssetsDir, name), ms.ToArray(), ct);
             return AssetPath.FromRoot(ctx.AssetsSubdir, name);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;   // отмену не глотаем: иначе «отменённая» генерация тихо доедет до PDF без картинок
         }
         catch (Exception)
         {

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/ImageBlobMigration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/ImageBlobMigration.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Infrastructure.Generation;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+// Пространство имён НЕ «…Infrastructure.Migration»: оно перекрывало бы тип Migration из EF Core во
+// всех файлах папки Migrations/ — сборка падала с «Migration is a namespace but is used like a type».
+namespace BHS.CRG.Infrastructure.Maintenance;
+
+/// <summary>Что сделала (или сделала бы) миграция картинок.</summary>
+/// <param name="Objects">Записей затронуто.</param>
+/// <param name="Images">Картинок перенесено.</param>
+/// <param name="Bytes">Освобождено из JSONB (размер самих data-URI).</param>
+public record ImageMigrationReport(int Objects, int Images, long Bytes);
+
+/// <summary>
+/// Разовый перенос картинок из JSONB в блоб-хранилище (issue #522).
+///
+/// НЕ EF-миграция сознательно: миграции применяются на старте приложения, а блоб-хранилище на этот
+/// момент может быть недоступно — получили бы падающий или наполовину сконвертированный старт.
+/// Это действие администратора: он выбирает момент и видит отчёт.
+///
+/// Идемпотентна и перезапускаема: узлы, уже переехавшие, пропускаются. Перезапускаемость не
+/// теоретическая — восстановление старого бэкапа заново впрыскивает data-URI, и миграцию можно будет
+/// прогнать снова.
+/// </summary>
+public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
+{
+    /// <param name="dryRun">Только посчитать: ничего не грузить и не сохранять.</param>
+    public async Task<ImageMigrationReport> RunAsync(bool dryRun, CancellationToken ct = default)
+    {
+        var objects = 0;
+        var images = 0;
+        var bytes = 0L;
+
+        // Фильтруем в памяти: записей каталога десятки, а выразить «в JSONB есть data:image» через
+        // EF пришлось бы сырым SQL — цена не окупается.
+        var all = await db.DomainObjects.ToListAsync(ct);
+        var candidates = all.Where(o => o.Data.RootElement.GetRawText().Contains("data:image", StringComparison.Ordinal));
+
+        foreach (var obj in candidates)
+        {
+            var node = JsonNode.Parse(obj.Data.RootElement.GetRawText());
+            if (node is null) continue;
+
+            var moved = await MoveAsync(node, dryRun, ct);
+            if (moved.Count == 0) continue;
+
+            objects++;
+            images += moved.Count;
+            bytes += moved.Bytes;
+
+            if (!dryRun)
+            {
+                obj.SetData(JsonDocument.Parse(node.ToJsonString()));
+                db.DomainObjects.Update(obj);
+            }
+        }
+
+        if (!dryRun && objects > 0) await db.SaveChangesAsync(ct);
+        return new ImageMigrationReport(objects, images, bytes);
+    }
+
+    private async Task<(int Count, long Bytes)> MoveAsync(JsonNode node, bool dryRun, CancellationToken ct)
+    {
+        var count = 0;
+        var bytes = 0L;
+
+        // Возвращаем ПАРУ «узнали ли картинку» и «чем заменить»: без первого флага сухой прогон
+        // считал каждую картинку дважды — замены нет, обход спускается внутрь узла {src, ...} и
+        // видит ту же data-URI второй раз. Число из отчёта идёт человеку, ему врать нельзя.
+        async Task<(bool Handled, JsonNode? Replacement)> Convert(JsonNode? child)
+        {
+            // Голая строка (легаси) и объект {src, ...} — обе формы переезжают в одну и ту же ссылку.
+            var (dataUri, options) = child switch
+            {
+                JsonValue v when v.TryGetValue<string>(out var s) && ImageValues.IsDataImage(s) => (s, null as JsonObject),
+                JsonObject o when ImageValues.TryGetImageObjectSrc(o, out var src) => (src, o),
+                _ => (null, null),
+            };
+            if (dataUri is null) return (false, null);
+
+            count++;
+            bytes += dataUri.Length;
+            if (dryRun) return (true, null);
+
+            var comma = dataUri.IndexOf(',', StringComparison.Ordinal);
+            var mime = dataUri[5..dataUri.IndexOf(';', StringComparison.Ordinal)];
+            var raw = System.Convert.FromBase64String(dataUri[(comma + 1)..]);
+            var ext = mime switch
+            {
+                "image/png" => "png", "image/jpeg" => "jpg", "image/gif" => "gif",
+                "image/webp" => "webp", "image/svg+xml" => "svg", _ => "bin",
+            };
+            var path = await blob.UploadAsync($"image.{ext}", new MemoryStream(raw), mime, ct);
+
+            var replacement = new JsonObject
+            {
+                ["$type"] = ImageValues.BlobTypeMarker,
+                ["blobPath"] = path,
+                ["fileName"] = $"image.{ext}",
+                ["mimeType"] = mime,
+            };
+            // Опции размера переносим как есть — иначе печать «поедет» в вёрстке документа.
+            foreach (var key in ImageValues.OptionKeys)
+                if (options?[key] is JsonValue opt) replacement[key] = opt.DeepClone();
+            return (true, replacement);
+        }
+
+        async Task WalkAsync(JsonNode? current)
+        {
+            switch (current)
+            {
+                case JsonObject obj:
+                    foreach (var key in obj.Select(kv => kv.Key).ToList())
+                    {
+                        var (handled, replacement) = await Convert(obj[key]);
+                        if (replacement is not null) obj[key] = replacement;
+                        else if (!handled) await WalkAsync(obj[key]);
+                    }
+                    break;
+                case JsonArray arr:
+                    for (var i = 0; i < arr.Count; i++)
+                    {
+                        var (handled, replacement) = await Convert(arr[i]);
+                        if (replacement is not null) arr[i] = replacement;
+                        else if (!handled) await WalkAsync(arr[i]);
+                    }
+                    break;
+            }
+        }
+
+        await WalkAsync(node);
+        return (count, bytes);
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/ImageBlobMigration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/ImageBlobMigration.cs
@@ -13,7 +13,8 @@ namespace BHS.CRG.Infrastructure.Maintenance;
 /// <param name="Objects">Записей затронуто.</param>
 /// <param name="Images">Картинок перенесено.</param>
 /// <param name="Bytes">Освобождено из JSONB (размер самих data-URI).</param>
-public record ImageMigrationReport(int Objects, int Images, long Bytes);
+/// <param name="Failed">Картинок не удалось перенести (битый base64, недоступное хранилище).</param>
+public record ImageMigrationReport(int Objects, int Images, long Bytes, int Failed = 0);
 
 /// <summary>
 /// Разовый перенос картинок из JSONB в блоб-хранилище (issue #522).
@@ -35,17 +36,23 @@ public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
         var images = 0;
         var bytes = 0L;
 
-        // Фильтруем в памяти: записей каталога десятки, а выразить «в JSONB есть data:image» через
-        // EF пришлось бы сырым SQL — цена не окупается.
-        var all = await db.DomainObjects.ToListAsync(ct);
-        var candidates = all.Where(o => o.Data.RootElement.GetRawText().Contains("data:image", StringComparison.Ordinal));
+        // Отбор ИДЁТ В БАЗЕ (issue #532). Читать всё в память нельзя: в этой же таблице лежат
+        // экземпляры документов, то есть ровно те многомегабайтные JSONB, ради которых миграция и
+        // затевается, — мы бы вытащили их целиком, да ещё и пересобрали в строку на каждую запись.
+        var sql = "SELECT \"Id\" FROM domain_objects WHERE \"Data\"::text LIKE '%data:image%'";
+        var ids = await db.Database.SqlQueryRaw<Guid>(sql).ToListAsync(ct);
 
-        foreach (var obj in candidates)
+        var failed = 0;
+        foreach (var id in ids)
         {
+            var obj = await db.DomainObjects.FirstOrDefaultAsync(o => o.Id == id, ct);
+            if (obj is null) continue;   // запись успели удалить, пока шёл перенос
+
             var node = JsonNode.Parse(obj.Data.RootElement.GetRawText());
             if (node is null) continue;
 
             var moved = await MoveAsync(node, dryRun, ct);
+            failed += moved.Failed;
             if (moved.Count == 0) continue;
 
             objects++;
@@ -56,17 +63,49 @@ public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
             {
                 obj.SetData(JsonDocument.Parse(node.ToJsonString()));
                 db.DomainObjects.Update(obj);
+                // Сохраняем ПОЗАПИСНО (issue #532): один общий SaveChanges держал бы весь перенос
+                // одной транзакцией, а правки, сделанные людьми во время прогона, затирались бы
+                // снимком, снятым до его начала.
+                await db.SaveChangesAsync(ct);
             }
         }
 
-        if (!dryRun && objects > 0) await db.SaveChangesAsync(ct);
-        return new ImageMigrationReport(objects, images, bytes);
+        // Документы качества хранят реквизиты в своей таблице, и поле-картинка там тоже бывает
+        // (QualityDocForm рисует ImageField). Без этого прохода отчёт «переносить больше нечего»
+        // означал бы «в domain_objects нечего», а человек прочитал бы его как «JSONB чист» (#532).
+        var qualitySql = "SELECT \"Id\" FROM quality_documents WHERE \"Requisites\"::text LIKE '%data:image%'";
+        foreach (var id in await db.Database.SqlQueryRaw<Guid>(qualitySql).ToListAsync(ct))
+        {
+            var doc = await db.QualityDocuments.FirstOrDefaultAsync(d => d.Id == id, ct);
+            if (doc is null) continue;
+
+            var node = JsonNode.Parse(doc.Requisites.RootElement.GetRawText());
+            if (node is null) continue;
+
+            var moved = await MoveAsync(node, dryRun, ct);
+            failed += moved.Failed;
+            if (moved.Count == 0) continue;
+
+            objects++;
+            images += moved.Count;
+            bytes += moved.Bytes;
+
+            if (!dryRun)
+            {
+                doc.Update(doc.DocumentTypeId, doc.DisplayName, JsonDocument.Parse(node.ToJsonString()));
+                db.QualityDocuments.Update(doc);
+                await db.SaveChangesAsync(ct);
+            }
+        }
+
+        return new ImageMigrationReport(objects, images, bytes, failed);
     }
 
-    private async Task<(int Count, long Bytes)> MoveAsync(JsonNode node, bool dryRun, CancellationToken ct)
+    private async Task<(int Count, long Bytes, int Failed)> MoveAsync(JsonNode node, bool dryRun, CancellationToken ct)
     {
         var count = 0;
         var bytes = 0L;
+        var failed = 0;
 
         // Возвращаем ПАРУ «узнали ли картинку» и «чем заменить»: без первого флага сухой прогон
         // считал каждую картинку дважды — замены нет, обход спускается внутрь узла {src, ...} и
@@ -82,31 +121,44 @@ public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
             };
             if (dataUri is null) return (false, null);
 
-            count++;
-            bytes += dataUri.Length;
-            if (dryRun) return (true, null);
+            if (dryRun) { count++; bytes += dataUri.Length; return (true, null); }
 
-            var comma = dataUri.IndexOf(',', StringComparison.Ordinal);
-            var mime = dataUri[5..dataUri.IndexOf(';', StringComparison.Ordinal)];
-            var raw = System.Convert.FromBase64String(dataUri[(comma + 1)..]);
-            var ext = mime switch
+            // Отказ ОДНОЙ картинки не должен губить весь прогон (issue #532): битый base64 в системе
+            // ожидаем — материализатор Typst его молча пропускает, — а перебой в хранилище на девятой
+            // записи из десяти оставил бы восемь перенесённых и ни одной сохранённой.
+            try
             {
-                "image/png" => "png", "image/jpeg" => "jpg", "image/gif" => "gif",
-                "image/webp" => "webp", "image/svg+xml" => "svg", _ => "bin",
-            };
-            var path = await blob.UploadAsync($"image.{ext}", new MemoryStream(raw), mime, ct);
+                var comma = dataUri.IndexOf(',', StringComparison.Ordinal);
+                var mime = dataUri[5..dataUri.IndexOf(';', StringComparison.Ordinal)];
+                var raw = System.Convert.FromBase64String(dataUri[(comma + 1)..]);
+                var ext = mime switch
+                {
+                    "image/png" => "png", "image/jpeg" => "jpg", "image/gif" => "gif",
+                    "image/webp" => "webp", "image/svg+xml" => "svg", _ => "bin",
+                };
+                var path = await blob.UploadAsync($"image.{ext}", new MemoryStream(raw), mime, ct);
 
-            var replacement = new JsonObject
+                var replacement = new JsonObject
+                {
+                    ["$type"] = ImageValues.BlobTypeMarker,
+                    ["blobPath"] = path,
+                    ["fileName"] = $"image.{ext}",
+                    ["mimeType"] = mime,
+                };
+                // Опции размера переносим как есть — иначе печать «поедет» в вёрстке документа.
+                foreach (var key in ImageValues.OptionKeys)
+                    if (options?[key] is JsonValue opt) replacement[key] = opt.DeepClone();
+
+                count++;
+                bytes += dataUri.Length;
+                return (true, replacement);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception)
             {
-                ["$type"] = ImageValues.BlobTypeMarker,
-                ["blobPath"] = path,
-                ["fileName"] = $"image.{ext}",
-                ["mimeType"] = mime,
-            };
-            // Опции размера переносим как есть — иначе печать «поедет» в вёрстке документа.
-            foreach (var key in ImageValues.OptionKeys)
-                if (options?[key] is JsonValue opt) replacement[key] = opt.DeepClone();
-            return (true, replacement);
+                failed++;
+                return (true, null);   // узел оставляем как был — заберём следующим прогоном
+            }
         }
 
         async Task WalkAsync(JsonNode? current)
@@ -133,6 +185,6 @@ public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
         }
 
         await WalkAsync(node);
-        return (count, bytes);
+        return (count, bytes, failed);
     }
 }

--- a/src/server/BHS.CRG.Tests/Generation/TypstImageMaterializerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/TypstImageMaterializerTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BHS.CRG.Infrastructure.Generation;
+using BHS.CRG.Tests.Integration;
 
 namespace BHS.CRG.Tests.Generation;
 
@@ -12,7 +13,7 @@ public class TypstImageMaterializerTests
     private static JsonElement El(object v) => JsonSerializer.SerializeToElement(v);
 
     [Fact]
-    public void Materialize_WritesFiles_AndReplacesWithPaths_IncludingNested()
+    public async Task Materialize_WritesFiles_AndReplacesWithPaths_IncludingNested()
     {
         var dir = Path.Combine(Path.GetTempPath(), "matz-" + Guid.NewGuid());
         Directory.CreateDirectory(dir);
@@ -29,7 +30,7 @@ public class TypstImageMaterializerTests
                 ["Текст"] = El("обычная строка"),
             };
 
-            var json = TypstImageMaterializer.Materialize(data, dir);
+            var json = await TypstImageMaterializer.MaterializeAsync(data, dir);
 
             // записаны четыре файла-изображения (Логотип, Печать, СканПечати, Материалы[0].Фото)
             var files = Directory.GetFiles(Path.Combine(dir, "assets"));
@@ -64,16 +65,83 @@ public class TypstImageMaterializerTests
     }
 
     [Fact]
-    public void Materialize_NoImages_NoAssetsDir()
+    public async Task Materialize_NoImages_NoAssetsDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), "matz-" + Guid.NewGuid());
         Directory.CreateDirectory(dir);
         try
         {
-            var json = TypstImageMaterializer.Materialize(
+            var json = await TypstImageMaterializer.MaterializeAsync(
                 new Dictionary<string, object?> { ["A"] = El("x"), ["N"] = El(5) }, dir);
             Assert.False(Directory.Exists(Path.Combine(dir, "assets")));
             Assert.Contains("\"A\"", json);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    /// <summary>
+    /// Картинка из блоб-хранилища (issue #522): байты берутся из хранилища, а на выходе форма ТА ЖЕ,
+    /// что и у data-URI, — шаблоны и хелпер img() не должны различать, откуда пришло изображение.
+    /// </summary>
+    [Fact]
+    public async Task Materialize_ReadsImageFromBlobStorage()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "matz-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var blob = new FakeBlobStorage();
+            var bytes = Convert.FromBase64String(Png[(Png.IndexOf(",", StringComparison.Ordinal) + 1)..]);
+            var path = await blob.UploadAsync("печать.png", new MemoryStream(bytes), "image/png");
+
+            var data = new Dictionary<string, object?>
+            {
+                ["Печать"] = El(new Dictionary<string, object?>
+                {
+                    ["$type"] = "image", ["blobPath"] = path, ["width"] = "4cm", ["align"] = "center",
+                }),
+            };
+
+            var json = await TypstImageMaterializer.MaterializeAsync(data, dir, blob);
+
+            var files = Directory.GetFiles(Path.Combine(dir, "assets"));
+            Assert.Single(files);
+            Assert.EndsWith(".png", files[0]);
+            Assert.Equal(bytes, await File.ReadAllBytesAsync(files[0]));
+
+            using var doc = JsonDocument.Parse(json);
+            var node = doc.RootElement.GetProperty("Печать");
+            Assert.StartsWith("/assets/img_", node.GetProperty("src").GetString());   // путь от корня (#513)
+            Assert.Equal("4cm", node.GetProperty("width").GetString());               // опции сохранены
+            Assert.Equal("center", node.GetProperty("align").GetString());
+            Assert.False(node.TryGetProperty("$type", out _));                        // служебное наружу не течёт
+            Assert.False(node.TryGetProperty("blobPath", out _));
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    /// <summary>
+    /// Блоб недоступен — генерация не должна падать целиком из-за одной картинки: узел остаётся как
+    /// есть, остальной документ собирается.
+    /// </summary>
+    [Fact]
+    public async Task Materialize_MissingBlob_LeavesNodeAndKeepsGoing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "matz-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var data = new Dictionary<string, object?>
+            {
+                ["Печать"] = El(new Dictionary<string, object?> { ["$type"] = "image", ["blobPath"] = "нет/такого.png" }),
+                ["Номер"] = El("12-АОСР"),
+            };
+
+            var json = await TypstImageMaterializer.MaterializeAsync(data, dir, new FakeBlobStorage());
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal("12-АОСР", doc.RootElement.GetProperty("Номер").GetString());
+            Assert.Equal("image", doc.RootElement.GetProperty("Печать").GetProperty("$type").GetString());
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }

--- a/src/server/BHS.CRG.Tests/Integration/ImageBlobMigrationTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ImageBlobMigrationTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Objects;
+using BHS.CRG.Infrastructure.Maintenance;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Разовый перенос картинок из JSONB в блоб-хранилище (issue #522). Главные свойства: сухой прогон
+/// ничего не меняет, повторный прогон безвреден, опции размера переживают переезд.
+/// </summary>
+[Collection("Integration")]
+public class ImageBlobMigrationTests(IntegrationTestFixture fx)
+{
+    private const string Png =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+    private static JsonDocument Data(string json) => JsonDocument.Parse(json);
+
+    private async Task<Guid> SeedAsync(string json)
+    {
+        await fx.ResetDatabaseAsync();
+        using var scope = fx.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var obj = DomainObject.Create(Guid.NewGuid(), "Организация", Data(json), CatalogScope.System, null);
+        db.DomainObjects.Add(obj);
+        await db.SaveChangesAsync();
+        return obj.Id;
+    }
+
+    private static ImageBlobMigration MigrationFor(IServiceScope scope) =>
+        new(scope.ServiceProvider.GetRequiredService<AppDbContext>(),
+            scope.ServiceProvider.GetRequiredService<IBlobStorage>());
+
+    [Fact]
+    public async Task DryRun_CountsButChangesNothing()
+    {
+        var id = await SeedAsync("{\"Печать\":{\"src\":\"" + Png + "\",\"width\":\"4cm\"}}");
+        using var scope = fx.Services.CreateScope();
+        var report = await MigrationFor(scope).RunAsync(dryRun: true);
+
+        Assert.Equal(1, report.Objects);
+        // Ровно одна: узел {src, ...} — это ОДНА картинка. Пока обход спускался внутрь него, сухой
+        // прогон считал её дважды и врал бы в отчёте, который читает человек.
+        Assert.Equal(1, report.Images);
+        Assert.True(report.Bytes > 0);
+
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var saved = await db.DomainObjects.FindAsync(id);
+        Assert.Contains("data:image", saved!.Data.RootElement.GetRawText());   // ничего не тронуто
+    }
+
+    [Fact]
+    public async Task Migrates_KeepsOptions_AndIsIdempotent()
+    {
+        var id = await SeedAsync(
+            "{\"Печать\":{\"src\":\"" + Png + "\",\"width\":\"4cm\",\"align\":\"center\"},"
+            + "\"Логотип\":\"" + Png + "\","
+            + "\"ИНН\":\"7701234567\"}");
+        using (var scope = fx.Services.CreateScope())
+        {
+            var report = await MigrationFor(scope).RunAsync(dryRun: false);
+            Assert.Equal(1, report.Objects);
+            Assert.Equal(2, report.Images);   // объект-значение и легаси-строка
+        }
+
+        using (var scope = fx.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var saved = await db.DomainObjects.FindAsync(id);
+            var root = saved!.Data.RootElement;
+
+            Assert.DoesNotContain("data:image", root.GetRawText());            // байтов в JSONB больше нет
+            var stamp = root.GetProperty("Печать");
+            Assert.Equal("image", stamp.GetProperty("$type").GetString());
+            Assert.False(string.IsNullOrEmpty(stamp.GetProperty("blobPath").GetString()));
+            Assert.Equal("4cm", stamp.GetProperty("width").GetString());       // опции пережили переезд
+            Assert.Equal("center", stamp.GetProperty("align").GetString());
+            Assert.Equal("image", root.GetProperty("Логотип").GetProperty("$type").GetString());
+            Assert.Equal("7701234567", root.GetProperty("ИНН").GetString());   // остальное не тронуто
+        }
+
+        // Повторный прогон обязан быть безвредным: восстановление старого бэкапа заново впрыскивает
+        // data-URI, и миграцию будут запускать снова.
+        using (var scope = fx.Services.CreateScope())
+        {
+            var again = await MigrationFor(scope).RunAsync(dryRun: false);
+            Assert.Equal(0, again.Objects);
+            Assert.Equal(0, again.Images);
+        }
+    }
+
+    /// <summary>Картинки бывают во вложенных объектах и в строках массивов — их тоже надо забрать.</summary>
+    [Fact]
+    public async Task FindsImagesInNestedStructures()
+    {
+        await SeedAsync(
+            "{\"Орг\":{\"Скан\":{\"src\":\"" + Png + "\"}},"
+            + "\"Материалы\":[{\"Фото\":\"" + Png + "\"}]}");
+        using var scope = fx.Services.CreateScope();
+        var report = await MigrationFor(scope).RunAsync(dryRun: false);
+
+        Assert.Equal(2, report.Images);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/ImageBlobMigrationTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ImageBlobMigrationTests.cs
@@ -105,4 +105,29 @@ public class ImageBlobMigrationTests(IntegrationTestFixture fx)
 
         Assert.Equal(2, report.Images);
     }
+
+    /// <summary>
+    /// Битый base64 в системе ожидаем — материализатор Typst его молча пропускает. Отказ ОДНОЙ
+    /// картинки не должен губить весь прогон: соседняя обязана переехать, а отказ — попасть в отчёт
+    /// (issue #532).
+    /// </summary>
+    [Fact]
+    public async Task BrokenImage_DoesNotKillTheRun()
+    {
+        var id = await SeedAsync(
+            "{\"Битая\":\"data:image/png;base64,не-base64!!\","
+            + "\"Целая\":\"" + Png + "\"}");
+
+        using var scope = fx.Services.CreateScope();
+        var report = await MigrationFor(scope).RunAsync(dryRun: false);
+
+        Assert.Equal(1, report.Images);   // целая переехала
+        Assert.Equal(1, report.Failed);   // битая честно посчитана
+
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var saved = await db.DomainObjects.FindAsync(id);
+        var root = saved!.Data.RootElement;
+        Assert.Equal("image", root.GetProperty("Целая").GetProperty("$type").GetString());
+        Assert.StartsWith("data:image", root.GetProperty("Битая").GetString());   // оставлена как была
+    }
 }


### PR DESCRIPTION
Closes #522. Шаг 3 эпика #518 — самый крупный: сервер, клиент и миграция.

Три коммита в порядке, который важен: **читатели принимают новую форму раньше, чем клиент начинает её писать.** Иначе сохранение или миграция обгонят генерацию, и документ соберётся без печати.

## 1. Сервер читает картинку из блоба

Значение бывает и ссылкой `{$type:"image", blobPath, width?, …}`. Байты берутся из хранилища, **на выходе форма та же** (`{src, width, …}`) — шаблоны и хелпер `img()` не различают, откуда пришло изображение.

Дискриминатор `"image"`, не `"file"`: узел вложения обслуживает `TypstFileMaterializer` со своим контрактом (`fileName`/`mimeType`/`pageCount`), и сведение отняло бы у картинки `width`/`align`/`fit`. Бэкап такой узел **уже** понимал (`is "file" or "image"`), поэтому переезд аддитивен — без правки манифеста и bump'а схемы.

Недоступный блоб не роняет генерацию: узел остаётся как есть, остальной документ собирается.

## 2. Клиент пишет ссылку, а не байты

Загрузка через существующий эндпоинт вложений; в значении остаётся ссылка плюс опции размера (переносятся со старого значения — смена картинки не должна сбрасывать заданную ширину).

- **Мгновенность не потеряна**: файл уже в браузере, поэтому локальное превью показывается сразу, с индикатором в углу, а не пустой рамкой.
- Как только картинка поехала **из хранилища** — показываем её, а превью отпускаем: иначе поле до конца жизни показывало бы копию из памяти, и «читается ли блоб» никто бы не проверил.
- **Сохранение на время загрузки гаснет**: значение появляется только после загрузки, и сохранив раньше, человек потерял бы картинку молча — он ведь её уже видит. Сигнал сделан счётчиком с подпиской, а не пропом: поле живёт в четырёх местах, в одном из них внутри вложенных составных полей и строк массива.
- При ошибке превью убирается — иначе человек уверен, что картинка на месте.

## 3. Разовый перенос существующих записей

`POST /api/maintenance/images/migrate?dryRun=true` (по умолчанию сухой). Не EF-миграция: те применяются на старте приложения, когда хранилище может быть недоступно. Идемпотентна и перезапускаема — восстановление старого бэкапа заново впрыскивает data-URI.

**Тест поймал настоящую ошибку**: в сухом прогоне картинка считалась дважды (замена не возвращается, обход спускается внутрь узла и видит ту же data-URI). Отчёт читает человек, ему врать нельзя.

## Проверка

| | |
|---|---|
| Загрузка в поле | одна загрузка в хранилище, картинка затем читается **из него** (`src` становится `blob:`) |
| Кнопка сохранения | активна → погашена во время загрузки → активна снова |
| Сухой прогон на живых данных | 9 записей, 10 картинок, 4,2 МБ; база побайтово не изменилась |

796 backend-тестов (+5) и 266 frontend, `tsc -b` чист.

## Что дальше

Настоящий перенос (`dryRun=false`) на боевых данных **не запускался** — это решение администратора. После него станет ненужной клиентская константа предела из #521 (её заменит 413 сервера), и откроется #523: уменьшение как производная от сохранённого оригинала.

🤖 Generated with [Claude Code](https://claude.com/claude-code)