### PR TITLE
Качество: различать одноимённые документы (#588)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -25,6 +25,7 @@ import {
   type BulkLinkAssessment,
 } from './qualityMatch';
 import { QualityDocForm } from '@/features/quality-docs/QualityDocForm';
+import { docIdentityLine } from '@/features/quality-docs/docIdentity';
 import { recognizeAndUpdate } from '@/features/quality-docs/recognizeImported';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
 
@@ -186,7 +187,15 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
                   <div key={d.id} className="flex items-center gap-2 px-3 py-2 hover:bg-brand-subtle transition-colors">
                     <button onClick={() => onPick(d)} className="flex-1 flex items-center gap-2 min-w-0 text-left">
                       <ShieldCheck size={14} className={expired ? 'text-fg4 shrink-0' : 'text-brand shrink-0'} />
-                      <span className="flex-1 text-sm text-fg1 truncate">{d.displayName}</span>
+                      {/* Номер документа рядом с именем (issue #588): два сертификата в библиотеке
+                          назывались одинаково, а внутри были разные номера, органы и области
+                          продукции — по имени человек выбирал вслепую. */}
+                      <span className="flex-1 min-w-0">
+                        <span className="block text-sm text-fg1 truncate">{d.displayName}</span>
+                        {docIdentityLine(d, allDocTypes) && (
+                          <span className="block text-[11px] text-fg4 truncate">{docIdentityLine(d, allDocTypes)}</span>
+                        )}
+                      </span>
                       {queryTokens.length > 0 && score > 0 && (
                         <span className="text-[10px] px-1.5 py-0.5 rounded bg-brand-subtle text-brand shrink-0">{Math.round(score * 100)}%</span>
                       )}

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -17,10 +17,11 @@ import {
   importQualityDocFromUrl, type QualityDocument, type SearchCandidate, type MaterialQualityLink,
 } from '@/shared/api/qualityDocs';
 import type { CatalogScope } from '@/shared/api/types';
-import { resolveEffectiveFields, findTaggedFieldPath, typeHasTag } from '@/shared/api/schema';
+import { resolveEffectiveFields, typeHasTag } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import type { DocumentType } from '@/shared/api/types';
 import { QualityDocForm } from './QualityDocForm';
+import { ambiguousDocNames, docFieldByTag, docNumberOf, isAmbiguous } from './docIdentity';
 import { recognizeAndUpdate } from './recognizeImported';
 import { QualityDocLinks, matchesLink } from './QualityDocLinks';
 import { docState, EXPIRING_SOON_DAYS, type DocState } from './docState';
@@ -28,16 +29,9 @@ import { docState, EXPIRING_SOON_DAYS, type DocState } from './docState';
 const SCOPE_LABEL: Record<string, string> = { System: 'Общая', Construction: 'Стройка', Section: 'Раздел', Set: 'Комплект' };
 const SOURCE_LABEL: Record<string, string> = { file: 'Файл', fgis: 'ФГИС', manufacturer: 'Произв.', web: 'Веб' };
 
-function readPath(obj: Record<string, unknown>, path: string[]): unknown {
-  return path.reduce<unknown>((o, k) => (o && typeof o === 'object') ? (o as Record<string, unknown>)[k] : undefined, obj);
-}
-/** Значение реквизита по функциональному тэгу (имена полей не хардкодим — для того тэги и заведены). */
-function byTag(doc: QualityDocument, docTypes: DocumentType[], tag: string): string {
-  const dt = docTypes.find(t => t.id === doc.documentTypeId);
-  const path = dt ? findTaggedFieldPath(dt, tag, docTypes) : null;
-  const v = path ? readPath(doc.requisites, path) : undefined;
-  return typeof v === 'string' ? v.trim() : '';
-}
+/** Значение реквизита по функциональному тэгу — общий модуль опознания документа (issue #588):
+ *  имена полей не хардкодим, для того тэги и заведены. */
+const byTag = docFieldByTag;
 
 const STATE_META: Record<DocState, { label: string; icon: typeof AlertTriangle; danger: boolean }> = {
   expired: { label: 'Просрочен, связки живы', icon: AlertTriangle, danger: true },
@@ -94,6 +88,10 @@ export function QualityDocsPage() {
       || (linksByDoc.get(d.id) ?? []).some(l => matchesLink(l, q)));
   }, [docs, docTypes, search, stateFilter, states, linksByDoc]);
 
+  // Имена, которые в библиотеке встречаются дважды (issue #588) — считаем по ВСЕЙ библиотеке, а не
+  // по видимой части: имя не перестаёт быть неоднозначным оттого, что второй документ отфильтрован.
+  const ambiguousNames = useMemo(() => ambiguousDocNames(docs), [docs]);
+
   const current = selected ? docs.find(d => d.id === selected) ?? null : null;
 
   // Если ни у одного документа срок не резолвится тэгом, состояния по сроку посчитать нельзя —
@@ -136,8 +134,14 @@ export function QualityDocsPage() {
           </p>
         )}
         <NavSection label={stateFilter ? STATE_META[stateFilter].label : 'Документы'} />
+        {/* Одноимённым документам дописываем номер (issue #588): в библиотеке два сертификата
+            назывались одинаково, а внутри — разные номера, органы и области продукции. Приписывать
+            номер ВСЕМ незачем: тогда он примелькается и перестанет читаться там, где нужен. */}
         {visibleDocs.map(d => (
-          <NavItem key={d.id} icon={<ShieldCheck size={15} />} label={d.displayName}
+          <NavItem key={d.id} icon={<ShieldCheck size={15} />}
+            label={isAmbiguous(d, ambiguousNames)
+              ? `${d.displayName} · ${docNumberOf(d, docTypes) || 'без номера'}`
+              : d.displayName}
             count={linksByDoc.get(d.id)?.length ?? 0}
             active={selected === d.id} onClick={() => setSelected(d.id)} />
         ))}

--- a/src/client/src/features/quality-docs/docIdentity.test.ts
+++ b/src/client/src/features/quality-docs/docIdentity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { ambiguousDocNames, isAmbiguous } from './docIdentity';
+import type { QualityDocument } from '@/shared/api/qualityDocs';
+
+/**
+ * Опознание документа качества в списках (issue #588). Живой случай: два сертификата назывались
+ * «EKF — автоматические выключатели», а внутри были разные номера, органы и области продукции —
+ * человек выбирал вслепую.
+ */
+const doc = (id: string, displayName: string) => ({ id, displayName } as QualityDocument);
+
+describe('одноимённые документы', () => {
+  it('находит имя, встречающееся дважды', () => {
+    const docs = [
+      doc('41d18642', 'EKF — автоматические выключатели'),
+      doc('94e33abc', 'EKF — автоматические выключатели'),
+      doc('c0ffee', 'Кабели силовые РЭМЗ'),
+    ];
+    const ambiguous = ambiguousDocNames(docs);
+    expect(isAmbiguous(docs[0], ambiguous)).toBe(true);
+    expect(isAmbiguous(docs[1], ambiguous)).toBe(true);
+    expect(isAmbiguous(docs[2], ambiguous)).toBe(false);
+  });
+
+  /** Сравнение как у серверной проверки уникальности — иначе UI и запрет разошлись бы. */
+  it('регистр и краевые пробелы не создают разных имён', () => {
+    const docs = [doc('a', ' EKF — автоматические выключатели'), doc('b', 'ekf — Автоматические Выключатели')];
+    expect(ambiguousDocNames(docs).size).toBe(1);
+    expect(isAmbiguous(docs[0], ambiguousDocNames(docs))).toBe(true);
+  });
+
+  it('уникальное имя неоднозначным не считается', () => {
+    expect(ambiguousDocNames([doc('a', 'Один'), doc('b', 'Другой')]).size).toBe(0);
+  });
+});

--- a/src/client/src/features/quality-docs/docIdentity.ts
+++ b/src/client/src/features/quality-docs/docIdentity.ts
@@ -1,0 +1,68 @@
+import type { DocumentType } from '@/shared/api/types';
+import type { QualityDocument } from '@/shared/api/qualityDocs';
+import { findTaggedFieldPath } from '@/shared/api/schema';
+import { FUNCTIONAL_TAG } from '@/shared/api/tags';
+import { formatDateRu } from '@/shared/utils/date';
+
+/**
+ * Чем один документ качества отличается от другого (issue #588).
+ *
+ * Живой случай: два сертификата назывались одинаково — «EKF — автоматические выключатели», а внутри
+ * разные номера (RU C-CN.HA46.B.06753/23 и ЕАЭС RU C-CN.АД07.B.05521/23), разные органы и разные
+ * области продукции (AV-125 против AV-6 и AV-10). В списке они неразличимы, и человек выбирает
+ * вслепую — а выбирает он, какой сертификат уедет в исполнительную документацию.
+ *
+ * Реквизиты читаются по функциональным тэгам, а не по именам полей: у разных типов документов
+ * качества поля называются по-разному.
+ */
+
+function readPath(obj: Record<string, unknown>, path: string[]): unknown {
+  return path.reduce<unknown>((o, k) => (o && typeof o === 'object') ? (o as Record<string, unknown>)[k] : undefined, obj);
+}
+
+/** Значение поля документа по функциональному тэгу; пусто, если тэг не проставлен или поля нет. */
+export function docFieldByTag(doc: QualityDocument, docTypes: DocumentType[], tag: string): string {
+  const dt = docTypes.find(t => t.id === doc.documentTypeId);
+  const path = dt ? findTaggedFieldPath(dt, tag, docTypes) : null;
+  const v = path ? readPath(doc.requisites, path) : undefined;
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+export const docNumberOf = (doc: QualityDocument, docTypes: DocumentType[]) =>
+  docFieldByTag(doc, docTypes, FUNCTIONAL_TAG.docNumber);
+
+export const docValidUntilOf = (doc: QualityDocument, docTypes: DocumentType[]) =>
+  docFieldByTag(doc, docTypes, FUNCTIONAL_TAG.qualityValidUntil);
+
+/**
+ * Строка-опознание: «№ … · до …». Пустая, когда сказать нечего — тэги не проставлены или реквизиты
+ * не распознаны. Пустую строку показывать не нужно: место она займёт, а вопрос «какой из двух» не
+ * решит.
+ */
+export function docIdentityLine(doc: QualityDocument, docTypes: DocumentType[]): string {
+  const number = docNumberOf(doc, docTypes);
+  const validUntil = docValidUntilOf(doc, docTypes);
+  return [number && `№ ${number}`, validUntil && `до ${formatDateRu(validUntil)}`].filter(Boolean).join(' · ');
+}
+
+/**
+ * Имена, встречающиеся у ДВУХ И БОЛЕЕ документов списка (сравнение как у серверной проверки
+ * уникальности: без регистра и краевых пробелов).
+ *
+ * Нужны, чтобы приписывать номер только там, где имя действительно не различает: приписывать всем
+ * значит засорить список ради редкого случая, и тогда номер перестанут замечать ровно тогда, когда
+ * он понадобится.
+ */
+export function ambiguousDocNames(docs: readonly QualityDocument[]): Set<string> {
+  const seen = new Map<string, number>();
+  for (const d of docs) {
+    const key = d.displayName.trim().toLowerCase();
+    seen.set(key, (seen.get(key) ?? 0) + 1);
+  }
+  return new Set([...seen].filter(([, n]) => n > 1).map(([name]) => name));
+}
+
+/** Одноимённый ли документ в этом списке — значит имени недостаточно, нужен номер. */
+export function isAmbiguous(doc: QualityDocument, ambiguous: Set<string>): boolean {
+  return ambiguous.has(doc.displayName.trim().toLowerCase());
+}

--- a/src/server/BHS.CRG.Api/Endpoints/QualityDocs/QualityDocEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/QualityDocs/QualityDocEndpoints.cs
@@ -27,17 +27,30 @@ public static class QualityDocEndpoints
             return doc is null ? Results.NotFound() : Results.Ok(ToDto(doc));
         });
 
+        // 409 на занятое имя (issue #588): в области имена документов различаются, иначе выбор из
+        // списка становится выбором вслепую.
         g.MapPost("/", async (CreateReq req, IMediator m) =>
         {
-            var doc = await m.Send(new CreateQualityDocumentCommand(
-                req.DocumentTypeId, req.DisplayName, ToDoc(req.Requisites),
-                ParseScope(req.Scope), req.ScopeId, ParseSource(req.Source),
-                req.ScanBlobPath, req.ScanFileName, req.ScanMimeType));
-            return Results.Ok(ToDto(doc));
+            try
+            {
+                var doc = await m.Send(new CreateQualityDocumentCommand(
+                    req.DocumentTypeId, req.DisplayName, ToDoc(req.Requisites),
+                    ParseScope(req.Scope), req.ScopeId, ParseSource(req.Source),
+                    req.ScanBlobPath, req.ScanFileName, req.ScanMimeType));
+                return Results.Ok(ToDto(doc));
+            }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
 
-        g.MapPut("/{id:guid}", async (Guid id, UpdateReq req, IMediator m)
-            => Results.Ok(ToDto(await m.Send(new UpdateQualityDocumentCommand(id, req.DocumentTypeId, req.DisplayName, ToDoc(req.Requisites))))));
+        g.MapPut("/{id:guid}", async (Guid id, UpdateReq req, IMediator m) =>
+        {
+            try
+            {
+                return Results.Ok(ToDto(await m.Send(
+                    new UpdateQualityDocumentCommand(id, req.DocumentTypeId, req.DisplayName, ToDoc(req.Requisites)))));
+            }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
 
         g.MapPut("/{id:guid}/scan", async (Guid id, ScanReq req, IMediator m)
             => Results.Ok(ToDto(await m.Send(new SetQualityDocScanCommand(id, req.ScanBlobPath, req.ScanFileName, req.ScanMimeType)))));

--- a/src/server/BHS.CRG.Application/QualityDocs/Handlers.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/Handlers.cs
@@ -1,4 +1,5 @@
 using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 using MediatR;
 
@@ -22,6 +23,7 @@ public class QualityDocHandlers(
 {
     public async Task<QualityDocument> Handle(CreateQualityDocumentCommand cmd, CancellationToken ct)
     {
+        await EnsureNameFreeAsync(cmd.DisplayName, cmd.Scope, cmd.ScopeId, exceptId: null, ct);
         var doc = QualityDocument.Create(cmd.DocumentTypeId, cmd.DisplayName, cmd.Requisites, cmd.Scope, cmd.ScopeId, cmd.Source);
         doc.SetScan(cmd.ScanBlobPath, cmd.ScanFileName, cmd.ScanMimeType);
         await repo.AddAsync(doc, ct);
@@ -32,10 +34,40 @@ public class QualityDocHandlers(
     public async Task<QualityDocument> Handle(UpdateQualityDocumentCommand cmd, CancellationToken ct)
     {
         var doc = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException($"QualityDocument {cmd.Id} not found");
+        await EnsureNameFreeAsync(cmd.DisplayName, doc.Scope, doc.ScopeId, exceptId: doc.Id, ct);
         doc.Update(cmd.DocumentTypeId, cmd.DisplayName, cmd.Requisites);
         repo.Update(doc);
         await repo.SaveChangesAsync(ct);
         return doc;
+    }
+
+    /// <summary>
+    /// Имя документа качества уникально В СВОЕЙ ОБЛАСТИ (issue #588).
+    ///
+    /// Живой случай: два сертификата назывались одинаково — «EKF — автоматические выключатели», а
+    /// внутри разные номера (RU C-CN.HA46.B.06753/23 и ЕАЭС RU C-CN.АД07.B.05521/23), разные органы
+    /// и разные области продукции (AV-125 против AV-6/AV-10). В выпадающем списке они неразличимы, и
+    /// человек выбирает вслепую.
+    ///
+    /// Проверяем только ручные пути (создание и правка формы). Импорт из интернета сюда не заходит:
+    /// у него своя защита от дублей — по URL, а имя приходит из чужой выдачи, и отказывать в импорте
+    /// из-за совпадения заголовка значило бы ломать рабочий сценарий ради косметики.
+    /// </summary>
+    private async Task EnsureNameFreeAsync(
+        string displayName, CatalogScope scope, Guid? scopeId, Guid? exceptId, CancellationToken ct)
+    {
+        var name = (displayName ?? "").Trim();
+        if (name.Length == 0) return; // пустое имя — забота валидации формы, не этой проверки
+
+        var sameScope = await repo.FindAsync(d => d.Scope == scope && d.ScopeId == scopeId, ct);
+        var taken = sameScope.Any(d =>
+            (exceptId is null || d.Id != exceptId)
+            && string.Equals(d.DisplayName.Trim(), name, StringComparison.OrdinalIgnoreCase));
+
+        if (taken)
+            throw new InvalidOperationException(
+                $"Документ качества с именем «{name}» в этой области уже есть. Имена должны различаться: "
+                + "иначе при выборе из списка непонятно, какой из документов берут.");
     }
 
     public async Task<QualityDocument> Handle(SetQualityDocScanCommand cmd, CancellationToken ct)

--- a/src/server/BHS.CRG.Tests/Integration/QualityDocNameUniquenessTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/QualityDocNameUniquenessTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Имя документа качества уникально в своей области (issue #588).
+///
+/// Живой случай: два сертификата назывались «EKF — автоматические выключатели», а внутри были разные
+/// номера (RU C-CN.HA46.B.06753/23 и ЕАЭС RU C-CN.АД07.B.05521/23), разные органы и разные области
+/// продукции (AV-125 против AV-6 и AV-10). Выбирая из списка, человек не видел, какой берёт.
+/// </summary>
+[Collection("Integration")]
+public class QualityDocNameUniquenessTests(IntegrationTestFixture fx)
+{
+    private static IMediator M(IServiceScope scope) => scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    private async Task<T> InScopeAsync<T>(Func<IMediator, Task<T>> action)
+    {
+        using var scope = fx.Services.CreateScope();
+        return await action(M(scope));
+    }
+
+    private Task<Guid> SeedTypeAsync() => InScopeAsync(async m =>
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var type = await m.Send(new CreateDocumentTypeCommand(
+            $"Сертификат {suffix}", $"CERT{suffix}"[..12], DocumentTypeKind.Document, null,
+            JsonDocument.Parse("""{"fields":[]}""")));
+        return type.Id;
+    });
+
+    private Task<QualityDocument> CreateAsync(Guid typeId, string name, CatalogScope scope, Guid? scopeId)
+        => InScopeAsync(m => m.Send(new CreateQualityDocumentCommand(
+            typeId, name, JsonDocument.Parse("{}"), scope, scopeId, QualityDocSource.Manual, null, null, null)));
+
+    [Fact]
+    public async Task SameNameInSameScope_IsRejected()
+    {
+        var typeId = await SeedTypeAsync();
+        var name = $"EKF — автоматические выключатели {Guid.NewGuid():N}";
+        await CreateAsync(typeId, name, CatalogScope.System, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateAsync(typeId, name, CatalogScope.System, null));
+    }
+
+    /// <summary>Сравнение без регистра и краевых пробелов — иначе запрет обходится пробелом, и в
+    /// списке снова два неразличимых имени.</summary>
+    [Fact]
+    public async Task CaseAndSpaces_DoNotSlipThrough()
+    {
+        var typeId = await SeedTypeAsync();
+        var name = $"Сертификат ЭКФ {Guid.NewGuid():N}";
+        await CreateAsync(typeId, name, CatalogScope.System, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateAsync(typeId, $"  {name.ToUpperInvariant()} ", CatalogScope.System, null));
+    }
+
+    /// <summary>Разные области — разные списки: имя, занятое на комплекте, общей библиотеке не мешает.</summary>
+    [Fact]
+    public async Task SameNameInAnotherScope_IsAllowed()
+    {
+        var typeId = await SeedTypeAsync();
+        var name = $"Сертификат {Guid.NewGuid():N}";
+        await CreateAsync(typeId, name, CatalogScope.System, null);
+
+        var setScoped = await CreateAsync(typeId, name, CatalogScope.Set, Guid.NewGuid());
+        Assert.Equal(name, setScoped.DisplayName);
+    }
+
+    /// <summary>Правка документа не должна спотыкаться о его собственное имя.</summary>
+    [Fact]
+    public async Task UpdatingDocumentKeepingItsOwnName_IsAllowed()
+    {
+        var typeId = await SeedTypeAsync();
+        var name = $"Сертификат {Guid.NewGuid():N}";
+        var doc = await CreateAsync(typeId, name, CatalogScope.System, null);
+
+        var updated = await InScopeAsync(m => m.Send(new UpdateQualityDocumentCommand(
+            doc.Id, typeId, name, JsonDocument.Parse("""{"Продукция":"Выключатели"}"""))));
+
+        Assert.Equal(name, updated.DisplayName);
+    }
+
+    [Fact]
+    public async Task RenamingOntoAnotherDocumentName_IsRejected()
+    {
+        var typeId = await SeedTypeAsync();
+        var first = $"Первый {Guid.NewGuid():N}";
+        var second = $"Второй {Guid.NewGuid():N}";
+        await CreateAsync(typeId, first, CatalogScope.System, null);
+        var doc = await CreateAsync(typeId, second, CatalogScope.System, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InScopeAsync(
+            m => m.Send(new UpdateQualityDocumentCommand(doc.Id, typeId, first, JsonDocument.Parse("{}")))));
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.67.0</Version>
+    <Version>0.68.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #588 (пункт I-7 плана).

## Зачем

Два сертификата в живой библиотеке назывались одинаково — «EKF — автоматические выключатели», — а
внутри были разные номера (`RU C-CN.HA46.B.06753/23` и `ЕАЭС RU C-CN.АД07.B.05521/23`), разные органы
и разные области продукции (AV-125 против AV-6 и AV-10). Выбирая из списка, человек не видел, какой
берёт, — а выбирал он, какой сертификат уедет в исполнительную документацию.

## Что сделано

**Запрет на будущее.** Имя документа уникально **в своей области**; повтор — 409 с объяснением.
Проверяются ручные пути (создание и правка формы). Импорт из интернета сюда не заходит намеренно: у
него своя защита от дублей — по URL, а заголовок приходит из чужой выдачи, и отказывать в импорте
из-за совпадения заголовка значило бы ломать рабочий сценарий ради косметики.

**Различение сейчас.** В пикере документа под именем всегда идёт «№ … · до …». В библиотеке номер
приписывается **только одноимённым**: приписывать всем незачем — номер примелькается и перестанет
читаться ровно там, где нужен. Неоднозначность считается по всей библиотеке, а не по видимой части —
имя не перестаёт быть неоднозначным оттого, что второй документ отфильтрован.

Чтение реквизитов по тэгам вынесено в общий модуль `docIdentity`: раньше эта логика жила копией в
странице библиотеки, а вкладке привязок была недоступна.

MCP-инструмент `list_quality_documents` не трогаю — он в части II плана, и реквизиты документа там и
так отдаются целиком.

## Проверка

`dotnet test` — 932 зелёных (5 новых `QualityDocNameUniquenessTests`: та же область, регистр и
пробелы, другая область, правка со своим же именем, переименование на чужое), `npx tsc -b` чисто,
`npm test` — 334 зелёных (3 новых на `ambiguousDocNames`).

Версия 0.68.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
