### PR TITLE
Перестановка не теряет фокус на краю списка (#542)

### DIFF
--- a/src/client/src/features/datasets/SortSpecDialog.tsx
+++ b/src/client/src/features/datasets/SortSpecDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Plus, Trash2, ArrowUp, ArrowDown } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { Modal } from '@/shared/ui/Modal';
 import { rowKey, withRowUid, withRowUids } from '@/shared/utils/rowIdentity';
 import type { SortColumn, SortSpec } from '@/shared/api/types';
@@ -47,18 +48,8 @@ function SortRow({
           </button>
         ))}
       </div>
-      {/* aria-disabled, а не disabled (issue #517): фокус с погасшей кнопки браузер снимает, и
-          на последнем шаге перестановки клавиатурой пользователь терял место. */}
-      <button type="button" onClick={() => { if (!isFirst) onMoveUp(); }} aria-disabled={isFirst}
-        className="p-1 rounded text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4 shrink-0"
-        title="Выше приоритетом">
-        <ArrowUp size={12} />
-      </button>
-      <button type="button" onClick={() => { if (!isLast) onMoveDown(); }} aria-disabled={isLast}
-        className="p-1 rounded text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4 shrink-0"
-        title="Ниже приоритетом">
-        <ArrowDown size={12} />
-      </button>
+      <MoveButtons onUp={onMoveUp} onDown={onMoveDown} isFirst={isFirst} isLast={isLast}
+        className="rounded shrink-0" upTitle="Выше приоритетом" downTitle="Ниже приоритетом" />
       <button type="button" onClick={onRemove} className="p-1 rounded text-fg4 hover:text-danger shrink-0" title="Удалить">
         <Trash2 size={12} />
       </button>

--- a/src/client/src/features/document-sets/SetDetail.tsx
+++ b/src/client/src/features/document-sets/SetDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams, Link } from 'react-router-dom';
-import { Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy, FolderInput, FolderOutput, ArrowUp, ArrowDown, Layers, FileText, Mail, Database, Table2, Users, AlertTriangle } from 'lucide-react';
+import { Plus, Trash2, Download, Pencil, FolderOpen, Eye, GripVertical, Copy, FolderInput, FolderOutput, Layers, FileText, Mail, Database, Table2, Users, AlertTriangle } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { Modal } from '@/shared/ui/Modal';
 import { Button, IconButton } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
@@ -271,14 +272,10 @@ export function SetDetail() {
                           <GripVertical size={14} />
                         </button>
                         <div className="flex flex-col items-center -my-1">
-                          <button onClick={() => moveDoc(index, -1)} disabled={index === 0 || reorderMutation.isPending}
-                            className="p-0.5 text-fg4 hover:text-brand disabled:opacity-25 disabled:hover:text-fg4 transition-colors" title="Выше">
-                            <ArrowUp size={13} />
-                          </button>
-                          <button onClick={() => moveDoc(index, 1)} disabled={index === lastIndex || reorderMutation.isPending}
-                            className="p-0.5 text-fg4 hover:text-brand disabled:opacity-25 disabled:hover:text-fg4 transition-colors" title="Ниже">
-                            <ArrowDown size={13} />
-                          </button>
+                          <MoveButtons onUp={() => moveDoc(index, -1)} onDown={() => moveDoc(index, 1)}
+                            isFirst={index === 0} isLast={index === lastIndex}
+                            busy={reorderMutation.isPending} size={13}
+                            className="hover:text-brand transition-colors" />
                         </div>
                       </div>
                     </td>

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Plus, Trash2, GripVertical, ArrowUp, ArrowDown } from 'lucide-react';
+import { Plus, Trash2, GripVertical } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { useCreateEnumType, buildEnumTypeDto } from '@/shared/api/enumTypes';
@@ -60,16 +61,8 @@ export function ValuesEditor({ values, onChange }: { values: EnumOptionDef[]; on
           <input value={v.label} onChange={e => update(i, { label: e.target.value })} placeholder="Согласован"
             className="border border-stroke-strong rounded px-2 py-1.5 text-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-brand bg-surface" />
           <span className="flex items-center gap-0.5">
-            {/* aria-disabled, а не disabled (issue #517): браузер снимает фокус с кнопки, которая
-                стала disabled, и пользователь, доведя строку клавиатурой до края, терял место —
-                последний шаг ровно того сценария, ради которого всё это. */}
-            <button type="button" onClick={() => { if (i > 0) move(i, i - 1); }} aria-disabled={i === 0}
-              className="p-0.5 text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4"
-              title="Выше"><ArrowUp size={12} /></button>
-            <button type="button" onClick={() => { if (i < values.length - 1) move(i, i + 1); }}
-              aria-disabled={i === values.length - 1}
-              className="p-0.5 text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4"
-              title="Ниже"><ArrowDown size={12} /></button>
+            <MoveButtons onUp={() => move(i, i - 1)} onDown={() => move(i, i + 1)}
+              isFirst={i === 0} isLast={i === values.length - 1} />
             <button type="button" onClick={() => remove(i)} className="p-0.5 text-fg4 hover:text-danger" title="Удалить"><Trash2 size={13} /></button>
           </span>
         </div>

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Plus, Trash2, ArrowUp, ArrowDown, Cpu, GripVertical, ChevronDown, ChevronUp, Lock, Link2, FunctionSquare } from 'lucide-react';
+import { Plus, Trash2, Cpu, GripVertical, ChevronDown, ChevronUp, Lock, Link2, FunctionSquare } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -434,14 +435,8 @@ export function FieldCard({
         )}
         {/* Actions */}
         <div className="flex items-center justify-end gap-0.5">
-          <button type="button" onClick={onMoveUp} disabled={isFirst}
-            className="p-1 text-fg4 hover:text-fg2 disabled:opacity-25">
-            <ArrowUp size={12} />
-          </button>
-          <button type="button" onClick={onMoveDown} disabled={isLast}
-            className="p-1 text-fg4 hover:text-fg2 disabled:opacity-25">
-            <ArrowDown size={12} />
-          </button>
+          <MoveButtons onUp={() => onMoveUp?.()} onDown={() => onMoveDown?.()}
+            isFirst={!!isFirst} isLast={!!isLast} />
           <button type="button" onClick={onRemove}
             className="p-1 text-fg4 hover:text-danger">
             <Trash2 size={12} />

--- a/src/client/src/features/settings/GroupedFieldsEditor.tsx
+++ b/src/client/src/features/settings/GroupedFieldsEditor.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { GripVertical, Layers, Trash2, ArrowUp, ArrowDown, Plus, Lock } from 'lucide-react';
+import { GripVertical, Layers, Trash2, Plus, Lock } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { Button } from '@/shared/ui/Button';
 import { FIELD_UID, withFieldUid, type SchemaField, type FieldGroup } from '@/shared/api/schema';
 import { FieldCard, fieldTypeSummary, type FieldRegistries } from './FieldBuilder';
@@ -294,10 +295,8 @@ export function GroupedFieldsEditor({
               />
               <span className="text-xs text-fg4 shrink-0">{members.length}</span>
               <div className="flex items-center gap-0.5 shrink-0">
-                <button type="button" onClick={() => moveGroup(group.key, -1)} disabled={gi === 0}
-                  className="p-1 text-fg4 hover:text-fg2 disabled:opacity-20" title="Выше"><ArrowUp size={13} /></button>
-                <button type="button" onClick={() => moveGroup(group.key, 1)} disabled={gi === groups.length - 1}
-                  className="p-1 text-fg4 hover:text-fg2 disabled:opacity-20" title="Ниже"><ArrowDown size={13} /></button>
+                <MoveButtons onUp={() => moveGroup(group.key, -1)} onDown={() => moveGroup(group.key, 1)}
+                  isFirst={gi === 0} isLast={gi === groups.length - 1} size={13} />
                 <button type="button" onClick={() => deleteGroup(group.key)}
                   className="p-1 text-fg4 hover:text-danger" title="Удалить группу (поля → «Без группы»)"><Trash2 size={13} /></button>
               </div>

--- a/src/client/src/features/settings/RecognitionProfilesPage.tsx
+++ b/src/client/src/features/settings/RecognitionProfilesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Plus, Trash2, ArrowUp, ArrowDown, Lock, RotateCcw, ScanText, AlertTriangle } from 'lucide-react';
+import { Plus, Trash2, Lock, RotateCcw, ScanText, AlertTriangle } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { Modal } from '@/shared/ui/Modal';
@@ -91,16 +92,8 @@ function FieldsEditor({ fields, onChange, systemNames, addLabel }: {
               {FIELD_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
             </select>
             <span className="flex items-center gap-0.5">
-              {/* aria-disabled, а не disabled (issue #517) — см. ValuesEditor: браузер снимает
-                  фокус с погасшей кнопки, и на последнем шаге перестановки клавиатурой
-                  пользователь терял место. */}
-              <button type="button" onClick={() => { if (i > 0) move(i, i - 1); }} aria-disabled={i === 0}
-                className="p-0.5 text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4"
-                title="Выше"><ArrowUp size={12} /></button>
-              <button type="button" onClick={() => { if (i < fields.length - 1) move(i, i + 1); }}
-                aria-disabled={i === fields.length - 1}
-                className="p-0.5 text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4"
-                title="Ниже"><ArrowDown size={12} /></button>
+              <MoveButtons onUp={() => move(i, i - 1)} onDown={() => move(i, i + 1)}
+                isFirst={i === 0} isLast={i === fields.length - 1} />
               <button type="button" onClick={() => remove(i)} disabled={locked}
                 className="p-0.5 text-fg4 hover:text-danger disabled:opacity-25"
                 title={locked ? 'Обязательное поле — удалить нельзя' : 'Удалить'}><Trash2 size={13} /></button>

--- a/src/client/src/features/templates/TemplateParamsPanel.tsx
+++ b/src/client/src/features/templates/TemplateParamsPanel.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
-import {
-  ChevronDown, ChevronUp, SlidersHorizontal, Plus, Trash2, GripVertical, ArrowUp, ArrowDown,
-} from 'lucide-react';
+import { ChevronDown, ChevronUp, SlidersHorizontal, Plus, Trash2, GripVertical } from 'lucide-react';
+import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { useUpdateTemplateParameters } from '@/shared/api/templates';
 import { moveItem } from '@/shared/utils/moveItem';
 import type { Template, TemplateParam } from '@/shared/api/types';
@@ -99,10 +98,8 @@ export function TemplateParamsPanel({ template, onSaved }: { template: Template;
               </select>
               <ParamDefault type={p.type} value={p.default} onChange={v => patch(i, { default: v })} />
               <span className="flex items-center gap-0.5 shrink-0">
-                <button onClick={() => move(i, i - 1)} disabled={i === 0} title="Выше"
-                  className="p-0.5 text-fg4 hover:text-fg2 disabled:opacity-25"><ArrowUp size={12} /></button>
-                <button onClick={() => move(i, i + 1)} disabled={i === rows.length - 1} title="Ниже"
-                  className="p-0.5 text-fg4 hover:text-fg2 disabled:opacity-25"><ArrowDown size={12} /></button>
+                <MoveButtons onUp={() => move(i, i - 1)} onDown={() => move(i, i + 1)}
+                  isFirst={i === 0} isLast={i === rows.length - 1} />
                 <button onClick={() => save(rows.filter((_, idx) => idx !== i))} title="Удалить параметр"
                   className="p-1 text-stroke-strong hover:text-danger"><Trash2 size={12} /></button>
               </span>

--- a/src/client/src/shared/ui/MoveButtons.tsx
+++ b/src/client/src/shared/ui/MoveButtons.tsx
@@ -1,0 +1,46 @@
+import { ArrowUp, ArrowDown } from 'lucide-react';
+
+/**
+ * Пара кнопок «Выше»/«Ниже» для списков с перестановкой (issue #542).
+ *
+ * Существует ради одной детали, на которой независимо спотыкались шесть редакторов: на краю списка
+ * кнопку НЕЛЬЗЯ делать `disabled`. Браузер снимает фокус с элемента, ставшего выключенным, поэтому
+ * пользователь, доводящий строку клавиатурой до края, оказывается на `<body>` и теряет место —
+ * последний шаг ровно того сценария, ради которого чинился #517.
+ *
+ * Поэтому `aria-disabled`: кнопка остаётся фокусируемой, для скринридера по-прежнему выключена, а
+ * край проверяется в обработчике. Внешне — то же приглушение.
+ */
+export function MoveButtons({
+  onUp, onDown, isFirst, isLast, busy = false,
+  size = 12, className = '', upTitle = 'Выше', downTitle = 'Ниже',
+}: {
+  onUp: () => void;
+  onDown: () => void;
+  isFirst: boolean;
+  isLast: boolean;
+  /** Перестановка временно недоступна (например, сохраняется предыдущая) — по той же причине
+   *  не `disabled`: фокус нужен пользователю ПОСЛЕ того, как сохранение закончится. */
+  busy?: boolean;
+  size?: number;
+  /** Доп. классы для каждой кнопки (отступы/цвета конкретного редактора). */
+  className?: string;
+  upTitle?: string;
+  downTitle?: string;
+}) {
+  const cls = `p-0.5 text-fg4 hover:text-fg2 aria-disabled:opacity-25 aria-disabled:hover:text-fg4 ${className}`;
+  const upBlocked = isFirst || busy;
+  const downBlocked = isLast || busy;
+  return (
+    <>
+      <button type="button" onClick={() => { if (!upBlocked) onUp(); }} aria-disabled={upBlocked}
+        title={upTitle} className={cls}>
+        <ArrowUp size={size} />
+      </button>
+      <button type="button" onClick={() => { if (!downBlocked) onDown(); }} aria-disabled={downBlocked}
+        title={downTitle} className={cls}>
+        <ArrowDown size={size} />
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
Closes #542

## Суть

Кнопки «Выше»/«Ниже» на краю становились `disabled`, а браузер снимает фокус с выключенного элемента: пользователь, доводящий строку клавиатурой до края, оказывался на `<body>` и терял место — последний шаг ровно того сценария, ради которого чинился #517.

Замер на вариантах перечисления (клик мышью, дальше только Enter):

| | до | после |
|---|---|---|
| Enter #1 | `Р,И,П,РП` · фокус `BUTTON[Ниже]` | то же |
| Enter #2 | `Р,И,РП,П` · **фокус `BODY`** | `Р,И,РП,П` · фокус `BUTTON[Ниже]` |

## Что сделано

Шесть редакторов независимо повторили одну и ту же ловушку, поэтому пара кнопок сведена в примитив `shared/ui/MoveButtons`: `aria-disabled` вместо `disabled` (кнопка остаётся фокусируемой, для скринридера по-прежнему выключена), край проверяется в обработчике. Внешне без изменений — замер: на краю `opacity: 0.25` и `aria-disabled="true"`, как и выглядело раньше.

Переведены **все семь** мест, включая три исправленных в #541 — иначе следующий редактор повторил бы ловушку в восьмой раз:

- варианты перечисления, поля профиля распознавания, уровни сортировки (были на локальной правке из #541);
- поля типа документа — третий редактор из #517, у его кнопок заодно не было `title`;
- группы полей, параметры шаблона, порядок документов в комплекте.

У порядка документов `disabled` стоял ещё и на время сохранения — тот же вред, только посреди действия (фокус нужен пользователю после того, как сохранение закончится), поэтому у примитива есть `busy`.

## Проверка

Живьём в каждом редакторе: клик мышью по «Ниже», дальше только Enter, мышь не трогаем.

- **поля типа документа** — «Первое» доезжает до последней позиции, фокус на кнопке;
- **варианты перечисления** — доезжает, фокус на кнопке (до правки — `BODY`);
- **поля профиля распознавания** — «Позиция» доезжает с 1-й до 4-й;
- **уровни сортировки** — «Цена» доезжает с 1-й до 3-й;
- **группы полей** — меняются местами, на краю фокус сохраняется;
- **порядок документов в комплекте** — 8 документов, фокус переживает и перестановку, и сохранение.

Порядок документов в живом комплекте после проверки восстановлен — сверено с API (строки там ключуются `inst.id`, поэтому кнопка едет вместе со строкой, и обратные шаги легли верно).

`npx tsc -b` чисто, `npm test` — 287 тестов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)