### PR TITLE
Select в слое формы: подпись в вырезе рамки (#574)

### DIFF
--- a/src/client/src/features/datasets/PdfSourceDialog.tsx
+++ b/src/client/src/features/datasets/PdfSourceDialog.tsx
@@ -57,14 +57,11 @@ export function PdfSourceDialog({ fileId, onClose }: { fileId: string; onClose: 
         <TextField label="Название" value={name} onChange={e => setName(e.target.value)} autoFocus
           hint={profile === 'invoice' ? 'Счёт на оплату' : 'Реестр листов'} />
 
-        <div>
-          <label className="block text-sm font-medium text-fg1 mb-1">Профиль распознавания</label>
-          <Select value={profile} onValueChange={v => setProfile(v as 'gost-titleblock' | 'invoice')}
-            aria-label="Профиль распознавания">
-            <SelectItem value="gost-titleblock">Основная надпись (ГОСТ Р 21.101-2020) — реестр по страницам</SelectItem>
-            <SelectItem value="invoice">Счёт на оплату — шапка + таблица товаров</SelectItem>
-          </Select>
-        </div>
+        <Select label="Профиль распознавания" value={profile}
+          onValueChange={v => setProfile(v as 'gost-titleblock' | 'invoice')}>
+          <SelectItem value="gost-titleblock">Основная надпись (ГОСТ Р 21.101-2020) — реестр по страницам</SelectItem>
+          <SelectItem value="invoice">Счёт на оплату — шапка + таблица товаров</SelectItem>
+        </Select>
 
         {profile === 'gost-titleblock' && datasetTags(allTags).length > 0 && (
           <div>

--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -161,8 +161,7 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
 
         {isPdf ? (
           <div>
-            <label className="block text-sm font-medium text-fg1 mb-1">Данные набора</label>
-            <Select value={sheetOrPath || undefined} placeholder="— выберите —" aria-label="Данные набора"
+            <Select label="Данные набора" value={sheetOrPath || undefined} placeholder="— выберите —"
               onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
               {readyCandidates.map(c => (
                 <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
@@ -184,8 +183,7 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
         ) : tabular ? (
           needsSheet ? (
             <div>
-              <label className="block text-sm font-medium text-fg1 mb-1">Лист</label>
-              <Select value={sheetOrPath || undefined} placeholder="— выберите лист —" aria-label="Лист"
+              <Select label="Лист" value={sheetOrPath || undefined} placeholder="— выберите лист —"
                 onValueChange={setSheetOrPath}>
                 {candidates.map(c => (
                   <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
@@ -208,9 +206,9 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
           <>
             {isZip && (
               <div>
-                <label className="block text-sm font-medium text-fg1 mb-1">Файл в архиве</label>
-                <Select value={entryPath || undefined} placeholder="— выберите XML-файл в архиве —"
-                  aria-label="Файл в архиве" onValueChange={setEntryPath} className="font-mono">
+                <Select label="Файл в архиве" value={entryPath || undefined}
+                  placeholder="— выберите XML-файл в архиве —"
+                  onValueChange={setEntryPath} className="font-mono">
                   {entryOptions.map(p => <SelectItem key={p} value={p}>{p}</SelectItem>)}
                 </Select>
                 {entryOptions.length === 0 && (

--- a/src/client/src/features/document-sets/editor/RequisitesTab.tsx
+++ b/src/client/src/features/document-sets/editor/RequisitesTab.tsx
@@ -401,7 +401,12 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
                       allDocTypes={allDocTypes} bindings={dsBindings} />
                   </div>
                 )}
-                {field.type !== 'boolean' && field.type !== 'complex' && field.type !== 'array' && (
+                {/* Текст подписывает себя сам (issue #574): подпись живёт в вырезе рамки, как у
+                    соседних однострочных полей. Своя подпись здесь дала бы вторую — над полем.
+                    Кроме привязанного к источнику: там контрол read-only и подпись сверху идёт
+                    вместе с бейджем привязки — как и у простых полей ниже. */}
+                {field.type !== 'boolean' && field.type !== 'complex' && field.type !== 'array'
+                  && !(field.type === 'text' && !bound) && (
                   <label className="block text-xs font-medium text-fg2 mb-1 pr-5">
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
@@ -456,6 +461,7 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
                     } : undefined} />
                 ) : (
                   <PrimitiveInput field={field} value={displayValue}
+                    label={field.type === 'text' && !bound ? field.title : undefined}
                     onChange={v => setValue(field.key, v, primitiveDef)}
                     invalid={hasError} primitiveTypeDef={primitiveDef} enumTypeDef={getEnumDef(field)} readOnly={bound} />
                 )}

--- a/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
+++ b/src/client/src/features/document-sets/fields/PrimitiveInput.tsx
@@ -1,9 +1,9 @@
-import type { ReactNode } from 'react';
 import { formatDateRu, ruToISO } from '@/shared/utils/date';
 import { DateInput } from '@/shared/ui/DateInput';
 import { DateField } from '@/shared/ui/DateField';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import { TextField } from '@/shared/ui/TextField';
+import { TextAreaField } from '@/shared/ui/TextAreaField';
 import type { SchemaField } from '@/shared/api/schema';
 import type { PrimitiveTypeDef, FieldConstraints, EnumTypeDef } from '@/shared/api/types';
 import { isFieldRef } from '@/shared/api/types';
@@ -48,25 +48,19 @@ export function validateConstraint(value: unknown, def: PrimitiveTypeDef): strin
 export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeDef, enumTypeDef, readOnly, label, hint }: {
   field: SchemaField; value: unknown; onChange: (val: unknown) => void; invalid: boolean;
   primitiveTypeDef?: PrimitiveTypeDef; enumTypeDef?: EnumTypeDef; readOnly?: boolean;
-  /** Если задано — контрол сам рендерит подпись (issue #110 G1): floating для одностроч. полей,
-   *  label-сверху для textarea/enum/date. Чекбокс подписывает себя сам (field.title). */
+  /** Если задано — контрол сам рендерит подпись в вырезе рамки (issue #110 G1, #565): всплывающую
+   *  у однострочных полей, постоянно поднятую у текста, даты и перечисления (там у контрола нет
+   *  состояния «пусто» в смысле CSS). Чекбокс подписывает себя сам (field.title). */
   label?: string; hint?: string;
 }) {
   const strVal = value == null ? '' : String(value);
   const cls = fieldInputClass(invalid, readOnly);
-  // Обёртка «подпись сверху» для не-floating контролов (textarea/select/date).
-  const withLabel = (control: ReactNode) => label == null ? <>{control}</> : (
-    <div>
-      <label className="block text-xs font-medium text-fg2 mb-1">
-        {label}{field.required && <span className="ml-0.5 text-danger">*</span>}
-      </label>
-      {control}
-      {hint && <p className="mt-0.5 px-1 text-xs text-fg4">{hint}</p>}
-    </div>
-  );
 
   if (field.type === 'text')
-    return withLabel(<textarea value={strVal} onChange={e => onChange(e.target.value)} rows={3} readOnly={readOnly} className={cls + ' resize-y'} />);
+    return label != null
+      ? <TextAreaField label={label} required={field.required} hint={hint} invalid={invalid}
+          value={strVal} readOnly={readOnly} onChange={e => onChange(e.target.value)} className="resize-y" />
+      : <textarea value={strVal} onChange={e => onChange(e.target.value)} rows={3} readOnly={readOnly} className={cls + ' resize-y'} />;
   if (field.type === 'boolean')
     return (
       <label className="flex items-center gap-2 cursor-pointer">
@@ -75,24 +69,27 @@ export function PrimitiveInput({ field, value, onChange, invalid, primitiveTypeD
       </label>
     );
   if (field.type === 'enum') {
-    const selCls = invalid ? 'border-danger' : '';
-    const sel = enumTypeDef ? (
-      <Select value={strVal || undefined} onValueChange={onChange} disabled={readOnly}
-        placeholder="— выберите —" aria-label={field.title} className={selCls}>
-        {enumTypeDef.values.map(v => <SelectItem key={v.code} value={v.code}>{v.label}</SelectItem>)}
+    // Подпись отдаём самому контролу (issue #574): в слое формы она живёт в вырезе рамки, как у
+    // соседних строк, чисел и дат. Рамку ошибки там рисует оболочка — свой border-danger не нужен.
+    const NO_OPTIONS = 'Нет вариантов — добавьте их в схеме типа документа';
+    const opts = enumTypeDef
+      ? enumTypeDef.values.map(v => ({ code: v.code, label: v.label }))
+      : (field.options ?? []).filter(o => o !== '').map(o => ({ code: o, label: o }));
+    const empty = opts.length === 0;
+    if (empty && label == null)
+      return <p className="text-xs text-fg4 italic py-1">{NO_OPTIONS}</p>;
+    return (
+      <Select value={strVal || undefined} onValueChange={onChange} disabled={readOnly || empty}
+        placeholder={empty ? '—' : '— выберите —'}
+        label={label} required={label != null ? field.required : undefined}
+        // Про отсутствие вариантов сообщаем подписью ПОД полем, а не вместо поля: иначе исчезала бы
+        // и подпись, и на форме оставалась висеть фраза без имени поля, к которому она относится.
+        hint={empty ? NO_OPTIONS : hint} invalid={invalid}
+        aria-label={label == null ? field.title : undefined}
+        className={label == null && invalid ? 'border-danger' : ''}>
+        {opts.map(o => <SelectItem key={o.code} value={o.code}>{o.label}</SelectItem>)}
       </Select>
-    ) : (() => {
-      const opts = (field.options ?? []).filter(o => o !== '');
-      if (opts.length === 0)
-        return <p className="text-xs text-fg4 italic py-1">Нет вариантов — добавьте их в схеме типа документа</p>;
-      return (
-        <Select value={strVal || undefined} onValueChange={onChange} disabled={readOnly}
-          placeholder="— выберите —" aria-label={field.title} className={selCls}>
-          {opts.map(opt => <SelectItem key={opt} value={opt}>{opt}</SelectItem>)}
-        </Select>
-      );
-    })();
-    return withLabel(sel);
+    );
   }
   if (field.type === 'primitive' && primitiveTypeDef) {
     const bt = primitiveTypeDef.baseType;

--- a/src/client/src/features/reconciliations/DecisionDialog.tsx
+++ b/src/client/src/features/reconciliations/DecisionDialog.tsx
@@ -49,8 +49,7 @@ export function DecisionDialog({ finding, onClose, onSave, onRemove }: {
         </div>
 
         <div>
-          <label className="block text-xs text-fg3 mb-1">Решение</label>
-          <Select value={kind} onValueChange={v => setKind(v as DecisionKind)} aria-label="Решение">
+          <Select label="Решение" value={kind} onValueChange={v => setKind(v as DecisionKind)}>
             <SelectItem value="Accepted">{DECISION_LABELS.Accepted}</SelectItem>
             <SelectItem value="Suppressed">{DECISION_LABELS.Suppressed}</SelectItem>
           </Select>

--- a/src/client/src/features/reconciliations/ReconciliationEditor.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationEditor.tsx
@@ -59,8 +59,9 @@ function PartEditor({ part, onChange, onRemove, sources, index }: {
   return (
     <div className="space-y-2 rounded-md bg-muted/40 p-2">
       <div className="flex items-center gap-2">
-        <Select value={part.sourceId} onValueChange={v => onChange({ ...EMPTY_PART, sourceId: v })}
-          placeholder="Источник данных" aria-label={`Источник ${index + 1}`} className="flex-1">
+        <Select label={`Источник ${index + 1}`} value={part.sourceId}
+          onValueChange={v => onChange({ ...EMPTY_PART, sourceId: v })}
+          placeholder="— выберите —" containerClassName="flex-1">
           {sources.map(({ source, fileName }) => (
             <SelectItem key={source.id} value={source.id}>{fileName} — {source.name}</SelectItem>
           ))}
@@ -98,8 +99,8 @@ function PartEditor({ part, onChange, onRemove, sources, index }: {
             </div>
           </div>
 
-          <Select value={part.valueColumn} onValueChange={v => onChange({ ...part, valueColumn: v })}
-            placeholder="Колонка количества" aria-label={`Количество ${index + 1}`}>
+          <Select label="Колонка количества" value={part.valueColumn}
+            onValueChange={v => onChange({ ...part, valueColumn: v })} placeholder="— выберите —">
             {columns.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
           </Select>
         </>

--- a/src/client/src/features/settings/IntegrationSettingsSection.tsx
+++ b/src/client/src/features/settings/IntegrationSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
+import { TextAreaField } from '@/shared/ui/TextAreaField';
 import { Select, SelectItem } from '@/shared/ui/Select';
 import {
   useIntegrationSettings,
@@ -80,10 +81,6 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-const inputCls =
-  'w-full px-2.5 py-1.5 text-sm rounded-md border border-stroke bg-surface text-fg1 ' +
-  'focus:outline-none focus:border-brand placeholder:text-fg4';
-
 function EngineCard({
   meta, form, onChange, reorder, modelOptions,
 }: {
@@ -126,20 +123,20 @@ function EngineCard({
         // в список добавляем текущее значение, чтобы кастомная модель из конфига не потерялась
         const opts = Array.from(new Set([...(modelOptions ?? []), form.model].filter(Boolean)));
         return (
-          <Field label={meta.modelLabel}>
-            {opts.length === 0 ? (
+          opts.length === 0 ? (
+            <Field label={meta.modelLabel}>
               <div className="text-xs text-fg4 px-2.5 py-2 rounded-md border border-dashed border-stroke">
                 {meta.key === 'Ollama'
                   ? <>Нет скачанных моделей. Выполните <code className="font-mono text-fg3">ollama pull qwen2.5vl:7b</code></>
                   : 'Список моделей недоступен'}
               </div>
-            ) : (
-              <Select value={form.model || undefined} placeholder="— выберите —" aria-label={meta.modelLabel}
-                onValueChange={m => onChange({ ...form, model: m })}>
-                {opts.map(o => <SelectItem key={o} value={o}>{o}</SelectItem>)}
-              </Select>
-            )}
-          </Field>
+            </Field>
+          ) : (
+            <Select label={meta.modelLabel} value={form.model || undefined} placeholder="— выберите —"
+              onValueChange={m => onChange({ ...form, model: m })}>
+              {opts.map(o => <SelectItem key={o} value={o}>{o}</SelectItem>)}
+            </Select>
+          )
         );
       })()}
 
@@ -175,16 +172,13 @@ function DomainList({ label, hint, value, onChange }: {
   }, [value]);
 
   return (
-    <Field label={label}>
-      <p className="text-xs text-fg4 mb-1">{hint}</p>
-      <textarea
-        value={text}
-        onChange={e => { setText(e.target.value); onChange(e.target.value.split('\n').map(s => s.trim()).filter(Boolean)); }}
-        rows={Math.min(Math.max(text.split('\n').length + 1, 3), 12)}
-        className={`${inputCls} font-mono resize-y`}
-        spellCheck={false}
-      />
-    </Field>
+    <TextAreaField
+      label={label} hint={hint} value={text}
+      onChange={e => { setText(e.target.value); onChange(e.target.value.split('\n').map(s => s.trim()).filter(Boolean)); }}
+      rows={Math.min(Math.max(text.split('\n').length + 1, 3), 12)}
+      className="font-mono resize-y"
+      spellCheck={false}
+    />
   );
 }
 

--- a/src/client/src/features/settings/UsersPage.tsx
+++ b/src/client/src/features/settings/UsersPage.tsx
@@ -153,13 +153,10 @@ function CreateUserModal({ open, onClose }: { open: boolean; onClose: () => void
         <TextField label="Начальный пароль" type="text" value={password} onChange={e => setPassword(e.target.value)}
           required minLength={PASSWORD_MIN_LENGTH} className="font-mono"
           hint={`${PASSWORD_HINT} Пользователь сможет сменить его сам.`} />
-        <div>
-          <label className="block text-sm font-medium text-fg2 mb-1">Роль</label>
-          <Select value={role} onValueChange={v => setRole(v as UserRole)} aria-label="Роль">
-            <SelectItem value="User">Пользователь — только документы и данные</SelectItem>
-            <SelectItem value="Admin">Администратор — полный доступ</SelectItem>
-          </Select>
-        </div>
+        <Select label="Роль" value={role} onValueChange={v => setRole(v as UserRole)}>
+          <SelectItem value="User">Пользователь — только документы и данные</SelectItem>
+          <SelectItem value="Admin">Администратор — полный доступ</SelectItem>
+        </Select>
         {error && <p className="text-sm text-danger">{error}</p>}
         <div className="flex justify-end gap-2 pt-1">
           <Button type="button" variant="text" onClick={() => { reset(); onClose(); }}>Отмена</Button>

--- a/src/client/src/shared/ui/Select.tsx
+++ b/src/client/src/shared/ui/Select.tsx
@@ -33,7 +33,8 @@ export interface SelectProps {
   onValueChange: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
-  /** Для участия в форме (валидация required через скрытый нативный select у Radix). */
+  /** В слое обвязки — участие в нативной валидации формы (скрытый `<select required>` у Radix).
+   *  В слое формы (задан `label`) — только звёздочка при подписи и `aria-required`, см. ниже. */
   required?: boolean;
   name?: string;
   /** Класс триггера (например ширина). */
@@ -76,12 +77,19 @@ export function Select({
   const labelId = useId();
   const framed = label !== undefined;
 
+  // В слое формы `required` — ТОЛЬКО звёздочка при подписи: в Radix он включает скрытый
+  // `<select required>` (1×1 px, `aria-hidden`), и внутри `<form>` браузер молча отказывается
+  // отправлять форму, пока значение пусто. Обработчик submit при этом не вызывается — приложение
+  // не показывает ни своей ошибки, ни подсказки браузера (её некуда прицепить: контрол невидим).
+  // Обязательность в слое формы проверяет само приложение (`isFieldMissing` + «Обязательное поле»),
+  // поэтому в Radix не передаём, а доступность закрываем `aria-required` на триггере.
   const control = (
-    <RS.Root value={value} onValueChange={onValueChange} disabled={disabled} required={required}
-      name={name} onOpenChange={setOpen}>
+    <RS.Root value={value} onValueChange={onValueChange} disabled={disabled}
+      required={framed ? undefined : required} name={name} onOpenChange={setOpen}>
       <RS.Trigger className={`${framed ? FRAMED_TRIGGER : TRIGGER} ${className}`}
         aria-label={framed ? undefined : aria['aria-label']}
         aria-labelledby={framed ? labelId : undefined}
+        aria-required={framed && required ? true : undefined}
         onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}>
         {/* min-w-0 + truncate: длинное выбранное значение обрезается многоточием, а не переносится
             на вторую строку, распирая триггер фиксированной высоты. */}

--- a/src/client/src/shared/ui/Select.tsx
+++ b/src/client/src/shared/ui/Select.tsx
@@ -1,12 +1,29 @@
 import * as RS from '@radix-ui/react-select';
 import { Check, ChevronDown } from 'lucide-react';
-import { forwardRef, type ReactNode } from 'react';
+import { forwardRef, useId, useState, type ReactNode } from 'react';
+import { OutlinedField } from './OutlinedField';
 
 /**
  * MD3-Select (issue #110, фаза 2) поверх Radix Select — замена нативному `<select>`
  * (дефект «смесь нативных и кастомных контролов» из хендоффа). Radix даёт полный
  * APG-listbox с клавиатуры (стрелки/Home/End/typeahead/Esc) — закрывает #107 F5.
- * Outlined-поле в стиле MD3, кольцо фокуса, тема light/dark через токены.
+ * Тема light/dark через токены.
+ *
+ * Два слоя (issue #565, шаг 4 — #574), и выбирает между ними наличие `label`, как у
+ * `TypePickerField`:
+ *
+ * - **слой формы** (`label` задан) — общая MD3-оболочка `OutlinedField` высотой `h-14`, подпись
+ *   всегда в вырезе рамки. Свой `<label>` в вызывающем коде НЕ пишем: пока подпись жила снаружи,
+ *   у семи площадок набралось четыре разные типографики (`text-xs/fg2`, `text-sm/fg1`,
+ *   `text-sm/fg2`, `text-xs/fg3`) — при том, что соседние `TextField` в тех же формах уже носили
+ *   подпись в вырезе. Связываем через `aria-labelledby`, а не `<label for>`: у кнопки-триггера
+ *   щелчок по подписи открывал бы список;
+ * - **слой обвязки** (`label` нет) — компактный триггер `h-9` со своей рамкой для шапок, фильтров
+ *   и ячеек таблиц, там и живёт плотность.
+ *
+ * Метка в слое формы поднята ПОСТОЯННО (`raise="always"`): у кнопки-триггера нет состояния «пусто»
+ * в смысле CSS — `:placeholder-shown` есть только у `input`, поэтому всплывание по peer-селекторам,
+ * как в `TextField`, здесь неосуществимо. Фокус по той же причине приходит пропом.
  *
  * ВНИМАНИЕ: Radix запрещает пустую строку как value у Item. Для «пусто/все» используйте
  * placeholder (не передавайте value) либо отдельный Item с непустым sentinel-значением.
@@ -23,6 +40,16 @@ export interface SelectProps {
   className?: string;
   /** Доступная подпись, если рядом нет <label>. */
   'aria-label'?: string;
+  /** Подпись поля. Задана — контрол переходит в слой формы (outlined-рамка с вырезом). */
+  label?: string;
+  /** Красная рамка без сообщения (сообщение рисует вызывающий код). Только в слое формы. */
+  invalid?: boolean;
+  /** Сообщение об ошибке под полем; заодно красит рамку. Только в слое формы. */
+  error?: string;
+  /** Вспомогательный текст под полем. Только в слое формы. */
+  hint?: string;
+  /** Классы внешней обёртки поля (ширина, `col-span`). Только в слое формы. */
+  containerClassName?: string;
   children: ReactNode;
 }
 
@@ -32,12 +59,30 @@ const TRIGGER =
   'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand data-[state=open]:ring-2 ' +
   'data-[state=open]:ring-brand disabled:opacity-50 disabled:pointer-events-none';
 
+// В слое формы рамку рисует оболочка — триггер внутри неё прозрачный и без своей границы, иначе
+// вышла бы рамка в рамке, а непрозрачный фон затёр бы вырез на не-surface подложке (та же ловушка,
+// что у пикера типа). Кольцо фокуса там тоже лишнее: фокус показывает сама оболочка.
+const FRAMED_TRIGGER =
+  'inline-flex items-center justify-between gap-2 w-full h-14 px-4 rounded-md bg-transparent ' +
+  'text-sm text-fg1 data-[placeholder]:text-fg4 outline-none ' +
+  'disabled:opacity-50 disabled:pointer-events-none';
+
 export function Select({
-  value, onValueChange, placeholder, disabled, required, name, className = '', children, ...aria
+  value, onValueChange, placeholder, disabled, required, name, className = '',
+  label, invalid, error, hint, containerClassName = '', children, ...aria
 }: SelectProps) {
-  return (
-    <RS.Root value={value} onValueChange={onValueChange} disabled={disabled} required={required} name={name}>
-      <RS.Trigger className={`${TRIGGER} ${className}`} aria-label={aria['aria-label']}>
+  const [open, setOpen] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const labelId = useId();
+  const framed = label !== undefined;
+
+  const control = (
+    <RS.Root value={value} onValueChange={onValueChange} disabled={disabled} required={required}
+      name={name} onOpenChange={setOpen}>
+      <RS.Trigger className={`${framed ? FRAMED_TRIGGER : TRIGGER} ${className}`}
+        aria-label={framed ? undefined : aria['aria-label']}
+        aria-labelledby={framed ? labelId : undefined}
+        onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}>
         {/* min-w-0 + truncate: длинное выбранное значение обрезается многоточием, а не переносится
             на вторую строку, распирая триггер фиксированной высоты. */}
         <span className="min-w-0 flex-1 truncate text-left"><RS.Value placeholder={placeholder} /></span>
@@ -52,6 +97,17 @@ export function Select({
         </RS.Content>
       </RS.Portal>
     </RS.Root>
+  );
+
+  if (!framed) return control;
+
+  // Пока список открыт, фокус живёт в нём, а не на триггере — без `open` рамка гасла бы ровно на то
+  // время, что человек выбирает значение.
+  return (
+    <OutlinedField label={label} required={required} invalid={invalid} error={error} hint={hint}
+      raise="always" focused={focused || open} labelId={labelId} containerClassName={containerClassName}>
+      {control}
+    </OutlinedField>
   );
 }
 

--- a/src/client/src/shared/ui/TextAreaField.tsx
+++ b/src/client/src/shared/ui/TextAreaField.tsx
@@ -1,0 +1,53 @@
+import { forwardRef, useId, useState, type TextareaHTMLAttributes } from 'react';
+import { OutlinedField } from './OutlinedField';
+
+/**
+ * MD3 outlined-поле для многострочного текста (issue #574) — тот же `OutlinedField`, что у
+ * `TextField`, но с `<textarea>` внутри.
+ *
+ * Заведено ради последней легаси-обёртки «подпись сверху» в редакторе реквизитов: после перевода
+ * enum-полей на `Select` в слое формы в ней оставался ровно один потребитель — текстовая область.
+ * Пока она жила, в одной форме соседствовали подпись в вырезе (строка, число, дата, перечисление)
+ * и подпись над полем (текст).
+ *
+ * Метка поднята постоянно (`raise="always"`), хотя у `<textarea>` `:placeholder-shown` работает и
+ * всплывание по peer-селекторам было бы технически возможно: в режиме `auto` метка покоится по
+ * ЦЕНТРУ поля, а у области в три строки центр — это середина текста. Фокус поэтому приходит пропом,
+ * как у даты и пикеров.
+ */
+export interface TextAreaFieldProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label: string;
+  error?: string;
+  /** Красная рамка без сообщения (сообщение об ошибке рисует вызывающий код). */
+  invalid?: boolean;
+  /** Вспомогательный текст под полем — скрывается при наличии error. */
+  hint?: string;
+  containerClassName?: string;
+}
+
+export const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(function TextAreaField(
+  { label, error, invalid, hint, className = '', containerClassName = '', id, required, rows = 3,
+    onFocus, onBlur, ...rest },
+  ref,
+) {
+  const [focused, setFocused] = useState(false);
+  const autoId = useId();
+  const areaId = id ?? autoId;
+
+  return (
+    <OutlinedField
+      label={label} required={required} invalid={invalid} error={error} hint={hint}
+      raise="always" focused={focused} htmlFor={areaId} containerClassName={containerClassName}
+    >
+      <textarea
+        ref={ref} id={areaId} required={required} rows={rows}
+        // pt-4: верхняя строка текста не должна наезжать на метку, сидящую в вырезе рамки.
+        className={`block w-full rounded-md bg-transparent px-4 pt-4 pb-2 text-sm text-fg1 ` +
+          `outline-none disabled:opacity-50 ${className}`}
+        onFocus={e => { setFocused(true); onFocus?.(e); }}
+        onBlur={e => { setFocused(false); onBlur?.(e); }}
+        {...rest}
+      />
+    </OutlinedField>
+  );
+});

--- a/src/client/src/shared/ui/TextAreaField.tsx
+++ b/src/client/src/shared/ui/TextAreaField.tsx
@@ -41,8 +41,12 @@ export const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldProps>
     >
       <textarea
         ref={ref} id={areaId} required={required} rows={rows}
-        // pt-4: верхняя строка текста не должна наезжать на метку, сидящую в вырезе рамки.
-        className={`block w-full rounded-md bg-transparent px-4 pt-4 pb-2 text-sm text-fg1 ` +
+        // Отступ под метку — ВНЕШНИЙ (`mt-4`), а не верхний padding. `<textarea>` обрезает
+        // содержимое по padding-box, поэтому при прокрутке строки проезжают сквозь верхний padding
+        // и перечёркивают метку, сидящую в вырезе рамки (видно на «Домены для тиров поиска», где
+        // строк больше двенадцати). С внешним отступом прокручиваемая область начинается ниже
+        // метки, и наехать на неё нечему.
+        className={`block w-full rounded-md bg-transparent mt-4 px-4 pb-2 text-sm text-fg1 ` +
           `outline-none disabled:opacity-50 ${className}`}
         onFocus={e => { setFocused(true); onFocus?.(e); }}
         onBlur={e => { setFocused(false); onBlur?.(e); }}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.59.6</Version>
+    <Version>0.60.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.60.0</Version>
+    <Version>0.60.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #574 — шаг 4 (последний) эпика #565.

## Что сделано

`Select` получил те же два слоя, что уже носит `TypePickerField`:

* **слой формы** (задан `label`) — оболочка `OutlinedField`, высота `h-14`, подпись в вырезе рамки, свой `<label>` в вызывающем коде не нужен;
* **слой обвязки** (без `label`) — прежний компактный триггер `h-9` со своей рамкой.

Метка в слое формы поднята постоянно (`raise="always"`): `:placeholder-shown` есть только у `input`, а у кнопки-триггера состояния «пусто» в смысле CSS не существует — всплывание по peer-селекторам, как в `TextField`, здесь неосуществимо. Фокус по той же причине приходит пропом, причём как `focused || open`: пока список открыт, фокус живёт в нём, и без `open` рамка гасла бы ровно на то время, что человек выбирает значение.

Триггер в слое формы прозрачный и без своей границы — рамка в рамке и затёртый вырез на не-surface подложке это та же ловушка, что ловили у пикера (отмечена в теле issue).

### Переведённые площадки (7)

| Где | Поле |
|---|---|
| Реквизиты документа | перечисление (`PrimitiveInput`) |
| Диалог PDF-источника | «Профиль распознавания» |
| Диалог источника набора | «Данные набора», «Лист», «Файл в архиве» |
| Решение по расхождению | «Решение» |
| Новый пользователь | «Роль» |
| Настройки интеграций | «Модель» |
| Редактор сверки | два «Источник N» |

Их подписи жили в **четырёх** разных типографиках — `text-xs/fg2`, `text-sm/fg1`, `text-sm/fg2`, `text-xs/fg3` — при том, что соседние `TextField` в тех же формах уже носили подпись в вырезе.

### `TextAreaField`

После ухода enum у легаси-обёртки «подпись сверху» в `PrimitiveInput` оставался ровно один потребитель — текстовая область. Пока она жила, в одной форме соседствовали подпись в вырезе (строка, число, дата, перечисление) и подпись над полем (текст) — то есть разнобой не исчезал, а переселялся внутрь одного экрана. Отсюда `TextAreaField` на той же оболочке.

Метка у него тоже поднята постоянно, хотя у `<textarea>` `:placeholder-shown` работает: в режиме `auto` метка покоится по ЦЕНТРУ поля, а у области в три строки центр — это середина текста.

Ушли легаси-обёртки: `PrimitiveInput` (та самая `:57` из issue), `Field` в настройках интеграций, семь `<label>` на переведённых площадках.

### Что осознанно НЕ тронуто

* **Слой обвязки** — «Область связи», «Прогон», «Комплект для отчёта», роль в ячейке таблицы, перенос в группу, оператор и вид допуска внутри фразы: `h-8`/`h-9` без подписи, как и предписывает правило раздела.
* **Поля, привязанные к источнику данных** в реквизитах: там контрол read-only, а серый фон и подпись сверху вместе с бейджем работают признаком «значение приходит из набора». Перевод на прозрачную оболочку этот признак стёр бы — отдельный вопрос, не про `Select`.
* **Контейнерные поля** (составное, массив, ссылка на документ, изображение, файл) — их эпик не трогал ни на одном шаге.
* `EmailSendDialog` / `SendMessageDialog` — там подписи стоят над полями со СОДЕРЖАТЕЛЬНЫМИ плейсхолдерами-примерами («Через запятую: client@…»), а механика выреза требует `placeholder=" "`. Отдельная задача, если понадобится.

## Проверка

`npx tsc -b` чисто, 303 фронтовых теста зелёные.

На живом приложении (admin@bhs.local): реквизиты АОСР (текст) и кабельного журнала (перечисление), форма документа качества, диалог нового пользователя, настройки интеграций, диалог источника, редактор сверки.

Замеры на поле «Форма кабельного журнала»:

* в фокусе — рамка `rgb(29,95,176) / 2px`, метка того же цвета, вырез раскрыт (`max-width: 100%`), фон триггера `rgba(0,0,0,0)`;
* без фокуса — `rgb(116,119,127) / 1px`;
* Enter открывает список (8 пунктов), Esc возвращает фокус на триггер;
* тёмная тема — по токенам, проверена на форме документа качества.

В редакторе сверки состав контролов подтверждён по DOM: «Комплект для отчёта» 36px (обвязка), два «Источник 1» 56px (форма), «Оператор» и «Вид допуска» 36px (обвязка).

## Замеченное попутно, НЕ правил

В диалоге источника PDF поле «Данные набора» выглядит пустым, хотя значение есть: `sheetOrPath` инициализируется row-selector'ом по умолчанию, которого нет среди пунктов, и Radix рисует пустоту вместо плейсхолдера. Проверено сравнением с master (`git stash`) — поведение то же самое до правки, не регресс этого PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)