### PR TITLE
Курсор в «Название» сразу после добавления поля (#526)

### DIFF
--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -114,6 +114,10 @@ interface FieldCardProps {
   siblingFields?: { key: string; title: string; type: string; computed?: boolean; expression?: string }[];
   /** Смена ключа СОХРАНЁННОГО поля (issue #357) — для предложения миграции данных на сохранении схемы. */
   onKeyRename?: (from: string, to: string) => void;
+  /** Поле только что добавлено (issue #526): курсор ставится в «Название», чтобы можно было сразу печатать. */
+  autoFocus?: boolean;
+  /** Курсор поставлен — контейнеру пора забыть о добавлении (иначе фокус вернётся при перерисовке). */
+  onAutoFocused?: () => void;
   open: boolean;
   onToggleOpen: () => void;
   onChange: (patch: Partial<SchemaField>) => void;
@@ -268,12 +272,22 @@ function ComputedFieldEditor({ field, siblingFields, onChange }: {
  *  редактор (все ветки типов/опций/тэгов). Индекс-независима — переиспользуется в плоском и
  *  группированном представлении (issue #197 Фаза C). */
 export function FieldCard({
-  field, reg, keyConflict, persistedKeys, siblingFields, onKeyRename, open, onToggleOpen, onChange, onRemove,
+  field, reg, keyConflict, persistedKeys, siblingFields, onKeyRename, autoFocus, onAutoFocused,
+  open, onToggleOpen, onChange, onRemove,
   onMoveUp, onMoveDown, isFirst, isLast, dragging, onDragStart, onDragEnd, onDragOver, onDrop,
 }: FieldCardProps) {
   const { primitiveTypes, enumTypes, tagRegistry } = reg;
   const tags = field.tags ?? [];
   const [pickerOpen, setPickerOpen] = useState(false);
+  // Курсор в «Название» сразу после добавления поля (issue #526): иначе после нажатия «Добавить поле»
+  // приходится ещё раз целиться мышью в развернувшуюся карточку.
+  const titleRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!autoFocus) return;
+    titleRef.current?.focus();
+    onAutoFocused?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoFocus]);
   // Стабильность ключа (issue #355): у сохранённого поля ключ заморожен (read-only + замок), меняется
   // только явной разблокировкой с предупреждением о дрейфе данных.
   const [keyUnlocked, setKeyUnlocked] = useState(false);
@@ -363,6 +377,7 @@ export function FieldCard({
       <div className="grid grid-cols-[1fr_1fr_160px_72px_76px] gap-2 items-center">
         {/* Title */}
         <input
+          ref={titleRef}
           value={field.title}
           onChange={e => updateTitle(e.target.value)}
           placeholder="Название"
@@ -623,7 +638,13 @@ export function FieldBuilder({ fields, onChange, disabledKeys, persistedKeys, co
   const { data: tagRegistry } = useTagRegistry();
   const reg: FieldRegistries = { compositeTypes, primitiveTypes, enumTypes, allDocTypes, tagRegistry };
 
-  const add = () => onChange([...fields, withFieldUid({ key: '', title: '', type: 'string', required: false })]);
+  const [justAdded, setJustAdded] = useState<string | null>(null);
+  const add = () => {
+    const field = withFieldUid({ key: '', title: '', type: 'string', required: false });
+    onChange([...fields, field]);
+    setOpenIndex(fields.length);          // без раскрытой карточки ставить курсор некуда
+    setJustAdded(field[FIELD_UID]);
+  };
   // Раскрытие карточки (одна за раз) и drag-and-drop переупорядочивания (issue #197 Фаза B).
   const [openIndex, setOpenIndex] = useState<number | null>(null);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -653,6 +674,8 @@ export function FieldBuilder({ fields, onChange, disabledKeys, persistedKeys, co
           reg={reg}
           keyConflict={!!field.key && !!disabledKeys?.has(field.key.trim())}
           persistedKeys={persistedKeys}
+          autoFocus={!!justAdded && field[FIELD_UID] === justAdded}
+          onAutoFocused={() => setJustAdded(null)}
           siblingFields={fields.filter((_, idx) => idx !== i).map(f => ({ key: f.key, title: f.title, type: f.type, computed: f.computed, expression: f.expression }))}
           open={openIndex === i}
           onToggleOpen={() => setOpenIndex(o => o === i ? null : i)}

--- a/src/client/src/features/settings/GroupedFieldsEditor.tsx
+++ b/src/client/src/features/settings/GroupedFieldsEditor.tsx
@@ -31,6 +31,7 @@ export function GroupedFieldsEditor({
   reg: FieldRegistries;
 }) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [justAdded, setJustAdded] = useState<string | null>(null);   // uid только что добавленного поля (issue #526)
   const [dragKey, setDragKey] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null); // ключ группы (или '__ungrouped__') под курсором
   const [dropBeforeKey, setDropBeforeKey] = useState<string | null>(null); // поле, ПЕРЕД которым ляжет; null = в конец контейнера
@@ -117,8 +118,10 @@ export function GroupedFieldsEditor({
   }
 
   function addField() {
-    onFieldsChange([...fields, withFieldUid({ key: '', title: '', type: 'string', required: false })]);
+    const field = withFieldUid({ key: '', title: '', type: 'string', required: false });
+    onFieldsChange([...fields, field]);
     setOpenIndex(fields.length);
+    setJustAdded(field[FIELD_UID]);   // курсор в «Название» (issue #526)
   }
 
   // ── Операции над группами ─────────────────────────────────────────────────
@@ -188,6 +191,8 @@ export function GroupedFieldsEditor({
           reg={reg}
           keyConflict={!!own.key && !!disabledKeys?.has(own.key.trim())}
           persistedKeys={persistedKeys}
+          autoFocus={!!justAdded && own[FIELD_UID] === justAdded}
+          onAutoFocused={() => setJustAdded(null)}
           onKeyRename={onKeyRename}
           open={openIndex === idx}
           onToggleOpen={() => setOpenIndex(o => o === idx ? null : idx)}

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -15,8 +15,9 @@ export const FIELD_UID: unique symbol = Symbol('fieldUid');
 let uidCounter = 0;
 
 /** Поле с личностью: уже помеченное возвращается как есть (личность обязана переживать правки). */
-export function withFieldUid<T extends SchemaField>(field: T): T {
-  return field[FIELD_UID] ? field : { ...field, [FIELD_UID]: `f${++uidCounter}` };
+export function withFieldUid<T extends SchemaField>(field: T): T & { [FIELD_UID]: string } {
+  type Identified = T & { [FIELD_UID]: string };
+  return field[FIELD_UID] ? field as Identified : { ...field, [FIELD_UID]: `f${++uidCounter}` };
 }
 
 export interface SchemaField {


### PR DESCRIPTION
Closes #526

После нажатия «Добавить поле» приходилось ещё раз целиться мышью в развернувшуюся карточку. Теперь контейнер помечает добавленное поле по его личности (`FIELD_UID`, из #527), карточка ставит курсор в «Название» и сообщает об этом обратно — чтобы фокус не возвращался при перерисовке.

В форме создания типа карточка вдобавок раскрывается: раньше новое поле оставалось свёрнутым, и ставить курсор было некуда.

## Проверка

Живой UI (Playwright), оба редактора — существующий тип (`GroupedFieldsEditor`) и форма создания (`FieldBuilder`). Стенд гонялся и до правки, и после:

| | до | после |
|---|---|---|
| фокус после «Добавить поле» | `BUTTON` (сама кнопка) | `INPUT[Название]` |
| набранное сразу с клавиатуры имя | пропадало | даёт ключ «ПроверкаФокуса» |

`npx tsc -b` чисто, `npm test` — 273 теста.

🤖 Generated with [Claude Code](https://claude.com/claude-code)