### PR TITLE
Крестик пикера: фокус не теряется, вслепую не срабатывает (#572)

### DIFF
--- a/src/client/src/shared/ui/TypePickerField.tsx
+++ b/src/client/src/shared/ui/TypePickerField.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { Boxes, Search, X } from 'lucide-react';
 import { TypePicker, typeIcon, type PickType } from './TypePicker';
 import { OutlinedField } from './OutlinedField';
@@ -47,6 +47,7 @@ export function TypePickerField({
 }) {
   const [open, setOpen] = useState(false);
   const [focused, setFocused] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const labelId = useId();
   const selected = value ? types.find(t => t.id === value) : undefined;
   const Icon = selected ? typeIcon(selected) : Boxes;
@@ -67,8 +68,8 @@ export function TypePickerField({
 
   const trigger = (
     <button
+      ref={triggerRef}
       type="button" disabled={disabled} onClick={() => setOpen(true)}
-      onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}
       aria-haspopup="dialog" aria-expanded={open}
       aria-label={framed ? undefined : ariaLabel} aria-labelledby={framed ? labelId : undefined}
       className={`inline-flex items-center gap-2 ${triggerClass}`}
@@ -92,11 +93,23 @@ export function TypePickerField({
   // «Очистить» — отдельная кнопка РЯДОМ с триггером, а не `<span role="button">` внутри него
   // (issue #565): вложенный интерактив невалиден, и с клавиатуры до него было не добраться.
   // Лишняя остановка Tab здесь правильная — действие полноценное.
+  //
+  // Фокус после нажатия возвращаем на триггер (issue #572): кнопка исчезает вместе со значением, а
+  // удалённому элементу браузер не шлёт blur — обработчик обёртки не срабатывал, поле навсегда
+  // оставалось «в фокусе» (бренд-рамка без фокуса), а сам фокус падал на <body>, и следующий Tab
+  // начинался с начала страницы.
   const clear = showClear && (
     <button type="button" aria-label="Очистить" title="Очистить"
-      onClick={() => onChange(null)}
+      onClick={() => { onChange(null); triggerRef.current?.focus(); }}
       className={`absolute ${framed ? 'right-10' : 'right-9'} top-1/2 -translate-y-1/2 z-10 text-fg4 ` +
-        `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-fg2 transition-opacity ` +
+        // Прозрачность НЕ отменяет попадания, а крестик лежит поверх триггера: без
+        // pointer-events-none нажатие у правого края на тач-устройстве молча очищало бы значение
+        // вместо открытия пикера (в диалоге материализации — вместе со всем маппингом).
+        // Где hover'а нет, показываем его сразу, иначе до него было бы не добраться.
+        `opacity-0 pointer-events-none transition-opacity hover:text-fg2 ` +
+        `group-hover:opacity-100 group-hover:pointer-events-auto ` +
+        `group-focus-within:opacity-100 group-focus-within:pointer-events-auto ` +
+        `[@media(pointer:coarse)]:opacity-100 [@media(pointer:coarse)]:pointer-events-auto ` +
         `focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-sm`}>
       <X size={14} />
     </button>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.59.3</Version>
+    <Version>0.59.4</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #572 — три замечания `/code-review` по уже слитому эпику #565.

Все три проверены **на живом пикере** «Родительский тип» (составные типы), сравнением двух
клиентов — master и правка:

| | до | после |
|---|---|---|
| `pointer-events` без hover | `auto` | `none` |
| фокус после нажатия ✕ | `BODY` | триггер пикера |

## Что было

1. **Фокус терялся, рамка залипала.** `showClear` зависит от `value`, поэтому `onChange(null)`
   размонтирует кнопку, пока она держит фокус. Браузер не шлёт `blur` удалённому элементу —
   `onBlur` обёртки не срабатывал, `focused` оставался `true` (бренд-рамка 2px без фокуса), а сам
   фокус падал на `<body>`, и следующий Tab начинался с начала страницы.
2. **Триггер гасил рамку сам.** Его `onFocus`/`onBlur` дублировали обработчики обёртки, ради
   которых всё и затевалось (переход Tab'ом на соседний крестик не должен гасить рамку).
   Безусловный `onBlur(false)` спасал только батчинг React.
3. **Прозрачный крестик ловил нажатия.** `opacity-0` не отменяет попаданий, а элемент лежит поверх
   триггера. На тач-устройстве нажатие у правого края очищало значение вместо открытия пикера — а в
   `MaterializationDialog` тот же `onChange` выбрасывает ещё и весь маппинг материализации, без
   подтверждения и без отката.

## Проверка

* Доступ с клавиатуры цел: Tab с триггера приводит на крестик, `opacity` при этом 1.
* Фронт **300** тестов, `npx tsc -b --force` чисто. Версия 0.59.3 → **0.59.4**.

> Ветка сделана в отдельном worktree — основное дерево занято другой работой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
