### PR TITLE
Пикер типа в слое формы: подпись внутри контрола (#565)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -91,18 +91,15 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
           Маппинг задаётся здесь один раз — поля документов совместимого типа ссылаются на источник без маппинга.
         </p>
 
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Тип для материализации</label>
-          <TypePickerField className="w-full" aria-label="Тип для материализации" title="Тип для материализации"
-            placeholder="— не материализовать —" clearable={{ label: 'Не материализовать' }}
-            recentKey="materialize-type"
-            types={allDocTypes.filter(t => !t.isAbstract).map<PickType>(t => ({
-              id: t.id, name: t.name, code: t.code,
-              section: t.kind === 'Composite' ? 'Составные типы' : 'Типы документов',
-            }))}
-            value={typeId || undefined}
-            onChange={id => { setTypeId(id ?? ''); setMapping({}); setVariantStash({}); }} />
-        </div>
+        <TypePickerField className="w-full" label="Тип для материализации" title="Тип для материализации"
+          placeholder="— не материализовать —" clearable={{ label: 'Не материализовать' }}
+          recentKey="materialize-type"
+          types={allDocTypes.filter(t => !t.isAbstract).map<PickType>(t => ({
+            id: t.id, name: t.name, code: t.code,
+            section: t.kind === 'Composite' ? 'Составные типы' : 'Типы документов',
+          }))}
+          value={typeId || undefined}
+          onChange={id => { setTypeId(id ?? ''); setMapping({}); setVariantStash({}); }} />
 
         {selectedType && (
           effectiveFields.length === 0 ? (

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -170,14 +170,11 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
       {/* Тип документа — своей строкой, а не в паре с названием (issue #565): он решает, какие поля
           нарисуются ниже, то есть управляет всей остальной формой. Соседство с рядовым текстовым
           полем читалось как «два равных реквизита». */}
-      <div>
-        <label className="block text-xs font-medium text-fg2 mb-1">Тип документа</label>
-        <TypePickerField className="w-full" aria-label="Тип документа" title="Тип документа"
-          placeholder="Выберите тип…"
-          types={qualityTypes.map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Документы качества' }))}
-          value={typeId || undefined}
-          onChange={id => { if (id) setTypeId(id); }} />
-      </div>
+      <TypePickerField className="w-full" label="Тип документа" title="Тип документа"
+        placeholder="Выберите тип…"
+        types={qualityTypes.map<PickType>(dt => ({ id: dt.id, name: dt.name, code: dt.code, section: 'Документы качества' }))}
+        value={typeId || undefined}
+        onChange={id => { if (id) setTypeId(id); }} />
       <TextField label="Название в библиотеке" value={displayName}
         onChange={e => setDisplayName(e.target.value)} hint="авто из номера" />
 

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -253,13 +253,10 @@ function PropertiesEditor({ docType, allDocTypes }: { docType: DocumentType; all
         <TextField label="Код" value={code} onChange={e => setCode(e.target.value)}
           required spellCheck={false} className="font-mono" />
       </div>
-      <div>
-        <label className="block text-xs font-medium text-fg2 mb-1">Родительский тип</label>
-        <TypePickerField className="w-full" aria-label="Родительский тип" title="Родительский тип"
-          placeholder="— без родителя —" clearable={{ label: 'Без родителя' }}
-          types={toParentPickTypes(eligibleParents)} value={parentId || undefined}
-          onChange={id => setParentId(id ?? '')} />
-      </div>
+      <TypePickerField className="w-full" label="Родительский тип" title="Родительский тип"
+        placeholder="— без родителя —" clearable={{ label: 'Без родителя' }}
+        types={toParentPickTypes(eligibleParents)} value={parentId || undefined}
+        onChange={id => setParentId(id ?? '')} />
       {/* Прокси/абстрактность — отдельные мгновенные переключатели (не часть формы «Сохранить
           параметры»): каждый — своя мутация, применяется сразу по щелчку (issue #197 Фаза C). */}
       <div className="flex flex-col gap-2 pt-1">
@@ -358,15 +355,10 @@ function CreateForm({
       )}
 
       {sameKindTypes.length > 0 && (
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">
-            Родительский тип (наследование)
-          </label>
-          <TypePickerField className="w-full" aria-label="Родительский тип" title="Родительский тип"
-            placeholder="— без родителя —" clearable={{ label: 'Без родителя' }}
-            types={toParentPickTypes(sameKindTypes)} value={parentId || undefined}
-            onChange={id => setParentId(id ?? '')} />
-        </div>
+        <TypePickerField className="w-full" label="Родительский тип (наследование)" title="Родительский тип"
+          placeholder="— без родителя —" clearable={{ label: 'Без родителя' }}
+          types={toParentPickTypes(sameKindTypes)} value={parentId || undefined}
+          onChange={id => setParentId(id ?? '')} />
       )}
 
       {parentEffectiveFields.length > 0 && (

--- a/src/client/src/shared/ui/TypePickerField.tsx
+++ b/src/client/src/shared/ui/TypePickerField.tsx
@@ -1,21 +1,31 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { Boxes, Search, X } from 'lucide-react';
 import { TypePicker, typeIcon, type PickType } from './TypePicker';
+import { OutlinedField } from './OutlinedField';
 
 /**
- * Триггер-поле над `TypePicker` (issue #266): закрытый вид читается как form-поле в тон нашего
- * `Select` (значок семейства + имя выбранного типа + код по showCode + лупа), клик/Enter/Space
- * открывают богатую модалку выбора.
+ * Триггер-поле над `TypePicker` (issue #266): закрытый вид читается как поле формы (значок
+ * семейства + имя выбранного типа + код по showCode + лупа), клик/Enter/Space открывают богатую
+ * модалку выбора. Единый контрол для ЛЮБОГО выбора типа (документа/поля/родителя), чтобы не плодить
+ * свои триггеры на каждом сайте. Триггер — настоящий `<button aria-haspopup>`, фокус возвращается
+ * на него по Esc (Radix Dialog). Не-типовые короткие списки (роль/scope) — обычный Select.
  *
  * Замыкающий значок — ЛУПА, а не шеврон (issue #565). Обещание о том, что произойдёт по клику,
  * несёт именно он: шеврон в MD3 означает приклеенное меню, а у нас открывается модалка с поиском,
- * группами и «недавними». Оболочку поля при этом можно носить честно — врал только значок. Единый контрол для ЛЮБОГО выбора типа (документа/поля/родителя),
- * чтобы не плодить свои триггеры на каждом сайте. Триггер — настоящий `<button aria-haspopup>`, фокус
- * возвращается на него по Esc (Radix Dialog). Не-типовые короткие списки (роль/scope) — обычный Select.
+ * группами и «недавними». Оболочку поля при этом можно носить честно — врал только значок.
+ *
+ * Два слоя (issue #565), и выбирает между ними наличие `label`:
+ *
+ * - **слой формы** (`label` задан) — MD3 outlined-оболочка `OutlinedField` высотой `h-14`, подпись
+ *   всегда в вырезе рамки. Свой `<label>` в вызывающем коде НЕ пишем: он разъехался на три разные
+ *   типографики, пока жил снаружи. Подпись связана через `aria-labelledby`, а не `<label for>` —
+ *   у кнопки щелчок по подписи открывал бы модалку;
+ * - **слой обвязки** (`label` нет) — компактный триггер `h-8`/`h-9` для шапок и фильтров, там и
+ *   живёт плотность.
  */
 export function TypePickerField({
   types, value, onChange, recentKey, title = 'Выберите тип', placeholder = 'Выберите тип',
-  size = 'md', clearable, disabled, className = '', 'aria-label': ariaLabel,
+  size = 'md', label, required, clearable, disabled, className = '', 'aria-label': ariaLabel,
 }: {
   types: PickType[];
   value: string | undefined;
@@ -26,6 +36,9 @@ export function TypePickerField({
   placeholder?: string;
   /** `sm` — компактный триггер для шапок (без кода); `md` — обычное поле формы. */
   size?: 'sm' | 'md';
+  /** Подпись поля. Задана — контрол переходит в слой формы (outlined-рамка с вырезом). */
+  label?: string;
+  required?: boolean;
   /** Показать строку «нет значения» в пикере + крестик-сброс на триггере. */
   clearable?: { label: string };
   disabled?: boolean;
@@ -33,39 +46,73 @@ export function TypePickerField({
   'aria-label'?: string;
 }) {
   const [open, setOpen] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const labelId = useId();
   const selected = value ? types.find(t => t.id === value) : undefined;
   const Icon = selected ? typeIcon(selected) : Boxes;
   const code = selected?.code.trim();
   const showCode = size !== 'sm' && !!code && code.toLowerCase() !== selected!.name.trim().toLowerCase();
-  const h = size === 'sm' ? 'h-8' : 'h-9';
+  const framed = label !== undefined;
+  const showClear = !!clearable && !!selected && !disabled;
+
+  // В слое формы рамку и фон рисует оболочка — триггер внутри неё прозрачный и без своей границы,
+  // иначе получилась бы рамка в рамке. Кольцо фокуса там тоже не нужно: фокус показывает сама
+  // оболочка (border-2 + подпись цветом бренда), как у `DateField`.
+  const triggerClass = framed
+    ? `w-full h-14 px-4 rounded-md bg-transparent text-sm text-left outline-none ` +
+      `disabled:opacity-50 disabled:pointer-events-none ${showClear ? 'pr-12' : ''}`
+    : `w-full ${size === 'sm' ? 'h-8' : 'h-9'} px-3 rounded-md border border-stroke-strong bg-surface ` +
+      `text-sm text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
+      `data-[state=open]:ring-2 disabled:opacity-50 disabled:pointer-events-none ${showClear ? 'pr-11' : ''}`;
+
+  const trigger = (
+    <button
+      type="button" disabled={disabled} onClick={() => setOpen(true)}
+      onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}
+      aria-haspopup="dialog" aria-expanded={open}
+      aria-label={framed ? undefined : ariaLabel} aria-labelledby={framed ? labelId : undefined}
+      className={`inline-flex items-center gap-2 ${triggerClass}`}
+      data-state={open ? 'open' : 'closed'}
+    >
+      <Icon size={16} className={`shrink-0 ${selected ? 'text-fg3' : 'text-fg4'}`} />
+      {/* Подсказка — на самом обрезаемом тексте, а не на кнопке (issue #548): подсказку кнопки
+          наследуют и лупа, и код типа, и всплывало бы имя типа поверх них. */}
+      <span className={`flex-1 truncate ${selected ? 'text-fg1' : 'text-fg4'}`}
+        title={selected ? (showCode ? `${selected.name} (${code})` : selected.name) : undefined}>
+        {selected ? selected.name : placeholder}
+      </span>
+      {showCode && <span className="text-[11px] font-mono text-fg4 shrink-0">{code}</span>}
+      <Search size={15} className="shrink-0 text-fg4" />
+    </button>
+  );
+
+  // «Очистить» — отдельная кнопка РЯДОМ с триггером, а не `<span role="button">` внутри него
+  // (issue #565): вложенный интерактив невалиден, и с клавиатуры до него было не добраться.
+  // Лишняя остановка Tab здесь правильная — действие полноценное.
+  const clear = showClear && (
+    <button type="button" aria-label="Очистить" title="Очистить"
+      onClick={() => onChange(null)}
+      className={`absolute ${framed ? 'right-8' : 'right-7'} top-1/2 -translate-y-1/2 z-10 text-fg4 ` +
+        `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-fg2 transition-opacity ` +
+        `focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-sm`}>
+      <X size={14} />
+    </button>
+  );
 
   return (
     <>
-      <button
-        type="button" disabled={disabled} onClick={() => setOpen(true)}
-        aria-haspopup="dialog" aria-label={ariaLabel} aria-expanded={open}
-        className={`group inline-flex items-center gap-2 ${h} px-3 rounded-md border border-stroke-strong ` +
-          `bg-surface text-sm text-left transition-colors focus:outline-none focus-visible:ring-2 ` +
-          `focus-visible:ring-brand data-[state=open]:ring-2 disabled:opacity-50 disabled:pointer-events-none ${className}`}
-        data-state={open ? 'open' : 'closed'}
-      >
-        <Icon size={16} className={`shrink-0 ${selected ? 'text-fg3' : 'text-fg4'}`} />
-        {/* Подсказка — на самом обрезаемом тексте, а не на кнопке (issue #548): подсказку кнопки
-            наследуют и крестик, и шеврон, и на «Очистить» всплывало бы имя типа. */}
-        <span className={`flex-1 truncate ${selected ? 'text-fg1' : 'text-fg4'}`}
-          title={selected ? (showCode ? `${selected.name} (${code})` : selected.name) : undefined}>
-          {selected ? selected.name : placeholder}
-        </span>
-        {showCode && <span className="text-[11px] font-mono text-fg4 shrink-0">{code}</span>}
-        {clearable && selected && !disabled && (
-          <span role="button" tabIndex={-1} aria-label="Очистить" title="Очистить"
-            onClick={e => { e.stopPropagation(); onChange(null); }}
-            className="shrink-0 text-fg4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-fg2 transition-opacity">
-            <X size={14} />
-          </span>
-        )}
-        <Search size={15} className="shrink-0 text-fg4" />
-      </button>
+      {framed ? (
+        <OutlinedField label={label} required={required} raise="always" focused={focused}
+          labelId={labelId} containerClassName={`group relative ${className}`}>
+          {trigger}
+          {clear}
+        </OutlinedField>
+      ) : (
+        <div className={`group relative inline-flex ${className}`}>
+          {trigger}
+          {clear}
+        </div>
+      )}
 
       <TypePicker
         open={open} onOpenChange={setOpen} title={title} recentKey={recentKey}

--- a/src/client/src/shared/ui/TypePickerField.tsx
+++ b/src/client/src/shared/ui/TypePickerField.tsx
@@ -60,10 +60,10 @@ export function TypePickerField({
   // оболочка (border-2 + подпись цветом бренда), как у `DateField`.
   const triggerClass = framed
     ? `w-full h-14 px-4 rounded-md bg-transparent text-sm text-left outline-none ` +
-      `disabled:opacity-50 disabled:pointer-events-none ${showClear ? 'pr-12' : ''}`
+      `disabled:opacity-50 disabled:pointer-events-none`
     : `w-full ${size === 'sm' ? 'h-8' : 'h-9'} px-3 rounded-md border border-stroke-strong bg-surface ` +
       `text-sm text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
-      `data-[state=open]:ring-2 disabled:opacity-50 disabled:pointer-events-none ${showClear ? 'pr-11' : ''}`;
+      `data-[state=open]:ring-2 disabled:opacity-50 disabled:pointer-events-none`;
 
   const trigger = (
     <button
@@ -82,6 +82,9 @@ export function TypePickerField({
         {selected ? selected.name : placeholder}
       </span>
       {showCode && <span className="text-[11px] font-mono text-fg4 shrink-0">{code}</span>}
+      {/* Место под крестик резервируем В ПОТОКЕ, а не правым паддингом: паддинг сдвинул бы влево и
+          саму лупу (она такой же элемент потока), и у края поля осталась бы дыра. */}
+      {showClear && <span aria-hidden className="w-[22px] shrink-0" />}
       <Search size={15} className="shrink-0 text-fg4" />
     </button>
   );
@@ -92,26 +95,33 @@ export function TypePickerField({
   const clear = showClear && (
     <button type="button" aria-label="Очистить" title="Очистить"
       onClick={() => onChange(null)}
-      className={`absolute ${framed ? 'right-8' : 'right-7'} top-1/2 -translate-y-1/2 z-10 text-fg4 ` +
+      className={`absolute ${framed ? 'right-10' : 'right-9'} top-1/2 -translate-y-1/2 z-10 text-fg4 ` +
         `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-fg2 transition-opacity ` +
         `focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-sm`}>
       <X size={14} />
     </button>
   );
 
+  // Фокус слушаем на обёртке, а не на самом триггере: крестик — его сосед и визуально часть того же
+  // поля, поэтому переход Tab'ом на него не должен гасить рамку. Приём тот же, что в `DateField`.
+  const body = (
+    <div className="relative flex w-full"
+      onFocus={() => setFocused(true)}
+      onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocused(false); }}>
+      {trigger}
+      {clear}
+    </div>
+  );
+
   return (
     <>
       {framed ? (
         <OutlinedField label={label} required={required} raise="always" focused={focused}
-          labelId={labelId} containerClassName={`group relative ${className}`}>
-          {trigger}
-          {clear}
+          labelId={labelId} containerClassName={`group ${className}`}>
+          {body}
         </OutlinedField>
       ) : (
-        <div className={`group relative inline-flex ${className}`}>
-          {trigger}
-          {clear}
-        </div>
+        <div className={`group ${className}`}>{body}</div>
       )}
 
       <TypePicker

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.59.2</Version>
+    <Version>0.59.3</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Шаг 3 из #565. **Стек:** ветка содержит #567 и #568 — сливать по порядку 567 → 568 → этот; после их слияния диффом здесь останется только шаг 3.

Подпись переезжает **из вызывающего кода внутрь контрола**, и это не косметика: пока она жила снаружи, у одного и того же пикера она разъехалась на три типографики — `text-xs/fg2` в двух местах, `text-sm/fg1` в третьем, `text-sm/fg2` в четвёртом.

Наличие `label` теперь и выбирает слой:

- **слой формы** — `OutlinedField` с вырезом, высота `h-14`, подпись всегда в вырезе рамки. Триггер внутри оболочки прозрачный и без своей рамки (иначе рамка в рамке), кольцо фокуса тоже снято: фокус показывает оболочка, как у `DateField`;
- **слой обвязки** (`label` нет) — прежний компактный триггер `h-8`/`h-9` для шапок и фильтров: `QualityLinksTab`, `TemplateSidebar`. Там живёт плотность, их не трогаем.

Переведены четыре формовые площадки: диалог документа качества, оба места в «Типах документов», диалог материализации набора. Свой `<label>` у каждой удалён.

## Доступность — два долга закрыты по дороге

**Подпись связана через `aria-labelledby`**, а не `<label for>`: для кнопки последний валиден, но щелчок по подписи открывал бы модалку выбора — обещание не то. Доступное имя теперь равно видимому (WCAG 2.5.3), раньше видимая подпись не была связана с контролом вовсе.

**«Очистить» стал отдельной кнопкой рядом с триггером** вместо `<span role="button" tabIndex={-1}>` внутри него: вложенный интерактив невалиден, и с клавиатуры до крестика было не добраться. Лишняя остановка Tab здесь правильная — действие полноценное.

## Проверено

`npx tsc -b` чист. Вид снят на живом фронте временным пробником (в коммит не входит, роут удалён):

| что | измерено |
|---|---|
| рамка оборачивает триггер | 512×56, fieldset 512×61 со сдвигом вверх на 5 |
| вырез ровно по подписи | legend 92 против ширины подписи 92 |
| подпись сидит на границе | её верх 24 против верха рамки 27 |
| `aria-labelledby` | указывает на id подписи |
| крестик не наезжает на лупу | крестик 498–512, лупа 513–528 |
| обвязка не изменилась | компактный триггер 224×32, без рамки и подписи |

Состояние фокуса вживую снять снова не вышло — панель браузера не в фокусе, `:focus` в ней не срабатывает.

Версия поднята до 0.59.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
