### PR TITLE
OutlinedField: общая оболочка MD3-поля вместо двух копий выреза (#565)

### DIFF
--- a/src/client/src/shared/ui/DateField.tsx
+++ b/src/client/src/shared/ui/DateField.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { DateInput } from './DateInput';
+import { OutlinedField } from './OutlinedField';
 import type { DatePrecision } from '@/shared/api/types';
 
 /**
  * MD3 outlined-поле даты (issue #176): сегментный ввод ДД.ММ.ГГГГ внутри той же outlined-рамки
- * с вырезом, что и TextField (#178). Поскольку у даты всегда видны плейсхолдеры сегментов,
- * метка держится ПОСТОЯННО во всплывшем положении (notch всегда открыт) — это штатный MD3-паттерн
- * для полей с форматной подсказкой. Фон прозрачный → корректно на любом фоне.
+ * с вырезом, что и TextField (#178) — общая оболочка `OutlinedField` (#565). Поскольку у даты
+ * всегда видны плейсхолдеры сегментов, метка держится ПОСТОЯННО во всплывшем положении
+ * (`raise="always"`, notch всегда открыт) — это штатный MD3-паттерн для полей с форматной
+ * подсказкой. Фокус ловим сами: он приходит на любой из сегментов, а не на единственный input.
  */
 export function DateField({
   label, value, onChange, precision, required, hint, invalid, disabled,
@@ -21,27 +23,14 @@ export function DateField({
   disabled?: boolean;
 }) {
   const [focused, setFocused] = useState(false);
-  const borderColor = invalid ? 'border-danger' : focused ? 'border-brand' : 'border-stroke-strong';
-  const labelColor = invalid ? 'text-danger' : focused ? 'text-brand' : 'text-fg4';
   return (
-    <div>
-      <div className="relative"
+    <OutlinedField label={label} required={required} invalid={invalid} hint={hint}
+      raise="always" focused={focused}>
+      <div className={`h-14 rounded-md px-4 flex items-center text-sm text-fg1 ${disabled ? 'opacity-50' : ''}`}
         onFocus={() => setFocused(true)}
         onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocused(false); }}>
-        <div className={`h-14 rounded-md px-4 flex items-center text-sm text-fg1 ${disabled ? 'opacity-50' : ''}`}>
-          <DateInput value={value} onChange={onChange} precision={precision} disabled={disabled} />
-        </div>
-        <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 top-[-5px] m-0 rounded-md border px-3 transition-colors ${borderColor} ${focused ? 'border-2' : ''}`}>
-          <legend className="h-2.5 w-auto max-w-full whitespace-nowrap p-0 text-xs">
-            <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
-          </legend>
-        </fieldset>
-        <span className={`absolute left-3 top-0 -translate-y-1/2 px-1 text-xs pointer-events-none transition-colors ${labelColor} block max-w-[calc(100%-1.5rem)] truncate`}>
-          {label}{required && <span className="ml-0.5 text-danger">*</span>}
-        </span>
+        <DateInput value={value} onChange={onChange} precision={precision} disabled={disabled} />
       </div>
-      {hint && <p className="mt-1 px-1 text-xs text-fg4">{hint}</p>}
-    </div>
+    </OutlinedField>
   );
 }

--- a/src/client/src/shared/ui/OutlinedField.tsx
+++ b/src/client/src/shared/ui/OutlinedField.tsx
@@ -1,0 +1,102 @@
+import { type ReactNode } from 'react';
+
+/**
+ * Оболочка MD3 outlined-поля (issue #565): рамка с НАСТОЯЩИМ вырезом под меткой (fieldset+legend),
+ * сама метка, состояния фокуса/ошибки и подпись под полем. Контрол внутрь передаётся детьми.
+ *
+ * Появилась, потому что разметка выреза уже была продублирована в `TextField` (#178) и `DateField`
+ * (#176), а пикер типа и `Select` дали бы третью и четвёртую копию. Контейнер прозрачный, поэтому
+ * поле корректно выглядит на ЛЮБОМ фоне (surface/base/карточка), а не только на surface;
+ * тема light/dark — через токены.
+ *
+ * Метка живёт в двух режимах, и это не украшение, а разные механики:
+ *
+ * - `raise="auto"` — метка всплывает по CSS: покоится по центру у пустого поля и уезжает в вырез
+ *   при фокусе или заполнении. Работает только если ребёнок — сам `<input>` с классом `peer` и
+ *   `placeholder=" "` (по `:placeholder-shown` CSS и отличает пустое поле). Так живёт `TextField`.
+ * - `raise="always"` — метка ПОСТОЯННО во всплывшем положении, вырез всегда открыт. Нужен там, где
+ *   у контрола нет состояния «пусто» в смысле CSS: у даты всегда видны плейсхолдеры сегментов
+ *   (штатный MD3-паттерн для полей с форматной подсказкой), у кнопки-триггера пикера — значок и
+ *   имя выбранного. Фокус в этом режиме приходит пропом `focused`: он живёт на составном контроле,
+ *   а не на единственном input, и поймать его селектором нельзя.
+ */
+export interface OutlinedFieldProps {
+  label: string;
+  required?: boolean;
+  /** Красная рамка без сообщения (сообщение рисует вызывающий код). */
+  invalid?: boolean;
+  /** Сообщение об ошибке под полем; заодно красит рамку. */
+  error?: string;
+  /** Вспомогательный текст под полем (напр. пример ввода) — скрывается при наличии `error`. */
+  hint?: string;
+  raise?: 'auto' | 'always';
+  /** Только для `raise="always"`: подсветить рамку и метку как при фокусе. */
+  focused?: boolean;
+  /** id управляемого контрола — метка станет `<label for>`. Для кнопок-триггеров НЕ задавать:
+   *  щелчок по подписи открывал бы модалку. Там доступное имя связывают через `labelId`. */
+  htmlFor?: string;
+  /** id самой метки — для `aria-labelledby` у контролов, которым `<label for>` не годится. */
+  labelId?: string;
+  /** Правый адорнмент (например «глаз» пароля). */
+  trailing?: ReactNode;
+  /** Классы внешней обёртки (поле + подпись под ним). */
+  containerClassName?: string;
+  children: ReactNode;
+}
+
+export function OutlinedField({
+  label, required, invalid, error, hint, raise = 'auto', focused, htmlFor, labelId,
+  trailing, containerClassName = '', children,
+}: OutlinedFieldProps) {
+  const bad = !!error || invalid;
+  const auto = raise === 'auto';
+
+  // peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение вешаем на
+  // fieldset (он сосед) и целим вложенный legend через [&>legend].
+  const borderColor = bad
+    ? 'border-danger'
+    : auto ? 'border-stroke-strong peer-focus:border-brand'
+      : focused ? 'border-brand' : 'border-stroke-strong';
+  const borderWidth = auto ? 'peer-focus:border-2' : focused ? 'border-2' : '';
+  // Вырез раскрывает legend, а он ВНУТРИ fieldset — соседом input'у он не приходится, поэтому
+  // peer-варианты вешаем на fieldset и целим вложенный legend через [&>legend].
+  const legendWidth = auto ? 'max-w-[0.01px]' : 'max-w-full';
+  const legendOpener = auto
+    ? 'peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full'
+    : '';
+  const labelColor = bad
+    ? 'text-danger'
+    : auto ? 'text-fg4 peer-focus:text-brand'
+      : focused ? 'text-brand' : 'text-fg4';
+  // В `auto` метка стоит по центру и уезжает наверх; в `always` она уже наверху.
+  const labelPosition = auto
+    ? 'top-1/2 -translate-y-1/2 text-sm peer-focus:top-0 peer-focus:text-xs '
+      + 'peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:text-xs'
+    : 'top-0 -translate-y-1/2 text-xs';
+
+  const labelContent = <>{label}{required && <span className="ml-0.5 text-danger">*</span>}</>;
+  const labelClass = `absolute left-3 px-1 pointer-events-none transition-all block max-w-[calc(100%-1.5rem)] truncate ${labelColor} ${labelPosition}`;
+
+  return (
+    <div className={containerClassName}>
+      <div className="relative">
+        {children}
+        {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под меткой. Ширина legend
+            и есть вырез — она же анимируется, когда метка всплывает. */}
+        <fieldset aria-hidden
+          className={`pointer-events-none absolute inset-x-0 bottom-0 top-[-5px] m-0 rounded-md border px-3 transition-colors ${borderColor} ${borderWidth} ${legendOpener}`}>
+          <legend className={`h-2.5 w-auto whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100 ${legendWidth}`}>
+            <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
+          </legend>
+        </fieldset>
+        {htmlFor
+          ? <label id={labelId} htmlFor={htmlFor} className={labelClass}>{labelContent}</label>
+          : <span id={labelId} className={labelClass}>{labelContent}</span>}
+        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">{trailing}</div>}
+      </div>
+      {error
+        ? <p className="mt-1 px-1 text-xs text-danger">{error}</p>
+        : hint ? <p className="mt-1 px-1 text-xs text-fg4">{hint}</p> : null}
+    </div>
+  );
+}

--- a/src/client/src/shared/ui/TextField.tsx
+++ b/src/client/src/shared/ui/TextField.tsx
@@ -1,12 +1,13 @@
 import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
+import { OutlinedField } from './OutlinedField';
 
 /**
- * MD3 outlined-текстовое поле (issue #110/#178) с плавающей подписью. Реализован НАСТОЯЩИЙ
- * вырез рамки (MD3 notch) через fieldset+legend: контейнер прозрачный, верхняя рамка реально
- * прерывается под меткой. Благодаря этому поле корректно выглядит на ЛЮБОМ фоне (surface/base/
- * карточка), а не только на surface. Тема light/dark — через токены.
+ * MD3 outlined-текстовое поле (issue #110/#178) с плавающей подписью. Рамку с настоящим вырезом,
+ * метку и подпись под полем рисует общая оболочка `OutlinedField` (#565) — здесь остаётся сам
+ * `<input>` и его состояния.
  *
- * Требует placeholder=" " (пробел) — по нему :placeholder-shown отличает пустое поле.
+ * Требует placeholder=" " (пробел) — по нему :placeholder-shown отличает пустое поле, и на этом же
+ * держится всплывание метки в режиме `raise="auto"`.
  */
 export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
   label: string;
@@ -26,44 +27,18 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
 ) {
   const autoId = useId();
   const inputId = id ?? autoId;
-  const bad = !!error || invalid;
-  const borderColor = bad
-    ? 'border-danger peer-focus:border-danger'
-    : 'border-stroke-strong peer-focus:border-brand';
-  const labelColor = bad ? 'text-danger peer-focus:text-danger' : 'text-fg4 peer-focus:text-brand';
 
   return (
-    <div className={containerClassName}>
-      <div className="relative">
-        <input
-          ref={ref} id={inputId} placeholder=" " required={required}
-          className={`peer w-full h-14 rounded-md bg-transparent text-sm text-fg1 px-4 ` +
-            `outline-none disabled:opacity-50 ${trailing ? 'pr-11' : ''} ${className}`}
-          {...rest}
-        />
-        {/* Рамка с вырезом: fieldset даёт границу, legend прорезает верх под плавающей меткой. */}
-        {/* peer-* реагируют только на СОСЕДЕЙ input'а, поэтому реакцию на фокус/заполнение
-            вешаем на fieldset (он сосед) и целим вложенный legend через [&>legend]. */}
-        <fieldset aria-hidden
-          className={`pointer-events-none absolute inset-x-0 bottom-0 top-[-5px] m-0 rounded-md border px-3 transition-colors ${borderColor} peer-focus:border-2 ` +
-            `peer-focus:[&>legend]:max-w-full peer-[:not(:placeholder-shown)]:[&>legend]:max-w-full`}>
-          <legend className="h-2.5 w-auto max-w-[0.01px] whitespace-nowrap p-0 text-xs invisible transition-[max-width] duration-100">
-            <span className="inline-block px-1 opacity-0">{label}{required ? ' *' : ''}</span>
-          </legend>
-        </fieldset>
-        <label
-          htmlFor={inputId}
-          className={`absolute left-3 top-1/2 -translate-y-1/2 px-1 text-sm pointer-events-none transition-all ${labelColor} ` +
-            `block max-w-[calc(100%-1.5rem)] truncate ` +
-            `peer-focus:top-0 peer-focus:text-xs peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:text-xs`}
-        >
-          {label}{required && <span className="ml-0.5 text-danger">*</span>}
-        </label>
-        {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">{trailing}</div>}
-      </div>
-      {error
-        ? <p className="mt-1 px-1 text-xs text-danger">{error}</p>
-        : hint ? <p className="mt-1 px-1 text-xs text-fg4">{hint}</p> : null}
-    </div>
+    <OutlinedField
+      label={label} required={required} invalid={invalid} error={error} hint={hint}
+      htmlFor={inputId} trailing={trailing} containerClassName={containerClassName}
+    >
+      <input
+        ref={ref} id={inputId} placeholder=" " required={required}
+        className={`peer w-full h-14 rounded-md bg-transparent text-sm text-fg1 px-4 ` +
+          `outline-none disabled:opacity-50 ${trailing ? 'pr-11' : ''} ${className}`}
+        {...rest}
+      />
+    </OutlinedField>
   );
 });

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.59.0</Version>
+    <Version>0.59.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Шаг 2 из #565. **Ни один экран не меняется** — это извлечение общей оболочки, на которую следующими шагами переедут пикер типа и `Select`.

Разметка рамки с настоящим вырезом (`fieldset`+`legend`) была написана дважды — в `TextField` (#178) и `DateField` (#176). Пикер и `Select` дали бы третью и четвёртую копию, поэтому шелл вынесен до того, как их трогать.

`OutlinedField` держит рамку, метку, состояния фокуса/ошибки и подпись под полем; сам контрол передаётся детьми. Метка работает в двух режимах, и это разные механики:

- `raise="auto"` — метка всплывает по CSS через peer-селекторы; требует, чтобы ребёнок был самим `<input class="peer" placeholder=" ">`. Так живёт `TextField`.
- `raise="always"` — метка постоянно наверху, вырез всегда открыт. Нужен там, где у контрола нет состояния «пусто» в смысле CSS: у даты всегда видны плейсхолдеры сегментов, у будущей кнопки-триггера — значок и имя выбранного типа. Фокус в этом режиме приходит пропом, потому что живёт на составном контроле, а не на единственном `input`.

Тонкость, ради которой стоит заглянуть в код: peer-варианты реагируют только на **соседей** `input`'а, а вырез раскрывает `legend` **внутри** `fieldset` — поэтому классы висят на `fieldset` и целят вложенный `legend` через `[&>legend]`.

Заодно оболочка умеет `labelId` — задел на шаг 3: кнопке-триггеру `<label for>` не годится (щелчок по подписи открывал бы модалку), доступное имя там свяжут через `aria-labelledby`.

## Проверено

`npx tsc -b` чист. Поскольку рендер-тестов во фронте нет (юниты покрывают чистую логику), равенство поведения проверял на живом фронте:

- заполнение поля вживую поднимает метку (14px → 12px, `top` 18 → −8) и раскрывает вырез (`legend` 0 → 46px) — то есть ветка `:not(:placeholder-shown)` работает;
- все нужные классы Tailwind действительно сгенерированы, включая обе формы `[&>legend]:max-w-full` и семейство `peer-focus:*` — это и был главный риск при сборке классов из кусков;
- состояние фокуса вживую снять не вышло: панель браузера не в фокусе, и `:focus` в ней не срабатывает (`document.hasFocus()` = false). Классы фокуса при этом посимвольно те же, что были до извлечения.

Версия поднята до 0.59.2. Если #567 сливается первым, конфликт будет только в строке версии.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
