### PR TITLE
Системные наборы: не предлагать набор там, где консолидаций нет

### DIFF
--- a/src/client/src/features/datasets/DataSetsResource.tsx
+++ b/src/client/src/features/datasets/DataSetsResource.tsx
@@ -4,7 +4,9 @@ import { Upload, Trash2, Database, RefreshCw, Download, FileText, LayoutGrid, Ch
 import { Button, IconButton } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
-import { useCreateSystemDataSetFile, useListDataSetFiles, useUploadDataSetFile } from '@/shared/api/datasets';
+import {
+  useCreateSystemDataSetFile, useListDataSetFiles, useSystemDataCandidates, useUploadDataSetFile,
+} from '@/shared/api/datasets';
 import { useRecognitionJobs, useCancelJob, type ActiveJob } from '@/shared/api/jobs';
 import type { CatalogScope, DataSetFile } from '@/shared/api/types';
 import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
@@ -146,6 +148,8 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
   const { data: files = [], isLoading } = useListDataSetFiles(scope, scopeId);
   const upload = useUploadDataSetFile();
   const createSystem = useCreateSystemDataSetFile();
+  // Нечего консолидировать на этом уровне — системный набор здесь не предлагаем (issue #606).
+  const { data: systemCandidates = [] } = useSystemDataCandidates(scope, scopeId);
   const recogJobs = useRecognitionJobs();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
@@ -165,6 +169,7 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
   const isAll = selected === ALL;
   const selectedFile = !isAll ? files.find(f => f.id === selected) : undefined;
   const hasSystemFile = files.some(f => f.format === 'System');
+  const offerSystemFile = !hasSystemFile && systemCandidates.length > 0;
 
   // Статус набора: активная задача распознавания (targetId = file.id для ГОСТ, иначе id источника).
   const jobForFile = (f: DataSetFile) =>
@@ -220,8 +225,8 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
         {uploading ? 'Загрузка…' : 'Загрузить файл'}
       </Button>
       {/* Набор без файла: сырьё — данные самой системы. На уровень нужен один, поэтому кнопка
-          прячется, как только он появился. */}
-      {!hasSystemFile && (
+          прячется, как только он появился, и не показывается там, где консолидаций нет. */}
+      {offerSystemFile && (
         <Button variant="text" size="sm" onClick={() => { void addSystemFile(); }}
           loading={createSystem.isPending} icon={<Database size={14} />}>
           Данные системы
@@ -245,13 +250,16 @@ export function DataSetsResource({ scope, scopeId }: { scope: CatalogScope; scop
         <>
           <input ref={fileInputRef} type="file" accept={ACCEPT} className="hidden" onChange={handleFileInput} />
           <EmptyState icon={<Database size={30} />} title="Пока нет наборов данных"
-            description="Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) или перетащите его сюда — из него можно собирать источники для колонок и таблиц документов. Либо возьмите данные самой системы: например, перечень документов комплекта."
+            description={'Загрузите файл (CSV, XLSX, XML, JSON, ZIP, PDF) или перетащите его сюда — из него можно собирать источники для колонок и таблиц документов.'
+              + (offerSystemFile ? ' Либо возьмите данные самой системы: например, перечень документов комплекта.' : '')}
             action={
               <div className="flex items-center gap-2">
                 <Button variant="filled" size="sm" onClick={() => fileInputRef.current?.click()}
                   loading={uploading} icon={<Upload size={14} />}>Загрузить файл</Button>
-                <Button variant="outlined" size="sm" onClick={() => { void addSystemFile(); }}
-                  loading={createSystem.isPending} icon={<Database size={14} />}>Данные системы</Button>
+                {offerSystemFile && (
+                  <Button variant="outlined" size="sm" onClick={() => { void addSystemFile(); }}
+                    loading={createSystem.isPending} icon={<Database size={14} />}>Данные системы</Button>
+                )}
               </div>
             } />
           {uploadError && <p className="text-xs text-danger text-center mt-2">{uploadError}</p>}

--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -7,6 +7,7 @@ import { TextField } from '@/shared/ui/TextField';
 import { useCreateDataSetSource, useUpdateDataSetSource, useListZipXmlEntries, useSourceCandidates } from '@/shared/api/datasets';
 import { XPathBuilder } from './xpath/XPathBuilder';
 import { JsonPathBuilder } from './jsonpath/JsonPathBuilder';
+import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
 import type { ColumnExprDef, DataSetSource, DataSetFormat } from '@/shared/api/types';
 
 type PathFormat = 'Xml' | 'Json';
@@ -146,40 +147,50 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
 
   const dialogTitle = initial
     ? 'Редактировать источник'
-    : `Новый источник (${isZip ? 'XML в архиве' : format})`;
+    : `Новый источник (${isZip ? 'XML в архиве' : DATA_SET_FORMAT_LABELS[format]})`;
+
+  // Выбирать не из чего — сохранять нечего: кнопка «Сохранить» осталась бы активной и молча
+  // упиралась бы в ошибку валидации (issue #606).
+  const nothingToPick = picksCandidate && !initial && readyCandidates.length === 0;
 
   return (
     <Modal open onOpenChange={open => { if (!open) onClose(); }} title={dialogTitle} wide
       footer={
         <div className="flex justify-end gap-2">
           <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
-          <Button type="button" variant="filled" onClick={handleSave} loading={isPending}>
+          <Button type="button" variant="filled" onClick={handleSave} loading={isPending}
+            disabled={nothingToPick}>
             {isPending ? 'Сохранение…' : 'Сохранить'}
           </Button>
         </div>
       }>
       <div className="space-y-4 min-w-[520px]">
-        <TextField label="Название" value={name} onChange={e => setName(e.target.value)}
-          hint="Позиции спецификации" />
+        {!nothingToPick && (
+          <TextField label="Название" value={name} onChange={e => setName(e.target.value)}
+            hint="Позиции спецификации" />
+        )}
 
         {picksCandidate ? (
           <div>
-            <Select label={isSystem ? 'Данные системы' : 'Данные набора'} value={sheetOrPath || undefined} placeholder="— выберите —"
-              onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
-              {readyCandidates.map(c => (
-                <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
-              ))}
-            </Select>
-            {readyCandidates.length === 0 && (
-              <p className="text-xs text-fg4 mt-1">
+            {/* Пустой выпадающий список выглядел бы поломкой — когда выбирать не из чего,
+                показываем причину вместо самого поля (issue #606). */}
+            {readyCandidates.length === 0 ? (
+              <p className="text-sm text-fg3">
                 {isSystem
-                  ? 'Нет доступных консолидаций: либо все уже добавлены, либо на этом уровне их нет (напр. «Документы комплекта» доступны только у набора комплекта).'
+                  ? 'Система пока не может ничего консолидировать на этом уровне: либо всё уже добавлено, либо здесь таких данных нет — «Документы комплекта», например, доступны только у набора внутри комплекта.'
                   : pendingTableCount > 0
                     ? 'Все проекции набора уже добавлены. Таблицы документов сначала распознайте — кнопка «Распознать таблицу» в списке кандидатов под источниками.'
                     : candidates.length === 0
                       ? 'Нет доступных проекций. Если набор ещё не распознан — запустите «Распознать»; таблицы документов распознаются отдельно (кнопка ✂ разбиения).'
                       : 'Все проекции набора уже добавлены как источники.'}
               </p>
+            ) : (
+              <Select label={isSystem ? 'Данные системы' : 'Данные набора'} value={sheetOrPath || undefined} placeholder="— выберите —"
+                onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
+                {readyCandidates.map(c => (
+                  <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
+                ))}
+              </Select>
             )}
             {selectedCandidate && selectedCandidate.columns.length > 0 && (
               <p className="text-xs text-fg4 mt-1">Колонки: {selectedCandidate.columns.join(', ')}</p>

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -39,6 +39,19 @@ export function useUploadDataSetFile() {
   });
 }
 
+/**
+ * Что система готова консолидировать на этом уровне — ДО создания набора (issue #606).
+ * Пусто ⇒ предлагать системный набор здесь незачем: «Документы комплекта» осмысленны только
+ * внутри комплекта, и на разделе пользователь упирался бы в пустой список источников.
+ */
+export function useSystemDataCandidates(scope: CatalogScope, scopeId?: string) {
+  return useQuery<SourceCandidate[]>({
+    queryKey: ['datasets', 'system-candidates', scope, scopeId],
+    queryFn: () =>
+      apiClient.get('/datasets/system-candidates', { params: { scope, scopeId } }).then(r => r.data),
+  });
+}
+
 /** Набор без файла: сырьё — данные самой системы в границах уровня (issue #580). Идемпотентно. */
 export function useCreateSystemDataSetFile() {
   const qc = useQueryClient();

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -44,6 +44,11 @@ public static class DataSetEndpoints
         g.MapPost("/files/system", async (CreateSystemFileInput input, IDataSetService svc, CancellationToken ct) =>
             Results.Ok(await svc.CreateSystemFileAsync(input, ct)));
 
+        // Что система готова консолидировать на этом уровне — ДО создания набора (issue #606):
+        // пусто ⇒ предлагать системный набор здесь незачем.
+        g.MapGet("/system-candidates", async (string scope, Guid? scopeId, IDataSetService svc, CancellationToken ct) =>
+            Results.Ok(await svc.ListSystemCandidatesAsync(scope, scopeId, ct)));
+
         g.MapPut("/files/{id:guid}", async (Guid id, HttpRequest request, IDataSetService svc, CancellationToken ct) =>
         {
             if (!request.HasFormContentType)

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -14,6 +14,8 @@ public interface IDataSetService
     Task<DataSetFileDto> UploadFileAsync(UploadFileInput input, CancellationToken ct);
     /// <summary>Создать набор без файла — сырьём служат данные системы (issue #580). Идемпотентно на уровень.</summary>
     Task<DataSetFileDto> CreateSystemFileAsync(CreateSystemFileInput input, CancellationToken ct);
+    /// <summary>Какие консолидации данных системы возможны на уровне — до создания набора (issue #606).</summary>
+    Task<IReadOnlyList<DataSetSourceInfo>> ListSystemCandidatesAsync(string scope, Guid? scopeId, CancellationToken ct);
     Task<DataSetFileDto?> ReplaceFileAsync(Guid id, ReplaceFileInput input, CancellationToken ct);
     Task<FileDownloadDto?> DownloadFileAsync(Guid id, CancellationToken ct);
     Task<bool> DeleteFileAsync(Guid id, CancellationToken ct);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -1,4 +1,5 @@
 ﻿using BHS.CRG.Application.DataSets;
+using BHS.CRG.Domain.Catalog;
 
 namespace BHS.CRG.Infrastructure.DataSets;
 
@@ -27,6 +28,11 @@ public class DataSetService(
         files.UploadFileAsync(input, ct);
     public Task<DataSetFileDto> CreateSystemFileAsync(CreateSystemFileInput input, CancellationToken ct) =>
         files.CreateSystemFileAsync(input, ct);
+    public Task<IReadOnlyList<DataSetSourceInfo>> ListSystemCandidatesAsync(
+        string scope, Guid? scopeId, CancellationToken ct) =>
+        Enum.TryParse<CatalogScope>(scope, out var s)
+            ? sources.ListSystemCandidatesAsync(s, scopeId, ct)
+            : throw new ArgumentException("Неверный scope");
     public Task<DataSetFileDto?> ReplaceFileAsync(Guid id, ReplaceFileInput input, CancellationToken ct) =>
         files.ReplaceFileAsync(id, input, ct);
     public Task<FileDownloadDto?> DownloadFileAsync(Guid id, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -4,6 +4,7 @@ using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Recognition;
 using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Domain.Objects;
 using BHS.CRG.Infrastructure.Persistence;
@@ -41,6 +42,21 @@ public class DataSetSourceService(
                 .GroupBy(b => b.SourceId)
                 .ToDictionaryAsync(g => g.Key, g => g.Count(), ct);
         return sources.Select(s => DataSetDtoMapper.MapSource(s, bindingCounts.GetValueOrDefault(s.Id))).ToList();
+    }
+
+    /// <summary>
+    /// Какие консолидации данных системы возможны на уровне — ДО создания набора (issue #606).
+    /// Нужно, чтобы не предлагать системный набор там, где предложить нечего: «Документы комплекта»
+    /// осмысленны только внутри комплекта, и на уровне раздела пользователь иначе упирался бы в
+    /// пустой список источников.
+    /// </summary>
+    public async Task<IReadOnlyList<DataSetSourceInfo>> ListSystemCandidatesAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct)
+    {
+        var candidates = new List<DataSetSourceInfo>();
+        foreach (var provider in systemProviders.All)
+            candidates.AddRange(await provider.GetCandidatesAsync(scope, scopeId, ct));
+        return candidates;
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Tests/Integration/SystemDataSetTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/SystemDataSetTests.cs
@@ -217,4 +217,27 @@ public class SystemDataSetTests(IntegrationTestFixture fixture) : IAsyncLifetime
         var file = await svc.CreateSystemFileAsync(new CreateSystemFileInput("System", null, null), default);
         Assert.Empty(await svc.DetectSourceCandidatesAsync(file.Id, default));
     }
+
+    /// <summary>
+    /// Что система готова консолидировать на уровне — известно ДО создания набора (issue #606).
+    /// Без этого интерфейс предлагал набор на разделе, где выбирать потом нечего.
+    /// </summary>
+    [Fact]
+    public async Task SystemCandidates_KnownBeforeFileExists()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var (setId, _, _, _) = await SeedSetAsync(scope);
+
+        var inSet = await svc.ListSystemCandidatesAsync("Set", setId, default);
+        Assert.Equal(SystemDataSets.SetDocumentsMarker, Assert.Single(inSet).SheetOrPath);
+
+        // Раздел/стройка/система: консолидировать нечего — кнопку показывать незачем.
+        Assert.Empty(await svc.ListSystemCandidatesAsync("Section", Guid.NewGuid(), default));
+        Assert.Empty(await svc.ListSystemCandidatesAsync("Construction", Guid.NewGuid(), default));
+        Assert.Empty(await svc.ListSystemCandidatesAsync("System", null, default));
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => svc.ListSystemCandidatesAsync("Ерунда", null, default));
+    }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.62.1</Version>
+    <Version>0.62.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #606. Продолжение эпика #580 по вашему замечанию с экрана раздела.

## Проблема

Кнопка «Данные системы» показывалась на любом уровне, а единственная сегодняшняя консолидация — «Документы комплекта» — по смыслу существует только внутри комплекта. На разделе пользователь создавал набор, открывал «Добавить источник» и упирался в **пустой выпадающий список**: выбрать нечего, «Сохранить» ни к чему не приводит. Тупик, созданный интерфейсом.

## Решение

- `GET /api/datasets/system-candidates?scope=&scopeId=` — что система готова консолидировать на уровне, **до** создания набора. Кнопка показывается только при непустом ответе. Механизм остаётся расширяемым: появится провайдер уровня стройки — кнопка возникнет там сама, без правок клиента.
- Диалог источника: заголовок «Новый источник (Данные системы)» вместо технического «(System)».
- Когда выбирать не из чего — вместо пустого поля показывается причина, «Сохранить» заблокирована, поле имени скрыто (заполнять его было не для чего). Это же чинит и старый PDF-случай, где пустой список выглядел поломкой.

## Проверка

`dotnet test` — 874/874 (новый тест: кандидаты известны до создания набора, пусто на Section/Construction/System, неверный scope → 400). `npx tsc -b`, `npm test` (303) — чисто.

Живой стенд: в комплекте ОВиК-1 кнопка на месте и диалог даёт выбрать «Документы комплекта»; на разделе ОВиК и на стройке ДНС ЕЦДМ кнопки больше нет; для набора, оставшегося на разделе, диалог объясняет причину и блокирует сохранение. Ошибок в консоли нет, проверочные наборы удалены.

Версия 0.62.2 (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)