### PR TITLE
Схемы: предупреждать, что правка полей-идентификаторов осиротит связки (#584)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -26,7 +26,10 @@ import {
   useSetDocumentTypeAbstract,
   useSetDocumentTypeAllowsProxy,
   useSetDocumentTypeGroup,
+  useIdentityImpact,
+  type IdentityImpact,
 } from '@/shared/api/documentTypes';
+import { ruCount, ruPlural } from '@/shared/utils/pluralize';
 import { GroupPicker } from './TypeGroupAccordion';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
@@ -459,6 +462,11 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
   const migrateKey = useMigrateFieldKey(docType.id);
   const schemaToast = useToast();
   const [pendingMigration, setPendingMigration] = useState<{ from: string; to: string }[] | null>(null);
+  // Гейт правки полей-идентификаторов (issue #584): держим решение пользователя как промис, потому
+  // что спрашивать надо ВНУТРИ save() — до записи схемы, а не после, когда связки уже осиротели.
+  const identityImpact = useIdentityImpact();
+  const [identityGate, setIdentityGate] = useState<
+    { impact: IdentityImpact; decide: (proceed: boolean) => void } | null>(null);
 
   const compositeTypes = allDocTypes.filter(dt => dt.kind === 'Composite');
   const parentType = docType.parentId ? allDocTypes.find(dt => dt.id === docType.parentId) ?? null : null;
@@ -517,8 +525,28 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
     const crossDup = definedFnNames.find(n => foreignFnNames.has(n));
     if (crossDup) { const m = `Имя функции "${crossDup}" уже используется в другом типе`; setError(m); throw new Error(m); }
 
+    const schemaJson = schemaToJson(fields, excludedFields, fieldOverrides, groups, typstRenders, docTypeTags, ungroupedOrder, help);
+
+    // Правка полей-идентификаторов осиротит связки «материал → документ качества» (issue #584):
+    // ключ составной, и добавление поля, снятие тэга или перенумерация меняют ключи ВСЕХ материалов
+    // разом. Молча этого делать нельзя — документ выпустился бы без сертификатов при здоровом виде
+    // в UI. Отказ сервера считать последствия сохранение не блокирует: предупреждение — не гейт
+    // целостности, а помощь, и ронять из-за него правку схемы неправильно.
     try {
-      await mutation.mutateAsync({ id: docType.id, schema: schemaToJson(fields, excludedFields, fieldOverrides, groups, typstRenders, docTypeTags, ungroupedOrder, help) });
+      const impact = await identityImpact.mutateAsync({ id: docType.id, schema: schemaJson });
+      if (impact.changed && impact.affectedLinks > 0) {
+        const proceed = await new Promise<boolean>(decide => setIdentityGate({ impact, decide }));
+        if (!proceed) {
+          const m = 'Сохранение отменено: правка полей-идентификаторов не подтверждена';
+          setError(m); throw new Error(m);
+        }
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.startsWith('Сохранение отменено')) throw err;
+    }
+
+    try {
+      await mutation.mutateAsync({ id: docType.id, schema: schemaJson });
       setDirty(false);
       // Проверка сборки блоков после сохранения (issue #309, фаза 2) — не блокирует save.
       if (typstRenders.length > 0) void blocksCheck.run(typstRenders);
@@ -715,6 +743,38 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
       )}
 
       {!showJson && error && <p className="text-xs text-danger pt-1">{error}</p>}
+
+      {/* Гейт правки полей-идентификаторов (issue #584): показываем, во что превратится ключ и
+          сколько связок перестанут находиться. Отмена диалога = отказ, поэтому решение отдаём в
+          decide и в onOpenChange тоже. */}
+      <ConfirmDialog
+        open={!!identityGate}
+        onOpenChange={o => { if (!o) { identityGate?.decide(false); setIdentityGate(null); } }}
+        title="Изменение полей-идентификаторов осиротит связки"
+        errorTitle="Изменение полей-идентификаторов осиротит связки"
+        description={identityGate && (
+          <div className="space-y-2">
+            <p>
+              Ключ материала склеивается из всех полей с тэгом «Идентификатор». После сохранения он
+              станет другим у ВСЕХ материалов, и{' '}
+              <b>{ruCount(identityGate.impact.affectedLinks, 'связка', 'связки', 'связок')}</b>{' '}
+              «материал → документ качества»{' '}
+              {ruPlural(identityGate.impact.affectedLinks, 'перестанет', 'перестанут', 'перестанут')}{' '}
+              находиться. Сертификаты просто не попадут в документ — ошибки при этом не будет.
+            </p>
+            <div className="text-xs font-mono text-fg3 space-y-0.5">
+              <p>было: {identityGate.impact.before.join(' | ') || '—'}</p>
+              <p>станет: {identityGate.impact.after.join(' | ') || '—'}</p>
+            </div>
+            <p className="text-xs text-fg4">
+              Связки придётся завести заново — на вкладке «Документы качества» в документе.
+            </p>
+          </div>
+        )}
+        confirmLabel="Сохранить схему"
+        requireCheckbox="Понимаю, что связки материалов перестанут находиться"
+        onConfirm={() => { identityGate?.decide(true); setIdentityGate(null); }}
+      />
 
       {/* Предложение миграции данных при переименовании ключа сохранённого поля (issue #357). */}
       <ConfirmDialog

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -148,6 +148,30 @@ export function useDeleteDocumentType() {
   });
 }
 
+/**
+ * Что случится с картой привязок, если сохранить черновик схемы (issue #584): изменится ли составной
+ * ключ идентичности и сколько связок «материал → документ качества» это осиротит.
+ *
+ * Считает сервер — он же строит ключ на генерации. Спрашивать клиента значило бы предупреждать по
+ * одному правилу, а ломать по другому.
+ */
+export interface IdentityImpact {
+  changed: boolean;
+  /** Компоненты ключа сейчас — в порядке склейки. */
+  before: string[];
+  /** Компоненты ключа после сохранения. */
+  after: string[];
+  /** Сколько связок перестанут находиться (либо все, либо ни одной — ключ у материалов общий). */
+  affectedLinks: number;
+}
+
+export function useIdentityImpact() {
+  return useMutation({
+    mutationFn: ({ id, schema }: { id: string; schema: string }) =>
+      apiClient.post<IdentityImpact>(`/document-types/${id}/identity-impact`, { schema }).then(r => r.data),
+  });
+}
+
 export function useUpdateDocumentTypeSchema() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.QualityDocs;
 using BHS.CRG.Domain.Documents;
 using MediatR;
 
@@ -56,6 +57,12 @@ public static class DocumentTypeEndpoints
             try { return Results.Ok(await m.Send(new UpdateDocumentTypeSchemaCommand(id, JsonDocument.Parse(req.Schema)))); }
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
+
+        // Последствия правки полей-идентификаторов (issue #584): изменится ли составной ключ и
+        // сколько связок «материал → документ качества» это осиротит. Не мутирует — предпросчёт по
+        // черновику схемы, тот же, что уйдёт в PUT /schema.
+        admin.MapPost("/{id:guid}/identity-impact", async (Guid id, UpdateSchemaRequest req, IMediator m)
+            => Results.Ok(await m.Send(new IdentityImpactQuery(id, JsonDocument.Parse(req.Schema)))));
 
         // Проверка сборки Typst-блоков (issue #309, фаза 2): глобально по всем типам, с draft-overlay
         // редактируемого типа (тело = его несохранённый массив typstRenders). Ловит циклы/дубликаты

--- a/src/server/BHS.CRG.Application/QualityDocs/IdentityImpact.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/IdentityImpact.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+
+namespace BHS.CRG.Application.QualityDocs;
+
+/// <summary>
+/// Что случится с картой привязок, если сохранить черновик схемы (issue #584).
+/// </summary>
+/// <param name="Changed">Меняется ли набор или порядок компонентов ключа идентичности.</param>
+/// <param name="Before">Компоненты ключа сейчас — в порядке склейки.</param>
+/// <param name="After">Компоненты ключа после сохранения — в порядке склейки.</param>
+/// <param name="AffectedLinks">Сколько существующих связок «материал → документ качества» перестанут
+/// находиться. Либо ВСЕ, либо ни одной: ключ общий для всех материалов, и меняется он целиком.</param>
+public record IdentityImpact(
+    bool Changed, IReadOnlyList<string> Before, IReadOnlyList<string> After, int AffectedLinks);
+
+/// <summary>
+/// Предпросчёт последствий правки полей-идентификаторов (issue #584).
+///
+/// Составной ключ (#582) склеивается из ВСЕХ полей с тэгом «Идентификатор» по всем типам материала,
+/// поэтому добавление поля, снятие тэга или перенумерация меняют ключи всех материалов РАЗОМ —
+/// заведённые связки перестают находиться, и происходит это молча: документ выпускается без
+/// сертификатов, а в UI ошибки нет.
+///
+/// Риск не гипотетический: поле «Производитель» несёт тэг и сейчас пусто во всех 151 строке реестра —
+/// как только распознавание начнёт его заполнять, ключи изменятся сами собой.
+///
+/// Считает СЕРВЕР, а не клиент: ключ строит сервер, и вопрос «изменится ли он» должен решаться там
+/// же, иначе предупреждение разошлось бы с последствием.
+/// </summary>
+public record IdentityImpactQuery(Guid TypeId, JsonDocument DraftSchema) : IRequest<IdentityImpact>;
+
+public class IdentityImpactHandler(
+    IRepository<DocumentType> typeRepo,
+    IRepository<MaterialQualityLink> linkRepo
+) : IRequestHandler<IdentityImpactQuery, IdentityImpact>
+{
+    public async Task<IdentityImpact> Handle(IdentityImpactQuery q, CancellationToken ct)
+    {
+        var types = await typeRepo.GetAllAsync(ct);
+        var before = MaterialIdentity.KeysOf(types);
+        // Черновик накладываем КОПИЕЙ типа: у загруженной сущности схему менять нельзя — она
+        // отслеживаемая, и чужой SaveChanges записал бы несохранённый черновик в базу.
+        var after = MaterialIdentity.KeysOf(
+            [.. types.Select(t => t.Id == q.TypeId ? t.WithSchema(q.DraftSchema) : t)]);
+
+        if (before.SequenceEqual(after)) return new(false, before, after, 0);
+
+        // Осиротеют ВСЕ связки, а не только относящиеся к правимому типу: ключ у материалов общий.
+        var links = await linkRepo.GetAllAsync(ct);
+        return new(true, before, after, links.Count);
+    }
+}

--- a/src/server/BHS.CRG.Domain/Documents/DocumentType.cs
+++ b/src/server/BHS.CRG.Domain/Documents/DocumentType.cs
@@ -46,6 +46,21 @@ public class DocumentType : Entity
         };
 
     public void UpdateSchema(JsonDocument schema) { Schema = schema; TouchUpdatedAt(); }
+
+    /// <summary>
+    /// Копия типа с ДРУГОЙ схемой — не сущность БД, а проекция «что будет, если сохранить»
+    /// (issue #584). Идентификатор и родитель сохраняются: расчёты, зависящие от схемы, идут по
+    /// цепочке наследования и по составу типов, поэтому подменять их нельзя.
+    ///
+    /// Нужна потому, что менять схему у загруженной сущности ради предпросчёта опасно: это
+    /// отслеживаемый объект, и чужой SaveChanges в том же запросе записал бы черновик в базу.
+    /// </summary>
+    public DocumentType WithSchema(JsonDocument schema)
+    {
+        var copy = (DocumentType)MemberwiseClone();
+        copy.Schema = schema;
+        return copy;
+    }
     public void Rename(string name, string code) { Name = name; Code = code; TouchUpdatedAt(); }
     public void SetParent(Guid? parentId) { ParentId = parentId; TouchUpdatedAt(); }
     public void UpdatePluginBindings(JsonDocument bindings) { PluginBindings = bindings; TouchUpdatedAt(); }

--- a/src/server/BHS.CRG.Tests/QualityDocs/IdentityImpactHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/QualityDocs/IdentityImpactHandlerTests.cs
@@ -1,0 +1,125 @@
+using System.Linq.Expressions;
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.QualityDocs;
+
+/// <summary>
+/// Предупреждение о правке полей-идентификаторов (issue #584): изменение состава ИЛИ порядка
+/// компонентов ключа осиротит все заведённые связки разом, и молча — документ выпустится без
+/// сертификатов, а ошибки в UI не будет.
+/// </summary>
+public class IdentityImpactHandlerTests
+{
+    private sealed class FakeRepo<T>(IReadOnlyList<T> items) : IRepository<T> where T : Domain.Common.Entity
+    {
+        public Task<IReadOnlyList<T>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(items);
+        public Task<T?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IReadOnlyList<T>> FindAsync(Expression<Func<T, bool>> p, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task AddAsync(T e, CancellationToken ct = default) => throw new NotImplementedException();
+        public void Update(T e) => throw new NotImplementedException();
+        public void Remove(T e) => throw new NotImplementedException();
+        public Task SaveChangesAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    }
+
+    private static DocumentType Material(string schema)
+        => DocumentType.Create("Материал", "MAT", DocumentTypeKind.Composite, null, JsonDocument.Parse(schema));
+
+    private const string TwoKeys = """
+        { "fields": [
+            { "key": "Наименование", "tags": ["identity"] },
+            { "key": "Артикул", "tags": ["identity"] },
+            { "key": "Кач", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+        """;
+
+    private static IdentityImpactHandler Handler(DocumentType type, int linkCount)
+        => new(new FakeRepo<DocumentType>([type]),
+            new FakeRepo<MaterialQualityLink>([.. Enumerable.Range(0, linkCount)
+                .Select(i => MaterialQualityLink.Create(CatalogScope.System, null, $"ключ-{i}", Guid.NewGuid()))]));
+
+    private static Task<IdentityImpact> Run(DocumentType type, string draft, int linkCount = 3)
+        => Handler(type, linkCount).Handle(new IdentityImpactQuery(type.Id, JsonDocument.Parse(draft)), default);
+
+    [Fact]
+    public async Task UnchangedSchema_NothingToWarnAbout()
+    {
+        var impact = await Run(Material(TwoKeys), TwoKeys);
+        Assert.False(impact.Changed);
+        Assert.Equal(0, impact.AffectedLinks);
+    }
+
+    /// <summary>Правка, не касающаяся идентичности (заголовок, новое обычное поле), тревоги не поднимает —
+    /// иначе предупреждение обесценилось бы и его перестали бы читать.</summary>
+    [Fact]
+    public async Task UnrelatedFieldAdded_NotChanged()
+    {
+        var draft = """
+            { "fields": [
+                { "key": "Наименование", "tags": ["identity"] },
+                { "key": "Артикул", "tags": ["identity"] },
+                { "key": "Примечание" },
+                { "key": "Кач", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+            """;
+        Assert.False((await Run(Material(TwoKeys), draft)).Changed);
+    }
+
+    [Fact]
+    public async Task IdentityFieldAdded_AllLinksAffected()
+    {
+        var draft = """
+            { "fields": [
+                { "key": "Наименование", "tags": ["identity"] },
+                { "key": "Артикул", "tags": ["identity"] },
+                { "key": "Производитель", "tags": ["identity"] },
+                { "key": "Кач", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+            """;
+        var impact = await Run(Material(TwoKeys), draft);
+        Assert.True(impact.Changed);
+        Assert.Equal(["Наименование", "Артикул"], impact.Before);
+        Assert.Equal(["Наименование", "Артикул", "Производитель"], impact.After);
+        Assert.Equal(3, impact.AffectedLinks);   // осиротеют ВСЕ: ключ у материалов общий
+    }
+
+    [Fact]
+    public async Task TagRemoved_AllLinksAffected()
+    {
+        var draft = """
+            { "fields": [
+                { "key": "Наименование", "tags": ["identity"] },
+                { "key": "Артикул" },
+                { "key": "Кач", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+            """;
+        var impact = await Run(Material(TwoKeys), draft);
+        Assert.True(impact.Changed);
+        Assert.Equal(["Наименование"], impact.After);
+    }
+
+    /// <summary>Перенумерация состав не меняет, но меняет ПОРЯДОК склейки — то есть все ключи.</summary>
+    [Fact]
+    public async Task Renumbering_ChangesKeysToo()
+    {
+        var draft = """
+            { "fields": [
+                { "key": "Наименование", "tags": ["identity:2"] },
+                { "key": "Артикул", "tags": ["identity:1"] },
+                { "key": "Кач", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+            """;
+        var impact = await Run(Material(TwoKeys), draft);
+        Assert.True(impact.Changed);
+        Assert.Equal(["Артикул", "Наименование"], impact.After);
+    }
+
+    /// <summary>Черновик — ПРОЕКЦИЯ: сохранённая схема типа после расчёта та же, иначе предпросчёт
+    /// записал бы несохранённое в базу первым же чужим SaveChanges.</summary>
+    [Fact]
+    public async Task DraftDoesNotTouchStoredSchema()
+    {
+        var type = Material(TwoKeys);
+        var before = type.Schema.RootElement.GetRawText();
+        await Run(type, """{ "fields": [] }""");
+        Assert.Equal(before, type.Schema.RootElement.GetRawText());
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.63.0</Version>
+    <Version>0.64.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #584 (пункт I-3 плана `docs/PLAN_QUALITY_LINKS_AND_MCP.md`).

## Зачем

Составной ключ (#582) склеивается из **всех** полей с тэгом «Идентификатор» по всем типам материала.
Значит добавление поля, снятие тэга или перенумерация меняют ключи всех материалов разом — заведённые
связки «материал → документ качества» перестают находиться. И происходит это **молча**: документ
выпускается без сертификатов, а в UI всё выглядит здоровым.

Риск не гипотетический и не требует чьей-то ошибки: поле «Производитель» несёт тэг и сейчас пусто во
всех 151 строке реестра — как только распознавание начнёт его заполнять, ключи изменятся сами собой.

## Как

- `POST /api/document-types/{id}/identity-impact` — предпросчёт по черновику схемы (тому же, что уйдёт
  в `PUT /schema`): состав ключа **до** и **после**, изменился ли он, сколько связок осиротеет.
  Считает сервер, потому что ключ строит он: спрашивай клиента — предупреждали бы по одному правилу,
  а ломали по другому.
- Осиротеют **все связки или ни одной** — ключ у материалов общий, промежуточного случая нет.
- Черновик накладывается копией типа (`DocumentType.WithSchema`): менять схему у загруженной сущности
  ради предпросчёта нельзя — она отслеживаемая, и чужой `SaveChanges` в том же запросе записал бы
  несохранённый черновик в базу. На это есть тест.
- В редакторе схем — гейт **внутри** `save()`, до записи: диалог с составом ключа «было/станет»,
  числом связок и барьером-галочкой. Отказ отменяет сохранение.
- Отказ самого предпросчёта (сеть, 500) сохранение **не** блокирует: предупреждение — помощь, а не
  проверка целостности, и ронять из-за него правку схемы неправильно.
- Правка, не касающаяся идентичности, тревоги не поднимает — иначе диалог примелькался бы.

## Тэг с «Производителя» не снимаем

Как и записано в issue: один артикул у разных изготовителей — разный товар с разными сертификатами.
Защита работает для любого поля, а не угадывает «настоящий» идентификатор.

## Проверка

`npx tsc -b` чисто, `npm test` — 327 зелёных, юнит-тесты сервера — 634 зелёных, прицельный прогон
`QualityDocs|MaterialLink|DocumentTypeHandler|Schema` — 135 зелёных (в т.ч. 6 новых
`IdentityImpactHandlerTests`).

Полный прогон интеграционных в этот момент недостоверен: параллельно шли тесты из соседних worktree
(`docs-doc-date`, `verify-master`) на той же базе `bhs_crg_test`, и их `TRUNCATE` роняет чужие тесты —
наборы падений в двух подряд прогонах не пересекаются вовсе. К изменению это отношения не имеет.

Версия 0.64.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
