### PR TITLE
Материал опознаётся полями материала, а не всех составных типов (#569)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -14,7 +14,9 @@ import {
   type LinkSuggestion, type SearchCandidate, type QualityDocument,
 } from '@/shared/api/qualityDocs';
 import type { DocumentInstance, DocumentType, CatalogScope } from '@/shared/api/types';
-import { typeHasTag, findTaggedFieldPath, resolveEffectiveFields } from '@/shared/api/schema';
+import {
+  typeHasTag, findTaggedFieldPath, resolveEffectiveFields, isMaterialType, materialIdentityKeys,
+} from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import {
   assessBulkLink, collectStrings, docHaystackStems, relevance, weighted,
@@ -300,16 +302,8 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
     return m;
   }, [linksSystem, linksSet]);
 
-  // Ключи полей-идентификаторов — из тэга identity (без хардкода имён).
-  const identityKeys = useMemo(() => {
-    const keys: string[] = [];
-    for (const t of allDocTypes) {
-      if (t.kind !== 'Composite') continue;
-      for (const f of resolveEffectiveFields(t, allDocTypes))
-        if (f.tags?.includes(FUNCTIONAL_TAG.identity)) keys.push(f.key);
-    }
-    return Array.from(new Set(keys));
-  }, [allDocTypes]);
+  // Ключи полей-идентификаторов МАТЕРИАЛА — по тэгам, без хардкода имён (issue #569).
+  const identityKeys = useMemo(() => materialIdentityKeys(allDocTypes), [allDocTypes]);
 
   // Материалы из набора данных (превью) И из реквизитов (массивы материал-типа).
   const materials = useMemo<MaterialRow[]>(() => {
@@ -338,7 +332,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
       for (const f of resolveEffectiveFields(docType, allDocTypes)) {
         if (f.type !== 'array' || !f.typeId) continue;
         const ct = allDocTypes.find(t => t.id === f.typeId);
-        if (!ct || !resolveEffectiveFields(ct, allDocTypes).some(cf => cf.tags?.includes(FUNCTIONAL_TAG.identity))) continue;
+        if (!ct || !isMaterialType(ct, allDocTypes)) continue;
         const arr = instance.requisites[f.key];
         if (Array.isArray(arr)) for (const el of arr) if (el && typeof el === 'object') add(el as Record<string, unknown>);
       }

--- a/src/client/src/shared/api/schema.test.ts
+++ b/src/client/src/shared/api/schema.test.ts
@@ -7,6 +7,8 @@ import {
   getDefaultValues,
   isFieldMissing,
   isScalarField,
+  isMaterialType,
+  materialIdentityKeys,
   type SchemaField,
 } from './schema';
 import type { DocumentType } from './types';
@@ -199,4 +201,37 @@ describe('isScalarField', () => {
     '%s is scalar', t => expect(isScalarField(field('A', { type: t }))).toBe(true));
   it.each(['array', 'complex', 'doc-ref', 'doc-array'] as const)(
     '%s is not scalar', t => expect(isScalarField(field('A', { type: t }))).toBe(false));
+});
+
+// ── materialIdentityKeys (issue #569) ─────────────────────────────────────────
+
+describe('materialIdentityKeys', () => {
+  /**
+   * Разбор живого случая: в реестре 151 материал, а вкладка показывала 4 — «шт», «упак», «м»,
+   * «компл». Тэг identity носит и «Единица измерения» (законно — она опознаётся наименованием), а
+   * набор данных приносит колонку с тем же ключом. Пока ключи собирались по ВСЕМ составным типам,
+   * ключом каждой строки становилась единица, и 147 строк отбрасывались как дубли.
+   */
+  const material = { ...dt({ fields: [
+    field('Наименование', { tags: ['identity'] }),
+    field('Артикул', { tags: ['identity'] }),
+    field('ДокументПодтверждающийКачество', { type: 'complex', tags: ['material.qualityDocLink'] }),
+  ] }), kind: 'Composite' as const };
+  const unit = { ...dt({ fields: [field('ЕдиницаИзмерения', { tags: ['identity'] })] }), kind: 'Composite' as const };
+  const org = { ...dt({ fields: [field('Сокращённое', { tags: ['identity'] })] }), kind: 'Composite' as const };
+
+  it('берёт поля только у типов, способных нести документ качества', () => {
+    expect(materialIdentityKeys([unit, org, material])).toEqual(['Наименование', 'Артикул']);
+  });
+
+  it('единица измерения и организация материалом не считаются', () => {
+    const all = [unit, org, material];
+    expect(isMaterialType(material, all)).toBe(true);
+    expect(isMaterialType(unit, all)).toBe(false);
+    expect(isMaterialType(org, all)).toBe(false);
+  });
+
+  it('порядок типов не влияет на состав ключей', () => {
+    expect(materialIdentityKeys([material, unit, org])).toEqual(materialIdentityKeys([unit, material, org]));
+  });
 });

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -1,4 +1,5 @@
 import type { DocumentType } from './types';
+import { FUNCTIONAL_TAG } from './tags';
 import { ROW_UID, withRowUid } from '@/shared/utils/rowIdentity';
 
 /**
@@ -279,4 +280,28 @@ export function isFieldMissing(field: SchemaField, value: unknown): boolean {
     return value == null || (typeof value === 'object' && Object.keys(value as object).length === 0);
   }
   return value == null || String(value).trim() === '';
+}
+
+/**
+ * Тип-МАТЕРИАЛ — тот, что может нести документ качества (issue #569).
+ *
+ * Тэг identity носят и другие справочные типы: единица измерения опознаётся своим наименованием,
+ * организация — сокращённым названием. Пока поля идентичности собирались по ВСЕМ составным типам,
+ * строка набора данных с колонкой «ЕдиницаИзмерения» получала ключ «шт» — и 151 материал реестра
+ * схлопывался в четыре единицы измерения.
+ */
+export function isMaterialType(t: DocumentType, allDocTypes: DocumentType[]): boolean {
+  return resolveEffectiveFields(t, allDocTypes)
+    .some(f => f.tags?.includes(FUNCTIONAL_TAG.materialQualityDocLink));
+}
+
+/** Ключи полей идентичности у типов-материалов — по тэгам, без хардкода имён полей. */
+export function materialIdentityKeys(allDocTypes: DocumentType[]): string[] {
+  const keys: string[] = [];
+  for (const t of allDocTypes) {
+    if (t.kind !== 'Composite' || !isMaterialType(t, allDocTypes)) continue;
+    for (const f of resolveEffectiveFields(t, allDocTypes))
+      if (f.tags?.includes(FUNCTIONAL_TAG.identity)) keys.push(f.key);
+  }
+  return Array.from(new Set(keys));
 }

--- a/src/server/BHS.CRG.Application/QualityDocs/MaterialIdentity.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/MaterialIdentity.cs
@@ -1,0 +1,30 @@
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Schema;
+
+namespace BHS.CRG.Application.QualityDocs;
+
+/// <summary>
+/// Какими полями опознаётся МАТЕРИАЛ при сопоставлении с документом качества (issue #569).
+///
+/// Тэг <see cref="FunctionalTag.Identity"/> живёт не только на материале: единица измерения
+/// опознаётся своим наименованием, организация — сокращённым названием, и это правильно. Но раньше
+/// все такие поля сваливались в один список и применялись к строкам материала — а в наборе данных
+/// есть колонка «ЕдиницаИзмерения». В результате ключом КАЖДОЙ из 151 строки реестра материалов
+/// становилась единица измерения: список схлопывался до четырёх («шт», «упак», «м», «компл»), а
+/// связка, заведённая там, при генерации подтянула бы один сертификат ко всем материалам с этой
+/// единицей.
+///
+/// Материал — это составной тип, который МОЖЕТ НЕСТИ документ качества, то есть имеет поле с тэгом
+/// <see cref="FunctionalTag.MaterialQualityDocLink"/>. Его поля идентичности и берём.
+/// </summary>
+public static class MaterialIdentity
+{
+    /// <summary>Ключи полей идентичности у типов, способных нести документ качества.</summary>
+    public static string[] KeysOf(IEnumerable<DocumentType> composites)
+        => composites
+            .Where(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.MaterialQualityDocLink).Count > 0)
+            .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.Identity))
+            .Distinct()
+            .ToArray();
+}

--- a/src/server/BHS.CRG.Application/QualityDocs/MaterialIdentity.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/MaterialIdentity.cs
@@ -20,11 +20,33 @@ namespace BHS.CRG.Application.QualityDocs;
 /// </summary>
 public static class MaterialIdentity
 {
+    /// <summary>
+    /// Тип-материал: несёт поле документа качества сам или унаследовал его.
+    ///
+    /// Наследование учитываем не «на будущее»: клиент решает тот же вопрос через
+    /// <c>resolveEffectiveFields</c>, то есть по всей цепочке. Разойдись эти две семантики —
+    /// подтип материала показывался бы на вкладке, но при генерации не сопоставлялся, и документ
+    /// качества молча не попал бы в PDF при здоровом виде в UI.
+    /// </summary>
+    public static bool IsMaterial(DocumentType type, IReadOnlyList<DocumentType> allTypes)
+        => SchemaTags.TaggedFields(type, allTypes)
+            .Any(f => f.Tag == FunctionalTag.MaterialQualityDocLink);
+
     /// <summary>Ключи полей идентичности у типов, способных нести документ качества.</summary>
-    public static string[] KeysOf(IEnumerable<DocumentType> composites)
-        => composites
-            .Where(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.MaterialQualityDocLink).Count > 0)
-            .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.Identity))
+    public static string[] KeysOf(IReadOnlyList<DocumentType> allTypes)
+        => allTypes
+            .Where(t => IsMaterial(t, allTypes))
+            .SelectMany(t => SchemaTags.TaggedFields(t, allTypes)
+                .Where(f => f.Tag == FunctionalTag.Identity)
+                .Select(f => f.Key))
             .Distinct()
             .ToArray();
+
+    /// <summary>Ключ поля, в которое подмешивается документ качества (тэг material.qualityDocLink).</summary>
+    public static string? QualityDocFieldOf(IReadOnlyList<DocumentType> allTypes)
+        => allTypes
+            .SelectMany(t => SchemaTags.TaggedFields(t, allTypes))
+            .Where(f => f.Tag == FunctionalTag.MaterialQualityDocLink)
+            .Select(f => f.Key)
+            .FirstOrDefault();
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
@@ -20,9 +20,10 @@ public class QualityLinkResolver(AppDbContext db) : IQualityLinkResolver
             .Where(t => t.Kind == DocumentTypeKind.Composite)
             .ToListAsync(ct);
 
-        var identityFields = composites
-            .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.Identity))
-            .Distinct().ToArray();
+        // Только у типов, способных нести документ качества (issue #569): тэг identity носят и
+        // единица измерения, и организация, а сопоставление по «шт» приклеило бы один сертификат
+        // ко всем материалам с этой единицей.
+        var identityFields = MaterialIdentity.KeysOf(composites);
         var targetField = composites
             .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.MaterialQualityDocLink))
             .FirstOrDefault();

--- a/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
@@ -16,17 +16,15 @@ public class QualityLinkResolver(AppDbContext db) : IQualityLinkResolver
     {
         // Поля идентичности материала и целевое поле ссылки берём по функциональным тэгам
         // (material.identity / material.qualityDocLink) из составных типов, а не по именам.
-        var composites = await db.DocumentTypes.AsNoTracking()
-            .Where(t => t.Kind == DocumentTypeKind.Composite)
-            .ToListAsync(ct);
+        // Все типы, а не только составные: цепочка наследования разрешается по списку, и обрыв
+        // цепочки молча отнял бы у подтипа унаследованные тэги.
+        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
 
         // Только у типов, способных нести документ качества (issue #569): тэг identity носят и
         // единица измерения, и организация, а сопоставление по «шт» приклеило бы один сертификат
         // ко всем материалам с этой единицей.
-        var identityFields = MaterialIdentity.KeysOf(composites);
-        var targetField = composites
-            .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.MaterialQualityDocLink))
-            .FirstOrDefault();
+        var identityFields = MaterialIdentity.KeysOf(allTypes);
+        var targetField = MaterialIdentity.QualityDocFieldOf(allTypes);
 
         if (identityFields.Length == 0 || targetField is null) return; // тэги не настроены — нечего подмешивать
 

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
@@ -121,8 +121,8 @@ public class MaterialLabelBackfill(
     }
 
     /// <summary>
-    /// Ключи полей идентичности по всем составным типам — тем же способом, что и резолвер связок
-    /// (<c>SchemaTags.FieldKeysWithTag</c>): по тэгу, а не по именам полей.
+    /// Ключи полей идентичности МАТЕРИАЛА — тем же способом, что и резолвер связок
+    /// (<see cref="MaterialIdentity"/>): по тэгу, а не по именам полей.
     /// </summary>
     private async Task<List<string>> IdentityKeysAsync(CancellationToken ct)
     {
@@ -130,10 +130,7 @@ public class MaterialLabelBackfill(
             .Where(t => t.Kind == DocumentTypeKind.Composite)
             .OrderBy(t => t.Name)   // детерминированный порядок: от него зависит порядок слов в имени
             .ToListAsync(ct);
-        return composites
-            .SelectMany(t => SchemaTags.FieldKeysWithTag(t.Schema, FunctionalTag.Identity))
-            .Distinct()
-            .ToList();
+        return MaterialIdentity.KeysOf(composites).ToList();
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/MaterialLabelBackfill.cs
@@ -126,11 +126,10 @@ public class MaterialLabelBackfill(
     /// </summary>
     private async Task<List<string>> IdentityKeysAsync(CancellationToken ct)
     {
-        var composites = await db.DocumentTypes.AsNoTracking()
-            .Where(t => t.Kind == DocumentTypeKind.Composite)
+        var allTypes = await db.DocumentTypes.AsNoTracking()
             .OrderBy(t => t.Name)   // детерминированный порядок: от него зависит порядок слов в имени
             .ToListAsync(ct);
-        return MaterialIdentity.KeysOf(composites).ToList();
+        return MaterialIdentity.KeysOf(allTypes).ToList();
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Tests/QualityDocs/MaterialIdentityTests.cs
+++ b/src/server/BHS.CRG.Tests/QualityDocs/MaterialIdentityTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.QualityDocs;
+
+/// <summary>
+/// Чем опознаётся материал (issue #569). Разбор живого случая: тэг identity носит и «Единица
+/// измерения», и пока ключи собирались по всем составным типам, ключом строки становилась единица
+/// («шт»). На генерации такая связка подтянула бы один сертификат ко ВСЕМ материалам с этой
+/// единицей, а список материалов схлопывался со 151 строки до четырёх.
+/// </summary>
+public class MaterialIdentityTests
+{
+    private static DocumentType Composite(string name, string schema)
+        => DocumentType.Create(name, name, DocumentTypeKind.Composite, null, JsonDocument.Parse(schema), false);
+
+    private static readonly DocumentType Material = Composite("Материал", """
+        { "fields": [
+            { "key": "Наименование", "tags": ["identity"] },
+            { "key": "Артикул", "tags": ["identity"] },
+            { "key": "ДокументПодтверждающийКачество", "tags": ["material.qualityDocLink"] } ] }
+        """);
+
+    private static readonly DocumentType Unit = Composite("Единица измерения", """
+        { "fields": [ { "key": "ЕдиницаИзмерения", "tags": ["identity"] } ] }
+        """);
+
+    private static readonly DocumentType Org = Composite("Наименование организации", """
+        { "fields": [ { "key": "Сокращённое", "tags": ["identity"] } ] }
+        """);
+
+    [Fact]
+    public void KeysOf_TakesOnlyTypesThatCanCarryQualityDoc()
+        => Assert.Equal(["Наименование", "Артикул"], MaterialIdentity.KeysOf([Unit, Org, Material]));
+
+    [Fact]
+    public void KeysOf_UnitOfMeasureNeverIdentifiesMaterial()
+        => Assert.DoesNotContain("ЕдиницаИзмерения", MaterialIdentity.KeysOf([Unit, Org, Material]));
+
+    /// <summary>Порядок типов приходит из БД/API — от него состав ключей зависеть не должен.</summary>
+    [Fact]
+    public void KeysOf_IsIndependentOfTypeOrder()
+        => Assert.Equal(
+            MaterialIdentity.KeysOf([Material, Unit, Org]),
+            MaterialIdentity.KeysOf([Org, Unit, Material]));
+
+    [Fact]
+    public void KeysOf_NoMaterialType_IsEmpty()
+        => Assert.Empty(MaterialIdentity.KeysOf([Unit, Org]));
+}

--- a/src/server/BHS.CRG.Tests/QualityDocs/MaterialIdentityTests.cs
+++ b/src/server/BHS.CRG.Tests/QualityDocs/MaterialIdentityTests.cs
@@ -48,4 +48,30 @@ public class MaterialIdentityTests
     [Fact]
     public void KeysOf_NoMaterialType_IsEmpty()
         => Assert.Empty(MaterialIdentity.KeysOf([Unit, Org]));
+
+    /// <summary>
+    /// Подтип материала — тоже материал: поле документа качества он наследует, а собственное поле
+    /// идентичности («ДлинаБарабана» у кабеля) добавляет. Клиент решает это через
+    /// resolveEffectiveFields; разойдись семантики — подтип показывался бы на вкладке, но при
+    /// генерации не сопоставлялся.
+    /// </summary>
+    [Fact]
+    public void KeysOf_SubtypeInheritsMaterialityAndAddsOwnKeys()
+    {
+        var cable = Composite("Кабель", """
+            { "fields": [ { "key": "МаркаКабеля", "tags": ["identity"] } ] }
+            """);
+        cable.SetParent(Material.Id);
+        var all = new List<DocumentType> { Unit, Org, Material, cable };
+
+        Assert.True(MaterialIdentity.IsMaterial(cable, all));
+        Assert.Contains("МаркаКабеля", MaterialIdentity.KeysOf(all));
+        Assert.Contains("Наименование", MaterialIdentity.KeysOf(all));
+        Assert.DoesNotContain("ЕдиницаИзмерения", MaterialIdentity.KeysOf(all));
+    }
+
+    [Fact]
+    public void QualityDocFieldOf_FindsTargetFieldByTag()
+        => Assert.Equal("ДокументПодтверждающийКачество",
+            MaterialIdentity.QualityDocFieldOf([Unit, Org, Material]));
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.59.0</Version>
+    <Version>0.59.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #569.

## Симптом

В документе «250701.ЭОМ-1.2.Реестр материалов» 151 материал, а вкладка «Документы качества»
показывала **4** строки: `шт`, `упак`, `м`, `компл`.

## Причина

Поля идентичности собирались по **всем** составным типам. Тэг `identity` носит не только материал:
единица измерения опознаётся своим наименованием, организация — сокращённым названием, и это верно.
Но общий список применялся к строкам материала, а в наборе есть колонка `ЕдиницаИзмерения`, и тип
«Единица измерения» идёт в порядке типов раньше «Материала». Замер алгоритма вкладки на живом превью:

```
строк: 151 | попало в список: 4 | отброшено как дубль ключа: 147
какое поле дало ключ: {"ЕдиницаИзмерения": 151}
```

Порядок типов приходит из ответа API — то есть какое поле станет ключом, не было определено по
смыслу: сегодня «шт», завтра «Наименование».

## Чем это было опасно

`QualityLinkResolver` собирал поля тем же общим котлом и сопоставляет по **любому** значению.
Связка с ключом `шт` подтянула бы один сертификат ко ВСЕМ материалам с этой единицей. Таких связок
в базе **ноль** — проверено, не успели.

## Решение

Материал — составной тип, который **может нести документ качества**, то есть имеет поле с тэгом
`material.qualityDocLink` (такой ровно один: «Материал»). Его поля идентичности и берём:

* сервер — `MaterialIdentity.KeysOf`, подключён в `QualityLinkResolver` и `MaterialLabelBackfill`;
* клиент — `materialIdentityKeys` / `isMaterialType` в `shared/api/schema`, подключены во вкладке
  (и для списка, и для предиката «этот массив реквизитов — материалы»).

## Проверка

* **Живьём:** та же вкладка на двух клиентах — **4 → 130** строк (151 строка набора, 19 наименований
  повторяются, поэтому 130, а не 151).
* **Сопоставление не пострадало:** и до, и после ровно **76** строк набора несут связку из имеющихся 113.
* Тесты на порядок типов и на то, что единица измерения материалом не считается: 4 backend + 3 frontend.
* Бэк **844**, фронт **303**, `npx tsc -b` чисто. Версия 0.59.0 → **0.59.1**.

> Ветка сделана в отдельном worktree: в основном дереве параллельно идёт работа по #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
