### PR TITLE
Пустая ячейка не оседает строкой в числовом поле (#544)

### DIFF
--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetValueCoercion.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetValueCoercion.cs
@@ -63,8 +63,13 @@ public static class DataSetValueCoercion
         return QuantityParser.TryParse(text, out var number) ? number : value;
     }
 
-    /// <summary>Обход собранного объекта по схеме его типа.</summary>
-    public static Dictionary<string, object?> CoerceObject(
+    /// <summary>
+    /// Обход собранного объекта по схеме его типа. Ключи, для которых приведение дало null (пустая
+    /// числовая ячейка, issue #544), удаляются; объект, оставшийся БЕЗ значений, возвращается как
+    /// null — «нет значений» на всех уровнях выглядит одинаково, и это то же правило, по которому
+    /// собирает объекты <c>DataSetMappingApplier</c> (<c>obj.Count == 0 ? null : obj</c>).
+    /// </summary>
+    public static Dictionary<string, object?>? CoerceObject(
         Dictionary<string, object?> obj, Guid? typeId,
         IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
         IReadOnlyDictionary<Guid, DocumentType>? typesById, int depth = 0)
@@ -78,14 +83,15 @@ public static class DataSetValueCoercion
         {
             if (!fields.TryGetValue(key, out var f)) continue;
             var coerced = Coerce(obj[key], f, primitivesById, typesById, depth + 1);
-            // Пустая ячейка в числовом поле даёт null — ключ УДАЛЯЕМ, а не оставляем с null
-            // (issue #544): шаблоны читают вложенные поля через at/dig с умолчанием, и ключ со
-            // значением none проходит их проверки, а потом ломает конкатенацию.
+            // Ключ с null УДАЛЯЕМ, а не оставляем (issue #544): шаблоны читают вложенные поля через
+            // at/dig с умолчанием, и ключ со значением none проходит их проверки, а потом ломает
+            // конкатенацию. Правило шире, чем пустая числовая ячейка: любой null здесь означает
+            // «значения нет», и вложенный объект, у которого не осталось значений, тоже null.
             if (coerced is null) obj.Remove(key);
             else obj[key] = coerced;
         }
 
-        return obj;
+        return obj.Count == 0 ? null : obj;
     }
 
     private static bool IsNumeric(

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetValueCoercion.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetValueCoercion.cs
@@ -43,8 +43,20 @@ public static class DataSetValueCoercion
             return CoerceObject(nested, field.TypeId, primitivesById, typesById, depth);
 
         // Приводим только сырой текст ячейки: ссылки (@@ref) и файлы уже имеют свою форму.
-        if (value is not string text || string.IsNullOrWhiteSpace(text)) return value;
-        if (!IsNumeric(field, primitivesById)) return value;
+        if (value is not string text) return value;
+        if (!IsNumeric(field, primitivesById)) return value;   // в строковом поле пустая строка законна
+
+        // Пустая ячейка — ОТСУТСТВИЕ значения, а не значение неверного типа (issue #544). Раньше она
+        // возвращалась как есть и оседала пустой строкой в поле, объявленном числом: на протоколе
+        // измерений изоляции из 473 числовых ячеек 238 были такими, и проверка выдавала 238
+        // предупреждений «ожидается число, а хранится строка» — за ними уже ничего не разглядеть.
+        //
+        // Возвращаем null: вызывающие пишут значение под `if (value is not null)`, поэтому ключа
+        // просто не будет. Именно отсутствие ключа, а не null: домашняя идиома шаблонов —
+        // `it.at("X", default: "")` и `dig(it, "X", default: …)` — отсутствующий ключ обрабатывает
+        // верно, а на null сломалась бы (`it.at("Телефон", default: "") != ""` пройдёт проверку и
+        // упадёт на `"тел.: " + none`).
+        if (string.IsNullOrWhiteSpace(text)) return null;
 
         // Не разобралось — оставляем строку. Молча подменить на ноль нельзя: ноль это заявленное
         // количество, а неразобранное — неизвестность; расхождение останется видимым в проверке.
@@ -63,8 +75,15 @@ public static class DataSetValueCoercion
             .GroupBy(f => f.Key).ToDictionary(g => g.Key, g => g.First());
 
         foreach (var key in obj.Keys.ToList())
-            if (fields.TryGetValue(key, out var f))
-                obj[key] = Coerce(obj[key], f, primitivesById, typesById, depth + 1);
+        {
+            if (!fields.TryGetValue(key, out var f)) continue;
+            var coerced = Coerce(obj[key], f, primitivesById, typesById, depth + 1);
+            // Пустая ячейка в числовом поле даёт null — ключ УДАЛЯЕМ, а не оставляем с null
+            // (issue #544): шаблоны читают вложенные поля через at/dig с умолчанием, и ключ со
+            // значением none проходит их проверки, а потом ломает конкатенацию.
+            if (coerced is null) obj.Remove(key);
+            else obj[key] = coerced;
+        }
 
         return obj;
     }

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -141,9 +141,13 @@ public class DataSetResolver(
                             if (value is not null)
                                 obj[fieldKey] = value;
                         }
-                        // Приоритет ниже маппинга: значение из строки (уже в obj) > defaultValue схемы.
+                        // Приоритет ниже маппинга: замапленное поле умолчание НЕ подменяет — даже когда
+                        // ячейка пуста. Проверять наличие ключа для этого нельзя (issue #544): пустая
+                        // числовая ячейка ключа больше не создаёт, и намеренно оставленный пробел в
+                        // документе стал бы значением из схемы — для протокола измерений это означало бы
+                        // напечатанный ноль там, где измерения просто не было.
                         foreach (var f in rowDefaults)
-                            if (!obj.ContainsKey(f.Key))
+                            if (!mapping.ContainsKey(f.Key) && !obj.ContainsKey(f.Key))
                                 obj[f.Key] = f.DefaultValue!.Value;
                         mapped.Add(obj);
                         rowIndex++;

--- a/src/server/BHS.CRG.Tests/DataSets/DataSetValueCoercionTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/DataSetValueCoercionTests.cs
@@ -143,7 +143,44 @@ public class DataSetValueCoercionTests
 
         var result = DataSetValueCoercion.CoerceObject(obj, rowTypeId, Primitives, types);
 
+        Assert.NotNull(result);
         Assert.False(result.ContainsKey("Длина"));
         Assert.Equal("", result["Марка"]);
+    }
+
+    /// <summary>
+    /// Объект, у которого не осталось ни одного значения, — это отсутствие объекта, а не пустой
+    /// объект (#544): вызывающие пишут его под `if (value is not null)`, поэтому ключа не будет.
+    /// Иначе строка отдавала бы шаблону `{}`, и обращение к вложенному полю падало бы вместо пустого
+    /// места. То же правило, по которому собирает объекты DataSetMappingApplier.
+    /// </summary>
+    [Fact]
+    public void ObjectLeftWithoutValues_BecomesNothing()
+    {
+        var rowTypeId = Guid.NewGuid();
+        var types = new Dictionary<Guid, DocumentType>
+        {
+            [rowTypeId] = Composite(rowTypeId, "Строка", """{"fields":[{"key":"Длина","type":"number"}]}"""),
+        };
+
+        Assert.Null(DataSetValueCoercion.CoerceObject(
+            new Dictionary<string, object?> { ["Длина"] = "" }, rowTypeId, Primitives, types));
+    }
+
+    /// <summary>@@ref-объект схемных ключей не содержит — его не должно ни обрезать, ни выбросить.</summary>
+    [Fact]
+    public void RefObject_IsLeftAlone()
+    {
+        var rowTypeId = Guid.NewGuid();
+        var types = new Dictionary<Guid, DocumentType>
+        {
+            [rowTypeId] = Composite(rowTypeId, "Строка", """{"fields":[{"key":"Длина","type":"number"}]}"""),
+        };
+        var obj = new Dictionary<string, object?> { ["$ref"] = "catalog:123" };
+
+        var result = DataSetValueCoercion.CoerceObject(obj, rowTypeId, Primitives, types);
+
+        Assert.NotNull(result);
+        Assert.Equal("catalog:123", result["$ref"]);
     }
 }

--- a/src/server/BHS.CRG.Tests/DataSets/DataSetValueCoercionTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/DataSetValueCoercionTests.cs
@@ -62,11 +62,31 @@ public class DataSetValueCoercionTests
         Assert.Same(obj, Coerce(obj, Field("number")));
     }
 
+    /// <summary>
+    /// Пустая ячейка в ЧИСЛОВОМ поле — отсутствие значения, а не значение неверного типа (#544).
+    /// Возвращаем null: вызывающие пишут значение под `if (value is not null)`, поэтому ключа не
+    /// будет вовсе. Прежде она оседала пустой строкой, и на протоколе измерений изоляции из 473
+    /// числовых ячеек 238 давали предупреждение «ожидается число, а хранится строка» — за таким
+    /// списком уже не разглядеть настоящую проблему.
+    /// </summary>
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void EmptyCell_IsUntouched(string cell)
-        => Assert.Equal(cell, Coerce(cell, Field("number")));
+    public void EmptyCell_InNumericField_BecomesNothing(string cell)
+    {
+        Assert.Null(Coerce(cell, Field("number")));
+        Assert.Null(Coerce(cell, Field("primitive", NumberTypeId)));
+    }
+
+    /// <summary>А в строковом поле пустая ячейка законна — там ничего не меняем.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyCell_InTextField_IsUntouched(string cell)
+    {
+        Assert.Equal(cell, Coerce(cell, Field("string")));
+        Assert.Equal(cell, Coerce(cell, Field("primitive", StringTypeId)));
+    }
 
     private static DocumentType Composite(Guid id, string name, string fieldsJson)
     {
@@ -103,5 +123,27 @@ public class DataSetValueCoercionTests
 
         var nested = (Dictionary<string, object?>)result["КабельПроложено"]!;
         Assert.Equal(48.5d, Assert.IsType<double>(nested["ДлинаЛинии"]));
+    }
+
+    /// <summary>
+    /// В собранном inline-объекте пустая числовая ячейка тоже не оставляет ключа (#544). Ключ со
+    /// значением none опаснее отсутствующего: `it.at("X", default: "") != ""` его пропустит, а
+    /// следом сломается конкатенация.
+    /// </summary>
+    [Fact]
+    public void EmptyCell_InNestedObject_LeavesNoKey()
+    {
+        var rowTypeId = Guid.NewGuid();
+        var types = new Dictionary<Guid, DocumentType>
+        {
+            [rowTypeId] = Composite(rowTypeId, "Строка",
+                """{"fields":[{"key":"Длина","type":"number"},{"key":"Марка","type":"string"}]}"""),
+        };
+        var obj = new Dictionary<string, object?> { ["Длина"] = "", ["Марка"] = "" };
+
+        var result = DataSetValueCoercion.CoerceObject(obj, rowTypeId, Primitives, types);
+
+        Assert.False(result.ContainsKey("Длина"));
+        Assert.Equal("", result["Марка"]);
     }
 }


### PR DESCRIPTION
Closes #544

## Причина

Проверка ссылок на «250701.ЭОМ-3.ПИ-48.Протокол измерения сопротивления изоляции» давала **0 ошибок и 238 предупреждений** «ожидается число, а хранится строка».

Замерено по отладочному пакету: из 473 числовых ячеек 235 стали числами, 238 остались строками — и **все 238 это пустая строка**, ни одной настоящей строки вроде `"1 000"`. То есть приведение типов (#466) работает; проблема в одном условии:

```csharp
if (value is not string text || string.IsNullOrWhiteSpace(text)) return value;
```

Пустая ячейка возвращалась как есть и попадала в объект — проверка `if (value is not null)` пустую строку пропускает. В поле, объявленном числом, оседало `""`. Масштаб дала форма данных: 43 строки, и однофазные линии заполняют 3 ячейки из 10.

## Решение

Пустая ячейка в числовом поле — отсутствие значения, а не значение неверного типа. `Coerce` возвращает для неё `null`, и существующая проверка у вызывающих просто не создаёт ключ. `CoerceObject` (собранные `@@inline`-объекты) по той же причине ключ удаляет.

Почему отсутствие ключа, а не `null`: домашняя идиома шаблонов — `it.at("X", default: "")`. Отсутствующий ключ она обрабатывает верно, а `null` сломал бы её на ровном месте (`it.at("Телефон", default: "") != ""` пройдёт проверку и упадёт на `"тел.: " + none`).

В строковых полях пустая строка законна и не трогается.

## Проверка

| | было | стало |
|---|---|---|
| проверка того же документа | 0 ошибок / **238** предупр. | 0 / **0** |
| пустых строк в числовых полях контекста | 238 | 0 |
| числа в строке 10 | 298, 296, 0.5 | те же |

**Шаблонам правка не видна**: `dig` из userlib уже нормализует пустую строку в `none`, то есть до и после отдаёт одно и то же — проверено настоящим Typst на живом `userlib.typ` (`dig(("Знач": ""))` → `none`, `dig((:))` → `none`).

Существующий тест `EmptyCell_IsUntouched` закреплял прежнее поведение — переписан на новое с объяснением, плюс тесты на строковое поле и на вложенный объект. Бэкенд: 818 тестов.

## Замечено попутно, не трогал

Шаблон «Типовой» этого типа не компилируется: строка 56 — незаконченная `#if dig(d, "")`. Одинаково в пакетах до и после правки, к этой задаче отношения не имеет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)