### PR TITLE
Лупа вместо шеврона у пикера типа; тип документа своей строкой (#565)

### DIFF
--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -167,18 +167,19 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
 
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-2 gap-x-4">
-        <div>
-          <label className="block text-xs font-medium text-fg2 mb-1">Тип документа</label>
-          <TypePickerField className="w-full" aria-label="Тип документа" title="Тип документа"
-            placeholder="Выберите тип…"
-            types={qualityTypes.map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Документы качества' }))}
-            value={typeId || undefined}
-            onChange={id => { if (id) setTypeId(id); }} />
-        </div>
-        <TextField label="Название в библиотеке" value={displayName}
-          onChange={e => setDisplayName(e.target.value)} hint="авто из номера" />
+      {/* Тип документа — своей строкой, а не в паре с названием (issue #565): он решает, какие поля
+          нарисуются ниже, то есть управляет всей остальной формой. Соседство с рядовым текстовым
+          полем читалось как «два равных реквизита». */}
+      <div>
+        <label className="block text-xs font-medium text-fg2 mb-1">Тип документа</label>
+        <TypePickerField className="w-full" aria-label="Тип документа" title="Тип документа"
+          placeholder="Выберите тип…"
+          types={qualityTypes.map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Документы качества' }))}
+          value={typeId || undefined}
+          onChange={id => { if (id) setTypeId(id); }} />
       </div>
+      <TextField label="Название в библиотеке" value={displayName}
+        onChange={e => setDisplayName(e.target.value)} hint="авто из номера" />
 
       {/* Кнопка, открывающая файловый диалог, — скрытый input + `Button` (как в `DataSetsResource`):
           сам `<label for>` не даёт ни формы-пилюли, ни кольца фокуса. «Распознать скан» — tonal, а не

--- a/src/client/src/shared/ui/TypePickerField.tsx
+++ b/src/client/src/shared/ui/TypePickerField.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
-import { Boxes, ChevronDown, X } from 'lucide-react';
+import { Boxes, Search, X } from 'lucide-react';
 import { TypePicker, typeIcon, type PickType } from './TypePicker';
 
 /**
  * Триггер-поле над `TypePicker` (issue #266): закрытый вид читается как form-поле в тон нашего
- * `Select` (значок семейства + имя выбранного типа + код по showCode + chevron), клик/Enter/Space
- * открывают богатую модалку выбора. Единый контрол для ЛЮБОГО выбора типа (документа/поля/родителя),
+ * `Select` (значок семейства + имя выбранного типа + код по showCode + лупа), клик/Enter/Space
+ * открывают богатую модалку выбора.
+ *
+ * Замыкающий значок — ЛУПА, а не шеврон (issue #565). Обещание о том, что произойдёт по клику,
+ * несёт именно он: шеврон в MD3 означает приклеенное меню, а у нас открывается модалка с поиском,
+ * группами и «недавними». Оболочку поля при этом можно носить честно — врал только значок. Единый контрол для ЛЮБОГО выбора типа (документа/поля/родителя),
  * чтобы не плодить свои триггеры на каждом сайте. Триггер — настоящий `<button aria-haspopup>`, фокус
  * возвращается на него по Esc (Radix Dialog). Не-типовые короткие списки (роль/scope) — обычный Select.
  */
@@ -60,7 +64,7 @@ export function TypePickerField({
             <X size={14} />
           </span>
         )}
-        <ChevronDown size={15} className="shrink-0 text-fg4" />
+        <Search size={15} className="shrink-0 text-fg4" />
       </button>
 
       <TypePicker

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.59.0</Version>
+    <Version>0.59.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Шаг 0 из #565 — самодостаточная часть, снимающая исходную жалобу до системной работы над `OutlinedField`. Issue остаётся открытым, шаги 2-4 идут отдельными PR.

**Значок замыкает обещание контрола, и до сих пор он врал.** В MD3 outlined-оболочка сама по себе не обещает меню — обещает trailing-значок: шеврон означает приклеенное меню, календарь означает модальный диалог. `TypePickerField` открывает модалку с поиском, группами и «недавними», а показывал шеврон. Лупа говорит правду; после неё оболочку текстового поля пикер сможет носить честно, что и требуется на шаге 3.

Значок общий, поэтому меняется и в обвязочных площадках (`size="sm"` в `QualityLinksTab` и `TemplateSidebar`) — это намеренно: контрол один, обещание одно.

**Тип документа в диалоге документа качества переехал на свою строку.** Он решает, какие поля нарисуются ниже, то есть управляет всей остальной формой; соседство с рядовым «Названием в библиотеке» читалось как «два равных реквизита».

Версия поднята до 0.59.1.

Проверено: `npx tsc -b` чист. Изменение разметочное, логики не касается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
