### PR TITLE
Загрузчик строк набора: инжектируемый IDataSetRowLoader вместо статического DataSetBindingProcessor

### DIFF
--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -330,6 +330,7 @@ builder.Services.AddSingleton<IDataSetParser, JsonDataSetParser>();
 builder.Services.AddSingleton<IDataSetParser, ZipDataSetParser>();
 builder.Services.AddSingleton<IDataSetParser, PdfDataSetParser>();
 builder.Services.AddSingleton<DataSetParserFactory>();
+builder.Services.AddScoped<IDataSetRowLoader, DataSetRowLoader>();
 builder.Services.AddScoped<DataSetProcessingTemplateService>();
 builder.Services.AddScoped<DataSetBindingTemplateService>();
 builder.Services.AddScoped<DataSetPdfRecognitionService>();

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetRowLoader.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetRowLoader.cs
@@ -1,0 +1,15 @@
+using BHS.CRG.Domain.DataSets;
+
+namespace BHS.CRG.Application.DataSets;
+
+/// <summary>
+/// Единая точка извлечения строк источника: extraction → computed columns (transformation) →
+/// row filter → sort. Через неё смотрят на данные генерация, превью, экспорт, материализация,
+/// MCP-срез и сверка — расширение способа извлечения (новый вид источника) делается здесь один раз.
+/// </summary>
+public interface IDataSetRowLoader
+{
+    /// <summary>Требует source.File загруженным (.Include) заранее у вызывающего кода.</summary>
+    Task<List<IReadOnlyDictionary<string, string?>>> LoadRowsAsync(
+        DataSetSource source, CancellationToken ct);
+}

--- a/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
@@ -21,7 +21,7 @@ public class DataSetSource : Entity
     /// <summary>
     /// JSON-массив полных распознанных строк (только для PDF — распознавание через vision-LLM
     /// дорого/недетерминированно, в отличие от остальных форматов не перепарсивается на каждый
-    /// вызов). Null — ещё не распознавали. См. DataSetBindingProcessor.LoadRowsAsync.
+    /// вызов). Null — ещё не распознавали. См. DataSetRowLoader.LoadRowsAsync.
     /// </summary>
     public string? CachedData { get; private set; }
     /// <summary>JSON-массив кодов функциональных тэгов источника (scope Dataset — TagRegistry).</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Infrastructure.Persistence;
@@ -14,8 +13,7 @@ namespace BHS.CRG.Infrastructure.DataSets;
 /// </summary>
 public class DataSetBindingService(
     AppDbContext db,
-    IBlobStorage blob,
-    DataSetParserFactory parserFactory,
+    IDataSetRowLoader rowLoader,
     ILogger<DataSetBindingService> logger)
 {
     public async Task<IReadOnlyList<DataSetBindingDto>> ListBindingsAsync(Guid ownerId, CancellationToken ct)
@@ -77,7 +75,7 @@ public class DataSetBindingService(
         {
             try
             {
-                var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, binding.Source, ct);
+                var rows = await rowLoader.LoadRowsAsync(binding.Source, ct);
 
                 // Материализованный источник (issue #19/#23): привязка без своего маппинга берёт маппинг
                 // с источника — как и резолвер генерации. Иначе превью пустое и материалы/сертификаты не

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetRowLoader.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetRowLoader.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.DataSets;
 using BHS.CRG.Domain.DataSets;
 
 namespace BHS.CRG.Infrastructure.DataSets;
@@ -16,11 +17,11 @@ namespace BHS.CRG.Infrastructure.DataSets;
 /// поэтому читает уже распознанные и закэшированные строки (DataSetSource.CachedData), не
 /// перезапускает распознавание — см. DataSetService.RecognizePdfSourceAsync.
 /// </summary>
-public static class DataSetBindingProcessor
+public class DataSetRowLoader(
+    IBlobStorage blob,
+    DataSetParserFactory parserFactory) : IDataSetRowLoader
 {
-    public static async Task<List<IReadOnlyDictionary<string, string?>>> LoadRowsAsync(
-        IBlobStorage blob,
-        DataSetParserFactory parserFactory,
+    public async Task<List<IReadOnlyDictionary<string, string?>>> LoadRowsAsync(
         DataSetSource source,
         CancellationToken ct)
     {

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -21,6 +21,7 @@ public class DataSetSourceService(
     AppDbContext db,
     IBlobStorage blob,
     DataSetParserFactory parserFactory,
+    IDataSetRowLoader rowLoader,
     IRecognitionProfileProvider profiles)
 {
     private record CachedColumnInfo(string Name, string[] SampleValues);
@@ -156,7 +157,7 @@ public class DataSetSourceService(
             .FirstOrDefaultAsync(s => s.Id == sourceId, ct);
         if (source == null) return null;
 
-        var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
+        var rows = await rowLoader.LoadRowsAsync(source, ct);
 
         var take = maxRows <= 0 ? 50 : maxRows;
         // Базовые колонки — из уже сохранённого кэша схемы (тот же парсер заполнил его при
@@ -180,7 +181,7 @@ public class DataSetSourceService(
         if (source == null) return null;
 
         // Все строки после обработки (Filter/Transformation/Sort) — тот же путь, что и превью, без лимита.
-        var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
+        var rows = await rowLoader.LoadRowsAsync(source, ct);
         var baseColumns = JsonSerializer.Deserialize<CachedColumnInfo[]>(source.CachedSchema, CachedSchemaJson) ?? [];
         var columns = baseColumns.Select(c => c.Name).ToList();
         columns.AddRange(rows.SelectMany(r => r.Keys).Distinct().Except(columns));
@@ -236,7 +237,7 @@ public class DataSetSourceService(
 
         try
         {
-            var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
+            var rows = await rowLoader.LoadRowsAsync(source, ct);
             var take = maxRows <= 0 ? 50 : maxRows;
 
             var mapped = new List<Dictionary<string, object?>>();

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSnapshotService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSnapshotService.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using BHS.CRG.Application.Common;
+using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.DataSnapshots;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Infrastructure.Persistence;
@@ -10,8 +10,7 @@ namespace BHS.CRG.Infrastructure.DataSets;
 /// <inheritdoc />
 public class DataSnapshotService(
     AppDbContext db,
-    IBlobStorage blob,
-    DataSetParserFactory parserFactory) : IDataSnapshotService
+    IDataSetRowLoader rowLoader) : IDataSnapshotService
 {
     private static readonly JsonSerializerOptions SchemaJson = new() { PropertyNameCaseInsensitive = true };
 
@@ -85,7 +84,7 @@ public class DataSnapshotService(
 
         // Строки ПОСЛЕ всей обработки источника (фильтр/вычисляемые колонки/сортировка) — тот же путь,
         // которым их видит генерация, поэтому внешний анализ и генерация смотрят на одни данные.
-        var all = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
+        var all = await rowLoader.LoadRowsAsync(source, ct);
         var page = all.Skip(offset).Take(limit).ToList();
 
         // Ключи колонок берём из СХЕМЫ, а не из первой строки: строка может не содержать пустых ячеек,

--- a/src/server/BHS.CRG.Infrastructure/DataSets/PdfDataSetParser.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/PdfDataSetParser.cs
@@ -9,7 +9,7 @@ namespace BHS.CRG.Infrastructure.DataSets;
 /// небыстро, недетерминированно. Поэтому источники создаются вручную (без авто-детекта, как и
 /// для XML), а реальные данные не идут через <see cref="ParseAsync"/> — распознавание запускается
 /// явным действием пользователя, результат кэшируется на DataSetSource.CachedData и оттуда же
-/// читается пайплайном (см. DataSetBindingProcessor.LoadRowsAsync), минуя повторный парсинг.
+/// читается пайплайном (см. DataSetRowLoader.LoadRowsAsync), минуя повторный парсинг.
 /// </summary>
 public class PdfDataSetParser : IDataSetParser
 {

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Generation;
 using BHS.CRG.Application.Resolution;
@@ -15,8 +14,7 @@ namespace BHS.CRG.Infrastructure.Generation;
 
 public class DataSetResolver(
     AppDbContext db,
-    IBlobStorage blobStorage,
-    DataSetParserFactory parserFactory,
+    IDataSetRowLoader rowLoader,
     IObjectResolver objectResolver,
     ILogger<DataSetResolver> logger
 ) : IDataSetResolver
@@ -73,8 +71,8 @@ public class DataSetResolver(
         {
             try
             {
-                // Download → parse → transformation → filter → sort (shared with preview via DataSetBindingProcessor).
-                var rows = await DataSetBindingProcessor.LoadRowsAsync(blobStorage, parserFactory, binding.Source, ct);
+                // Download → parse → transformation → filter → sort (shared with preview via DataSetRowLoader).
+                var rows = await rowLoader.LoadRowsAsync(binding.Source, ct);
 
                 // Материализация на источнике (issue #19): если источник настроен на материализацию, а
                 // привязка не несёт собственного маппинга — маппинг берётся с источника (тип↔тип), а

--- a/src/server/BHS.CRG.Infrastructure/Reconciliation/ReconciliationRunner.cs
+++ b/src/server/BHS.CRG.Infrastructure/Reconciliation/ReconciliationRunner.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using BHS.CRG.Application.Common;
+using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Reconciliation;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Domain.Reconciliation;
@@ -14,8 +14,7 @@ namespace BHS.CRG.Infrastructure.Reconciliation;
 /// <inheritdoc />
 public class ReconciliationRunner(
     AppDbContext db,
-    IBlobStorage blob,
-    DataSetParserFactory parserFactory) : IReconciliationRunner
+    IDataSetRowLoader rowLoader) : IReconciliationRunner
 {
     private static JsonSerializerOptions Json => ReconciliationSpecJson.Options;
 
@@ -112,7 +111,7 @@ public class ReconciliationRunner(
                 .FirstOrDefaultAsync(s => s.Id == part.SourceId, ct)
                 ?? throw new InvalidOperationException($"Источник {part.SourceId} не найден.");
 
-            var rows = await DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source, ct);
+            var rows = await rowLoader.LoadRowsAsync(source, ct);
 
             for (var i = 0; i < rows.Count; i++)
             {

--- a/src/server/BHS.CRG.Tests/DataSets/DataSetRowLoaderTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/DataSetRowLoaderTests.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Infrastructure.DataSets;
+
+namespace BHS.CRG.Tests.DataSets;
+
+/// <summary>
+/// Ветвление извлечения в DataSetRowLoader: обычные форматы — перепарсинг блоба на каждый вызов,
+/// PDF — только закэшированные распознанные строки (CachedData), блоб не трогается.
+/// </summary>
+public class DataSetRowLoaderTests
+{
+    /// <summary>Блоб-хранилище одного файла; считает скачивания и падает, если файла нет.</summary>
+    private sealed class FakeBlob(byte[]? content = null) : IBlobStorage
+    {
+        public int Downloads;
+        public Task<Stream> DownloadAsync(string blobPath, CancellationToken ct = default)
+        {
+            Downloads++;
+            if (content is null) throw new InvalidOperationException("Блоб недоступен — скачивания не ожидалось.");
+            return Task.FromResult<Stream>(new MemoryStream(content));
+        }
+        public Task<string> UploadAsync(string fileName, Stream s, string contentType, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task DeleteAsync(string blobPath, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task PutAsync(string blobPath, Stream s, string contentType, CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
+    private static DataSetRowLoader Loader(FakeBlob blob)
+        => new(blob, new DataSetParserFactory([new CsvDataSetParser()]));
+
+    private static DataSetSource Source(DataSetFormat format, string blobPath, string? cachedData = null)
+    {
+        var file = DataSetFile.Create("Файл", format, blobPath, CatalogScope.Set, Guid.NewGuid());
+        var source = file.AddSource("Источник", "default", "[]", 0, cachedData: cachedData);
+        // Навигацию File в домене заполняет EF; в юнит-тесте — напрямую.
+        typeof(DataSetSource).GetProperty(nameof(DataSetSource.File))!.SetValue(source, file);
+        return source;
+    }
+
+    [Fact]
+    public async Task CsvSource_ParsesBlobOnEveryCall()
+    {
+        var blob = new FakeBlob(Encoding.UTF8.GetBytes("Имя,Количество\nКабель,10\n"));
+        var source = Source(DataSetFormat.Csv, "bucket/file.csv");
+
+        var rows = await Loader(blob).LoadRowsAsync(source, default);
+
+        Assert.Single(rows);
+        Assert.Equal("Кабель", rows[0]["Имя"]);
+        Assert.Equal(1, blob.Downloads);
+    }
+
+    [Fact]
+    public async Task PdfSource_ReadsCachedData_WithoutTouchingBlob()
+    {
+        var blob = new FakeBlob(); // упадёт при любом скачивании
+        var source = Source(DataSetFormat.Pdf, "bucket/file.pdf",
+            cachedData: """[{"Колонка":"Значение"}]""");
+
+        var rows = await Loader(blob).LoadRowsAsync(source, default);
+
+        Assert.Single(rows);
+        Assert.Equal("Значение", rows[0]["Колонка"]);
+        Assert.Equal(0, blob.Downloads);
+    }
+
+    [Fact]
+    public async Task PdfSource_EmptyOrBrokenCache_YieldsNoRows()
+    {
+        var blob = new FakeBlob();
+        Assert.Empty(await Loader(blob).LoadRowsAsync(Source(DataSetFormat.Pdf, "b/p.pdf"), default));
+        Assert.Empty(await Loader(blob).LoadRowsAsync(
+            Source(DataSetFormat.Pdf, "b/p.pdf", cachedData: "не json"), default));
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.61.1</Version>
+    <Version>0.61.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #581. Часть эпика #580 (этап 1, без изменения поведения).

## Что сделано
- Статический `DataSetBindingProcessor.LoadRowsAsync(blob, parserFactory, source)` превращён в инжектируемый `IDataSetRowLoader` (интерфейс в Application/DataSets, реализация `DataSetRowLoader` в Infrastructure). Ветвление извлечения (Pdf→CachedData / блоб+парсер) и пост-обработка (computed→filter→sort) — без изменений, доккомментарий перенесён целиком.
- Своп 7 вызовов в 5 файлах: DataSetSourceService (превью/экспорт/превью материализации), DataSetBindingService, DataSetResolver, DataSnapshotService, ReconciliationRunner. У четырёх потребителей `IBlobStorage`+`DataSetParserFactory` были нужны только для LoadRows — зависимости из конструкторов сняты.
- Юнит-тесты ветвления (BHS.CRG.Tests/DataSets/DataSetRowLoaderTests.cs): CSV — перепарсинг блоба; PDF — только CachedData, блоб не трогается; пустой/битый кэш → пустой список.

## Зачем
Этап 2 эпика добавит в загрузчик ветку System-провайдеров (консолидации из данных системы) — им нужен scoped AppDbContext, который в статический класс не протащить.

## Проверка
- `dotnet build` — чисто; `dotnet test` — 863/863 (вкл. 3 новых).
- Версия 0.61.2 (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)