### PR TITLE
Качество: сверка «реестр материалов ↔ карта документов качества» на сервере (#589)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/QualityDocs/QualityDocEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/QualityDocs/QualityDocEndpoints.cs
@@ -102,6 +102,11 @@ public static class QualityDocEndpoints
             }));
         });
 
+        // Сверка «реестр материалов ↔ карта качества» по комплекту (issue #589): ответ — десяток
+        // строк вместо двух выгруженных таблиц.
+        g.MapGet("/audit/{setId:guid}", async (Guid setId, IMediator m, CancellationToken ct)
+            => Results.Ok(await m.Send(new QualitySetAuditQuery(setId), ct)));
+
         g.MapPost("/links", async (SetLinksReq req, IMediator m) =>
         {
             // Материалы приходят парами «ключ + имя»; имя необязательно (перепривязка идёт без него).

--- a/src/server/BHS.CRG.Application/QualityDocs/QualitySetAudit.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/QualitySetAudit.cs
@@ -1,0 +1,71 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Generation;
+using MediatR;
+
+namespace BHS.CRG.Application.QualityDocs;
+
+/// <summary>Одна находка сверки: что за материал, в каком документе и что с ним не так.</summary>
+/// <param name="Code">Вид находки — <c>material-no-quality-doc</c> либо <c>quality-doc-implausible</c>.</param>
+/// <param name="Path">Путь в контексте документа (поле-массив, индекс строки) — адрес, а не пересказ.</param>
+public record QualityAuditRow(Guid InstanceId, string InstanceName, string Code, string Path, string Message);
+
+/// <param name="Documents">Сколько документов комплекта проверено.</param>
+/// <param name="Failed">Документы, которые проверить НЕ удалось (тип удалён, набор не читается).
+/// Молчание об этом означало бы «всё хорошо» там, где просто не смотрели.</param>
+public record QualityAuditReport(
+    Guid SetId,
+    int Documents,
+    int Failed,
+    int MaterialsWithoutDoc,
+    int ImplausibleDocs,
+    IReadOnlyList<QualityAuditRow> Rows);
+
+/// <summary>
+/// Сверка «реестр материалов ↔ карта документов качества» по всему комплекту (issue #589).
+///
+/// Ровно эту проверку внешний агент делал руками: выгружал обе стороны целиком и сличал. Стороны
+/// большие (151 строка реестра против 113 связей), а ответ — десяток строк, поэтому считать должен
+/// сервер: выгрузка сырья ради вывода, который умещается в экран, — это и есть основная статья
+/// расхода контекста.
+///
+/// Считается ТЕМ ЖЕ путём, что и проверка отдельного документа: <see cref="ValidateInstanceResolutionQuery"/>
+/// прогоняет полный резолв и отдаёт диагностики, отсюда берутся только качественные. Своего прохода
+/// по данным здесь нет намеренно — пайплайн резолва и без того размножен по нескольким местам, и
+/// шестая копия неизбежно разошлась бы с остальными.
+/// </summary>
+public record QualitySetAuditQuery(Guid SetId) : IRequest<QualityAuditReport>;
+
+public class QualitySetAuditHandler(IDomainObjectRepository objects, IMediator mediator)
+    : IRequestHandler<QualitySetAuditQuery, QualityAuditReport>
+{
+    public async Task<QualityAuditReport> Handle(QualitySetAuditQuery q, CancellationToken ct)
+    {
+        var documents = await objects.GetSetDocumentsAsync(q.SetId, tracked: false, ct);
+        var rows = new List<QualityAuditRow>();
+        var failed = 0;
+
+        foreach (var doc in documents)
+        {
+            ct.ThrowIfCancellationRequested();
+            IReadOnlyList<ResolutionDiagnostic> diagnostics;
+            // Один нечитаемый документ не должен отменять сверку остальных: комплект собирают
+            // месяцами, и сломанный набор в одном документе — обычное состояние работы.
+            try { diagnostics = await mediator.Send(new ValidateInstanceResolutionQuery(doc.Id), ct); }
+            catch (Exception) { failed++; continue; }
+
+            foreach (var d in diagnostics)
+            {
+                if (d.Code != QualityLinkScanner.Code && d.Code != QualityLinkScanner.ImplausibleCode) continue;
+                rows.Add(new QualityAuditRow(doc.Id, doc.DisplayName ?? "", d.Code, d.Path, d.Message));
+            }
+        }
+
+        return new QualityAuditReport(
+            q.SetId,
+            documents.Count,
+            failed,
+            rows.Count(r => r.Code == QualityLinkScanner.Code),
+            rows.Count(r => r.Code == QualityLinkScanner.ImplausibleCode),
+            rows);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/QualitySetAuditTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/QualitySetAuditTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Сверка «реестр материалов ↔ карта документов качества» по комплекту (issue #589).
+///
+/// Проверка не бумажная: ровно её внешний агент делал руками, выгружая обе стороны целиком (151
+/// строка реестра против 113 связей) ради вывода в десяток строк. Тест идёт сквозь всю цепочку —
+/// составной ключ (#582) строится сервером, резолвер по нему находит связку, сканер (#585) видит
+/// непривязанный материал, а предикат области продукции (#586) — сертификат не про этот товар.
+/// </summary>
+[Collection("Integration")]
+public class QualitySetAuditTests(IntegrationTestFixture fx)
+{
+    private static IMediator M(IServiceScope scope) => scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    private async Task<T> InScopeAsync<T>(Func<IMediator, Task<T>> action)
+    {
+        using var scope = fx.Services.CreateScope();
+        return await action(M(scope));
+    }
+
+    private static string Uniq => Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>Комплект + документ с массивом материалов + сертификат на автоматы EKF.</summary>
+    private async Task<(Guid SetId, Guid InstanceId, Guid CertId)> SeedAsync()
+    {
+        var suffix = Uniq;
+
+        var materialType = await InScopeAsync(m => m.Send(new CreateDocumentTypeCommand(
+            $"Материал {suffix}", $"MAT{suffix}"[..11], DocumentTypeKind.Composite, null,
+            JsonDocument.Parse("""
+                { "fields": [
+                    { "key": "Наименование", "type": "string", "tags": ["identity:1"] },
+                    { "key": "Артикул", "type": "string", "tags": ["identity:2"] },
+                    { "key": "ДокументКачества", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+                """))));
+
+        var docType = await InScopeAsync(m => m.Send(new CreateDocumentTypeCommand(
+            $"Реестр материалов {suffix}", $"REG{suffix}"[..11], DocumentTypeKind.Document, null,
+            JsonDocument.Parse($$"""
+                { "fields": [ { "key": "Материалы", "type": "array", "typeId": "{{materialType.Id}}" } ] }
+                """))));
+
+        var certType = await InScopeAsync(m => m.Send(new CreateDocumentTypeCommand(
+            $"Сертификат {suffix}", $"CRT{suffix}"[..11], DocumentTypeKind.Document, null,
+            JsonDocument.Parse("""{"fields":[{"key":"Продукция","type":"string"}]}"""))));
+
+        var cert = await InScopeAsync(m => m.Send(new CreateQualityDocumentCommand(
+            certType.Id, $"EKF — автоматические выключатели {suffix}",
+            JsonDocument.Parse("""{"Продукция":"Выключатели автоматические, торговой марки EKF, модель: AV-125"}"""),
+            CatalogScope.System, null, QualityDocSource.Manual, null, null, null)));
+
+        var construction = await InScopeAsync(m => m.Send(new CreateConstructionCommand($"Стройка {suffix}", Guid.NewGuid())));
+        var section = await InScopeAsync(m => m.Send(new CreateSectionCommand(construction.Id, $"Раздел {suffix}")));
+        var set = await InScopeAsync(m => m.Send(new CreateDocumentSetCommand(section.Id, $"Комплект {suffix}")));
+        var instance = await InScopeAsync(m => m.Send(new AddDocumentToSetCommand(set.Id, docType.Id)));
+
+        // Три материала: автомат (сертификат по делу), трубка (сертификат не про неё), кабель (без связки).
+        await InScopeAsync(m => m.Send(new UpdateRequisitesCommand(instance.Id, JsonDocument.Parse("""
+            { "Материалы": [
+                { "Наименование": "Выключатель автоматический AV-125 3P 63А EKF", "Артикул": "AV-125-63" },
+                { "Наименование": "Трубка термоусаживаемая ТУТ нг 20/10", "Артикул": "TUT-20" },
+                { "Наименование": "Кабель ВВГнг 3х2.5", "Артикул": "VVG-3x25" } ] }
+            """))));
+
+        // Связки заводим ключами, которые строит сервер: порядок компонентов задан identity:1/identity:2.
+        await InScopeAsync(m => m.Send(new SetMaterialLinksCommand(CatalogScope.System, null,
+        [
+            new MaterialLinkInput(IdentityKey.From(["Выключатель автоматический AV-125 3P 63А EKF", "AV-125-63"])),
+            new MaterialLinkInput(IdentityKey.From(["Трубка термоусаживаемая ТУТ нг 20/10", "TUT-20"])),
+        ], cert.Id)));
+
+        return (set.Id, instance.Id, cert.Id);
+    }
+
+    [Fact]
+    public async Task Audit_SeparatesMissingLinkFromImplausibleCertificate()
+    {
+        var (setId, instanceId, _) = await SeedAsync();
+
+        var report = await InScopeAsync(m => m.Send(new QualitySetAuditQuery(setId)));
+
+        Assert.Equal(1, report.Documents);
+        Assert.Equal(0, report.Failed);
+        // Кабель — без связки вовсе.
+        Assert.Equal(1, report.MaterialsWithoutDoc);
+        // Трубка — связка есть, но сертификат на автоматы: именно этот случай дал 68 неверных связок.
+        Assert.Equal(1, report.ImplausibleDocs);
+        // Автомат не в отчёте: связка на месте и сертификат про него.
+        Assert.Equal(2, report.Rows.Count);
+        Assert.All(report.Rows, r => Assert.Equal(instanceId, r.InstanceId));
+
+        var missing = Assert.Single(report.Rows, r => r.Code == "material-no-quality-doc");
+        Assert.Contains("кабель ввгнг 3х2.5 | vvg-3x25", missing.Message);   // составной ключ целиком
+        Assert.StartsWith("Материалы[2]", missing.Path);   // адрес строки, а не пересказ
+
+        var implausible = Assert.Single(report.Rows, r => r.Code == "quality-doc-implausible");
+        Assert.StartsWith("Материалы[1]", implausible.Path);
+    }
+
+    [Fact]
+    public async Task EmptySet_IsQuietAndSaysSo()
+    {
+        var suffix = Uniq;
+        var construction = await InScopeAsync(m => m.Send(new CreateConstructionCommand($"Стройка {suffix}", Guid.NewGuid())));
+        var section = await InScopeAsync(m => m.Send(new CreateSectionCommand(construction.Id, $"Раздел {suffix}")));
+        var set = await InScopeAsync(m => m.Send(new CreateDocumentSetCommand(section.Id, $"Комплект {suffix}")));
+
+        var report = await InScopeAsync(m => m.Send(new QualitySetAuditQuery(set.Id)));
+
+        Assert.Equal(0, report.Documents);
+        Assert.Empty(report.Rows);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.68.0</Version>
+    <Version>0.69.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #589 (пункт I-8, последний в части I плана).

## Зачем

Ровно эту проверку внешний агент делал руками: выгружал обе стороны целиком (151 строка реестра
против 113 связей) и сличал сам. Стороны большие, а ответ — десяток строк; выгрузка сырья ради
вывода, который умещается в экран, и есть основная статья расхода контекста.

`GET /api/quality-docs/audit/{setId}` отдаёт находки и их количество по видам.

## Как

**Своего прохода по данным нет намеренно.** Сверка идёт тем же путём, что и проверка одного документа
(`ValidateInstanceResolutionQuery`), и берёт из его диагностик только качественные. Пайплайн резолва
и без того размножен по нескольким местам — шестая копия разошлась бы с остальными, и разошлась бы
молча.

**Два вида находок разделены**, потому что это разные решения человека: «материала нет в карте»
(#585) — завести связку; «документ не про этот материал» (#586) — перепривязать.

**Нечитаемый документ не отменяет сверку остальных, но и не замалчивается** — он идёт в счётчик
`Failed`: молчание означало бы «всё хорошо» там, где просто не смотрели.

## Проверка

Сквозной интеграционный тест на живом сценарии: составной ключ строит сервер, резолвер по нему
находит связку, сканер видит непривязанный кабель, предикат области продукции — термоусаживаемую
трубку с сертификатом на автоматы EKF AV-125. Автомат, у которого всё в порядке, в отчёт не попадает.
Отдельно — пустой комплект (отчёт молчит и говорит, что документов ноль).

`dotnet test` — 934 зелёных, `npx tsc -b` чисто, `npm test` — 334 зелёных.

Инструмент MCP для этой сверки — часть II плана, там же, где остальной контракт агента.

Версия 0.69.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
