### PR TITLE
Привязки материалов: правки по ревью части I (#587, #588, #589)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -25,9 +25,11 @@ import {
   type BulkLinkAssessment,
 } from './qualityMatch';
 import { QualityDocForm } from '@/features/quality-docs/QualityDocForm';
-import { docIdentityLine } from '@/features/quality-docs/docIdentity';
+import { docNumberOf } from '@/features/quality-docs/docIdentity';
+import { formatDateRu } from '@/shared/utils/date';
 import { recognizeAndUpdate } from '@/features/quality-docs/recognizeImported';
 import { openAttachmentInNewTab } from '@/shared/api/attachments';
+import { useToast } from '@/shared/ui/Toast';
 
 // ─── Срок действия документа качества (по функциональному тэгу quality.validUntil) ──
 function readPath(obj: Record<string, unknown>, path: string[]): unknown {
@@ -72,8 +74,13 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
   const [includeExpired, setIncludeExpired] = useState(false);
   // Единая строка поиска: фильтрует библиотеку и используется для веб-поиска.
   const [query, setQuery] = useState('');
-  // Грузим всю библиотеку по области; релевантность к материалу считаем на клиенте.
-  const { data: docs = [], isLoading } = useListQualityDocs({ scope, scopeId: scopeId ?? undefined, enabled: open });
+  // Библиотека грузится ЦЕЛИКОМ, без фильтра по области, и это не небрежность: scope здесь говорит,
+  // где будет заведена СВЯЗКА (и где создастся новый документ на вкладке «Создать вручную»), а не из
+  // чего можно выбирать. Пока областью по умолчанию была System, разница не замечалась; с дефолтом
+  // «комплект» (#587) фильтр по области оставил бы пикер пустым при полной библиотеке на System — и
+  // пользователь пошёл бы заново импортировать из интернета то, что у него уже есть.
+  // Релевантность к материалу считается на клиенте.
+  const { data: docs = [], isLoading } = useListQualityDocs({ enabled: open });
 
   const qualityTypes = useMemo(
     () => allDocTypes.filter(dt => dt.kind === 'Document' && !dt.isAbstract && typeHasTag(dt, FUNCTIONAL_TAG.typeQualityDocument, allDocTypes)),
@@ -192,15 +199,17 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
                           продукции — по имени человек выбирал вслепую. */}
                       <span className="flex-1 min-w-0">
                         <span className="block text-sm text-fg1 truncate">{d.displayName}</span>
-                        {docIdentityLine(d, allDocTypes) && (
-                          <span className="block text-[11px] text-fg4 truncate">{docIdentityLine(d, allDocTypes)}</span>
+                        {/* Только НОМЕР: срок действия у строки уже есть справа, и вторая дата рядом
+                            (да ещё в другом формате) читалась бы как два разных срока. */}
+                        {docNumberOf(d, allDocTypes) && (
+                          <span className="block text-[11px] text-fg4 truncate">№ {docNumberOf(d, allDocTypes)}</span>
                         )}
                       </span>
                       {queryTokens.length > 0 && score > 0 && (
                         <span className="text-[10px] px-1.5 py-0.5 rounded bg-brand-subtle text-brand shrink-0">{Math.round(score * 100)}%</span>
                       )}
                       {validUntil && <span className={`text-[10px] shrink-0 ${expired ? 'text-danger' : 'text-fg4'}`}>
-                        {expired ? 'просрочен ' : 'до '}{validUntil}</span>}
+                        {expired ? 'просрочен ' : 'до '}{formatDateRu(validUntil)}</span>}
                     </button>
                     {d.scanBlobPath && (
                       <button onClick={() => void openAttachmentInNewTab(d.scanBlobPath!)} title="Просмотр скана (в новой вкладке)"
@@ -297,6 +306,17 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
   const constructionId = set?.constructionId ?? null;
   /** Уровень готов принимать связки: System живёт без id, остальным id обязателен. */
   const scopeReady = scope === 'System' || !!(scope === 'Set' ? setId : scope === 'Section' ? sectionId : constructionId);
+  /**
+   * Область ещё не готова принимать связки (комплект догружается) — говорим об этом.
+   *
+   * Молчаливый выход отсюда был бы хуже отказа: пользователь нажал «Привязать», ничего не
+   * произошло, и объяснить это нечем — а окно осталось открытым с выбором, как будто всё идёт.
+   */
+  function scopeNotReady(): boolean {
+    if (scopeReady) return false;
+    linksToast.error('Область связи ещё не готова — комплект загружается. Повторите через мгновение.');
+    return true;
+  }
   const scopeId = scope === 'Set' ? setId
     : scope === 'Section' ? sectionId
     : scope === 'Construction' ? constructionId
@@ -315,6 +335,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
   const { data: docsSection = [] } = useListQualityDocs(
     { scope: 'Section', scopeId: sectionId ?? undefined, enabled: !!sectionId });
   const { data: docsSet = [] } = useListQualityDocs({ scope: 'Set', scopeId: setId });
+  const linksToast = useToast();
   const setLinks = useSetMaterialLinks();
   const removeLink = useRemoveMaterialLink();
 
@@ -443,7 +464,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
   async function linkChosen(docId: string, chosen: MaterialRow[]) {
     // Уровень выбран, а его id ещё не доехал (комплект перезагружается) — связку класть некуда:
     // с пустым scopeId она стала бы «на все разделы разом», чего в селекторе никто не выбирал.
-    if (!scopeReady) return;
+    if (scopeNotReady()) return;
     // Метку материала кладём в связку сразу (issue #554): человеческое имя есть только здесь —
     // строки наборов данных не хранятся, и на экране контроля восстановить его будет неоткуда.
     await setLinks.mutateAsync({
@@ -466,11 +487,11 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
 
   // Принять предложенный документ для одной строки / для всех с подсказкой.
   async function acceptSuggestion(mat: MaterialRow, docId: string) {
-    if (!scopeReady) return;
+    if (scopeNotReady()) return;
     await setLinks.mutateAsync({ scope, scopeId, materials: [{ key: mat.key, label: mat.label }], qualityDocumentId: docId });
   }
   async function acceptAllSuggestions() {
-    if (!scopeReady) return;
+    if (scopeNotReady()) return;
     const byDoc = new Map<string, { key: string; label: string }[]>();
     for (const mat of materials) {
       const s = suggestionByKey.get(mat.key);
@@ -482,7 +503,7 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
   }
 
   async function applySuggestions() {
-    if (!scopeReady) return;
+    if (scopeNotReady()) return;
     const chosen = (suggestions ?? []).filter(s => suggestSel.has(s.materialKey));
     // группируем по документу — один вызов на документ
     const byDoc = new Map<string, { key: string; label?: string }[]>();

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef } from 'react';
 import { Loader2, ShieldCheck, Upload, Eye } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
+import { apiError } from '@/shared/utils/apiError';
 import { TypePickerField } from '@/shared/ui/TypePickerField';
 import type { PickType } from '@/shared/ui/TypePicker';
 import { TextField } from '@/shared/ui/TextField';
@@ -162,7 +163,9 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
         });
       }
       onSaved(doc);
-    } catch (e: unknown) { setError(e instanceof Error ? e.message : 'Ошибка'); }
+    // apiError, а не e.message: у 409 (имя занято, issue #588) объяснение лежит в теле ответа, а
+    // e.message даёт «Request failed with status code 409» — то есть ровно ничего.
+    } catch (e: unknown) { setError(apiError(e, 'Ошибка сохранения')); }
   }
 
   return (

--- a/src/client/src/features/quality-docs/docIdentity.ts
+++ b/src/client/src/features/quality-docs/docIdentity.ts
@@ -2,7 +2,6 @@ import type { DocumentType } from '@/shared/api/types';
 import type { QualityDocument } from '@/shared/api/qualityDocs';
 import { findTaggedFieldPath } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
-import { formatDateRu } from '@/shared/utils/date';
 
 /**
  * Чем один документ качества отличается от другого (issue #588).
@@ -33,17 +32,6 @@ export const docNumberOf = (doc: QualityDocument, docTypes: DocumentType[]) =>
 
 export const docValidUntilOf = (doc: QualityDocument, docTypes: DocumentType[]) =>
   docFieldByTag(doc, docTypes, FUNCTIONAL_TAG.qualityValidUntil);
-
-/**
- * Строка-опознание: «№ … · до …». Пустая, когда сказать нечего — тэги не проставлены или реквизиты
- * не распознаны. Пустую строку показывать не нужно: место она займёт, а вопрос «какой из двух» не
- * решит.
- */
-export function docIdentityLine(doc: QualityDocument, docTypes: DocumentType[]): string {
-  const number = docNumberOf(doc, docTypes);
-  const validUntil = docValidUntilOf(doc, docTypes);
-  return [number && `№ ${number}`, validUntil && `до ${formatDateRu(validUntil)}`].filter(Boolean).join(' · ');
-}
 
 /**
  * Имена, встречающиеся у ДВУХ И БОЛЕЕ документов списка (сравнение как у серверной проверки

--- a/src/client/src/features/quality-docs/recognizeImported.ts
+++ b/src/client/src/features/quality-docs/recognizeImported.ts
@@ -35,9 +35,21 @@ export async function recognizeAndUpdate(doc: QualityDocument, allDocTypes: Docu
   }
 
   const requisites = applyRecognized(doc.requisites, fieldValues);
-  const displayName = summary || doc.displayName;
-  const { data } = await apiClient.put<QualityDocument>(`/quality-docs/${doc.id}`, {
+  const save = (displayName: string) => apiClient.put<QualityDocument>(`/quality-docs/${doc.id}`, {
     documentTypeId: doc.documentTypeId, displayName, requisites,
-  });
-  return data;
+  }).then(r => r.data);
+
+  const summarized = summary || doc.displayName;
+  if (summarized === doc.displayName) return save(summarized);
+
+  try {
+    return await save(summarized);
+  } catch (e: unknown) {
+    // 409 — краткое имя, придуманное распознаванием, уже занято в этой области (issue #588).
+    // Сдаём имя, но НЕ распознанные реквизиты: номер и срок действия — то, ради чего распознавание
+    // и запускалось, а на них держатся и «просрочен», и проверка правдоподобия сертификата.
+    // Совпадение здесь закономерно: два сертификата одного бренда суммируются в одно и то же имя.
+    if ((e as { response?: { status?: number } })?.response?.status !== 409) throw e;
+    return save(doc.displayName);
+  }
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentDtos.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentDtos.cs
@@ -30,12 +30,13 @@ public record GeneratedFileDto(Guid Id, Guid DocumentInstanceId, OutputFormat Fo
 /// <summary>Комплект с документами — форма клиентского DocumentSet.</summary>
 /// <param name="ConstructionId">Стройка комплекта (issue #587). Нужна там, где привязка заводится не
 /// на комплект, а на уровень выше: цепочку «комплект → раздел → стройка» иначе пришлось бы собирать
-/// клиенту двумя лишними запросами ради одного значения.</param>
+/// клиенту двумя лишними запросами ради одного значения. Null — раздел не найден: клиент проверяет
+/// наличие значения, и «нулевой» идентификатор такую проверку прошёл бы.</param>
 public record DocumentSetDto(
-    Guid Id, string Name, Guid SectionId, Guid ConstructionId, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt,
+    Guid Id, string Name, Guid SectionId, Guid? ConstructionId, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt,
     IReadOnlyList<InstanceDto> Instances)
 {
-    public static DocumentSetDto From(DocumentSet set, Guid constructionId, IReadOnlyList<DomainObject> documents) => new(
+    public static DocumentSetDto From(DocumentSet set, Guid? constructionId, IReadOnlyList<DomainObject> documents) => new(
         set.Id, set.Name, set.SectionId, constructionId, set.CreatedAt, set.UpdatedAt,
         documents.OrderBy(d => d.SortOrder).Select(InstanceDto.From).ToList());
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentSetEndpoints.cs
@@ -274,8 +274,13 @@ public static class DocumentSetEndpoints
     /// на уровень выше комплекта; собирать цепочку двумя лишними запросами ради одного значения
     /// расточительно, а знать её ему всё равно надо.
     /// </summary>
-    static async Task<Guid> ConstructionOfAsync(IMediator m, DocumentSet set)
-        => (await m.Send(new GetSectionQuery(set.SectionId)))?.ConstructionId ?? Guid.Empty;
+    /// <remarks>
+    /// Возвращает null, если раздел не найден, — не <c>Guid.Empty</c>: клиент проверяет наличие
+    /// значения, а строка из одних нулей проверку проходит, и «Вся стройка» стала бы доступной
+    /// областью, ведущей в никуда.
+    /// </remarks>
+    static async Task<Guid?> ConstructionOfAsync(IMediator m, DocumentSet set)
+        => (await m.Send(new GetSectionQuery(set.SectionId)))?.ConstructionId;
 
     static Guid GetUserId(ClaimsPrincipal user)
         => Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub")!);

--- a/src/server/BHS.CRG.Api/Endpoints/QualityDocs/QualityDocEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/QualityDocs/QualityDocEndpoints.cs
@@ -104,8 +104,11 @@ public static class QualityDocEndpoints
 
         // Сверка «реестр материалов ↔ карта качества» по комплекту (issue #589): ответ — десяток
         // строк вместо двух выгруженных таблиц.
-        g.MapGet("/audit/{setId:guid}", async (Guid setId, IMediator m, CancellationToken ct)
-            => Results.Ok(await m.Send(new QualitySetAuditQuery(setId), ct)));
+        g.MapGet("/audit/{setId:guid}", async (Guid setId, int? limit, IMediator m, CancellationToken ct) =>
+        {
+            try { return Results.Ok(await m.Send(new QualitySetAuditQuery(setId, limit ?? QualitySetAuditHandler.DefaultLimit), ct)); }
+            catch (KeyNotFoundException) { return Results.NotFound(); }
+        });
 
         g.MapPost("/links", async (SetLinksReq req, IMediator m) =>
         {

--- a/src/server/BHS.CRG.Application/QualityDocs/Handlers.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/Handlers.cs
@@ -34,7 +34,11 @@ public class QualityDocHandlers(
     public async Task<QualityDocument> Handle(UpdateQualityDocumentCommand cmd, CancellationToken ct)
     {
         var doc = await repo.GetByIdAsync(cmd.Id, ct) ?? throw new KeyNotFoundException($"QualityDocument {cmd.Id} not found");
-        await EnsureNameFreeAsync(cmd.DisplayName, doc.Scope, doc.ScopeId, exceptId: doc.Id, ct);
+        // Проверяем ТОЛЬКО смену имени. Дубли уже есть в живой базе (ради них issue #588 и заведена),
+        // и запрет на сохранение с НЕИЗМЕНЁННЫМ именем означал бы, что такой документ нельзя больше
+        // ни отредактировать, ни распознать, пока его не переименуют.
+        if (!string.Equals(doc.DisplayName.Trim(), (cmd.DisplayName ?? "").Trim(), StringComparison.OrdinalIgnoreCase))
+            await EnsureNameFreeAsync(cmd.DisplayName, doc.Scope, doc.ScopeId, exceptId: doc.Id, ct);
         doc.Update(cmd.DocumentTypeId, cmd.DisplayName, cmd.Requisites);
         repo.Update(doc);
         await repo.SaveChangesAsync(ct);

--- a/src/server/BHS.CRG.Application/QualityDocs/QualitySetAudit.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/QualitySetAudit.cs
@@ -12,13 +12,16 @@ public record QualityAuditRow(Guid InstanceId, string InstanceName, string Code,
 /// <param name="Documents">Сколько документов комплекта проверено.</param>
 /// <param name="Failed">Документы, которые проверить НЕ удалось (тип удалён, набор не читается).
 /// Молчание об этом означало бы «всё хорошо» там, где просто не смотрели.</param>
+/// <param name="Truncated">Находок больше, чем строк в <paramref name="Rows"/>. Счётчики при этом
+/// полные: усечён показ, а не подсчёт — иначе «10 из 10» читалось бы как «всё в порядке».</param>
 public record QualityAuditReport(
     Guid SetId,
     int Documents,
     int Failed,
     int MaterialsWithoutDoc,
     int ImplausibleDocs,
-    IReadOnlyList<QualityAuditRow> Rows);
+    IReadOnlyList<QualityAuditRow> Rows,
+    bool Truncated = false);
 
 /// <summary>
 /// Сверка «реестр материалов ↔ карта документов качества» по всему комплекту (issue #589).
@@ -32,14 +35,36 @@ public record QualityAuditReport(
 /// прогоняет полный резолв и отдаёт диагностики, отсюда берутся только качественные. Своего прохода
 /// по данным здесь нет намеренно — пайплайн резолва и без того размножен по нескольким местам, и
 /// шестая копия неизбежно разошлась бы с остальными.
+///
+/// Цена решения: резолв документа читает наборы данных (блоб + разбор файла), и на большом комплекте
+/// прогон занимает минуты внутри одного HTTP-запроса. Длинные прогоны переезжают в подсистему Job
+/// отдельной задачей — issue #628; здесь ограничен только объём ответа.
 /// </summary>
-public record QualitySetAuditQuery(Guid SetId) : IRequest<QualityAuditReport>;
+/// <param name="Limit">Сколько строк вернуть. Счётчики считаются по всем находкам.</param>
+public record QualitySetAuditQuery(Guid SetId, int Limit = QualitySetAuditHandler.DefaultLimit)
+    : IRequest<QualityAuditReport>;
 
-public class QualitySetAuditHandler(IDomainObjectRepository objects, IMediator mediator)
-    : IRequestHandler<QualitySetAuditQuery, QualityAuditReport>
+public class QualitySetAuditHandler(
+    IDomainObjectRepository objects,
+    IRepository<Domain.Documents.DocumentSet> sets,
+    IMediator mediator
+) : IRequestHandler<QualitySetAuditQuery, QualityAuditReport>
 {
+    /// <summary>
+    /// Сколько находок показывать. Смысл сверки — короткий ответ вместо двух выгруженных таблиц, а
+    /// на живых данных находок бывает под сотню (151 материал, 68 неверных связок): без предела
+    /// ответ вырос бы больше того сырья, которое он заменяет. Полные числа остаются в счётчиках.
+    /// </summary>
+    public const int DefaultLimit = 100;
+
     public async Task<QualityAuditReport> Handle(QualitySetAuditQuery q, CancellationToken ct)
     {
+        // Несуществующий комплект — 404, а не «проблем нет»: пустой отчёт на опечатку в
+        // идентификаторе читается как чистая совесть, и это ровно тот молчаливый ноль, из-за
+        // которого 68 неверных связок жили незамеченными.
+        _ = await sets.GetByIdAsync(q.SetId, ct)
+            ?? throw new KeyNotFoundException($"DocumentSet {q.SetId} not found");
+
         var documents = await objects.GetSetDocumentsAsync(q.SetId, tracked: false, ct);
         var rows = new List<QualityAuditRow>();
         var failed = 0;
@@ -51,6 +76,9 @@ public class QualitySetAuditHandler(IDomainObjectRepository objects, IMediator m
             // Один нечитаемый документ не должен отменять сверку остальных: комплект собирают
             // месяцами, и сломанный набор в одном документе — обычное состояние работы.
             try { diagnostics = await mediator.Send(new ValidateInstanceResolutionQuery(doc.Id), ct); }
+            // Отмену наружу: клиент ушёл — считать нечего и незачем, а записанная в Failed отмена
+            // выглядела бы как «документ сломан» и отправила бы человека искать несуществующий дефект.
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception) { failed++; continue; }
 
             foreach (var d in diagnostics)
@@ -60,12 +88,14 @@ public class QualitySetAuditHandler(IDomainObjectRepository objects, IMediator m
             }
         }
 
+        var limit = q.Limit > 0 ? q.Limit : DefaultLimit;
         return new QualityAuditReport(
             q.SetId,
             documents.Count,
             failed,
             rows.Count(r => r.Code == QualityLinkScanner.Code),
             rows.Count(r => r.Code == QualityLinkScanner.ImplausibleCode),
-            rows);
+            [.. rows.Take(limit)],
+            Truncated: rows.Count > limit);
     }
 }

--- a/src/server/BHS.CRG.Tests/Integration/QualityDocNameUniquenessTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/QualityDocNameUniquenessTests.cs
@@ -89,6 +89,36 @@ public class QualityDocNameUniquenessTests(IntegrationTestFixture fx)
         Assert.Equal(name, updated.DisplayName);
     }
 
+    /// <summary>
+    /// Документ-дубль, заведённый ДО запрета (а такие в живой базе есть — ради них issue и заведена),
+    /// обязан оставаться редактируемым. Иначе его нельзя ни поправить, ни распознать, пока не
+    /// переименуешь, — то есть запрет наказывал бы за то, что случилось раньше него.
+    /// </summary>
+    [Fact]
+    public async Task ExistingDuplicate_CanStillBeEdited_WhenNameUnchanged()
+    {
+        var typeId = await SeedTypeAsync();
+        var name = $"EKF — автоматические выключатели {Guid.NewGuid():N}";
+        var first = await CreateAsync(typeId, name, CatalogScope.System, null);
+        // Второй дубль заводим в обход команды — так, как его создаёт импорт из интернета.
+        QualityDocument second;
+        using (var scope = fx.Services.CreateScope())
+        {
+            var repo = scope.ServiceProvider
+                .GetRequiredService<BHS.CRG.Application.Common.IRepository<QualityDocument>>();
+            second = QualityDocument.Create(typeId, name, JsonDocument.Parse("{}"),
+                CatalogScope.System, null, QualityDocSource.Web, sourceUrl: $"https://example.test/{Guid.NewGuid():N}");
+            await repo.AddAsync(second);
+            await repo.SaveChangesAsync();
+        }
+
+        var updated = await InScopeAsync(m => m.Send(new UpdateQualityDocumentCommand(
+            second.Id, typeId, name, JsonDocument.Parse("""{"Продукция":"Выключатели AV-6"}"""))));
+
+        Assert.Equal(name, updated.DisplayName);
+        Assert.NotEqual(first.Id, updated.Id);
+    }
+
     [Fact]
     public async Task RenamingOntoAnotherDocumentName_IsRejected()
     {

--- a/src/server/BHS.CRG.Tests/Integration/QualitySetAuditTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/QualitySetAuditTests.cs
@@ -106,6 +106,16 @@ public class QualitySetAuditTests(IntegrationTestFixture fx)
         Assert.StartsWith("Материалы[1]", implausible.Path);
     }
 
+    /// <summary>
+    /// Несуществующий комплект — отказ, а не «проблем нет». Пустой отчёт на опечатку в
+    /// идентификаторе читается как чистая совесть, и это ровно тот молчаливый ноль, из-за которого
+    /// неверные связки жили незамеченными.
+    /// </summary>
+    [Fact]
+    public async Task UnknownSet_IsRejected_NotReportedAsClean()
+        => await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => InScopeAsync(m => m.Send(new QualitySetAuditQuery(Guid.NewGuid()))));
+
     [Fact]
     public async Task EmptySet_IsQuietAndSaysSo()
     {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.69.0</Version>
+    <Version>0.69.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Правки по итогам `/code-review` части I плана. Две находки — настоящие регрессы моих же изменений.

## Регрессы

**Пикер документа оставался пустым.** Библиотека в модалке грузилась с фильтром по области, а
областью по умолчанию стал комплект (#587): при полной библиотеке на System пользователь видел
«ничего не найдено» и шёл импортировать из интернета то, что у него уже есть. Область говорит, где
будет заведена **связка**, а не из чего выбирать, — библиотека грузится целиком.

**Распознавание после импорта молча теряло результат.** Оно придумывает документу краткое имя («EKF —
автоматические выключатели») и сохраняет его вместе с реквизитами одним PUT; с запретом одноимённых
(#588) второй сертификат того же бренда получал 409, а оба вызова глотают ошибку — документ оставался
и без имени, и **без реквизитов**. Теперь при 409 имя сдаётся, а реквизиты сохраняются: номер и срок
— то, ради чего распознавание и запускалось, и на них держатся «просрочен» и проверка правдоподобия.

## Остальное

- Запрет одноимённых проверяется только при **смене** имени: дубли в живой базе уже есть, и запрет на
  сохранение с неизменённым именем означал бы, что такой документ нельзя ни поправить, ни распознать,
  пока не переименуешь.
- Форма показывает причину 409 (было «Request failed with status code 409»).
- Сверка отвечает **404** на несуществующий комплект: пустой отчёт на опечатку в идентификаторе
  читается как чистая совесть — тот самый молчаливый ноль, из-за которого неверные связки жили
  незамеченными.
- Ответ сверки ограничен сотней строк с флагом `truncated`; **счётчики полные** — усечён показ, а не
  подсчёт. Без предела «короткий ответ вместо двух таблиц» на живых данных стал бы третьей таблицей.
- Отмена запроса больше не засчитывается как сломанный документ.
- Стройка комплекта отдаётся `null`, а не `Guid.Empty`: клиент проверяет наличие значения, а строка
  из нулей проверку проходит — «Вся стройка» стала бы областью, ведущей в никуда.
- В строке пикера остался только номер: срок действия там уже был справа, и вторая дата рядом (в
  другом формате) читалась как два разных срока.
- Отказ привязки из-за недогруженной области больше не молчит.

## Не правится здесь

Синхронный прогон сверки по всем документам комплекта (резолв тянет наборы данных — блоб + разбор
файла) — переезд в подсистему Job вынесен в **#628**. UI эту сверку пока не вызывает, объём ответа
ограничен, срочности нет.

## Проверка

`dotnet test` — 936 зелёных (новые: «дубль, заведённый до запрета, остаётся редактируемым» и
«несуществующий комплект — отказ, а не чистый отчёт»), `npx tsc -b` чисто, `npm test` — 334 зелёных.

Версия 0.69.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
