### PR TITLE
feat(settings): экран обслуживания изображений (#523, часть 2)

### DIFF
--- a/src/client/src/features/settings/ImageMaintenanceSection.tsx
+++ b/src/client/src/features/settings/ImageMaintenanceSection.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { ImageIcon, Loader2 } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { apiClient } from '@/shared/api/client';
+import { formatBytes } from '@/shared/api/attachments';
+import { apiError } from '@/shared/utils/apiError';
+import { CollapsibleSection } from './CollapsibleSection';
+
+interface Report {
+  objects: number;
+  images: number;
+  bytes: number;
+  failed: number;
+  downscaled: number;
+  savedBytes: number;
+  dryRun: boolean;
+}
+
+async function run(dryRun: boolean): Promise<Report> {
+  const { data } = await apiClient.post<Report>('/maintenance/images/migrate', null, { params: { dryRun } });
+  return data;
+}
+
+/**
+ * Обслуживание картинок (issues #522, #523) — единственное место, где мы СПРАШИВАЕМ.
+ *
+ * Уменьшение при загрузке действует только на новые картинки, поэтому уже лежащие остаются как есть:
+ * без этого шага план обслуживал бы будущее, а измеренная боль сохранялась. Но переделка чужих
+ * печатей — не то, что делают молча: по-человечески это звучит как «мою печать переделают без меня?».
+ *
+ * Поэтому: разово, у администратора, одним экраном, с числами, посчитанными ЧЕСТНО (сухой прогон
+ * действительно скачивает и уменьшает, просто ничего не сохраняет), и с подтверждением. Не у каждого
+ * владельца записи и не по одной. Оригиналы при этом сохраняются — переделка обратима.
+ */
+export function ImageMaintenanceSection() {
+  const [report, setReport] = useState<Report | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [done, setDone] = useState<Report | null>(null);
+
+  async function check() {
+    setBusy(true); setError(''); setDone(null);
+    try { setReport(await run(true)); }
+    catch (e) { setError(apiError(e, 'Не удалось посчитать')); }
+    finally { setBusy(false); }
+  }
+
+  async function apply() {
+    setConfirmOpen(false);
+    setBusy(true); setError('');
+    try {
+      const result = await run(false);
+      setDone(result);
+      setReport(await run(true));   // пересчёт: показываем, что осталось
+    } catch (e) {
+      setError(apiError(e, 'Не удалось выполнить'));
+    } finally { setBusy(false); }
+  }
+
+  const nothingToDo = report !== null && report.images === 0 && report.downscaled === 0;
+
+  return (
+    <CollapsibleSection title="Обслуживание изображений" storageKey="image-maintenance" defaultOpen={false}>
+      <div className="space-y-3">
+        <p className="text-xs text-fg3">
+          Картинки, загруженные раньше, лежат внутри записей и попадают в каждую резервную копию.
+          Их можно перенести в хранилище файлов и уменьшить — оригиналы при этом сохраняются.
+        </p>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outlined" size="sm" onClick={() => void check()} loading={busy}
+            icon={<ImageIcon size={14} />}>
+            Посчитать
+          </Button>
+          {report && !nothingToDo && (
+            <Button variant="filled" size="sm" onClick={() => setConfirmOpen(true)} disabled={busy}>
+              Выполнить
+            </Button>
+          )}
+          {busy && <Loader2 size={14} className="animate-spin text-brand" />}
+        </div>
+
+        {error && <p className="text-xs text-danger">{error}</p>}
+
+        {done && (
+          <p className="text-xs text-success">
+            Готово: перенесено {done.images}, уменьшено {done.downscaled}
+            {done.savedBytes > 0 && `, освобождено ${formatBytes(done.savedBytes)}`}
+            {done.failed > 0 && `, не удалось ${done.failed}`}
+          </p>
+        )}
+
+        {report && (
+          nothingToDo
+            ? <p className="text-xs text-fg3">Обслуживать нечего — все изображения уже в хранилище и укладываются в размер.</p>
+            : (
+              <ul className="text-xs text-fg2 space-y-1">
+                {report.images > 0 && (
+                  <li>
+                    Перенести из записей: <b>{report.images}</b> изображений
+                    в <b>{report.objects}</b> записях — освободится {formatBytes(report.bytes)}
+                  </li>
+                )}
+                {report.downscaled > 0 && (
+                  <li>Уменьшить: <b>{report.downscaled}</b> изображений — освободится {formatBytes(report.savedBytes)}</li>
+                )}
+                {report.failed > 0 && <li className="text-warning">Не поддаются обработке: {report.failed}</li>}
+              </ul>
+            )
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen} onOpenChange={setConfirmOpen}
+        title="Обслужить изображения?"
+        description={
+          report
+            ? `Будет перенесено ${report.images} и уменьшено ${report.downscaled} изображений. `
+              + 'Оригиналы сохраняются в хранилище, вид документов не меняется.'
+            : ''
+        }
+        confirmLabel="Выполнить"
+        onConfirm={() => apply()}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -11,6 +11,7 @@ import {
 import { IntegrationSettingsSection } from './IntegrationSettingsSection';
 import { EmailSettingsSection } from './EmailSettingsSection';
 import { CollapsibleSection } from './CollapsibleSection';
+import { ImageMaintenanceSection } from './ImageMaintenanceSection';
 
 // ─── Settings hook (re-exported for use by other pages) ───────────────────────
 
@@ -381,6 +382,8 @@ export function SettingsPage() {
       <EmailSettingsSection />
 
       {/* ── Backup & Restore ───────────────────────────────────────────────── */}
+      <ImageMaintenanceSection />
+
       <CollapsibleSection title="Резервное копирование" storageKey="backup" defaultOpen={false}>
         <p className="text-xs text-fg3">
           Резервная копия включает: типы документов, шаблоны, каталог сущностей и общие данные.

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -22,7 +22,11 @@ public static class MaintenanceEndpoints
         {
             var isDryRun = dryRun ?? true;
             var report = await migration.RunAsync(isDryRun, ct);
-            return Results.Ok(new { report.Objects, report.Images, report.Bytes, report.Failed, dryRun = isDryRun });
+            return Results.Ok(new
+            {
+                report.Objects, report.Images, report.Bytes, report.Failed,
+                report.Downscaled, report.SavedBytes, dryRun = isDryRun,
+            });
         });
     }
 }

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/ImageBlobMigration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/ImageBlobMigration.cs
@@ -13,8 +13,11 @@ namespace BHS.CRG.Infrastructure.Maintenance;
 /// <param name="Objects">Записей затронуто.</param>
 /// <param name="Images">Картинок перенесено.</param>
 /// <param name="Bytes">Освобождено из JSONB (размер самих data-URI).</param>
-/// <param name="Failed">Картинок не удалось перенести (битый base64, недоступное хранилище).</param>
-public record ImageMigrationReport(int Objects, int Images, long Bytes, int Failed = 0);
+/// <param name="Failed">Картинок не удалось обработать (битый base64, недоступное хранилище).</param>
+/// <param name="Downscaled">Картинок уменьшено (оригинал при этом сохранён).</param>
+/// <param name="SavedBytes">Сколько весили уменьшенные картинки и сколько весят копии — разница.</param>
+public record ImageMigrationReport(
+    int Objects, int Images, long Bytes, int Failed = 0, int Downscaled = 0, long SavedBytes = 0);
 
 /// <summary>
 /// Разовый перенос картинок из JSONB в блоб-хранилище (issue #522).
@@ -98,7 +101,36 @@ public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
             }
         }
 
-        return new ImageMigrationReport(objects, images, bytes, failed);
+        // Второй проход — УМЕНЬШЕНИЕ уже переехавших картинок (issue #523). Отдельно от переноса,
+        // потому что это разные вопросы: перенос убирает двоичное из JSONB, уменьшение сокращает сам
+        // блоб. Оригинал сохраняется — уменьшение остаётся производной и здесь.
+        var downscaled = 0;
+        var saved = 0L;
+        var blobSql = "SELECT \"Id\" FROM domain_objects WHERE \"Data\"::text LIKE '%\"$type\": \"image\"%' OR \"Data\"::text LIKE '%\"$type\":\"image\"%'";
+        foreach (var id in await db.Database.SqlQueryRaw<Guid>(blobSql).ToListAsync(ct))
+        {
+            var obj = await db.DomainObjects.FirstOrDefaultAsync(o => o.Id == id, ct);
+            if (obj is null) continue;
+
+            var node = JsonNode.Parse(obj.Data.RootElement.GetRawText());
+            if (node is null) continue;
+
+            var shrunk = await ShrinkAsync(node, dryRun, ct);
+            failed += shrunk.Failed;
+            if (shrunk.Count == 0) continue;
+
+            downscaled += shrunk.Count;
+            saved += shrunk.Saved;
+
+            if (!dryRun)
+            {
+                obj.SetData(JsonDocument.Parse(node.ToJsonString()));
+                db.DomainObjects.Update(obj);
+                await db.SaveChangesAsync(ct);
+            }
+        }
+
+        return new ImageMigrationReport(objects, images, bytes, failed, downscaled, saved);
     }
 
     private async Task<(int Count, long Bytes, int Failed)> MoveAsync(JsonNode node, bool dryRun, CancellationToken ct)
@@ -186,5 +218,75 @@ public class ImageBlobMigration(AppDbContext db, IBlobStorage blob)
 
         await WalkAsync(node);
         return (count, bytes, failed);
+    }
+
+    /// <summary>
+    /// Уменьшает уже переехавшие картинки, сохраняя оригинал (issue #523).
+    ///
+    /// Узел, у которого уже есть <c>originalBlobPath</c>, пропускаем — он уже уменьшен, и повторный
+    /// прогон обязан быть безвредным. Сухой прогон СЧИТАЕТ ЧЕСТНО: скачивает и уменьшает, но ничего
+    /// не сохраняет. Иначе экран подтверждения показывал бы выдуманные числа, а решать по ним
+    /// человеку.
+    /// </summary>
+    private async Task<(int Count, long Saved, int Failed)> ShrinkAsync(
+        JsonNode node, bool dryRun, CancellationToken ct)
+    {
+        var count = 0;
+        var saved = 0L;
+        var failed = 0;
+
+        async Task WalkAsync(JsonNode? current)
+        {
+            switch (current)
+            {
+                case JsonObject obj:
+                    if (obj["$type"] is JsonValue t && t.TryGetValue<string>(out var marker) && marker == "image")
+                    {
+                        if (obj["originalBlobPath"] is not null) return;   // уже уменьшена
+                        if (obj["blobPath"] is not JsonValue bv || !bv.TryGetValue<string>(out var path)) return;
+
+                        try
+                        {
+                            byte[] source;
+                            await using (var stream = await blob.DownloadAsync(path, ct))
+                            {
+                                using var ms = new MemoryStream();
+                                await stream.CopyToAsync(ms, ct);
+                                source = ms.ToArray();
+                            }
+
+                            var mime = obj["mimeType"] is JsonValue mv && mv.TryGetValue<string>(out var m) ? m : "image/png";
+                            var down = ImageDownscaler.Downscale(source, mime);
+                            // Копию берём только если легче — то же правило, что и при загрузке.
+                            if (down.Bytes is null || down.Bytes.Length >= source.Length) return;
+
+                            count++;
+                            saved += source.Length - down.Bytes.Length;
+                            if (dryRun) return;
+
+                            var ext = down.MimeType == "image/png" ? "png" : "jpg";
+                            var newPath = await blob.UploadAsync($"image_{down.Width}.{ext}",
+                                new MemoryStream(down.Bytes), down.MimeType, ct);
+
+                            obj["originalBlobPath"] = path;   // оригинал остаётся под рукой
+                            obj["blobPath"] = newPath;
+                            obj["mimeType"] = down.MimeType;
+                        }
+                        catch (OperationCanceledException) { throw; }
+                        catch (Exception) { failed++; }
+                        return;
+                    }
+                    foreach (var key in obj.Select(kv => kv.Key).ToList())
+                        await WalkAsync(obj[key]);
+                    break;
+                case JsonArray arr:
+                    foreach (var item in arr.ToList())
+                        await WalkAsync(item);
+                    break;
+            }
+        }
+
+        await WalkAsync(node);
+        return (count, saved, failed);
     }
 }


### PR DESCRIPTION
Closes #523. Завершает эпик #518.

## Единственное место, где мы спрашиваем

Уменьшение при загрузке действует только на новые картинки, поэтому уже лежащие остаются как есть: без этого шага план обслуживал бы будущее, а измеренная боль сохранялась бы. Но переделка чужих печатей не делается молча — по-человечески это звучит как «мою печать переделают без меня?».

Поэтому: **разово, у администратора, одним экраном, с подтверждением.** Не у каждого владельца записи и не по одной. Оригиналы сохраняются — переделка обратима.

Числа считаются **честно**: сухой прогон действительно скачивает и уменьшает, просто ничего не сохраняет. Показывать выдуманные оценки на экране, по которому человек принимает решение, нельзя.

## Серверная сторона

Второй проход обслуживания уменьшает уже переехавшие картинки, сохраняя оригинал в `originalBlobPath`. Узел, у которого оригинал уже есть, пропускается — повторный прогон безвреден. Копию берём, только если она легче: то же правило, что и при загрузке.

## Проверка

Живьём, **ничего не выполнял** — это решение пользователя:

| | |
|---|---|
| Раздел «Обслуживание изображений» | открывается |
| «Посчитать» | «Перенести из записей: **10 изображений в 9 записях — освободится 4.0 МБ**» |
| «Выполнить» | появляется только когда есть что делать |
| Подтверждение | называет, сколько будет перенесено и уменьшено, и что оригиналы сохраняются |

805 backend-тестов и 261 frontend, `tsc -b` чист.

## Что это закрывает

Эпик #518 целиком: список общих данных 5,43 МБ → 0,03 МБ (#520), поле больше не съедает не-картинку (#519), предел с внятным отказом (#521), картинки в блоб-хранилище (#522), уменьшение как производная от сохранённого оригинала (#523).

После нажатия «Выполнить» из JSONB уйдут 4,2 МБ, а резервная копия похудеет с 9 МБ примерно до 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)