### PR TITLE
Сегментированный чип для тэга с параметром (#630)

### DIFF
--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -9,9 +9,10 @@ import type { DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/t
 import { FIELD_UID, withFieldUid, type SchemaField, type FieldGroup } from '@/shared/api/schema';
 import { TYPE_LABELS, toCamelKey, nextAutoKey, nextSavedKey } from './schemaConstants';
 import {
-  useTagRegistry, fieldTags, findTagEntry, hasTag, tagCode, tagOrder, withTagOrder,
+  useTagRegistry, fieldTags, findTagEntry, hasTag, tagCode, withTagOrder,
   type TagDefinition,
 } from '@/shared/api/tags';
+import { FunctionalTagBadge, FunctionalTagChip } from './FunctionalTagChip';
 import { evalComputed, validateComputed, findComputedCycles, referencedKeys } from '@/shared/utils/computedExpression';
 import { moveItem } from '@/shared/utils/moveItem';
 // ─── JSON preview ──────────────────────────────────────────────────────────────
@@ -53,11 +54,6 @@ export interface FieldRegistries {
   enumTypes: EnumTypeDef[];
   allDocTypes: DocumentType[];
   tagRegistry: TagDefinition[] | undefined;
-}
-
-/** Человеко-имя функц. тэга по коду (фолбэк — сам код). */
-export function tagLabelOf(tagRegistry: TagDefinition[] | undefined, code: string): string {
-  return (tagRegistry ?? []).find(t => t.code === code)?.label ?? code;
 }
 
 /** Краткая метка типа поля для свёрнутой карточки. */
@@ -382,7 +378,7 @@ export function FieldCard({
             <span className="block text-xs text-fg4 font-mono truncate">{field.key || '—'}</span>
           </span>
           {tags.slice(0, 2).map(tc => (
-            <span key={tc} className="hidden md:inline text-[11px] px-1.5 py-0.5 rounded bg-brand-subtle text-brand shrink-0">{tagLabelOf(tagRegistry, tc)}</span>
+            <FunctionalTagBadge key={tc} registry={tagRegistry} entry={tc} />
           ))}
           {tags.length > 2 && <span className="text-[11px] text-fg4 shrink-0">+{tags.length - 2}</span>}
           <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-fg3 shrink-0">{fieldTypeSummary(field, reg)}</span>
@@ -590,38 +586,14 @@ export function FieldCard({
           <span className="text-xs text-fg4 shrink-0 w-28 mt-1">Функц. тэги:</span>
           <div className="flex flex-wrap gap-1.5">
             {applicableTags.map(t => {
-              const entry = findTagEntry(tags, t.code);
-              const on = entry !== undefined;
               return (
-                <span key={t.code} className="inline-flex items-center gap-1">
-                  <button
-                    type="button"
-                    title={t.description}
-                    onClick={() => toggleTag(t.code)}
-                    className={`px-2 py-0.5 rounded-full text-xs border transition-colors ${
-                      on
-                        ? 'bg-purple-500/15 border-purple-400 text-purple-700'
-                        : 'border-stroke text-fg4 hover:border-stroke-strong hover:text-fg2'
-                    }`}
-                  >
-                    {t.label}
-                  </button>
-                  {/* Номер параметра — только у проставленного тэга, который его принимает (#583):
-                      у неотмеченного поля номер задавать не над чем. */}
-                  {on && t.parameter && (
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      maxLength={2}
-                      value={tagOrder(entry) ?? ''}
-                      placeholder={t.parameter.label}
-                      title={t.parameter.description}
-                      onChange={e => setTagOrder(t.code, e.target.value)}
-                      className="w-11 px-1 py-0.5 rounded border border-purple-400 bg-surface
-                                 text-xs text-fg1 text-center"
-                    />
-                  )}
-                </span>
+                <FunctionalTagChip
+                  key={t.code}
+                  tag={t}
+                  entry={findTagEntry(tags, t.code)}
+                  onToggle={() => toggleTag(t.code)}
+                  onOrderChange={raw => setTagOrder(t.code, raw)}
+                />
               );
             })}
           </div>

--- a/src/client/src/features/settings/FunctionalTagChip.tsx
+++ b/src/client/src/features/settings/FunctionalTagChip.tsx
@@ -1,0 +1,98 @@
+import { Minus, Plus } from 'lucide-react';
+import { tagLabelOf, tagOrder, type TagDefinition } from '@/shared/api/tags';
+
+/**
+ * Функциональный тэг поля как ОДИН объект (issue #630).
+ *
+ * Номер параметра («Идентификатор 3», issue #583) жил рядом с чипом отдельным полем ввода в
+ * собственной рамке — среди соседних чипов строки «Функц. тэги» тройка читалась как самостоятельный
+ * элемент, а не как номер именно этого тэга. Здесь номер — второй сегмент того же чипа, отделённый
+ * линией.
+ *
+ * Стрелки −/+ появляются по наведению, но место под них зарезервировано ВСЕГДА: строка тэгов
+ * переносится по ширине, и чип, растущий под курсором, толкал бы соседей на другую строку.
+ * `invisible` (а не `opacity-0`) заодно снимает с них клики — невидимая кнопка, меняющая номер, была
+ * бы ловушкой, а номер здесь дорогой: его правка меняет ключи всех объектов разом.
+ */
+export function FunctionalTagChip({ tag, entry, onToggle, onOrderChange }: {
+  tag: TagDefinition;
+  /** Запись тэга как она лежит в схеме («identity:3»); undefined — тэг не проставлен. */
+  entry: string | undefined;
+  onToggle: () => void;
+  /** Сырой ввод номера — фильтрацию цифр и «пусто = без номера» делает вызывающий. */
+  onOrderChange: (raw: string) => void;
+}) {
+  const on = entry !== undefined;
+  const order = entry !== undefined ? tagOrder(entry) : null;
+  const showParameter = on && !!tag.parameter;
+
+  // Стрелки ходят в пределах 1…99: ноль и отрицательные сервер всё равно считает «без номера»
+  // (см. tagOrder), а два знака — предел поля ввода.
+  const step = (delta: number) => onOrderChange(String(Math.min(99, Math.max(1, (order ?? 0) + delta))));
+
+  const arrowClass = 'invisible group-hover:visible group-focus-within:visible '
+    + 'text-purple-600 hover:text-purple-800 disabled:opacity-40 shrink-0';
+
+  return (
+    <span
+      className={`group inline-flex items-stretch overflow-hidden rounded-full border text-xs transition-colors ${
+        on
+          ? 'bg-purple-500/15 border-purple-400 text-purple-700 focus-within:ring-1 focus-within:ring-purple-400'
+          : 'border-stroke text-fg4 hover:border-stroke-strong hover:text-fg2'
+      }`}
+    >
+      <button type="button" title={tag.description} onClick={onToggle} className="px-2 py-0.5">
+        {tag.label}
+      </button>
+      {/* Номер — только у проставленного тэга, который его принимает: у неотмеченного поля
+          номер задавать не над чем. */}
+      {showParameter && (
+        <span
+          className="flex items-center gap-0.5 border-l border-purple-400 pl-1 pr-1"
+          title={tag.parameter!.description}
+        >
+          <button type="button" className={arrowClass} onClick={() => step(-1)}
+            disabled={(order ?? 0) <= 1} aria-label={`Уменьшить порядок: ${tag.label}`}>
+            <Minus size={11} />
+          </button>
+          <input
+            type="text"
+            inputMode="numeric"
+            maxLength={2}
+            value={order ?? ''}
+            placeholder={tag.parameter!.label}
+            aria-label={`Порядок компонента: ${tag.label}`}
+            onChange={e => onOrderChange(e.target.value)}
+            className="w-5 bg-transparent text-center tabular-nums text-purple-700 outline-none
+                       placeholder:text-purple-400/70"
+          />
+          <button type="button" className={arrowClass} onClick={() => step(1)}
+            disabled={(order ?? 0) >= 99} aria-label={`Увеличить порядок: ${tag.label}`}>
+            <Plus size={11} />
+          </button>
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Тот же тэг в свёрнутой шапке поля — только показ, без правки. Сегменты те же: подпись и номер,
+ * потому что бейдж «Идентификатор» без номера у поля, которое номер несёт, скрывал бы ровно то,
+ * ради чего в шапку и смотрят.
+ */
+export function FunctionalTagBadge({ registry, entry }: {
+  registry: TagDefinition[] | undefined;
+  entry: string;
+}) {
+  const order = tagOrder(entry);
+  return (
+    <span className="hidden md:inline-flex items-center shrink-0 overflow-hidden rounded
+                     bg-brand-subtle text-[11px] text-brand">
+      <span className="px-1.5 py-0.5">{tagLabelOf(registry, entry)}</span>
+      {order !== null && (
+        <span className="border-l border-brand/40 px-1.5 py-0.5 tabular-nums">{order}</span>
+      )}
+    </span>
+  );
+}

--- a/src/client/src/shared/api/tags.test.ts
+++ b/src/client/src/shared/api/tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tagCode, tagOrder, hasTag, findTagEntry, withTagOrder } from './tags';
+import { tagCode, tagOrder, hasTag, findTagEntry, withTagOrder, tagLabelOf, type TagDefinition } from './tags';
 
 /**
  * Разбор записи тэга «код» / «код:параметр» (issue #583). Правила совпадают с серверным TagCode —
@@ -44,6 +44,26 @@ describe('поиск тэга по коду', () => {
   it('отдаёт запись как она лежит в схеме — из неё читается номер', () => {
     expect(findTagEntry(['doc.number', 'identity:2'], 'identity')).toBe('identity:2');
     expect(findTagEntry(['doc.number'], 'identity')).toBeUndefined();
+  });
+});
+
+describe('подпись тэга по записи', () => {
+  const registry: TagDefinition[] = [
+    { code: 'identity', label: 'Идентификатор', description: '', scope: 'Field', appliesTo: [], multiple: true },
+    { code: 'doc.number', label: 'Номер документа', description: '', scope: 'Field', appliesTo: [], multiple: false },
+  ];
+
+  it('находит подпись и у параметризованной записи', () => {
+    // Ровно этот случай показывал сырой «identity:3» в шапке свёрнутого поля (issue #630):
+    // поиск шёл по полной строке записи, а в реестре лежит голый код.
+    expect(tagLabelOf(registry, 'identity:3')).toBe('Идентификатор');
+    expect(tagLabelOf(registry, 'identity')).toBe('Идентификатор');
+    expect(tagLabelOf(registry, 'doc.number')).toBe('Номер документа');
+  });
+
+  it('незнакомый тэг показывает свой код без параметра — номер рисуется отдельным сегментом', () => {
+    expect(tagLabelOf(registry, 'какой.то:2')).toBe('какой.то');
+    expect(tagLabelOf(undefined, 'identity:3')).toBe('identity');
   });
 });
 

--- a/src/client/src/shared/api/tags.ts
+++ b/src/client/src/shared/api/tags.ts
@@ -42,6 +42,18 @@ export function tagOrder(raw: string): number | null {
   return /^\d+$/.test(param) ? Number(param) : null;
 }
 
+/**
+ * Человеко-имя тэга по ЗАПИСИ в схеме — «identity:3» даёт «Идентификатор».
+ *
+ * Именно по записи, а не по коду (issue #630): поиск по полной строке параметризованную запись не
+ * находил, и бейдж свёрнутого поля показывал сырой «identity:3». Номер при этом не теряется — его
+ * рисуют отдельным сегментом рядом, а не втискивают в подпись.
+ */
+export function tagLabelOf(registry: TagDefinition[] | undefined, entry: string): string {
+  const code = tagCode(entry);
+  return (registry ?? []).find(t => t.code === code)?.label ?? code;
+}
+
 /** Несёт ли набор тэгов указанный КОД — с параметром или без («identity» найдёт и «identity:2»). */
 export function hasTag(tags: string[] | undefined, code: string): boolean {
   return !!tags?.some(t => tagCode(t) === code);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.76.0</Version>
+    <Version>0.76.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #630. Стек: базируется на #637 (#628) — сливать снизу вверх.

Номер тэга «Идентификатор» (#583) выглядел **двумя отдельными объектами**: чип-кнопка и рядом самостоятельное поле ввода в собственной рамке. Среди соседних чипов строки «Функц. тэги» тройка читалась как отдельный элемент, а не как номер именно этого тэга.

Реализован выбранный дизайн (вариант 1a «Сегментированный чип»): номер живёт внутри чипа вторым сегментом, отделённым линией; стрелки −/+ появляются по наведению, значение вводится и с клавиатуры.

## Два решения, которых не было в макете

**Место под стрелки зарезервировано всегда.** Строка тэгов переносится по ширине, и чип, растущий под курсором, толкал бы соседей на другую строку — «Производитель» прыгал бы при каждом наведении. Стрелки скрыты `invisible`, а не `opacity-0`: так они ещё и не ловят клики. Невидимая кнопка, меняющая номер, была бы ловушкой, а номер здесь дорогой — его правка меняет ключи всех объектов разом.

**Палитра оставлена своя** (сиреневая, как у остальных включённых тэгов), а не синяя из макета: макет показывал форму чипа, а не место в палитре строки.

## Сопутствующий дефект

В шапке свёрнутого поля бейдж показывал сырой код `identity:3`: `tagLabelOf` искала в реестре по полной строке записи, а там лежит голый код — параметризованная запись не находилась и уходила в фолбэк. Функция переехала из `FieldBuilder.tsx` в `shared/api/tags.ts` к остальным хелперам разбора записи, резолвит через `tagCode()` и покрыта тестами. Номер в шапке рисуется тем же вторым сегментом — бейдж «Идентификатор» без номера скрывал бы ровно то, ради чего в шапку и смотрят.

## Проверено

`npx tsc -b`, 336 тестов vitest (+2 случая на `tagLabelOf`), eslint по затронутым файлам (осталась только прежняя претензия к смешанным экспортам `FieldBuilder.tsx`, и её на одну меньше). Живьём: покой — «Идентификатор │ 1», наведение — «Идентификатор │ − 1 +», ширина чипа не меняется, соседи стоят на месте; в шапках свёрнутых полей «Идентификатор │ 1/2/3» вместо `identity:N`.

Версия — 0.76.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)