### PR TITLE
Качество: показывать материалы без документа качества (#585)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
-import { Loader2, Link2, Unlink, ShieldCheck, Search, Globe, ExternalLink, Download, Eye, Check } from 'lucide-react';
+import { Loader2, Link2, Unlink, ShieldCheck, Search, Globe, ExternalLink, Download, Eye, Check, AlertTriangle } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -18,9 +18,9 @@ import {
   typeHasTag, findTaggedFieldPath, resolveEffectiveFields, isMaterialType, materialIdentityKeys,
 } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
-import { identityKey, isIdentityKeyEmpty } from '@/shared/api/identityKey';
+import { identityKey, isIdentityKeyEmpty, normalizeKey } from '@/shared/api/identityKey';
 import {
-  assessBulkLink, collectStrings, docHaystackStems, relevance, weighted,
+  assessBulkLink, collectStrings, collidingIdentities, docHaystackStems, relevance, weighted,
   type BulkLinkAssessment,
 } from './qualityMatch';
 import { QualityDocForm } from '@/features/quality-docs/QualityDocForm';
@@ -339,6 +339,9 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
     return rows;
   }, [preview, identityKeys, allDocTypes, instance]);
 
+  // Строки, спорящие за одну связку (issue #585): совпало значение идентичности, но не ключ целиком.
+  const colliding = useMemo(() => collidingIdentities(materials, normalizeKey), [materials]);
+
   // Связь ищем по СОСТАВНОМУ ключу материала — у него ровно один ключ (#582). Прежний перебор «любое
   // поле идентичности» позволял двум связкам претендовать на один материал: на живых данных из 151
   // строки реестра у 49 нашлась связка и по артикулу, и по наименованию, и во всех 49 сертификаты
@@ -495,7 +498,22 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
                         <input type="checkbox" checked={selected.has(m.key)} onChange={() => toggle(m.key)}
                           className="w-4 h-4 rounded border-stroke-strong text-brand" />
                       </td>
-                      <td className="px-2 py-1.5 text-fg1">{m.label}</td>
+                      <td className="px-2 py-1.5 text-fg1">
+                        <span className="flex items-center gap-1.5">
+                          <span className="truncate">{m.label}</span>
+                          {/* Строка спорит с другой за связку (issue #585): совпало значение, но не
+                              ключ целиком. Различить их система не может — решение за человеком. */}
+                          {colliding.has(m.key) && (
+                            <span
+                              title={`Совпадает с другой строкой по «${colliding.get(m.key)!.join('», «')}», но ключ целиком разный. `
+                                + 'Либо это одна позиция, записанная по-разному — тогда исправьте материал, '
+                                + 'либо разные товары — тогда заведите две связки.'}
+                              className="shrink-0 text-warning">
+                              <AlertTriangle size={13} />
+                            </span>
+                          )}
+                        </span>
+                      </td>
                       <td className="px-2 py-1.5">
                         {link ? (
                           <span className="flex items-center gap-1.5">

--- a/src/client/src/features/document-sets/editor/qualityMatch.test.ts
+++ b/src/client/src/features/document-sets/editor/qualityMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assessBulkLink, relevance, weighted, tokenize, stem } from './qualityMatch';
+import { assessBulkLink, collidingIdentities, relevance, weighted, tokenize, stem } from './qualityMatch';
 
 /** Сертификат на автоматы EKF модели AV-125 — тот самый, на котором висело 69 связок (#552). */
 const AV125 = [
@@ -74,5 +74,40 @@ describe('assessBulkLink (issue #552)', () => {
     expect(stem('выключатели')).toBe(stem('выключатель'));
     const hay = new Set(tokenize('Выключатели автоматические').map(stem));
     expect(relevance(weighted('Выключатель автоматический'), hay)).toBeGreaterThan(0.9);
+  });
+});
+
+describe('collidingIdentities (issue #585)', () => {
+  const norm = (s: string) => s.trim().toLowerCase();
+  const row = (key: string, ...idValues: string[]) => ({ key, idValues });
+
+  it('одинаковый артикул при разных полных ключах — спор за связку', () => {
+    const rows = [
+      row('трубка тут нг 20/10 | t-1', 'Трубка ТУТ нг 20/10', 'T-1'),
+      row('термоусаживаемая трубка | t-1', 'Термоусаживаемая трубка', 'T-1'),
+    ];
+    const colliding = collidingIdentities(rows, norm);
+    expect([...colliding.keys()]).toHaveLength(2);
+    expect(colliding.get('трубка тут нг 20/10 | t-1')).toEqual(['T-1']);
+  });
+
+  it('разные материалы без общих значений не спорят', () => {
+    const rows = [row('трубка | t-1', 'Трубка', 'T-1'), row('кабель | k-9', 'Кабель', 'K-9')];
+    expect(collidingIdentities(rows, norm).size).toBe(0);
+  });
+
+  /**
+   * Одна и та же строка приходит дважды — из набора данных и из реквизитов. Ключ у неё один, спорить
+   * ей не с кем, и тревожить этим нельзя: иначе значок висел бы на половине реестра и его перестали
+   * бы замечать.
+   */
+  it('дубль одной строки спором не считается', () => {
+    const rows = [row('трубка | t-1', 'Трубка', 'T-1'), row('трубка | t-1', 'Трубка', 'T-1')];
+    expect(collidingIdentities(rows, norm).size).toBe(0);
+  });
+
+  it('пустые значения не сводят строки вместе', () => {
+    const rows = [row('трубка | ', 'Трубка', ''), row('кабель | ', 'Кабель', '   ')];
+    expect(collidingIdentities(rows, norm).size).toBe(0);
   });
 });

--- a/src/client/src/features/document-sets/editor/qualityMatch.ts
+++ b/src/client/src/features/document-sets/editor/qualityMatch.ts
@@ -126,3 +126,38 @@ export function docHaystackStems(displayName: string, requisites: unknown): Set<
   collectStrings(requisites, parts);
   return new Set(tokenize(parts.join(' ')).map(stem));
 }
+
+/**
+ * Материалы, спорящие за одну связку (issue #585): совпадает ХОТЯ БЫ ОДНО значение идентичности
+ * (тот же артикул, то же наименование), а полный ключ разный — то есть это либо одна позиция,
+ * записанная в двух таблицах по-разному, либо два разных товара с общим артикулом.
+ *
+ * Различить их система не может и не должна: решение за пользователем — исправить материал или
+ * завести две связки. Её дело — показать, что выбор есть. До составного ключа (#582) такие строки
+ * молча делили одну связку, и побеждала та, чьё поле стояло в схеме раньше.
+ *
+ * Возвращает ключ строки → значения, которыми она пересекается с другими.
+ */
+export function collidingIdentities(
+  rows: readonly { key: string; idValues: string[] }[],
+  normalize: (s: string) => string,
+): Map<string, string[]> {
+  const keysByValue = new Map<string, Set<string>>();
+  for (const row of rows)
+    for (const value of row.idValues) {
+      const norm = normalize(value);
+      if (!norm) continue;
+      const keys = keysByValue.get(norm) ?? new Set<string>();
+      keys.add(row.key);
+      keysByValue.set(norm, keys);
+    }
+
+  const result = new Map<string, string[]>();
+  for (const row of rows) {
+    // Значение считается спорным, когда его делят РАЗНЫЕ полные ключи: одинаковые ключи — это одна
+    // и та же строка, встреченная дважды (набор данных и реквизиты), и спорить ей не с кем.
+    const shared = row.idValues.filter(v => (keysByValue.get(normalize(v))?.size ?? 0) > 1);
+    if (shared.length > 0) result.set(row.key, shared);
+  }
+  return result;
+}

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Notifications;
+using BHS.CRG.Application.QualityDocs;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Application.Templates;
 using BHS.CRG.Domain.Documents;
@@ -98,6 +99,12 @@ public class GenerateDocumentHandler(
             // отвечают на один вопрос по-разному, и человек выпускает то, о чём его предупреждали.
             var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
             ValueTypeScanner.Scan(context, effectiveFields, typesById, primitives, diagnostics);
+
+            // Материалы без документа качества (issue #585) — предупреждением: выпуск не блокируем
+            // (на живом комплекте таких было 75 из 151), но и молчать нельзя — сегодня документ
+            // выходит без сертификатов, не оставляя следа.
+            QualityLinkScanner.Scan(context, MaterialIdentity.KeysOf(allDocTypes),
+                MaterialIdentity.QualityDocFieldOf(allDocTypes), diagnostics);
 
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 throw new ResolutionValidationException(diagnostics);

--- a/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using BHS.CRG.Application.QualityDocs;
+
+namespace BHS.CRG.Application.Generation;
+
+/// <summary>
+/// Материалы, которым не досталось документа качества (issue #585).
+///
+/// Составной ключ (#582) строже прежнего «совпало любое поле», поэтому несопоставленных материалов
+/// станет больше ПО ПОСТРОЕНИЮ — и это не дефект, а перенос решения на пользователя: одна позиция,
+/// записанная в разных таблицах по-разному, даёт разные ключи, и только он решает — исправить
+/// материал или завести вторую связку. Но решать он может лишь то, что видит.
+///
+/// Уровень — Warning, а не Error: на замере комплекта 250701.ЭОМ-1 из 151 строки реестра 75 не имели
+/// сертификата вовсе, и выпуск документа блокировать нельзя — иначе система встанет в тот же день.
+/// Молчать тоже нельзя: сегодня такой документ выпускается без единого следа в UI.
+/// </summary>
+public static class QualityLinkScanner
+{
+    public const string Code = "material-no-quality-doc";
+
+    /// <summary>
+    /// Ищет в массивах контекста элементы-материалы (опознаются полями идентичности — тем же
+    /// способом, что и сопоставление) с пустым полем документа качества.
+    ///
+    /// Запускать ПОСЛЕ <see cref="IQualityLinkResolver.InjectAsync" />: до неё пусты вообще все, и
+    /// предупреждение говорило бы о порядке шагов, а не о данных.
+    /// </summary>
+    public static void Scan(
+        GenerationContext ctx,
+        IReadOnlyList<string> identityFields,
+        string? targetField,
+        List<ResolutionDiagnostic> diagnostics)
+    {
+        if (identityFields.Count == 0 || string.IsNullOrEmpty(targetField)) return; // тэги не настроены
+
+        foreach (var (key, value) in ctx.Data)
+        {
+            if (value is not JsonElement el || el.ValueKind != JsonValueKind.Array) continue;
+
+            var index = -1;
+            foreach (var item in el.EnumerateArray())
+            {
+                index++;
+                if (item.ValueKind != JsonValueKind.Object) continue;
+
+                // Материал ли это: у элемента есть хоть одно непустое поле идентичности. Тот же
+                // признак, по которому строка получает ключ, — иначе предупреждение доставалось бы
+                // строкам, которые сопоставлять и не собирались.
+                var identity = IdentityKey.From(identityFields, f => Text(item, f));
+                if (IdentityKey.IsEmpty(identity)) continue;
+
+                if (HasValue(item, targetField)) continue;
+
+                diagnostics.Add(new ResolutionDiagnostic(
+                    DiagnosticSeverity.Warning,
+                    $"{key}[{index}].{targetField}",
+                    $"Материал «{identity}» без документа качества: привязка не найдена.",
+                    Code));
+            }
+        }
+    }
+
+    private static string? Text(JsonElement item, string field)
+        => item.TryGetProperty(field, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    /// <summary>Заполнено ли целевое поле — тот же предикат, что у резолвера: он не перетирает
+    /// заданное вручную, и предупреждать о заполненном вручную было бы ложной тревогой.</summary>
+    private static bool HasValue(JsonElement item, string field)
+    {
+        if (!item.TryGetProperty(field, out var v)) return false;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => false,
+            JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
+            JsonValueKind.Object => v.EnumerateObject().Any(),
+            JsonValueKind.Array => v.GetArrayLength() > 0,
+            _ => true,
+        };
+    }
+}

--- a/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValidateInstanceResolution.cs
@@ -1,4 +1,5 @@
 using BHS.CRG.Application.Common;
+using BHS.CRG.Application.QualityDocs;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Documents;
 using BHS.CRG.Domain.Objects;
@@ -18,7 +19,8 @@ public class ValidateInstanceResolutionHandler(
     IRepository<DocumentType> docTypeRepo,
     IRepository<Domain.Catalog.PrimitiveType> primitiveRepo,
     IEntityResolver entityResolver,
-    IDataSetResolver dataSetResolver
+    IDataSetResolver dataSetResolver,
+    IQualityLinkResolver qualityLinkResolver
 ) : IRequestHandler<ValidateInstanceResolutionQuery, IReadOnlyList<ResolutionDiagnostic>>
 {
     public async Task<IReadOnlyList<ResolutionDiagnostic>> Handle(ValidateInstanceResolutionQuery q, CancellationToken ct)
@@ -32,6 +34,10 @@ public class ValidateInstanceResolutionHandler(
         await dataSetResolver.InjectAsync(context, view, diagnostics, ct);
         await entityResolver.ApplyDefaultsAsync(context, view, ct);
         await entityResolver.ResolveEnumLabelsAsync(context, view, ct);
+        // Документы качества подмешиваем и здесь (issue #585): без этого шага проверка не увидела бы
+        // ни привязанных сертификатов, ни их отсутствия — и ответила бы про документ не то, что
+        // покажет выпуск.
+        await qualityLinkResolver.InjectAsync(context, view, ct);
         await entityResolver.ResolveContextRefsAsync(context, view.DocumentSetId, ct);
         await entityResolver.ResolveComputedFieldsAsync(context, view, diagnostics, ct); // issue #368
         ResolutionScanner.ScanLeftoverRefs(context, diagnostics);
@@ -44,6 +50,11 @@ public class ValidateInstanceResolutionHandler(
         // и половина документов перестала бы выпускаться в тот же день.
         var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
         ValueTypeScanner.Scan(context, fields, byId, primitives, diagnostics);
+
+        // Материалы без документа качества (issue #585) — предупреждениями, как и при выпуске.
+        var allTypes = byId.Values.ToList();
+        QualityLinkScanner.Scan(context, MaterialIdentity.KeysOf(allTypes),
+            MaterialIdentity.QualityDocFieldOf(allTypes), diagnostics);
 
         return diagnostics;
     }

--- a/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using BHS.CRG.Application.Generation;
+
+namespace BHS.CRG.Tests.Generation;
+
+/// <summary>
+/// Диагностика «материал без документа качества» (issue #585). Составной ключ строже прежнего
+/// «совпало любое поле», поэтому несопоставленных материалов больше по построению — и пользователь
+/// должен их видеть, раз решение (исправить материал или завести вторую связку) за ним.
+/// </summary>
+public class QualityLinkScannerTests
+{
+    private static readonly string[] IdentityFields = ["Наименование", "Артикул"];
+    private const string Target = "ДокументПодтверждающийКачество";
+
+    private static List<ResolutionDiagnostic> Scan(string materialsJson)
+    {
+        var ctx = new GenerationContext();
+        ctx.Set("Материалы", JsonDocument.Parse(materialsJson).RootElement.Clone());
+        var diagnostics = new List<ResolutionDiagnostic>();
+        QualityLinkScanner.Scan(ctx, IdentityFields, Target, diagnostics);
+        return diagnostics;
+    }
+
+    [Fact]
+    public void MaterialWithoutQualityDoc_IsWarning()
+    {
+        var d = Assert.Single(Scan("""[ { "Наименование": "Трубка", "Артикул": "T-1" } ]"""));
+        Assert.Equal(DiagnosticSeverity.Warning, d.Severity);   // выпуск не блокируем
+        Assert.Equal(QualityLinkScanner.Code, d.Code);
+        Assert.Equal($"Материалы[0].{Target}", d.Path);
+        Assert.Contains("трубка | t-1", d.Message);             // в тексте — ключ, по которому искали
+    }
+
+    [Fact]
+    public void MaterialWithQualityDoc_IsSilent()
+        => Assert.Empty(Scan($$"""
+            [ { "Наименование": "Трубка", "{{Target}}": { "НомерДокумента": "РОСС RU.0001" } } ]
+            """));
+
+    /// <summary>Пустой объект — не документ: резолвер такое поле считает незаполненным, и проверка
+    /// обязана отвечать так же.</summary>
+    [Fact]
+    public void EmptyQualityDocObject_CountsAsMissing()
+        => Assert.Single(Scan($$"""[ { "Наименование": "Трубка", "{{Target}}": {} } ]"""));
+
+    /// <summary>Строка без единого поля идентичности материалом не считается — иначе предупреждение
+    /// доставалось бы строкам, которые сопоставлять и не собирались (примечания, итоги).</summary>
+    [Fact]
+    public void RowWithoutIdentityValues_IsNotAMaterial()
+        => Assert.Empty(Scan("""[ { "Примечание": "итого по разделу" }, { "Наименование": "  " } ]"""));
+
+    /// <summary>Материал без артикула — обычный случай (пустой слот в ключе), и он тоже должен быть
+    /// виден: именно такие теряются при переходе на составной ключ.</summary>
+    [Fact]
+    public void PartialIdentity_StillReported()
+    {
+        var d = Assert.Single(Scan("""[ { "Наименование": "Трубка" } ]"""));
+        Assert.Contains("трубка | ", d.Message);
+    }
+
+    [Fact]
+    public void TagsNotConfigured_ScannerStaysQuiet()
+    {
+        var ctx = new GenerationContext();
+        ctx.Set("Материалы", JsonDocument.Parse("""[ { "Наименование": "Трубка" } ]""").RootElement.Clone());
+        var diagnostics = new List<ResolutionDiagnostic>();
+        QualityLinkScanner.Scan(ctx, [], Target, diagnostics);
+        QualityLinkScanner.Scan(ctx, IdentityFields, null, diagnostics);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void IndexInPath_PointsAtTheRow()
+    {
+        var diagnostics = Scan("""
+            [ { "Наименование": "Есть", "ДокументПодтверждающийКачество": { "Н": "1" } },
+              { "Наименование": "Нет" } ]
+            """);
+        Assert.Equal($"Материалы[1].{Target}", Assert.Single(diagnostics).Path);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.64.0</Version>
+    <Version>0.65.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #585 (пункт I-4 плана).

## Зачем

Составной ключ (#582) строже прежнего «совпало любое поле», поэтому несопоставленных материалов
станет больше **по построению**. Это не дефект, а перенос решения на пользователя: позиция, записанная
в двух таблицах по-разному, даёт разные ключи, и только он решает — исправить материал или завести
вторую связку. Но решать он может лишь то, что видит: сегодня документ выпускается без сертификатов,
не оставляя следа. На комплекте 250701.ЭОМ-1 таких строк было **75 из 151**.

## Что сделано

- **Диагностика `material-no-quality-doc`, уровень Warning** — блокировать выпуск нельзя, система
  встала бы в тот же день. Счётчик предупреждений в сводке уже есть, отдельный не понадобился.
- Сканер опознаёт материал **тем же признаком, что и сопоставление** — непустым полем идентичности.
  Иначе предупреждение доставалось бы строкам, которые сопоставлять и не собирались (примечания,
  итоги). Заполненное вручную поле документа тревоги не поднимает: предикат тот же, что у резолвера,
  который такое поле не перетирает.
- **Проверка документа теперь тоже подмешивает документы качества.** Без этого шага она не видела ни
  привязанных сертификатов, ни их отсутствия — и отвечала не то, что покажет выпуск.
- **В UI привязок — значок у строк, спорящих за одну связку**: совпало значение идентичности (тот же
  артикул), но полный ключ разный. Это и есть подсказка «исправьте материал или заведите две связки».
  Дубль одной строки (набор данных + реквизиты) спором не считается — иначе значок висел бы на
  половине реестра и его перестали бы замечать.

## Проверка

`dotnet test` — 916 зелёных (7 новых `QualityLinkScannerTests`), `npx tsc -b` чисто, `npm test` —
331 зелёный (4 новых на `collidingIdentities`).

Версия 0.65.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
