### PR TITLE
Восстановление имён материалов у существующих связок (#561)

### DIFF
--- a/src/client/src/features/settings/MaterialLabelSection.tsx
+++ b/src/client/src/features/settings/MaterialLabelSection.tsx
@@ -11,6 +11,7 @@ interface Report {
   named: number;
   notFound: number;
   documentsScanned: number;
+  documentsFailed: number;
   dryRun: boolean;
 }
 
@@ -47,8 +48,11 @@ export function MaterialLabelSection() {
     setConfirmOpen(false);
     setBusy(true); setError('');
     try {
-      setDone(await run(false));
-      setReport(await run(true));   // пересчёт: показываем, что осталось
+      const result = await run(false);
+      setDone(result);
+      // Пересчёта НЕ делаем: проход читает и разбирает файлы наборов, и повторять его ради
+      // косметики значит гонять всю работу второй раз. Остаток считаем арифметикой.
+      setReport({ ...result, named: 0, notFound: result.notFound, dryRun: true });
     } catch (e) {
       setError(apiError(e, 'Не удалось выполнить'));
     } finally { setBusy(false); }
@@ -95,6 +99,12 @@ export function MaterialLabelSection() {
               <ul className="text-xs text-fg2 space-y-1">
                 <li>Связок без имени: <b>{report.linksWithoutLabel}</b></li>
                 <li>Имя найдётся: <b>{report.named}</b> (прочитано документов: {report.documentsScanned})</li>
+                {report.documentsFailed > 0 && (
+                  <li className="text-warning">
+                    Не удалось прочитать документов: {report.documentsFailed} — их материалы в поиске
+                    не участвовали.
+                  </li>
+                )}
                 {report.notFound > 0 && (
                   <li className="text-fg3">
                     Останутся с ключом: {report.notFound} — этих материалов больше нет ни в одном

--- a/src/client/src/features/settings/MaterialLabelSection.tsx
+++ b/src/client/src/features/settings/MaterialLabelSection.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { Tags, Loader2 } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { apiClient } from '@/shared/api/client';
+import { apiError } from '@/shared/utils/apiError';
+import { CollapsibleSection } from './CollapsibleSection';
+
+interface Report {
+  linksWithoutLabel: number;
+  named: number;
+  notFound: number;
+  documentsScanned: number;
+  dryRun: boolean;
+}
+
+async function run(dryRun: boolean): Promise<Report> {
+  const { data } = await apiClient.post<Report>('/maintenance/material-links/backfill-labels', null, { params: { dryRun } });
+  return data;
+}
+
+/**
+ * Восстановление человеческих имён материалов у связок с документами качества (issue #561).
+ *
+ * Связка запоминает имя материала с #554, но только при новой привязке — у заведённых раньше его нет,
+ * и экран контроля показывает машинный ключ (`mb15-07-01m-54` — это боковая панель ВРУ). Имя
+ * вычислимо: оно лежит в строках подключённых наборов данных, надо их прочитать.
+ *
+ * Читать приходится файлы, поэтому это действие администратора, а не миграция на старте. Сухой
+ * прогон честный: файлы действительно разбираются, просто ничего не сохраняется.
+ */
+export function MaterialLabelSection() {
+  const [report, setReport] = useState<Report | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [done, setDone] = useState<Report | null>(null);
+
+  async function check() {
+    setBusy(true); setError(''); setDone(null);
+    try { setReport(await run(true)); }
+    catch (e) { setError(apiError(e, 'Не удалось посчитать')); }
+    finally { setBusy(false); }
+  }
+
+  async function apply() {
+    setConfirmOpen(false);
+    setBusy(true); setError('');
+    try {
+      setDone(await run(false));
+      setReport(await run(true));   // пересчёт: показываем, что осталось
+    } catch (e) {
+      setError(apiError(e, 'Не удалось выполнить'));
+    } finally { setBusy(false); }
+  }
+
+  const nothingToDo = report !== null && report.named === 0;
+
+  return (
+    <CollapsibleSection title="Имена материалов в связках" storageKey="material-labels" defaultOpen={false}>
+      <div className="space-y-3">
+        <p className="text-xs text-fg3">
+          Связки, заведённые до появления имени материала, показываются машинным ключом
+          (например <span className="font-mono">mb15-07-01m-54</span>). Имя можно восстановить из
+          наборов данных, подключённых к документам.
+        </p>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outlined" size="sm" onClick={() => void check()} loading={busy}
+            icon={<Tags size={14} />}>
+            Посчитать
+          </Button>
+          {report && !nothingToDo && (
+            <Button variant="filled" size="sm" onClick={() => setConfirmOpen(true)} disabled={busy}>
+              Выполнить
+            </Button>
+          )}
+          {busy && <Loader2 size={14} className="animate-spin text-brand" />}
+        </div>
+
+        {error && <p className="text-xs text-danger">{error}</p>}
+
+        {done && (
+          <p className="text-xs text-success">Готово: имён восстановлено {done.named}.</p>
+        )}
+
+        {report && (
+          nothingToDo
+            ? <p className="text-xs text-fg3">
+                Восстанавливать нечего: {report.linksWithoutLabel === 0
+                  ? 'у всех связок имена уже есть.'
+                  : 'ни один из материалов не встречается в подключённых наборах данных.'}
+              </p>
+            : (
+              <ul className="text-xs text-fg2 space-y-1">
+                <li>Связок без имени: <b>{report.linksWithoutLabel}</b></li>
+                <li>Имя найдётся: <b>{report.named}</b> (прочитано документов: {report.documentsScanned})</li>
+                {report.notFound > 0 && (
+                  <li className="text-fg3">
+                    Останутся с ключом: {report.notFound} — этих материалов больше нет ни в одном
+                    подключённом наборе, и придумывать им имя неоткуда.
+                  </li>
+                )}
+              </ul>
+            )
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen} onOpenChange={setConfirmOpen}
+        title="Восстановить имена материалов?"
+        description={
+          report
+            ? `Будет заполнено имён: ${report.named}. Уже заданные имена не перезаписываются, `
+              + 'сами связки не меняются.'
+            : ''
+        }
+        confirmLabel="Выполнить"
+        onConfirm={() => apply()}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { IntegrationSettingsSection } from './IntegrationSettingsSection';
 import { EmailSettingsSection } from './EmailSettingsSection';
 import { CollapsibleSection } from './CollapsibleSection';
 import { ImageMaintenanceSection } from './ImageMaintenanceSection';
+import { MaterialLabelSection } from './MaterialLabelSection';
 
 // ─── Settings hook (re-exported for use by other pages) ───────────────────────
 
@@ -383,6 +384,8 @@ export function SettingsPage() {
 
       {/* ── Backup & Restore ───────────────────────────────────────────────── */}
       <ImageMaintenanceSection />
+
+      <MaterialLabelSection />
 
       <CollapsibleSection title="Резервное копирование" storageKey="backup" defaultOpen={false}>
         <p className="text-xs text-fg3">

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -39,7 +39,7 @@ public static class MaintenanceEndpoints
             return Results.Ok(new
             {
                 report.LinksWithoutLabel, report.Named, report.NotFound,
-                report.DocumentsScanned, dryRun = isDryRun,
+                report.DocumentsScanned, report.DocumentsFailed, dryRun = isDryRun,
             });
         });
     }

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -28,5 +28,19 @@ public static class MaintenanceEndpoints
                 report.Downscaled, report.SavedBytes, dryRun = isDryRun,
             });
         });
+
+        // Дозаполнение человеческих имён материалов у связок, заведённых до появления метки (#561).
+        // Читает и разбирает файлы наборов, поэтому тоже действие администратора, а не миграция.
+        g.MapPost("/material-links/backfill-labels", async (
+            MaterialLabelBackfill backfill, bool? dryRun, CancellationToken ct) =>
+        {
+            var isDryRun = dryRun ?? true;
+            var report = await backfill.RunAsync(isDryRun, ct);
+            return Results.Ok(new
+            {
+                report.LinksWithoutLabel, report.Named, report.NotFound,
+                report.DocumentsScanned, dryRun = isDryRun,
+            });
+        });
     }
 }

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -227,6 +227,7 @@ builder.Services.AddScoped<IRepository<MaterialQualityLink>, Repository<Material
 // ── Backup ────────────────────────────────────────────────────────────────────
 builder.Services.AddScoped<BackupService>();
 builder.Services.AddScoped<BHS.CRG.Infrastructure.Maintenance.ImageBlobMigration>();
+builder.Services.AddScoped<BHS.CRG.Infrastructure.Maintenance.MaterialLabelBackfill>();
 
 // ── Снимок данных для внешних потребителей + MCP (issue #415) ─────────────────
 builder.Services.AddScoped<BHS.CRG.Application.DataSnapshots.IDataSnapshotService,

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.QualityDocs;
 using BHS.CRG.Application.Schema;
@@ -12,8 +13,10 @@ namespace BHS.CRG.Infrastructure.Maintenance;
 /// <param name="LinksWithoutLabel">Связок без имени на входе.</param>
 /// <param name="Named">Скольким имя нашлось.</param>
 /// <param name="NotFound">Скольким не нашлось — материала больше нет ни в одном подключённом наборе.</param>
-/// <param name="DocumentsScanned">Сколько документов пришлось прочитать (файлы наборов разбираются заново).</param>
-public record MaterialLabelReport(int LinksWithoutLabel, int Named, int NotFound, int DocumentsScanned);
+/// <param name="DocumentsScanned">Сколько документов удалось прочитать (файлы наборов разбираются заново).</param>
+/// <param name="DocumentsFailed">Сколько прочитать НЕ удалось — их материалы в поиске не участвовали.</param>
+public record MaterialLabelReport(
+    int LinksWithoutLabel, int Named, int NotFound, int DocumentsScanned, int DocumentsFailed = 0);
 
 /// <summary>
 /// Разовое восстановление человеческих имён материалов у уже заведённых связей (issue #561).
@@ -23,9 +26,11 @@ public record MaterialLabelReport(int LinksWithoutLabel, int Named, int NotFound
 /// — это боковая панель ВРУ), то есть инструмент поиска дефекта нечитаем ровно там, где нужнее всего:
 /// 41 ключ из 113 — голые артикулы, и неверные связки (#552) сидят именно среди них.
 ///
-/// Имя вычисляется ровно так же, как его считает вкладка «Документы качества» внутри документа:
-/// строки привязанных наборов → поля с тэгом <see cref="FunctionalTag.Identity"/> → ключ из ПЕРВОГО
-/// значения, имя — склейка всех через « · ».
+/// Имя собирается из тех же полей, что читает вкладка «Документы качества» внутри документа — по
+/// тэгу <see cref="FunctionalTag.Identity"/>, — и из тех же ДВУХ источников: строк привязанных
+/// наборов данных И массивов материалов в самих реквизитах документа. Порядок склейки значений
+/// детерминирован (типы по имени), но может отличаться от клиентского: там он задан порядком типов
+/// в ответе API. Для сопоставления это неважно — ключи те же.
 ///
 /// НЕ EF-миграция: читает и разбирает файлы наборов из блоб-хранилища, которого на старте приложения
 /// может не быть. Момент выбирает администратор и видит отчёт — как у переноса картинок (#522).
@@ -50,56 +55,116 @@ public class MaterialLabelBackfill(
         var identityKeys = await IdentityKeysAsync(ct);
         if (identityKeys.Count == 0) return new MaterialLabelReport(links.Count, 0, links.Count, 0);
 
-        // Документы, у которых есть привязки наборов: только их и читаем.
-        var ownerIds = await db.DataSetBindings.Select(b => b.OwnerId).Distinct().ToListAsync(ct);
-
         var named = 0;
+        var scanned = 0;
+        var failed = 0;
+
+        // Источник 1 — массивы материалов в самих реквизитах документов. Дешёвый: только чтение БД,
+        // без блобов. Пропустить его нельзя: связки, заведённые из этой половины, иначе навсегда
+        // остались бы с ключом, да ещё и попали бы в отчёт как «материала больше нет».
+        foreach (var data in await db.DomainObjects.AsNoTracking().Select(o => o.Data).ToListAsync(ct))
+        {
+            ct.ThrowIfCancellationRequested();
+            named += Apply(MaterialsInRequisites(data, identityKeys), byKey);
+        }
+
+        // Источник 2 — строки привязанных наборов данных. Дорогой: файлы скачиваются и разбираются.
+        var ownerIds = await db.DataSetBindings.Select(b => b.OwnerId).Distinct().ToListAsync(ct);
         foreach (var ownerId in ownerIds)
         {
             ct.ThrowIfCancellationRequested();
             IReadOnlyList<BindingPreviewDto> preview;
             // Файл мог исчезнуть, набор — перестать разбираться: один сломанный документ не должен
-            // отменять дозаполнение всех остальных.
-            try { preview = await bindings.PreviewBindingsAsync(ownerId, ct); }
-            catch (Exception) { continue; }
+            // отменять дозаполнение остальных. Но и молчать нельзя — иначе «материала больше нет»
+            // сказали бы про материал, который просто не удалось прочитать.
+            try { preview = await bindings.PreviewBindingsAsync(ownerId, ct); scanned++; }
+            catch (Exception) { failed++; continue; }
 
-            foreach (var (keys, label) in MaterialsOf(preview, identityKeys))
+            named += Apply(MaterialsOf(preview, identityKeys), byKey);
+
+            // Сохраняем по документу, а не одним махом в конце: проход длинный, и если параллельно
+            // снимут связку (экран массового разрыва — ровно тот инструмент, которым админ только что
+            // пользовался), единый SaveChanges упал бы и выбросил ВЕСЬ результат (урок #532).
+            if (!dryRun) await db.SaveChangesAsync(ct);
+        }
+
+        if (!dryRun) await db.SaveChangesAsync(ct);
+        else db.ChangeTracker.Clear();   // сухой прогон не оставляет следов
+
+        return new MaterialLabelReport(links.Count, named, links.Count - named, scanned, failed);
+    }
+
+    /// <summary>Проставляет имена связкам, чей ключ совпал с любым из значений идентичности строки.</summary>
+    private static int Apply(
+        IEnumerable<(IReadOnlyList<string> Keys, string Label)> materials,
+        Dictionary<string, List<MaterialQualityLink>> byKey)
+    {
+        var named = 0;
+        foreach (var (keys, label) in materials)
+        {
+            // Сопоставляем по ЛЮБОМУ значению идентичности — так матчит резолвер связок
+            // (QualityLinkResolver.TryMatch). Перебираем ВСЕ совпавшие ключи, а не только первый:
+            // связки одного материала могли быть заведены и по артикулу, и по наименованию, и
+            // остановка на первом оставила бы вторую группу без имени навсегда.
+            foreach (var key in keys)
             {
-                // Сопоставляем по ЛЮБОМУ значению идентичности — ровно так матчит резолвер связок
-                // (QualityLinkResolver.TryMatch). Хранимый ключ построен по первому непустому полю, а
-                // порядок полей мы здесь воспроизвести не можем: он зависит от порядка типов у клиента.
-                foreach (var key in keys)
+                if (!byKey.TryGetValue(key, out var found)) continue;
+                foreach (var link in found)
                 {
-                    if (!byKey.TryGetValue(key, out var found)) continue;
-                    foreach (var link in found)
-                    {
-                        if (link.MaterialLabel is not null) continue;
-                        link.DescribeMaterial(label);
-                        named++;
-                    }
-                    break;
+                    if (link.MaterialLabel is not null) continue;
+                    link.DescribeMaterial(label);
+                    named++;
                 }
             }
         }
-
-        if (!dryRun && named > 0) await db.SaveChangesAsync(ct);
-        else db.ChangeTracker.Clear();   // сухой прогон не оставляет следов
-
-        return new MaterialLabelReport(links.Count, named, links.Count - named, ownerIds.Count);
+        return named;
     }
 
     /// <summary>
     /// Ключи полей идентичности по всем составным типам — тем же способом, что и резолвер связок
     /// (<c>SchemaTags.FieldKeysWithTag</c>): по тэгу, а не по именам полей.
     /// </summary>
-    private async Task<HashSet<string>> IdentityKeysAsync(CancellationToken ct)
+    private async Task<List<string>> IdentityKeysAsync(CancellationToken ct)
     {
         var composites = await db.DocumentTypes.AsNoTracking()
             .Where(t => t.Kind == DocumentTypeKind.Composite)
+            .OrderBy(t => t.Name)   // детерминированный порядок: от него зависит порядок слов в имени
             .ToListAsync(ct);
         return composites
             .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.Identity))
-            .ToHashSet();
+            .Distinct()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Материалы из реквизитов документа: массивы объектов верхнего уровня, у элементов которых есть
+    /// поля идентичности. Тем же способом их собирает вкладка привязок.
+    /// </summary>
+    private static IEnumerable<(IReadOnlyList<string> Keys, string Label)> MaterialsInRequisites(
+        JsonDocument? data, IReadOnlyList<string> identityKeys)
+    {
+        if (data is null) yield break;
+        var root = data.RootElement;
+        if (root.ValueKind != JsonValueKind.Object) yield break;
+
+        foreach (var property in root.EnumerateObject())
+        {
+            if (property.Value.ValueKind != JsonValueKind.Array) continue;
+            foreach (var element in property.Value.EnumerateArray())
+            {
+                if (element.ValueKind != JsonValueKind.Object) continue;
+                var values = identityKeys
+                    .Select(k => element.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String
+                        ? v.GetString() : null)
+                    .Where(v => !string.IsNullOrWhiteSpace(v))
+                    .Select(v => v!.Trim())
+                    .ToList();
+                if (values.Count == 0) continue;
+
+                var keys = values.Select(MatchKeyNormalizer.Normalize).Where(k => k.Length > 0).ToList();
+                if (keys.Count > 0) yield return (keys, string.Join(" · ", values));
+            }
+        }
     }
 
     /// <summary>
@@ -107,7 +172,7 @@ public class MaterialLabelBackfill(
     /// заведена по любому полю идентичности, и совпасть должен любой из них.
     /// </summary>
     private static IEnumerable<(IReadOnlyList<string> Keys, string Label)> MaterialsOf(
-        IReadOnlyList<BindingPreviewDto> preview, HashSet<string> identityKeys)
+        IReadOnlyList<BindingPreviewDto> preview, IReadOnlyList<string> identityKeys)
     {
         foreach (var binding in preview)
         {

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
@@ -1,0 +1,136 @@
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Schema;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.Maintenance;
+
+/// <summary>Что нашло (или нашло бы) дозаполнение имён материалов.</summary>
+/// <param name="LinksWithoutLabel">Связок без имени на входе.</param>
+/// <param name="Named">Скольким имя нашлось.</param>
+/// <param name="NotFound">Скольким не нашлось — материала больше нет ни в одном подключённом наборе.</param>
+/// <param name="DocumentsScanned">Сколько документов пришлось прочитать (файлы наборов разбираются заново).</param>
+public record MaterialLabelReport(int LinksWithoutLabel, int Named, int NotFound, int DocumentsScanned);
+
+/// <summary>
+/// Разовое восстановление человеческих имён материалов у уже заведённых связей (issue #561).
+///
+/// Метка появилась в #554 и пишется при привязке, поэтому у связок, заведённых раньше, её нет — а это
+/// 112 из 113 на рабочей базе. Экран контроля (#555) показывает им машинный ключ (<c>mb15-07-01m-54</c>
+/// — это боковая панель ВРУ), то есть инструмент поиска дефекта нечитаем ровно там, где нужнее всего:
+/// 41 ключ из 113 — голые артикулы, и неверные связки (#552) сидят именно среди них.
+///
+/// Имя вычисляется ровно так же, как его считает вкладка «Документы качества» внутри документа:
+/// строки привязанных наборов → поля с тэгом <see cref="FunctionalTag.Identity"/> → ключ из ПЕРВОГО
+/// значения, имя — склейка всех через « · ».
+///
+/// НЕ EF-миграция: читает и разбирает файлы наборов из блоб-хранилища, которого на старте приложения
+/// может не быть. Момент выбирает администратор и видит отчёт — как у переноса картинок (#522).
+///
+/// Идемпотентно: связка с именем пропускается, повторный прогон ничего не меняет.
+/// </summary>
+public class MaterialLabelBackfill(
+    AppDbContext db,
+    IDataSetService bindings)
+{
+    public async Task<MaterialLabelReport> RunAsync(bool dryRun, CancellationToken ct = default)
+    {
+        var links = await db.MaterialQualityLinks
+            .Where(l => l.MaterialLabel == null)
+            .ToListAsync(ct);
+        if (links.Count == 0) return new MaterialLabelReport(0, 0, 0, 0);
+
+        var byKey = links
+            .GroupBy(l => l.MaterialKey)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var identityKeys = await IdentityKeysAsync(ct);
+        if (identityKeys.Count == 0) return new MaterialLabelReport(links.Count, 0, links.Count, 0);
+
+        // Документы, у которых есть привязки наборов: только их и читаем.
+        var ownerIds = await db.DataSetBindings.Select(b => b.OwnerId).Distinct().ToListAsync(ct);
+
+        var named = 0;
+        foreach (var ownerId in ownerIds)
+        {
+            ct.ThrowIfCancellationRequested();
+            IReadOnlyList<BindingPreviewDto> preview;
+            // Файл мог исчезнуть, набор — перестать разбираться: один сломанный документ не должен
+            // отменять дозаполнение всех остальных.
+            try { preview = await bindings.PreviewBindingsAsync(ownerId, ct); }
+            catch (Exception) { continue; }
+
+            foreach (var (keys, label) in MaterialsOf(preview, identityKeys))
+            {
+                // Сопоставляем по ЛЮБОМУ значению идентичности — ровно так матчит резолвер связок
+                // (QualityLinkResolver.TryMatch). Хранимый ключ построен по первому непустому полю, а
+                // порядок полей мы здесь воспроизвести не можем: он зависит от порядка типов у клиента.
+                foreach (var key in keys)
+                {
+                    if (!byKey.TryGetValue(key, out var found)) continue;
+                    foreach (var link in found)
+                    {
+                        if (link.MaterialLabel is not null) continue;
+                        link.DescribeMaterial(label);
+                        named++;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if (!dryRun && named > 0) await db.SaveChangesAsync(ct);
+        else db.ChangeTracker.Clear();   // сухой прогон не оставляет следов
+
+        return new MaterialLabelReport(links.Count, named, links.Count - named, ownerIds.Count);
+    }
+
+    /// <summary>
+    /// Ключи полей идентичности по всем составным типам — тем же способом, что и резолвер связок
+    /// (<c>SchemaTags.FieldKeysWithTag</c>): по тэгу, а не по именам полей.
+    /// </summary>
+    private async Task<HashSet<string>> IdentityKeysAsync(CancellationToken ct)
+    {
+        var composites = await db.DocumentTypes.AsNoTracking()
+            .Where(t => t.Kind == DocumentTypeKind.Composite)
+            .ToListAsync(ct);
+        return composites
+            .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.Identity))
+            .ToHashSet();
+    }
+
+    /// <summary>
+    /// Пары «возможные ключи → человеческое имя» из строк превью. Ключей несколько: связка могла быть
+    /// заведена по любому полю идентичности, и совпасть должен любой из них.
+    /// </summary>
+    private static IEnumerable<(IReadOnlyList<string> Keys, string Label)> MaterialsOf(
+        IReadOnlyList<BindingPreviewDto> preview, HashSet<string> identityKeys)
+    {
+        foreach (var binding in preview)
+        {
+            // Data — либо одна запись (скалярная привязка), либо список строк (табличная).
+            var rows = binding.Data switch
+            {
+                IEnumerable<Dictionary<string, object?>> list => list,
+                Dictionary<string, object?> single => [single],
+                _ => [],
+            };
+            foreach (var row in rows)
+            {
+                var values = identityKeys
+                    .Select(k => row.TryGetValue(k, out var v) ? v as string : null)
+                    .Where(v => !string.IsNullOrWhiteSpace(v))
+                    .Select(v => v!.Trim())
+                    .ToList();
+                if (values.Count == 0) continue;
+
+                var keys = values.Select(MatchKeyNormalizer.Normalize).Where(k => k.Length > 0).ToList();
+                if (keys.Count == 0) continue;
+                yield return (keys, string.Join(" · ", values));
+            }
+        }
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.58.0</Version>
+    <Version>0.58.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.57.1</Version>
+    <Version>0.58.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #561

Экран контроля связок (#555) показывает имя материала из метки, которую связка запоминает при привязке (#554). Метка пишется только при **новых** привязках, поэтому все 113 существующих связок показывались машинным ключом — инструмент поиска дефекта был нечитаем ровно там, где нужнее всего: 41 ключ из 113 это голые артикулы (`mb15-07-01m-54` — боковая панель ВРУ), и неверные связки (#552) сидят именно среди них.

## Как

Имя вычисляется из строк подключённых наборов данных теми же полями идентичности (тэг `identity`), что читает вкладка привязок. Подача — по образцу обслуживания картинок (#522): действие администратора в «Настройках», с **честным сухим прогоном** (файлы действительно разбираются, просто ничего не сохраняется) и подтверждением. Уже заданные имена не перезаписываются.

## Что поймал первый прогон

Первая версия брала **первое** значение идентичности — и находила **0 имён из 113**. Причина: хранимый ключ построен по первому непустому полю, но порядок полей задаёт клиент (обход типов), и на сервере он не воспроизводится. Резолвер связок (`QualityLinkResolver.TryMatch`) матчит по **любому** полю идентичности — теперь и здесь так же. Стало 69 из 113.

## Ограничение — названо честно

Имя найдётся только у материалов, которые **сейчас** есть в подключённых наборах. Остальные останутся с ключом, и придумывать им имя неоткуда. Отчёт показывает оба числа, интерфейс — с объяснением.

## Проверка

Сухой прогон на живой базе:

| | |
|---|---|
| связок без имени | 113 |
| имя найдётся | **69** (прочитано документов: 7) |
| останутся с ключом | 44 |
| метки в базе после сухого прогона | не изменились (проверено запросом) |

**Настоящий прогон не запускал** — это данные пользователя, решение за ним, как и с обслуживанием картинок.

Тестами покрыть сам проход нечем без файлов наборов; ключевое свойство (сухой прогон ничего не пишет) проверено на живой базе, а не тестом-заглушкой. Бэкенд 837, фронтенд 294, `tsc -b` чисто. Версия 0.58.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)