### PR TITLE
Качество: единые правила соответствия значения типу (#642)

### DIFF
--- a/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
+++ b/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
@@ -16,6 +16,7 @@ import type { AuditFinding } from '@/shared/api/documentTypes';
 const CATEGORY_LABEL: Record<string, string> = {
   'orphan-key': 'Поля, которых нет в текущей схеме',
   'type-mismatch': 'Несовпадение вида значения с типом поля',
+  'value-type': 'Значение не соответствует объявленному типу', // issue #642
 };
 
 export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys, open, onClose }: {
@@ -77,7 +78,9 @@ export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys
                   {items.map(f => {
                     const canRename = f.code === 'orphan-key' && isTopLevel(f.path);
                     return (
-                      <div key={f.path} className="px-3 py-2.5">
+                      // Путь В КЛЮЧЕ не уникален: у одного значения бывает несколько претензий сразу
+                      // (например, «не целое» и «меньше допустимого»), и обе лежат по одному пути.
+                      <div key={`${f.path} ${f.message}`} className="px-3 py-2.5">
                         <div className="flex items-start gap-2">
                           <span className="min-w-0 flex-1">
                             <code className="text-xs text-fg2 break-all">{f.path}</code>

--- a/src/client/src/features/settings/TypeAuditModal.tsx
+++ b/src/client/src/features/settings/TypeAuditModal.tsx
@@ -15,6 +15,9 @@ import { useAuditDocumentType, useApplyAuditFixes, type AuditFix } from '@/share
 const CATEGORY_LABEL: Record<string, string> = {
   'orphan-key': 'Осиротевшие поля (нет в текущей схеме)',
   'type-mismatch': 'Несовпадение вида значения с типом поля',
+  // issue #642: тонкий слой — базовый тип, шаблон и границы примитива, разбор даты. Те же правила,
+  // что и при выпуске документа, но здесь их видят и записи общих данных.
+  'value-type': 'Значение не соответствует объявленному типу',
 };
 
 interface Row { code: string; path: string; message: string; instances: { id: string; name: string }[] }
@@ -89,7 +92,9 @@ export function TypeAuditModal({ typeId, typeName, schemaFieldKeys, open, onClos
                   </div>
                   <div className="divide-y divide-muted">
                     {rows.map(row => {
-                      const k = `${row.code} ${row.path}`;
+                      // Сообщение в ключе обязательно: у одного значения бывает несколько претензий
+                      // сразу («не целое» и «меньше допустимого»), и обе лежат по одному пути.
+                      const k = `${row.code} ${row.path} ${row.message}`;
                       const isOpen = expanded.has(k);
                       const canRename = row.code === 'orphan-key' && isTopLevel(row.path);
                       return (

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -18,6 +18,7 @@ public class DocumentTypeHandlers(
     IRepository<DomainObject> objectRepo,
     IRepository<Template> templateRepo,
     IRepository<QualityDocument> qualityDocRepo,
+    IRepository<PrimitiveType> primitiveRepo,
     IDataSetService dataSetService) :
     IRequestHandler<CreateDocumentTypeCommand, DocumentType>,
     IRequestHandler<UpdateDocumentTypeCommand, DocumentType>,
@@ -65,7 +66,8 @@ public class DocumentTypeHandlers(
         var inst = await objectRepo.GetByIdAsync(q.InstanceId, ct)
             ?? throw new KeyNotFoundException($"Instance {q.InstanceId} not found");
         var byId = (await repo.GetAllAsync(ct)).ToDictionary(t => t.Id);
-        return Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId)
+        var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+        return Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId, primitives)
             .Select(iss => new AuditFinding(inst.Id, inst.DisplayName, iss.Code, iss.Severity.ToString(), iss.Path, iss.Message))
             .ToList();
     }
@@ -123,10 +125,13 @@ public class DocumentTypeHandlers(
         var typeIds = all.Where(t => Schema.DocumentTypeSchemaReader.IsSameOrDescendant(t.Id, q.TypeId, byId))
             .Select(t => t.Id).ToList();
         var instances = (await objectRepo.FindAsync(o => typeIds.Contains(o.CompositeTypeId), ct)).ToList();
+        // Примитивы читаем один раз на прогон, а не на объект: тот же расчёт, что у справочников
+        // проверки выпуска (см. SchemaCatalog, issue #628).
+        var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
 
         var findings = new List<AuditFinding>();
         foreach (var inst in instances)
-            foreach (var iss in Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId))
+            foreach (var iss in Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId, primitives))
                 findings.Add(new(inst.Id, inst.DisplayName, iss.Code, iss.Severity.ToString(), iss.Path, iss.Message));
 
         return new(q.TypeId, type.Name, instances.Count, findings);

--- a/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
@@ -1,6 +1,4 @@
-using System.Globalization;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
@@ -13,6 +11,9 @@ namespace BHS.CRG.Application.Generation;
 /// Повод: поле «ПорядковыйНомер» объявлено примитивом «Цело число», а хранит иерархическую нумерацию
 /// «2.1», «3.4», «10». Восемнадцать значений строки, одно — дробное число; <c>validate_document</c>
 /// возвращал ноль ошибок и ноль предупреждений, потому что соответствие типу не проверялось вовсе.
+///
+/// Сами правила листа живут в <see cref="ValueTypeRules"/> — их разделяет аудит типа (issue #642).
+/// Здесь остаётся ОБХОД: по разрешённому контексту генерации, вглубь составных полей и строк таблиц.
 ///
 /// Всё выдаётся ПРЕДУПРЕЖДЕНИЯМИ: данные накоплены, и половина документов перестала бы выпускаться в
 /// тот же день. Задача — показать расхождение, а не заблокировать работу; что чинить — объявление
@@ -69,12 +70,9 @@ public static class ValueTypeScanner
             case "doc-ref" or "doc-array" or "file" or "image":
                 return;
 
-            case "primitive":
-                CheckPrimitive(path, field, value, primitivesById, diagnostics);
-                return;
-
             default:
-                CheckBase(path, field, value, field.Type, diagnostics);
+                foreach (var message in ValueTypeRules.CheckScalar(field, value, primitivesById))
+                    Warn(diagnostics, path, message);
                 return;
         }
     }
@@ -100,108 +98,6 @@ public static class ValueTypeScanner
             Check($"{path}.{inner.Key}", inner, innerValue, typesById, primitivesById, diagnostics, depth + 1);
         }
     }
-
-    private static void CheckPrimitive(
-        string path, SchemaFieldInfo field, JsonElement value,
-        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById, List<ResolutionDiagnostic> diagnostics)
-    {
-        if (field.TypeId is not { } id || !primitivesById.TryGetValue(id, out var primitive)) return;
-
-        if (!CheckBase(path, field, value, primitive.BaseType, diagnostics, primitive.Name)) return;
-        CheckConstraints(path, field, value, primitive, diagnostics);
-    }
-
-    /// <summary>Базовый тип. Возвращает false, если он уже не сошёлся — ограничения проверять незачем.</summary>
-    private static bool CheckBase(
-        string path, SchemaFieldInfo field, JsonElement value, string baseType,
-        List<ResolutionDiagnostic> diagnostics, string? typeName = null)
-    {
-        var actual = value.ValueKind switch
-        {
-            JsonValueKind.String => "строка",
-            JsonValueKind.Number => "число",
-            JsonValueKind.True or JsonValueKind.False => "логическое значение",
-            JsonValueKind.Array => "таблица",
-            JsonValueKind.Object => "составное значение",
-            _ => "пусто",
-        };
-
-        var ok = baseType switch
-        {
-            "number" => value.ValueKind == JsonValueKind.Number,
-            "bool" => value.ValueKind is JsonValueKind.True or JsonValueKind.False,
-            // Дата хранится строкой ISO — отдельная проверка разбора ниже, в ограничениях.
-            "string" or "date" or "enum" or "text" => value.ValueKind == JsonValueKind.String,
-            _ => true, // неизвестный вид — молчим, лучше промолчать, чем выдумать претензию
-        };
-
-        if (!ok)
-        {
-            var expected = typeName is null ? Expected(baseType) : $"{typeName} ({Expected(baseType)})";
-            Warn(diagnostics, path,
-                $"Поле «{Title(field)}»: ожидается {expected}, а хранится {actual}.");
-        }
-        return ok;
-    }
-
-    private static void CheckConstraints(
-        string path, SchemaFieldInfo field, JsonElement value, PrimitiveType primitive,
-        List<ResolutionDiagnostic> diagnostics)
-    {
-        var c = primitive.Constraints.RootElement;
-        if (c.ValueKind != JsonValueKind.Object) return;
-
-        double? Num(string name) => c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
-            ? v.GetDouble() : null;
-        string? Str(string name) => c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
-            ? v.GetString() : null;
-        var flag = c.TryGetProperty("integer", out var f) && f.ValueKind == JsonValueKind.True;
-
-        if (primitive.BaseType == "number" && value.TryGetDouble(out var n))
-        {
-            if (flag && Math.Abs(n - Math.Truncate(n)) > double.Epsilon)
-                Warn(diagnostics, path,
-                    $"Поле «{Title(field)}»: тип «{primitive.Name}» допускает только целые, а хранится {n.ToString(CultureInfo.InvariantCulture)}.");
-            if (Num("min") is { } min && n < min)
-                Warn(diagnostics, path, $"Поле «{Title(field)}»: значение меньше допустимого ({min}).");
-            if (Num("max") is { } max && n > max)
-                Warn(diagnostics, path, $"Поле «{Title(field)}»: значение больше допустимого ({max}).");
-        }
-
-        if (primitive.BaseType == "string" && value.GetString() is { } s)
-        {
-            if (Num("minLength") is { } minLen && s.Length < minLen)
-                Warn(diagnostics, path, $"Поле «{Title(field)}»: короче допустимого ({minLen} симв.).");
-            if (Num("maxLength") is { } maxLen && s.Length > maxLen)
-                Warn(diagnostics, path, $"Поле «{Title(field)}»: длиннее допустимого ({maxLen} симв.).");
-            if (Str("pattern") is { } pattern && !Matches(s, pattern))
-                Warn(diagnostics, path,
-                    Str("patternMessage") is { } msg && msg.Length > 0
-                        ? $"Поле «{Title(field)}»: {msg}"
-                        : $"Поле «{Title(field)}» не соответствует формату типа «{primitive.Name}».");
-        }
-
-        if (primitive.BaseType == "date" && value.GetString() is { } d && !DateTimeOffset.TryParse(
-                d, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out _))
-            Warn(diagnostics, path, $"Поле «{Title(field)}»: значение не разбирается как дата.");
-    }
-
-    /// <summary>Битый шаблон — ошибка НАСТРОЙКИ типа, а не данных: молча пропускаем значение, чтобы
-    /// не превратить одну опечатку администратора в предупреждение на каждой строке.</summary>
-    private static bool Matches(string value, string pattern)
-    {
-        try { return Regex.IsMatch(value, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(200)); }
-        catch (ArgumentException) { return true; }
-        catch (RegexMatchTimeoutException) { return true; }
-    }
-
-    private static string Expected(string baseType) => baseType switch
-    {
-        "number" => "число",
-        "date" => "дата",
-        "bool" => "логическое значение",
-        _ => "строка",
-    };
 
     private static string Title(SchemaFieldInfo f) => f.Title ?? f.Key;
 

--- a/src/server/BHS.CRG.Application/Schema/SchemaDataAuditor.cs
+++ b/src/server/BHS.CRG.Application/Schema/SchemaDataAuditor.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Application.Schema;
@@ -16,21 +17,36 @@ public record AuditIssue(string Code, AuditSeverity Severity, string Path, strin
 ///
 /// Работает над СЫРЫМИ данными (не над разрешённым контекстом): <c>$ref</c>-объекты (ссылки каталога/
 /// документа) — это ссылки, вглубь них не идём; мета-ключи (<c>_</c>-префикс: _baseRef и т.п.) не данные.
+///
+/// Тонкий слой (базовый тип значения, шаблон и границы примитива, разбор даты) — общий со сканером
+/// выпуска, <see cref="ValueTypeRules"/>, код находки <see cref="ValueType"/> (issue #642). До этого
+/// аудит видел только грубое несовпадение ВИДА значения, и записи общих данных — единственные
+/// объекты, которых сканер выпуска не касается вовсе, — не проверялись тонким слоем никогда.
 /// </summary>
 public static class SchemaDataAuditor
 {
     public const string OrphanKey = "orphan-key";
     public const string TypeMismatch = "type-mismatch";
+    public const string ValueType = "value-type";
 
-    public static IReadOnlyList<AuditIssue> Audit(JsonElement data, Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    /// <param name="primitivesById">Примитивные типы для тонкого слоя. Пустой словарь — поля с
+    /// <c>type=primitive</c> останутся без проверки (их правила описаны самим примитивом).</param>
+    public static IReadOnlyList<AuditIssue> Audit(
+        JsonElement data, Guid typeId,
+        IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById)
     {
         var issues = new List<AuditIssue>();
         if (data.ValueKind == JsonValueKind.Object)
-            Walk(data, typeId, "", byId, issues);
+            Walk(data, typeId, "", byId, primitivesById, issues);
         return issues;
     }
 
-    private static void Walk(JsonElement obj, Guid typeId, string basePath, IReadOnlyDictionary<Guid, DocumentType> byId, List<AuditIssue> issues)
+    private static void Walk(
+        JsonElement obj, Guid typeId, string basePath,
+        IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        List<AuditIssue> issues)
     {
         var fields = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).ToDictionary(f => f.Key);
         foreach (var p in obj.EnumerateObject())
@@ -43,11 +59,15 @@ public static class SchemaDataAuditor
                     $"Ключ «{p.Name}» отсутствует в текущей схеме типа (осиротевшее поле)."));
                 continue; // нет схемы для этого ключа — вглубь не идём
             }
-            CheckField(f, p.Value, path, byId, issues);
+            CheckField(f, p.Value, path, byId, primitivesById, issues);
         }
     }
 
-    private static void CheckField(SchemaFieldInfo f, JsonElement value, string path, IReadOnlyDictionary<Guid, DocumentType> byId, List<AuditIssue> issues)
+    private static void CheckField(
+        SchemaFieldInfo f, JsonElement value, string path,
+        IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        List<AuditIssue> issues)
     {
         var vk = value.ValueKind;
         if (vk == JsonValueKind.Null) return; // пусто — не расхождение
@@ -66,7 +86,7 @@ public static class SchemaDataAuditor
                 foreach (var item in value.EnumerateArray())
                 {
                     if (item.ValueKind == JsonValueKind.Object && !IsRef(item))
-                        Walk(item, etid, $"{path}[{i}]", byId, issues);
+                        Walk(item, etid, $"{path}[{i}]", byId, primitivesById, issues);
                     i++;
                 }
             }
@@ -77,13 +97,18 @@ public static class SchemaDataAuditor
                 issues.Add(new(TypeMismatch, AuditSeverity.Warning, path,
                     $"Поле «{f.Key}» ожидает составной объект, а в данных — {KindRu(vk)}."));
             else if (!IsRef(value) && f.TypeId is { } tid && byId.ContainsKey(tid))
-                Walk(value, tid, path, byId, issues); // инлайн-составной — рекурсивно
+                Walk(value, tid, path, byId, primitivesById, issues); // инлайн-составной — рекурсивно
         }
         else // скаляр (string/number/date/enum/boolean/primitive/file/image)
         {
             if (vk is JsonValueKind.Object or JsonValueKind.Array && f.Type is not ("file" or "image"))
+            {
                 issues.Add(new(TypeMismatch, AuditSeverity.Warning, path,
                     $"Поле «{f.Key}» ожидает скалярное значение, а в данных — {KindRu(vk)}."));
+                return; // вид не сошёлся — тонкий слой сказал бы то же самое второй раз
+            }
+            foreach (var message in ValueTypeRules.CheckScalar(f, value, primitivesById))
+                issues.Add(new(ValueType, AuditSeverity.Warning, path, message));
         }
     }
 

--- a/src/server/BHS.CRG.Application/Schema/ValueTypeRules.cs
+++ b/src/server/BHS.CRG.Application/Schema/ValueTypeRules.cs
@@ -37,6 +37,11 @@ public static class ValueTypeRules
         // Расчётное поле производное: претензия к его значению — претензия к выражению (#368).
         if (field.Computed) return None;
         if (value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined) return None;
+        // Пустая строка — это ОТСУТСТВИЕ значения, а не значение неверного вида: форма пишет именно
+        // её, когда поле очищают (`setValue(key, '')`). Без этой ветки очищенное поле даты навсегда
+        // оставалось бы с претензией «не разбирается как дата», а строковое с minLength — с «короче
+        // допустимого». Незаполненность — предмет отдельной проверки обязательных полей.
+        if (value.ValueKind == JsonValueKind.String && string.IsNullOrWhiteSpace(value.GetString())) return None;
 
         switch (field.Type)
         {
@@ -52,12 +57,24 @@ public static class ValueTypeRules
                 if (CheckBase(field, value, primitive.BaseType, primitive.Name) is { } baseMessage)
                     messages.Add(baseMessage);
                 else
+                {
+                    if (primitive.BaseType == "date") CheckDate(field, value, messages);
                     CheckConstraints(field, value, primitive, messages);
+                }
                 return messages;
             }
 
             default:
-                return CheckBase(field, value, field.Type) is { } m ? new[] { m } : None;
+            {
+                if (CheckBase(field, value, field.Type) is { } m) return new[] { m };
+                // Дату проверяем и у поля БЕЗ примитива: разбор жил в проверке ограничений, то есть
+                // не касался обычного поля type="date" вовсе — а именно такие и заполняет
+                // распознавание.
+                if (field.Type != "date") return None;
+                var dateMessages = new List<string>();
+                CheckDate(field, value, dateMessages);
+                return dateMessages;
+            }
         }
     }
 
@@ -124,9 +141,36 @@ public static class ValueTypeRules
                     : $"Поле «{Title(field)}» не соответствует формату типа «{primitive.Name}».");
         }
 
-        if (primitive.BaseType == "date" && value.GetString() is { } d && !DateTimeOffset.TryParse(
-                d, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out _))
-            messages.Add($"Поле «{Title(field)}»: значение не разбирается как дата.");
+    }
+
+    /// <summary>Формы, в которых дата считается записанной по-нашему: полный ISO и его усечения.</summary>
+    private static readonly string[] IsoFormats =
+    [
+        "yyyy-MM-dd", "yyyy-MM-ddTHH:mm", "yyyy-MM-ddTHH:mm:ss",
+        "yyyy-MM-ddTHH:mm:ssK", "yyyy-MM-ddTHH:mm:ss.FFFFFFF", "yyyy-MM-ddTHH:mm:ss.FFFFFFFK",
+    ];
+
+    /// <summary>
+    /// Дата хранится строкой ISO — и «разбирается вообще» здесь недостаточно.
+    ///
+    /// Прежняя проверка звала <c>DateTimeOffset.TryParse</c> инвариантной культурой, а та читает
+    /// «01.02.2026» как 2 ЯНВАРЯ и молчит. Значит, из двух дат одного распознавания «13.02.2026»
+    /// признавалась битой (месяца 13 нет), а «01.02.2026» тихо меняла смысл на противоположный —
+    /// худший из возможных исходов для проверки, которая существует ради доверия к данным.
+    ///
+    /// Поэтому: по-русски записанная дата — это РАСХОЖДЕНИЕ (его чинит приведение, #643), а не
+    /// молчаливо принятое значение. Совсем неразбираемое — расхождение другого рода: чинить руками.
+    /// </summary>
+    private static void CheckDate(SchemaFieldInfo field, JsonElement value, List<string> messages)
+    {
+        if (value.GetString() is not { } s) return;
+        if (DateTime.TryParseExact(s, IsoFormats, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces, out _))
+            return;
+
+        messages.Add(DateTime.TryParse(s, CultureInfo.GetCultureInfo("ru-RU"), DateTimeStyles.None, out _)
+            ? $"Поле «{Title(field)}»: дата записана не по ISO («{s}»), ожидается ГГГГ-ММ-ДД."
+            : $"Поле «{Title(field)}»: значение не разбирается как дата.");
     }
 
     /// <summary>Битый шаблон — ошибка НАСТРОЙКИ типа, а не данных: молча пропускаем значение, чтобы

--- a/src/server/BHS.CRG.Application/Schema/ValueTypeRules.cs
+++ b/src/server/BHS.CRG.Application/Schema/ValueTypeRules.cs
@@ -1,0 +1,150 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BHS.CRG.Domain.Catalog;
+
+namespace BHS.CRG.Application.Schema;
+
+/// <summary>
+/// Правила «скалярное значение соответствует объявленному типу поля» — ОДНА реализация на все пути
+/// проверки (issue #642, вариант C из #641).
+///
+/// До этого правил было две штуки разной полноты: <see cref="Generation.ValueTypeScanner"/> знал про
+/// базовый тип, шаблон примитива, целочисленность и границы, но запускался только в пайплайне
+/// генерации документа; <see cref="SchemaDataAuditor"/> обходил ВСЕ объекты типа (включая записи
+/// общих данных), но сравнивал лишь вид значения JSON. На живой базе это значило, что из 54 объектов
+/// тонкий слой видел 10, а 44 записи общих данных не проверял никто.
+///
+/// Здесь — только ЛИСТ (скаляр). Форму контейнера (массив пришёл вместо объекта и т.п.) каждый
+/// вызывающий проверяет сам: сканер идёт по разрешённому контексту, аудитор — по сырым данным, и
+/// обходы у них разные. Сведи их сюда — и аудит выдал бы на одно расхождение две находки разными
+/// словами.
+///
+/// Всё — предупреждениями: данные накоплены, и запрет остановил бы выпуск половины документов в тот
+/// же день. Что чинить, объявление типа или значение, решает человек.
+/// </summary>
+public static class ValueTypeRules
+{
+    private static readonly IReadOnlyList<string> None = [];
+
+    /// <summary>
+    /// Расхождения значения с типом поля, готовыми сообщениями. Пустой список — расхождений нет.
+    /// Составные поля, ссылки, файлы и картинки не наши: для них всегда пусто.
+    /// </summary>
+    public static IReadOnlyList<string> CheckScalar(
+        SchemaFieldInfo field, JsonElement value, IReadOnlyDictionary<Guid, PrimitiveType> primitivesById)
+    {
+        // Расчётное поле производное: претензия к его значению — претензия к выражению (#368).
+        if (field.Computed) return None;
+        if (value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined) return None;
+
+        switch (field.Type)
+        {
+            case "array" or "complex" or "doc-ref" or "doc-array" or "file" or "image":
+                return None;
+
+            case "primitive":
+            {
+                if (field.TypeId is not { } id || !primitivesById.TryGetValue(id, out var primitive)) return None;
+                var messages = new List<string>();
+                // Базовый тип не сошёлся — ограничения проверять незачем: они говорили бы о значении,
+                // которого в этом поле вообще быть не может.
+                if (CheckBase(field, value, primitive.BaseType, primitive.Name) is { } baseMessage)
+                    messages.Add(baseMessage);
+                else
+                    CheckConstraints(field, value, primitive, messages);
+                return messages;
+            }
+
+            default:
+                return CheckBase(field, value, field.Type) is { } m ? new[] { m } : None;
+        }
+    }
+
+    /// <summary>Базовый тип. Сообщение о расхождении либо null, если сошлось.</summary>
+    private static string? CheckBase(SchemaFieldInfo field, JsonElement value, string baseType, string? typeName = null)
+    {
+        var ok = baseType switch
+        {
+            "number" => value.ValueKind == JsonValueKind.Number,
+            // "bool" — базовый тип примитива, "boolean" — тип поля схемы; одно и то же по смыслу.
+            // Второе имя добавлено вместе с вынесением правил: до этого поля-флажки проваливались в
+            // «неизвестный вид» и не проверялись вовсе, хотя распознавание кладёт в них «да»/«нет».
+            "bool" or "boolean" => value.ValueKind is JsonValueKind.True or JsonValueKind.False,
+            // Дата хранится строкой ISO — отдельная проверка разбора ниже, в ограничениях.
+            "string" or "date" or "enum" or "text" => value.ValueKind == JsonValueKind.String,
+            _ => true, // неизвестный вид — молчим, лучше промолчать, чем выдумать претензию
+        };
+        if (ok) return null;
+
+        var actual = value.ValueKind switch
+        {
+            JsonValueKind.String => "строка",
+            JsonValueKind.Number => "число",
+            JsonValueKind.True or JsonValueKind.False => "логическое значение",
+            JsonValueKind.Array => "таблица",
+            JsonValueKind.Object => "составное значение",
+            _ => "пусто",
+        };
+        var expected = typeName is null ? Expected(baseType) : $"{typeName} ({Expected(baseType)})";
+        return $"Поле «{Title(field)}»: ожидается {expected}, а хранится {actual}.";
+    }
+
+    private static void CheckConstraints(
+        SchemaFieldInfo field, JsonElement value, PrimitiveType primitive, List<string> messages)
+    {
+        var c = primitive.Constraints.RootElement;
+        if (c.ValueKind != JsonValueKind.Object) return;
+
+        double? Num(string name) => c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetDouble() : null;
+        string? Str(string name) => c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() : null;
+        var flag = c.TryGetProperty("integer", out var f) && f.ValueKind == JsonValueKind.True;
+
+        if (primitive.BaseType == "number" && value.TryGetDouble(out var n))
+        {
+            if (flag && Math.Abs(n - Math.Truncate(n)) > double.Epsilon)
+                messages.Add($"Поле «{Title(field)}»: тип «{primitive.Name}» допускает только целые, а хранится {n.ToString(CultureInfo.InvariantCulture)}.");
+            if (Num("min") is { } min && n < min)
+                messages.Add($"Поле «{Title(field)}»: значение меньше допустимого ({min}).");
+            if (Num("max") is { } max && n > max)
+                messages.Add($"Поле «{Title(field)}»: значение больше допустимого ({max}).");
+        }
+
+        if (primitive.BaseType == "string" && value.GetString() is { } s)
+        {
+            if (Num("minLength") is { } minLen && s.Length < minLen)
+                messages.Add($"Поле «{Title(field)}»: короче допустимого ({minLen} симв.).");
+            if (Num("maxLength") is { } maxLen && s.Length > maxLen)
+                messages.Add($"Поле «{Title(field)}»: длиннее допустимого ({maxLen} симв.).");
+            if (Str("pattern") is { } pattern && !Matches(s, pattern))
+                messages.Add(Str("patternMessage") is { } msg && msg.Length > 0
+                    ? $"Поле «{Title(field)}»: {msg}"
+                    : $"Поле «{Title(field)}» не соответствует формату типа «{primitive.Name}».");
+        }
+
+        if (primitive.BaseType == "date" && value.GetString() is { } d && !DateTimeOffset.TryParse(
+                d, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out _))
+            messages.Add($"Поле «{Title(field)}»: значение не разбирается как дата.");
+    }
+
+    /// <summary>Битый шаблон — ошибка НАСТРОЙКИ типа, а не данных: молча пропускаем значение, чтобы
+    /// не превратить одну опечатку администратора в предупреждение на каждой строке.</summary>
+    private static bool Matches(string value, string pattern)
+    {
+        try { return Regex.IsMatch(value, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(200)); }
+        catch (ArgumentException) { return true; }
+        catch (RegexMatchTimeoutException) { return true; }
+    }
+
+    private static string Expected(string baseType) => baseType switch
+    {
+        "number" => "число",
+        "date" => "дата",
+        "bool" or "boolean" => "логическое значение",
+        _ => "строка",
+    };
+
+    private static string Title(SchemaFieldInfo f) => f.Title ?? f.Key;
+}

--- a/src/server/BHS.CRG.Tests/Schema/SchemaDataAuditorTests.cs
+++ b/src/server/BHS.CRG.Tests/Schema/SchemaDataAuditorTests.cs
@@ -14,6 +14,8 @@ public class SchemaDataAuditorTests
     private static readonly Guid DocId = Guid.Parse("d0000000-0000-0000-0000-000000000001");
     private static readonly Guid WorkId = Guid.Parse("00000000-0000-0000-0000-0000000000b1");
     private static readonly Guid IntId = Guid.Parse("00000000-0000-0000-0000-0000000000c1");
+    private static readonly Guid DateId = Guid.Parse("00000000-0000-0000-0000-0000000000c2");
+    private static readonly Guid ShortId = Guid.Parse("00000000-0000-0000-0000-0000000000c3");
 
     private static DocumentType T(Guid id, string name, string code, Guid? parent, string fieldsJson) =>
         DocumentType.Restore(id, name, code, DocumentTypeKind.Composite, parent,
@@ -28,6 +30,10 @@ public class SchemaDataAuditorTests
     {
         [IntId] = PrimitiveType.Restore(IntId, "Цело число", "int", "number", null,
             JsonDocument.Parse("{\"integer\":true}"), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        [DateId] = PrimitiveType.Restore(DateId, "Дата", "date", "date", null,
+            JsonDocument.Parse("{}"), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        [ShortId] = PrimitiveType.Restore(ShortId, "Шифр", "code", "string", null,
+            JsonDocument.Parse("{\"minLength\":3}"), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
     };
 
     private static IReadOnlyDictionary<Guid, DocumentType> Types() => ById(
@@ -99,6 +105,9 @@ public class SchemaDataAuditorTests
             $"[{{\"key\":\"Порядок\",\"type\":\"primitive\",\"typeId\":\"{IntId}\",\"title\":\"Порядковый номер\"}}," +
             "{\"key\":\"Кол\",\"type\":\"number\"}," +
             "{\"key\":\"Флаг\",\"type\":\"boolean\"}," +
+            "{\"key\":\"ДатаПростая\",\"type\":\"date\"}," +
+            $"{{\"key\":\"ДатаТипом\",\"type\":\"primitive\",\"typeId\":\"{DateId}\"}}," +
+            $"{{\"key\":\"Шифр\",\"type\":\"primitive\",\"typeId\":\"{ShortId}\"}}," +
             $"{{\"key\":\"Работы\",\"type\":\"array\",\"typeId\":\"{WorkId}\"}}]"),
         T(WorkId, "Работа", "WORK", null,
             $"[{{\"key\":\"Порядок\",\"type\":\"primitive\",\"typeId\":\"{IntId}\"}}]"));
@@ -154,6 +163,52 @@ public class SchemaDataAuditorTests
     public void Audit_TypedValues_NoIssues()
     {
         var data = J("{\"Кол\":12.5,\"Порядок\":3,\"Флаг\":true,\"Работы\":[{\"Порядок\":1}]}");
+        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, TypedTypes(), Prims()));
+    }
+
+    // ── Дата и пустое значение ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Audit_FlagsRussianDate_AsNotIso()
+    {
+        // Прежняя проверка звала инвариантную культуру, а та читает «01.02.2026» как 2 ЯНВАРЯ и
+        // МОЛЧИТ: из двух дат одного распознавания «13.02.2026» признавалась битой, а «01.02.2026»
+        // тихо меняла смысл. Теперь по-русски записанная дата — расхождение, и его чинит приведение.
+        var issues = SchemaDataAuditor.Audit(J("{\"ДатаТипом\":\"01.02.2026\"}"), DocId, TypedTypes(), Prims());
+        var issue = Assert.Single(issues);
+        Assert.Contains("не по ISO", issue.Message);
+    }
+
+    [Fact]
+    public void Audit_ChecksPlainDateField_NotOnlyPrimitive()
+    {
+        // Разбор даты жил в проверке ограничений примитива, то есть обычного поля type="date" не
+        // касался вовсе — а такие и заполняет распознавание.
+        var issues = SchemaDataAuditor.Audit(J("{\"ДатаПростая\":\"01.02.2026\"}"), DocId, TypedTypes(), Prims());
+        Assert.Single(issues);
+    }
+
+    [Fact]
+    public void Audit_IsoDate_IsClean()
+    {
+        var data = J("{\"ДатаПростая\":\"2026-02-01\",\"ДатаТипом\":\"2026-02-01T10:30:00Z\"}");
+        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, TypedTypes(), Prims()));
+    }
+
+    [Fact]
+    public void Audit_UnparsableDate_SaysSo()
+    {
+        var issues = SchemaDataAuditor.Audit(J("{\"ДатаТипом\":\"позавчера\"}"), DocId, TypedTypes(), Prims());
+        Assert.Contains("не разбирается как дата", Assert.Single(issues).Message);
+    }
+
+    [Fact]
+    public void Audit_EmptyString_IsAbsenceNotMismatch()
+    {
+        // Форма пишет именно пустую строку, когда поле очищают. Без этого правила очищенная дата
+        // навсегда оставалась бы с претензией, а короткий шифр — с «короче допустимого»; при том что
+        // null двумя строками выше объявлен «пусто — не расхождение».
+        var data = J("{\"ДатаТипом\":\"\",\"Шифр\":\"  \",\"Кол\":null}");
         Assert.Empty(SchemaDataAuditor.Audit(data, DocId, TypedTypes(), Prims()));
     }
 

--- a/src/server/BHS.CRG.Tests/Schema/SchemaDataAuditorTests.cs
+++ b/src/server/BHS.CRG.Tests/Schema/SchemaDataAuditorTests.cs
@@ -1,14 +1,19 @@
 using System.Text.Json;
 using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Tests.Schema;
 
-/// <summary>Аудитор данных инстанса против эффективной схемы (issue #348): осиротевшие ключи + несовпадение вида.</summary>
+/// <summary>
+/// Аудитор данных инстанса против эффективной схемы (issue #348): осиротевшие ключи + несовпадение
+/// вида + тонкий слой соответствия значения типу (issue #642).
+/// </summary>
 public class SchemaDataAuditorTests
 {
     private static readonly Guid DocId = Guid.Parse("d0000000-0000-0000-0000-000000000001");
     private static readonly Guid WorkId = Guid.Parse("00000000-0000-0000-0000-0000000000b1");
+    private static readonly Guid IntId = Guid.Parse("00000000-0000-0000-0000-0000000000c1");
 
     private static DocumentType T(Guid id, string name, string code, Guid? parent, string fieldsJson) =>
         DocumentType.Restore(id, name, code, DocumentTypeKind.Composite, parent,
@@ -17,6 +22,13 @@ public class SchemaDataAuditorTests
 
     private static IReadOnlyDictionary<Guid, DocumentType> ById(params DocumentType[] ts) => ts.ToDictionary(t => t.Id);
     private static JsonElement J(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    /// <summary>Примитив «Цело число» — тот самый тип из #461, на котором нашли строки «2.1».</summary>
+    private static IReadOnlyDictionary<Guid, PrimitiveType> Prims() => new Dictionary<Guid, PrimitiveType>
+    {
+        [IntId] = PrimitiveType.Restore(IntId, "Цело число", "int", "number", null,
+            JsonDocument.Parse("{\"integer\":true}"), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+    };
 
     private static IReadOnlyDictionary<Guid, DocumentType> Types() => ById(
         T(DocId, "АОСР", "AOSR", null,
@@ -28,7 +40,7 @@ public class SchemaDataAuditorTests
     public void Audit_FlagsOrphanTopLevelKey()
     {
         var data = J("{\"Номер\":\"1\",\"НовыеРаботы\":{\"x\":1}}");
-        var issues = SchemaDataAuditor.Audit(data, DocId, Types());
+        var issues = SchemaDataAuditor.Audit(data, DocId, Types(), Prims());
         var orphan = Assert.Single(issues, i => i.Code == SchemaDataAuditor.OrphanKey);
         Assert.Equal("НовыеРаботы", orphan.Path);
         Assert.Equal(AuditSeverity.Warning, orphan.Severity);
@@ -39,7 +51,7 @@ public class SchemaDataAuditorTests
     {
         // Осиротевший ключ ВНУТРИ элемента массива (по схеме подтипа Работа) — рекурсивно, путь Работы[0].Лишнее.
         var data = J("{\"Работы\":[{\"Наименование\":\"a\",\"Лишнее\":5}]}");
-        var issues = SchemaDataAuditor.Audit(data, DocId, Types());
+        var issues = SchemaDataAuditor.Audit(data, DocId, Types(), Prims());
         Assert.Contains(issues, i => i.Code == SchemaDataAuditor.OrphanKey && i.Path == "Работы[0].Лишнее");
     }
 
@@ -47,7 +59,7 @@ public class SchemaDataAuditorTests
     public void Audit_IgnoresMetaKeys()
     {
         var data = J("{\"Номер\":\"1\",\"_type\":{\"code\":\"AOSR\"},\"_baseRef\":\"x\"}");
-        var issues = SchemaDataAuditor.Audit(data, DocId, Types());
+        var issues = SchemaDataAuditor.Audit(data, DocId, Types(), Prims());
         Assert.DoesNotContain(issues, i => i.Path is "_type" or "_baseRef");
     }
 
@@ -55,7 +67,7 @@ public class SchemaDataAuditorTests
     public void Audit_FlagsTypeMismatch_ArrayFieldHoldsScalar()
     {
         var data = J("{\"Работы\":\"строка\"}"); // массив ожидается, строка в данных
-        var issues = SchemaDataAuditor.Audit(data, DocId, Types());
+        var issues = SchemaDataAuditor.Audit(data, DocId, Types(), Prims());
         Assert.Contains(issues, i => i.Code == SchemaDataAuditor.TypeMismatch && i.Path == "Работы");
     }
 
@@ -63,7 +75,7 @@ public class SchemaDataAuditorTests
     public void Audit_CleanData_NoIssues()
     {
         var data = J("{\"Номер\":\"1\",\"Работы\":[{\"Наименование\":\"a\"}]}");
-        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, Types()));
+        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, Types(), Prims()));
     }
 
     [Fact]
@@ -74,6 +86,82 @@ public class SchemaDataAuditorTests
             T(DocId, "T", "T", null, $"[{{\"key\":\"Орг\",\"type\":\"complex\",\"typeId\":\"{WorkId}\"}}]"),
             T(WorkId, "W", "W", null, "[{\"key\":\"Наименование\",\"type\":\"string\"}]"));
         var data = J("{\"Орг\":{\"$ref\":\"catalog\",\"entryId\":\"x\",\"ПостороннийКлюч\":1}}");
-        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, byId));
+        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, byId, Prims()));
+    }
+
+    // ── Тонкий слой: значение против объявленного типа (issue #642) ────────────────────────────
+    // До этого аудит видел только грубое несовпадение ВИДА (объект вместо скаляра). Всё, ради чего
+    // писали ValueTypeScanner — строка в числовом поле, дробь в целом, — проходило мимо, и записи
+    // общих данных (единственные объекты вне пайплайна генерации) не проверялись вовсе.
+
+    private static IReadOnlyDictionary<Guid, DocumentType> TypedTypes() => ById(
+        T(DocId, "Запись", "REC", null,
+            $"[{{\"key\":\"Порядок\",\"type\":\"primitive\",\"typeId\":\"{IntId}\",\"title\":\"Порядковый номер\"}}," +
+            "{\"key\":\"Кол\",\"type\":\"number\"}," +
+            "{\"key\":\"Флаг\",\"type\":\"boolean\"}," +
+            $"{{\"key\":\"Работы\",\"type\":\"array\",\"typeId\":\"{WorkId}\"}}]"),
+        T(WorkId, "Работа", "WORK", null,
+            $"[{{\"key\":\"Порядок\",\"type\":\"primitive\",\"typeId\":\"{IntId}\"}}]"));
+
+    [Fact]
+    public void Audit_FlagsStringInNumberField()
+    {
+        var issues = SchemaDataAuditor.Audit(J("{\"Кол\":\"12,5\"}"), DocId, TypedTypes(), Prims());
+        var issue = Assert.Single(issues);
+        Assert.Equal(SchemaDataAuditor.ValueType, issue.Code);
+        Assert.Equal("Кол", issue.Path);
+        Assert.Contains("ожидается число", issue.Message);
+    }
+
+    [Fact]
+    public void Audit_FlagsFractionInIntegerPrimitive_ByTitle()
+    {
+        var issues = SchemaDataAuditor.Audit(J("{\"Порядок\":2.1}"), DocId, TypedTypes(), Prims());
+        var issue = Assert.Single(issues);
+        Assert.Equal(SchemaDataAuditor.ValueType, issue.Code);
+        // Человеку показываем заголовок поля, а не ключ схемы — ключей он не видел никогда.
+        Assert.Contains("Порядковый номер", issue.Message);
+    }
+
+    [Fact]
+    public void Audit_FlagsValueTypeInsideArrayRow()
+    {
+        // Ровно случай #461: расхождение лежит внутри строки таблицы, на верхнем уровне его нет.
+        var issues = SchemaDataAuditor.Audit(J("{\"Работы\":[{\"Порядок\":\"2.1\"}]}"), DocId, TypedTypes(), Prims());
+        var issue = Assert.Single(issues);
+        Assert.Equal("Работы[0].Порядок", issue.Path);
+    }
+
+    [Fact]
+    public void Audit_FlagsStringInBooleanField()
+    {
+        // «да» вместо true: поля-флажки до вынесения правил не проверялись ни одним из двух путей.
+        var issues = SchemaDataAuditor.Audit(J("{\"Флаг\":\"да\"}"), DocId, TypedTypes(), Prims());
+        Assert.Contains(issues, i => i.Code == SchemaDataAuditor.ValueType && i.Path == "Флаг");
+    }
+
+    [Fact]
+    public void Audit_ObjectInScalarField_ReportsMismatchOnce()
+    {
+        // Вид не сошёлся — грубая находка уже всё сказала; тонкий слой не должен повторять её вторым
+        // сообщением о том же месте.
+        var issues = SchemaDataAuditor.Audit(J("{\"Кол\":{\"a\":1}}"), DocId, TypedTypes(), Prims());
+        var issue = Assert.Single(issues);
+        Assert.Equal(SchemaDataAuditor.TypeMismatch, issue.Code);
+    }
+
+    [Fact]
+    public void Audit_TypedValues_NoIssues()
+    {
+        var data = J("{\"Кол\":12.5,\"Порядок\":3,\"Флаг\":true,\"Работы\":[{\"Порядок\":1}]}");
+        Assert.Empty(SchemaDataAuditor.Audit(data, DocId, TypedTypes(), Prims()));
+    }
+
+    [Fact]
+    public void Audit_WithoutPrimitives_SkipsPrimitiveFields()
+    {
+        // Пустой словарь примитивов — правила примитива неизвестны, и придумывать их нечем.
+        var empty = new Dictionary<Guid, PrimitiveType>();
+        Assert.Empty(SchemaDataAuditor.Audit(J("{\"Порядок\":\"2.1\"}"), DocId, TypedTypes(), empty));
     }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.76.3</Version>
+    <Version>0.77.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.77.0</Version>
+    <Version>0.77.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 1 варианта C по #641. Closes #642.

## Что было

Правила «значение соответствует объявленному типу поля» существовали дважды и в разной полноте:

| | что проверяет | что видит |
|---|---|---|
| `ValueTypeScanner` (#461) | базовый тип, шаблон и границы примитива, целые, разбор даты | только документы, только в пайплайне генерации |
| `SchemaDataAuditor` (#348) | вид значения JSON (скаляр/объект/массив) | ВСЕ объекты типа, включая записи общих данных |

Из 54 объектов живой базы тонкий слой видел 10. Остальные 44 — записи общих данных — не проверялись
им никогда.

## Что стало

Лист вынесен в `ValueTypeRules` — одна реализация, её делят оба пути. Форма контейнера осталась в
обходах: сканер идёт по разрешённому контексту, аудитор — по сырым данным, обходы разные. При
несовпадении ВИДА тонкий слой молчит, иначе на одно расхождение приходили бы две находки разными
словами.

Аудит типа и аудит документа выдают новый код находки `value-type`; обе модалки его показывают.

## Что нашлось на живой базе

Прогон аудита по всем 65 типам после правки:

```
[value-type] Внешний документ / Приказ DNSS-17/2026 от 27.04.26 (Подрядчик) / КоличествоЛистов
    Поле «Количество листов»: ожидается Цело число (число), а хранится строка.
… ещё три таких же (IS-12/2024, DNSS-18/2026, Поверка С-ГЧЖ/23-01-2025)
[orphan-key] АОСР / 250701.ЭОМ-1.АОСР / КоличествоЛистов
```

Четыре расхождения, которых не видел ни один из прежних путей. Значения — «1», «3», «2», «1»:
приводятся однозначно, чинить их будет #643.

## Побочно

Поля-флажки не проверялись ни одним путём: тип поля схемы называется `boolean`, базовый тип примитива
— `bool`, и `boolean` проваливался в ветку «неизвестный вид». Теперь оба имени означают одно и то же.

## Проверка

- 968 backend-тестов (было 961), 353 frontend, `tsc -b` чист.
- Прогон аудита по всем 65 типам на живой базе — числа выше.
