### PR TITLE
Качество: сверять материал с областью продукции сертификата (#586)

### DIFF
--- a/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
@@ -4,7 +4,8 @@ using BHS.CRG.Application.QualityDocs;
 namespace BHS.CRG.Application.Generation;
 
 /// <summary>
-/// Материалы, которым не досталось документа качества (issue #585).
+/// Проверки связки материала с документом качества: документа НЕТ (issue #585) и документ есть, но
+/// не про этот материал (issue #586).
 ///
 /// Составной ключ (#582) строже прежнего «совпало любое поле», поэтому несопоставленных материалов
 /// станет больше ПО ПОСТРОЕНИЮ — и это не дефект, а перенос решения на пользователя: одна позиция,
@@ -18,6 +19,9 @@ namespace BHS.CRG.Application.Generation;
 public static class QualityLinkScanner
 {
     public const string Code = "material-no-quality-doc";
+
+    /// <summary>Документ есть, но материал не упоминается в его области продукции (issue #586).</summary>
+    public const string ImplausibleCode = "quality-doc-implausible";
 
     /// <summary>
     /// Ищет в массивах контекста элементы-материалы (опознаются полями идентичности — тем же
@@ -50,13 +54,32 @@ public static class QualityLinkScanner
                 var identity = IdentityKey.From(identityFields, f => Text(item, f));
                 if (IdentityKey.IsEmpty(identity)) continue;
 
-                if (HasValue(item, targetField)) continue;
+                if (!HasValue(item, targetField))
+                {
+                    diagnostics.Add(new ResolutionDiagnostic(
+                        DiagnosticSeverity.Warning,
+                        $"{key}[{index}].{targetField}",
+                        $"Материал «{identity}» без документа качества: привязка не найдена.",
+                        Code));
+                    continue;
+                }
 
-                diagnostics.Add(new ResolutionDiagnostic(
-                    DiagnosticSeverity.Warning,
-                    $"{key}[{index}].{targetField}",
-                    $"Материал «{identity}» без документа качества: привязка не найдена.",
-                    Code));
+                // Документ есть — правдоподобен ли он (issue #586). Реквизиты документа уже
+                // подмешаны в строку, отдельного запроса не нужно.
+                if (!item.TryGetProperty(targetField, out var doc)) continue;
+
+                var docTexts = new List<string>();
+                ProductScopeMatcher.CollectStrings(doc, docTexts);
+                // Человеческие значения, а не ключ: сравнивать надо со словами, а ключ — машинный.
+                var materialText = string.Join(' ', identityFields.Select(f => Text(item, f)).Where(v => !string.IsNullOrWhiteSpace(v)));
+
+                if (ProductScopeMatcher.Assess(materialText, docTexts) == ProductScopeVerdict.Mismatched)
+                    diagnostics.Add(new ResolutionDiagnostic(
+                        DiagnosticSeverity.Warning,
+                        $"{key}[{index}].{targetField}",
+                        $"Материал «{identity}» не упоминается в области продукции привязанного документа — "
+                        + "возможно, сертификат не тот.",
+                        ImplausibleCode));
             }
         }
     }

--- a/src/server/BHS.CRG.Application/QualityDocs/ProductScopeMatcher.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/ProductScopeMatcher.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace BHS.CRG.Application.QualityDocs;
+
+/// <summary>Как материал соотносится с областью продукции документа качества.</summary>
+public enum ProductScopeVerdict
+{
+    /// <summary>Слова материала нашлись в описании продукции.</summary>
+    Fits,
+    /// <summary>Сравнивать нечем — у материала (или у документа) нет словесных признаков.</summary>
+    Unverifiable,
+    /// <summary>Слова ЕСТЬ, и ни одно не совпало. Только это и есть повод предупредить.</summary>
+    Mismatched,
+}
+
+/// <summary>
+/// Правдоподобие связки «материал → документ качества» по ОБЛАСТИ ПРОДУКЦИИ (issue #586).
+///
+/// Область действия сертификата лежит в реквизитах («Выключатели автоматические, торговой марки
+/// EKF, модель: AV-125»), но с материалом не сверялась ничем. Следствие на живых данных: этот самый
+/// сертификат на автоматы был привязан к 68 материалам, среди которых термоусаживаемые трубки,
+/// светильники, короба, счётчик и клеммные коробки.
+///
+/// ЗЕРКАЛО клиентского <c>qualityMatch.ts</c> (issue #552): там та же оценка предупреждает при
+/// массовой привязке, здесь — при проверке и выпуске документа. Правила совпадают намеренно, иначе
+/// система предупреждала бы об одном, а выпускала другое. Пороги вымерены на 113 живых связках, их
+/// обоснование — в комментариях клиентского модуля, дублировать не стоит.
+///
+/// Три исхода, а не «процент»: 58 из 113 живых связок дают ровно ноль, и почти все нули — артикулы
+/// вроде <c>mb15-07-01m-54</c>, где сопоставлять просто нечего. Красить такой ноль тревогой значит
+/// приучить человека игнорировать сигнал на самой аккуратной половине данных.
+/// </summary>
+public static class ProductScopeMatcher
+{
+    /// <summary>Материал подходит документу, если совпала хотя бы такая доля веса слов.</summary>
+    public const double FitsThreshold = 0.34;
+
+    /// <summary>Сколько словесных основ должно быть у САМОГО документа, чтобы по нему можно было
+    /// судить: у нераспознанного («[PDF] Информационное письмо» с пустыми реквизитами) их две, и
+    /// без этого порога «не похоже» получили бы ВСЕ материалы подряд, включая верные.</summary>
+    private const int MinDocWords = 5;
+
+    private static readonly HashSet<string> Stop =
+        ["для", "или", "при", "без", "шт", "штук", "тип", "сертификат", "декларация", "соответствия"];
+
+    private static readonly Regex NonWord = new("[^a-zа-я0-9]+", RegexOptions.Compiled);
+    private static readonly Regex HasDigit = new(@"\d", RegexOptions.Compiled);
+    private static readonly Regex VowelEnd = new("[аеиоуыюяьй]$", RegexOptions.Compiled);
+
+    public static ProductScopeVerdict Assess(string materialText, IEnumerable<string> docTexts)
+    {
+        var hay = new HashSet<string>(Tokenize(string.Join(' ', docTexts)).Select(Stem));
+        if (hay.Count(IsWordy) < MinDocWords) return ProductScopeVerdict.Unverifiable;
+
+        var tokens = Weighted(materialText).Where(x => IsWordy(x.Token)).ToList();
+        if (tokens.Count == 0) return ProductScopeVerdict.Unverifiable;
+
+        return Relevance(tokens, hay) >= FitsThreshold ? ProductScopeVerdict.Fits : ProductScopeVerdict.Mismatched;
+    }
+
+    /// <summary>Все строковые значения JSON-объекта — «стог» для сопоставления (реквизиты документа
+    /// приходят подмешанными в строку материала, отдельного запроса не нужно).</summary>
+    public static void CollectStrings(JsonElement el, List<string> into)
+    {
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.String:
+                if (el.GetString() is { Length: > 0 } s) into.Add(s);
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in el.EnumerateArray()) CollectStrings(item, into);
+                break;
+            case JsonValueKind.Object:
+                foreach (var prop in el.EnumerateObject()) CollectStrings(prop.Value, into);
+                break;
+        }
+    }
+
+    // ── разбор текста: буква-в-букву как в qualityMatch.ts ──────────────────────
+
+    private static string NormText(string s)
+        => NonWord.Replace(s.ToLowerInvariant().Replace('ё', 'е'), " ").Trim();
+
+    private static IEnumerable<string> Tokenize(string s)
+        => NormText(s).Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(t => t.Length >= 3 && !Stop.Contains(t));
+
+    /// <summary>Грубая основа слова: снимаем одну конечную гласную (или мягкий знак) и ограничиваем
+    /// длину. Без снятия окончания «кабель» и «кабели» остаются разными словами — а именно короткие
+    /// существительные и составляют номенклатуру.</summary>
+    private static string Stem(string t)
+    {
+        var b = t.Length >= 5 && VowelEnd.IsMatch(t) ? t[..^1] : t;
+        return b.Length > 6 ? b[..6] : b;
+    }
+
+    /// <summary>Слово, по которому вообще можно судить: чисто буквенное и не короткое. Артикул
+    /// <c>mb15-07-01m-54</c> распадается на «слова» вроде <c>mb15</c> — они выглядят токенами, но ни
+    /// один сертификат их не содержит.</summary>
+    private static bool IsWordy(string token) => token.Length >= 4 && !HasDigit.IsMatch(token);
+
+    private static List<(string Token, int Weight)> Weighted(string query)
+    {
+        var seen = new HashSet<string>();
+        var result = new List<(string, int)>();
+        foreach (var t in Tokenize(query))
+        {
+            if (!seen.Add(t)) continue;
+            // числа/модели и длинные слова важнее общих коротких
+            result.Add((t, HasDigit.IsMatch(t) ? 3 : t.Length >= 6 ? 2 : 1));
+        }
+        return result;
+    }
+
+    private static double Relevance(IReadOnlyList<(string Token, int Weight)> tokens, HashSet<string> hayStems)
+    {
+        var matched = 0;
+        var total = 0;
+        foreach (var (token, weight) in tokens)
+        {
+            total += weight;
+            if (hayStems.Contains(Stem(token))) matched += weight;
+        }
+        return total == 0 ? 0 : (double)matched / total;
+    }
+}

--- a/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
@@ -70,6 +70,37 @@ public class QualityLinkScannerTests
         Assert.Empty(diagnostics);
     }
 
+    // ── правдоподобие привязанного документа (issue #586) ──────────────────────
+
+    private const string Av125 = """
+        { "Наименование": "EKF — автоматические выключатели",
+          "Продукция": "Выключатели автоматические, торговой марки «EKF», модель: AV-125" }
+        """;
+
+    /// <summary>Тот самый случай: сертификат на автоматы держал 68 связок, включая термоусадку.</summary>
+    [Fact]
+    public void ForeignCertificate_IsReportedAsImplausible()
+    {
+        var d = Assert.Single(Scan($$"""
+            [ { "Наименование": "Трубка термоусаживаемая ТУТ нг 20/10", "{{Target}}": {{Av125}} } ]
+            """));
+        Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+        Assert.Equal(QualityLinkScanner.ImplausibleCode, d.Code);
+    }
+
+    [Fact]
+    public void CertificateFromTheSameScope_IsSilent()
+        => Assert.Empty(Scan($$"""
+            [ { "Наименование": "Выключатель автоматический AV-125 3P 63А EKF", "{{Target}}": {{Av125}} } ]
+            """));
+
+    /// <summary>Материал, опознанный одним артикулом, проверить нечем — и тревожить им нельзя.</summary>
+    [Fact]
+    public void BareArticle_NotReportedAsImplausible()
+        => Assert.Empty(Scan($$"""
+            [ { "Артикул": "mb15-07-01m-54", "{{Target}}": {{Av125}} } ]
+            """));
+
     [Fact]
     public void IndexInPath_PointsAtTheRow()
     {

--- a/src/server/BHS.CRG.Tests/QualityDocs/ProductScopeMatcherTests.cs
+++ b/src/server/BHS.CRG.Tests/QualityDocs/ProductScopeMatcherTests.cs
@@ -1,0 +1,67 @@
+using BHS.CRG.Application.QualityDocs;
+
+namespace BHS.CRG.Tests.QualityDocs;
+
+/// <summary>
+/// Правдоподобие связки по области продукции (issue #586). Случаи взяты с живых данных: сертификат
+/// на автоматы EKF AV-125 держал 68 связок, среди которых термоусаживаемые трубки, светильники,
+/// короба, счётчик и клеммные коробки.
+///
+/// Правила — зеркало клиентского qualityMatch.ts (#552): разойдись они, система предупреждала бы при
+/// привязке об одном, а при выпуске о другом.
+/// </summary>
+public class ProductScopeMatcherTests
+{
+    /// <summary>Тот самый сертификат.</summary>
+    private static readonly string[] Av125 =
+    [
+        "EKF — автоматические выключатели",
+        "Выключатели автоматические, торговой марки «EKF», модель: AV-125. Продукция изготовлена в соответствии с Директивами.",
+    ];
+
+    [Fact]
+    public void MaterialFromTheCertificateScope_Fits()
+        => Assert.Equal(ProductScopeVerdict.Fits,
+            ProductScopeMatcher.Assess("Выключатель автоматический AV-125 3P 63А EKF", Av125));
+
+    [Fact]
+    public void ForeignMaterial_IsMismatched()
+        => Assert.Equal(ProductScopeVerdict.Mismatched,
+            ProductScopeMatcher.Assess("Трубка термоусаживаемая ТУТ нг 20/10", Av125));
+
+    /// <summary>
+    /// Голый артикул проверять нечем: 58 живых связок из 113 дают ровно ноль, и почти все нули —
+    /// именно артикулы. Объявить их «не похожими» значит приучить человека игнорировать сигнал на
+    /// самой аккуратной половине данных.
+    /// </summary>
+    [Fact]
+    public void BareArticle_IsUnverifiable()
+        => Assert.Equal(ProductScopeVerdict.Unverifiable, ProductScopeMatcher.Assess("mb15-07-01m-54", Av125));
+
+    /// <summary>Нераспознанный документ (название и пустые реквизиты) не даёт судить ни о чём —
+    /// иначе «не похоже» получили бы ВСЕ материалы подряд, включая верные.</summary>
+    [Fact]
+    public void DocumentWithoutWords_IsUnverifiable()
+        => Assert.Equal(ProductScopeVerdict.Unverifiable,
+            ProductScopeMatcher.Assess("Трубка термоусаживаемая", ["[PDF] Письмо"]));
+
+    /// <summary>Склонения не должны ссорить верную связку: «Кабель …, РЭМЗ» и «РЭМЗ — Кабели силовые».</summary>
+    [Fact]
+    public void RussianInflections_DoNotBreakAMatch()
+        => Assert.Equal(ProductScopeVerdict.Fits, ProductScopeMatcher.Assess(
+            "Кабель ВВГнг(А)-FRLS 4х1,5 ГОСТ, РЭМЗ",
+            ["Рыбинский электромонтажный завод — Кабели силовые",
+             "Кабели силовые с медными жилами ГОСТ 31996-2012"]));
+
+    [Fact]
+    public void CollectStrings_TakesNestedRequisites()
+    {
+        var doc = System.Text.Json.JsonDocument.Parse("""
+            { "Продукция": "Выключатели автоматические", "Орган": { "Название": "Эксперт-Сертификация" },
+              "Приложения": ["AV-125", 7] }
+            """);
+        var texts = new List<string>();
+        ProductScopeMatcher.CollectStrings(doc.RootElement, texts);
+        Assert.Equal(["Выключатели автоматические", "Эксперт-Сертификация", "AV-125"], texts);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.65.0</Version>
+    <Version>0.66.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #586 (пункт I-5 плана).

## Зачем

Область действия документа качества лежит в реквизитах («Выключатели автоматические, торговой марки
EKF, модель: AV-125»), но с материалом не сверялась ничем. На живых данных этот сертификат держал
**68 связок**, среди которых термоусаживаемые трубки, светильники, короба, счётчик и клеммные коробки.

Предупреждение **при привязке** появилось ещё в #552 (`assessBulkLink` на клиенте). Недоставало
второй половины: при проверке и выпуске документа связка не сверялась никак — то есть неверная
привязка, однажды заведённая, дальше не встречала ни одного вопроса.

## Что сделано

- `ProductScopeMatcher` — предикат «материал ↔ область продукции» на сервере, **зеркало клиентского
  `qualityMatch.ts` буква в букву**: те же токенизация, основа слова, веса, пороги. Разойдись они,
  система предупреждала бы при привязке об одном, а при выпуске о другом.
- Диагностика `quality-doc-implausible` (Warning) в проверке документа и при выпуске — рядом с
  «материал без документа качества» (#585).
- **Три исхода, а не процент.** 58 живых связок из 113 дают ровно ноль, и почти все нули — артикулы
  (`mb15-07-01m-54`), где сопоставлять нечего: «непроверяемо» отделено от «не похоже», иначе человек
  приучился бы игнорировать сигнал на самой аккуратной половине данных. Симметрично для документа: у
  нераспознанного («[PDF] Информационное письмо») слов почти нет, и без порога «не похоже» получили
  бы все материалы подряд.
- Реквизиты документа к этому моменту уже подмешаны в строку материала — отдельного запроса к
  библиотеке не нужно.

Предикат понадобится ещё раз в #589 (сверка «реестр материалов ↔ карта качества» на сервере) — там он
и будет переиспользован.

## Проверка

`dotnet test` — 925 зелёных (новые: `ProductScopeMatcherTests` + 3 случая в `QualityLinkScannerTests`,
все на живых примерах — AV-125 против термоусадки, кабель РЭМЗ против «Кабели силовые», голый артикул).

Версия 0.66.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
