### PR TITLE
Качество: четыре уровня привязки и дефолт «комплект» (#587)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -8,6 +8,7 @@ import { Select, SelectItem } from '@/shared/ui/Select';
 import { TypePickerField } from '@/shared/ui/TypePickerField';
 import type { PickType } from '@/shared/ui/TypePicker';
 import { usePreviewDataSetBindings } from '@/shared/api/datasets';
+import { useGetDocumentSet } from '@/shared/api/documentSets';
 import {
   useListQualityDocs, useListMaterialLinks, useSetMaterialLinks, useRemoveMaterialLink,
   suggestLinks, searchQualityDocs, importQualityDocFromUrl,
@@ -262,7 +263,11 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
 export function QualityLinksTab({ instance, setId, allDocTypes }: {
   instance: DocumentInstance; setId: string; allDocTypes: DocumentType[];
 }) {
-  const [scope, setScope] = useState<CatalogScope>('System');
+  // Дефолт — КОМПЛЕКТ (issue #587). Раньше стояла System, и привязка незаметно становилась
+  // общесистемной: все 113 связей комплекта 250701.ЭОМ-1 оказались на System, ни одной ниже.
+  // Узкая область — обратимая ошибка (не нашлась связка), широкая — тихая (чужой сертификат
+  // подставился в чужой документ).
+  const [scope, setScope] = useState<CatalogScope>('Set');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [pickerOpen, setPickerOpen] = useState(false);
   // Сводка перед массовой привязкой (issue #552) — показывается, только если что-то не сходится.
@@ -276,18 +281,41 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
   const [viewDoc, setViewDoc] = useState<QualityDocument | null>(null);
 
   const { data: preview, isFetching, refetch } = usePreviewDataSetBindings({ ownerId: instance.id });
+  // Цепочка уровней комплекта (issue #587): раздел и стройка нужны и чтобы ЗАВЕСТИ связку выше
+  // комплекта, и чтобы УВИДЕТЬ заведённую там — резолвер их учитывает с самого начала.
+  const { data: set } = useGetDocumentSet(setId);
+  const sectionId = set?.sectionId ?? null;
+  const constructionId = set?.constructionId ?? null;
+  /** Уровень готов принимать связки: System живёт без id, остальным id обязателен. */
+  const scopeReady = scope === 'System' || !!(scope === 'Set' ? setId : scope === 'Section' ? sectionId : constructionId);
+  const scopeId = scope === 'Set' ? setId
+    : scope === 'Section' ? sectionId
+    : scope === 'Construction' ? constructionId
+    : null;
+
   const { data: linksSystem = [] } = useListMaterialLinks({ scope: 'System' });
+  // enabled по наличию id: запрос уровня без scopeId вернул бы связки ВСЕХ разделов/строек.
+  const { data: linksConstruction = [] } = useListMaterialLinks(
+    { scope: 'Construction', scopeId: constructionId ?? undefined, enabled: !!constructionId });
+  const { data: linksSection = [] } = useListMaterialLinks(
+    { scope: 'Section', scopeId: sectionId ?? undefined, enabled: !!sectionId });
   const { data: linksSet = [] } = useListMaterialLinks({ scope: 'Set', scopeId: setId });
   const { data: docsSystem = [] } = useListQualityDocs({ scope: 'System' });
+  const { data: docsConstruction = [] } = useListQualityDocs(
+    { scope: 'Construction', scopeId: constructionId ?? undefined, enabled: !!constructionId });
+  const { data: docsSection = [] } = useListQualityDocs(
+    { scope: 'Section', scopeId: sectionId ?? undefined, enabled: !!sectionId });
   const { data: docsSet = [] } = useListQualityDocs({ scope: 'Set', scopeId: setId });
   const setLinks = useSetMaterialLinks();
   const removeLink = useRemoveMaterialLink();
 
   const docById = useMemo(() => {
     const m = new Map<string, QualityDocument>();
-    [...docsSet, ...docsSystem].forEach(d => { if (!m.has(d.id)) m.set(d.id, d); });
+    // Порядок = приоритет: узкий уровень раньше широкого, первый победивший остаётся.
+    [...docsSet, ...docsSection, ...docsConstruction, ...docsSystem]
+      .forEach(d => { if (!m.has(d.id)) m.set(d.id, d); });
     return m;
-  }, [docsSystem, docsSet]);
+  }, [docsSystem, docsConstruction, docsSection, docsSet]);
   const docName = useMemo(() => {
     const m = new Map<string, string>();
     docById.forEach((d, id) => m.set(id, d.displayName));
@@ -296,10 +324,12 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
 
   const linkByKey = useMemo(() => {
     const m = new Map<string, { id: string; docId: string }>();
-    // Set приоритетнее System
-    [...linksSystem, ...linksSet].forEach(l => m.set(l.materialKey, { id: l.id, docId: l.qualityDocumentId }));
+    // Узкий уровень побеждает широкий — тот же приоритет, что у QualityLinkResolver на генерации
+    // (Set=1 … System=5). Здесь это порядок перезаписи: последний записавший и остаётся.
+    [...linksSystem, ...linksConstruction, ...linksSection, ...linksSet]
+      .forEach(l => m.set(l.materialKey, { id: l.id, docId: l.qualityDocumentId }));
     return m;
-  }, [linksSystem, linksSet]);
+  }, [linksSystem, linksConstruction, linksSection, linksSet]);
 
   // Ключи полей-идентификаторов МАТЕРИАЛА — по тэгам, без хардкода имён (issue #569).
   const identityKeys = useMemo(() => materialIdentityKeys(allDocTypes), [allDocTypes]);
@@ -402,10 +432,13 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
   }
 
   async function linkChosen(docId: string, chosen: MaterialRow[]) {
+    // Уровень выбран, а его id ещё не доехал (комплект перезагружается) — связку класть некуда:
+    // с пустым scopeId она стала бы «на все разделы разом», чего в селекторе никто не выбирал.
+    if (!scopeReady) return;
     // Метку материала кладём в связку сразу (issue #554): человеческое имя есть только здесь —
     // строки наборов данных не хранятся, и на экране контроля восстановить его будет неоткуда.
     await setLinks.mutateAsync({
-      scope, scopeId: scope === 'Set' ? setId : null,
+      scope, scopeId,
       materials: chosen.map(m => ({ key: m.key, label: m.label })), qualityDocumentId: docId,
     });
     setPickerOpen(false);
@@ -424,9 +457,11 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
 
   // Принять предложенный документ для одной строки / для всех с подсказкой.
   async function acceptSuggestion(mat: MaterialRow, docId: string) {
-    await setLinks.mutateAsync({ scope, scopeId: scope === 'Set' ? setId : null, materials: [{ key: mat.key, label: mat.label }], qualityDocumentId: docId });
+    if (!scopeReady) return;
+    await setLinks.mutateAsync({ scope, scopeId, materials: [{ key: mat.key, label: mat.label }], qualityDocumentId: docId });
   }
   async function acceptAllSuggestions() {
+    if (!scopeReady) return;
     const byDoc = new Map<string, { key: string; label: string }[]>();
     for (const mat of materials) {
       const s = suggestionByKey.get(mat.key);
@@ -434,10 +469,11 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
       const arr = byDoc.get(s.doc.id) ?? []; arr.push({ key: mat.key, label: mat.label }); byDoc.set(s.doc.id, arr);
     }
     for (const [docId, items] of byDoc)
-      await setLinks.mutateAsync({ scope, scopeId: scope === 'Set' ? setId : null, materials: items, qualityDocumentId: docId });
+      await setLinks.mutateAsync({ scope, scopeId, materials: items, qualityDocumentId: docId });
   }
 
   async function applySuggestions() {
+    if (!scopeReady) return;
     const chosen = (suggestions ?? []).filter(s => suggestSel.has(s.materialKey));
     // группируем по документу — один вызов на документ
     const byDoc = new Map<string, { key: string; label?: string }[]>();
@@ -448,7 +484,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
       byDoc.set(s.qualityDocumentId, arr);
     }
     for (const [docId, items] of byDoc)
-      await setLinks.mutateAsync({ scope, scopeId: scope === 'Set' ? setId : null, materials: items, qualityDocumentId: docId });
+      await setLinks.mutateAsync({ scope, scopeId, materials: items, qualityDocumentId: docId });
     setSuggestions(null);
   }
 
@@ -465,10 +501,16 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
         <span className="text-xs text-fg4">{materials.length} материалов · привязано {linkedCount}</span>
         <div className="ml-auto flex items-center gap-2">
           <label className="text-xs text-fg3">Область связи:</label>
+          {/* Четыре уровня (issue #587) — ровно те, что разрешает резолвер. Раньше их было два, и
+              «общая» стояла по умолчанию: узкая ошибка обратима (связка не нашлась), широкая тиха
+              (чужой сертификат подставился в чужой документ). Уровень без известного id не
+              предлагаем — привязку было бы некуда положить. */}
           <Select value={scope} onValueChange={v => setScope(v as CatalogScope)}
-            aria-label="Область связи" className="w-52">
-            <SelectItem value="System">Общая (System)</SelectItem>
+            aria-label="Область связи" className="w-56">
             <SelectItem value="Set">Только этот комплект</SelectItem>
+            {sectionId && <SelectItem value="Section">Весь раздел</SelectItem>}
+            {constructionId && <SelectItem value="Construction">Вся стройка</SelectItem>}
+            <SelectItem value="System">Общая (System)</SelectItem>
           </Select>
         </div>
       </div>
@@ -611,7 +653,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
       />
 
       <LinkPickerModal open={pickerOpen} onClose={() => setPickerOpen(false)} allDocTypes={allDocTypes}
-        scope={scope} scopeId={scope === 'Set' ? setId : null}
+        scope={scope} scopeId={scopeId}
         materials={materials.filter(m => selected.has(m.key))} onPick={handlePick} />
 
       <Modal open={viewDoc !== null} onOpenChange={o => { if (!o) setViewDoc(null); }} title="Документ качества" extraWide>

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -123,6 +123,9 @@ export interface DocumentSet {
   id: string;
   name: string;
   sectionId: string;
+  /** Стройка комплекта — только у запроса одного комплекта (GET /document-sets/{id}); нужна там, где
+   *  привязка заводится на уровень выше комплекта (issue #587). */
+  constructionId?: string;
   createdAt: string;
   updatedAt: string;
   /** Полный состав документов — только у запроса одного комплекта (GET /document-sets/{id}). */

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentDtos.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentDtos.cs
@@ -28,12 +28,15 @@ public record GeneratedFileDto(Guid Id, Guid DocumentInstanceId, OutputFormat Fo
 }
 
 /// <summary>Комплект с документами — форма клиентского DocumentSet.</summary>
+/// <param name="ConstructionId">Стройка комплекта (issue #587). Нужна там, где привязка заводится не
+/// на комплект, а на уровень выше: цепочку «комплект → раздел → стройка» иначе пришлось бы собирать
+/// клиенту двумя лишними запросами ради одного значения.</param>
 public record DocumentSetDto(
-    Guid Id, string Name, Guid SectionId, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt,
+    Guid Id, string Name, Guid SectionId, Guid ConstructionId, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt,
     IReadOnlyList<InstanceDto> Instances)
 {
-    public static DocumentSetDto From(DocumentSet set, IReadOnlyList<DomainObject> documents) => new(
-        set.Id, set.Name, set.SectionId, set.CreatedAt, set.UpdatedAt,
+    public static DocumentSetDto From(DocumentSet set, Guid constructionId, IReadOnlyList<DomainObject> documents) => new(
+        set.Id, set.Name, set.SectionId, constructionId, set.CreatedAt, set.UpdatedAt,
         documents.OrderBy(d => d.SortOrder).Select(InstanceDto.From).ToList());
 }
 

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -80,7 +80,7 @@ public static class DocumentSetEndpoints
             var set = await m.Send(new GetDocumentSetQuery(id));
             if (set is null) return Results.NotFound();
             var docs = await objRepo.GetSetDocumentsAsync(id, tracked: false, ct);
-            return Results.Ok(DocumentSetDto.From(set, docs));
+            return Results.Ok(DocumentSetDto.From(set, await ConstructionOfAsync(m, set), docs));
         });
 
         g.MapPut("/{id:guid}", async (Guid id, RenameRequest req, IMediator m)
@@ -204,7 +204,7 @@ public static class DocumentSetEndpoints
         {
             var set = await m.Send(new ReorderDocumentInstancesCommand(setId, orderedIds));
             var docs = await objRepo.GetSetDocumentsAsync(setId, tracked: false, ct);
-            return Results.Ok(DocumentSetDto.From(set, docs));
+            return Results.Ok(DocumentSetDto.From(set, await ConstructionOfAsync(m, set), docs));
         });
 
         // Запуск сборки всего комплекта (или подмножества) в один PDF — фоновая задача (генерация
@@ -268,6 +268,14 @@ public static class DocumentSetEndpoints
             return Results.File(stream, "application/pdf", $"{set?.Name ?? "Комплект"}.pdf");
         });
     }
+
+    /// <summary>
+    /// Стройка комплекта — через его раздел (issue #587). Клиенту она нужна, чтобы завести привязку
+    /// на уровень выше комплекта; собирать цепочку двумя лишними запросами ради одного значения
+    /// расточительно, а знать её ему всё равно надо.
+    /// </summary>
+    static async Task<Guid> ConstructionOfAsync(IMediator m, DocumentSet set)
+        => (await m.Send(new GetSectionQuery(set.SectionId)))?.ConstructionId ?? Guid.Empty;
 
     static Guid GetUserId(ClaimsPrincipal user)
         => Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub")!);

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -70,6 +70,7 @@ public record GetConstructionQuery(Guid Id) : IRequest<Construction?>;
 public record ListConstructionsQuery(Guid UserId) : IRequest<IReadOnlyList<Construction>>;
 
 // --- Section ---
+public record GetSectionQuery(Guid Id) : IRequest<Section?>;
 public record CreateSectionCommand(Guid ConstructionId, string Name) : IRequest<Section>;
 public record RenameSectionCommand(Guid Id, string Name) : IRequest<Section>;
 public record DeleteSectionCommand(Guid Id) : IRequest;

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -332,6 +332,7 @@ public class ConstructionHandlers(
     IRequestHandler<DeleteConstructionCommand>,
     IRequestHandler<GetConstructionQuery, Construction?>,
     IRequestHandler<ListConstructionsQuery, IReadOnlyList<Construction>>,
+    IRequestHandler<GetSectionQuery, Section?>,
     IRequestHandler<CreateSectionCommand, Section>,
     IRequestHandler<RenameSectionCommand, Section>,
     IRequestHandler<DeleteSectionCommand>
@@ -365,6 +366,9 @@ public class ConstructionHandlers(
 
     public Task<IReadOnlyList<Construction>> Handle(ListConstructionsQuery q, CancellationToken ct)
         => constructionRepo.GetAllAsync(ct);
+
+    public Task<Section?> Handle(GetSectionQuery q, CancellationToken ct)
+        => sectionRepo.GetByIdAsync(q.Id, ct);
 
     public async Task<Section> Handle(CreateSectionCommand cmd, CancellationToken ct)
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.66.0</Version>
+    <Version>0.67.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #587 (пункт I-6 плана).

## Зачем

Селектор «Область связи» предлагал **два уровня из четырёх**, которые разрешает `QualityLinkResolver`,
и по умолчанию стоял `System` — то есть привязка незаметно становилась общесистемной. На комплекте
250701.ЭОМ-1 все 113 связей оказались на System, ни одной ниже: не потому что так решили, а потому
что так было проще всего.

## Что сделано

- **Дефолт — «Только этот комплект».** Асимметрия ошибок: узкая область ошибается обратимо и громко
  (связка не нашлась, материал виден в диагностике #585), широкая — тихо (чужой сертификат
  подставился в чужой документ и уехал в PDF).
- **Раздел и стройка — и в селекторе, и в чтении.** Связка, заведённая на разделе, обязана быть видна
  в комплекте: иначе пользователь заведёт её второй раз, не понимая, почему первая «не сработала».
  Порядок слияния списков тот же, что у резолвера: узкий уровень побеждает широкий.
- **Стройка приезжает в DTO комплекта** (`DocumentSetDto.ConstructionId`) — цепочку «комплект → раздел
  → стройка» иначе пришлось бы собирать клиенту двумя лишними запросами ради одного значения. Для
  этого добавлен `GetSectionQuery`: запроса раздела по идентификатору до сих пор не было.
- Уровень с неизвестным id в селекторе не предлагается, и привязка с пустым `scopeId` не отправляется:
  связка «на все разделы разом» — не то, что кто-то выбирал.

## Проверка

`npx tsc -b` чисто, `npm test` — 331 зелёный, прицельные серверные (`DocumentSetHandlerTests` и
соседние) зелёные.

Полный прогон интеграционных в момент подготовки PR недостоверен: параллельно идут тесты из соседних
worktree на общей базе `bhs_crg_test`, и их `TRUNCATE` роняет чужие тесты (наборы падений между
прогонами не пересекаются, часть прогонов обрывается). Чиню это отдельной issue — тестовой базе нужно
имя из переменной окружения, чтобы параллельные worktree не толкались.

Версия 0.67.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
