### PR TITLE
Тесты: имя тестовой БД из переменной окружения (#618)

### DIFF
--- a/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
+++ b/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
@@ -16,8 +16,20 @@ namespace BHS.CRG.Tests.Integration;
 /// </summary>
 public class IntegrationTestFixture : WebApplicationFactory<Program>
 {
-    internal const string TestConnectionString =
-        "Host=localhost;Port=5432;Database=bhs_crg_test;Username=postgres;Password=xxsystem";
+    /// <summary>
+    /// Имя тестовой БД — из переменной окружения <c>BHS_TEST_DB</c>, по умолчанию прежнее (issue #618).
+    ///
+    /// Разработка идёт в нескольких worktree одновременно, и прогоны в них пересекаются. База была
+    /// одна на всех, а <see cref="ResetDatabaseAsync" /> делает TRUNCATE всех таблиц перед каждым
+    /// классом — то есть чужой прогон вычищает данные у идущего. Падения при этом выглядят как
+    /// настоящие дефекты («Construction not found», «тип с кодом AOSR уже существует», нарушения
+    /// внешнего ключа), и каждый раз приходится доказывать, что упало не от твоей правки.
+    ///
+    /// Создавать базу вручную не нужно: приложение мигрирует при старте, а миграция создаёт БД.
+    /// </summary>
+    internal static readonly string TestConnectionString =
+        "Host=localhost;Port=5432;Username=postgres;Password=xxsystem;Database="
+        + (Environment.GetEnvironmentVariable("BHS_TEST_DB") is { Length: > 0 } db ? db : "bhs_crg_test");
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.66.0</Version>
+    <Version>0.66.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #618.

Интеграционные тесты были прибиты к одной базе `bhs_crg_test`, а `ResetDatabaseAsync` делает `TRUNCATE`
всех таблиц перед каждым классом. Пока сессия одна — работает; но worktree у нас несколько, и прогоны
в них пересекаются: чужой `TRUNCATE` вычищает данные у идущего.

Дорого не то, что тесты падают, а то, что падают они **убедительно**: «Construction not found», «тип с
кодом AOSR уже существует», нарушение внешнего ключа, обрыв прогона. Каждый раз приходится доказывать,
что упало не от твоей правки, — сверкой двух прогонов подряд (наборы падений не пересекались вовсе).

Имя базы теперь берётся из `BHS_TEST_DB`, значение по умолчанию прежнее — чужие прогоны и CI ничего не
замечают. Создавать базу вручную не нужно: приложение мигрирует при старте, а миграция создаёт БД.

Проверено на живой помехе: при занятой общей базе прогон с `BHS_TEST_DB=bhs_crg_test_wt583` дал
**925 зелёных**, тогда как на общей в те же минуты падало 24–45 тестов.

Версия 0.66.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
