### PR TITLE
Качество: действие «привести значение к типу» в аудите (#643)

### DIFF
--- a/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
+++ b/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
@@ -3,7 +3,7 @@ import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useToast } from '@/shared/ui/Toast';
-import { CheckCircle2, AlertTriangle, Loader2, Trash2 } from 'lucide-react';
+import { CheckCircle2, AlertTriangle, Loader2, Trash2, Wand2 } from 'lucide-react';
 import { useAuditInstance, useApplyInstanceAuditFixes } from '@/shared/api/documentSets';
 import type { AuditFinding } from '@/shared/api/documentTypes';
 
@@ -40,7 +40,7 @@ export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys
   const total = findings?.length ?? 0;
   const isTopLevel = (path: string) => !path.includes('.') && !path.includes('[');
 
-  async function apply(action: 'remove' | 'rename', path: string, targetKey?: string) {
+  async function apply(action: 'remove' | 'rename' | 'coerce', path: string, targetKey?: string) {
     try {
       const res = await applyFixes.mutateAsync([{ action, path, targetKey }]);
       if (res.applied > 0) toast.success('Документ исправлен');
@@ -88,6 +88,14 @@ export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys
                           </span>
                         </div>
                         <div className="flex flex-wrap items-center gap-2 pt-1.5">
+                          {/* Для расхождения с типом приведение — исправление, а удаление — потеря
+                              значения; поэтому оно первое и без подтверждения (issue #643). */}
+                          {f.code === 'value-type' && (
+                            <Button variant="text" size="sm" icon={<Wand2 size={13} />}
+                              disabled={applyFixes.isPending} onClick={() => apply('coerce', f.path)}>
+                              Привести к типу
+                            </Button>
+                          )}
                           <Button variant="text" size="sm" danger icon={<Trash2 size={13} />}
                             disabled={applyFixes.isPending} onClick={() => setConfirm(f)}>
                             Удалить

--- a/src/client/src/features/settings/TypeAuditModal.tsx
+++ b/src/client/src/features/settings/TypeAuditModal.tsx
@@ -3,7 +3,7 @@ import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { useToast } from '@/shared/ui/Toast';
-import { CheckCircle2, AlertTriangle, ChevronRight, ChevronDown, Loader2, Trash2 } from 'lucide-react';
+import { CheckCircle2, AlertTriangle, ChevronRight, ChevronDown, Loader2, Trash2, Wand2 } from 'lucide-react';
 import { useAuditDocumentType, useApplyAuditFixes, type AuditFix } from '@/shared/api/documentTypes';
 
 /**
@@ -52,11 +52,17 @@ export function TypeAuditModal({ typeId, typeName, schemaFieldKeys, open, onClos
   const total = data?.findings.length ?? 0;
   const isTopLevel = (path: string) => !path.includes('.') && !path.includes('[');
 
-  async function apply(row: Row, action: 'remove' | 'rename', targetKey?: string) {
+  async function apply(row: Row, action: 'remove' | 'rename' | 'coerce', targetKey?: string) {
     const fixes: AuditFix[] = row.instances.map(i => ({ instanceId: i.id, action, path: row.path, targetKey }));
     try {
       const res = await applyFixes.mutateAsync(fixes);
-      toast.success(`Применено: ${res.applied}${res.skipped ? `, пропущено: ${res.skipped}` : ''}`);
+      // Причину пропуска показываем текстом: у приведения «пропущено» — это содержательный ответ
+      // («дробное, а тип допускает только целые»), а не сбой, и без неё непонятно, что делать дальше.
+      const skippedReason = res.outcomes.find(o => !o.applied)?.reason;
+      if (res.applied > 0)
+        toast.success(`Применено: ${res.applied}${res.skipped ? `, пропущено: ${res.skipped}` : ''}`);
+      else
+        toast.info(skippedReason ?? 'Изменений не внесено');
     } catch {
       toast.error('Не удалось применить исправление');
     }
@@ -97,6 +103,7 @@ export function TypeAuditModal({ typeId, typeName, schemaFieldKeys, open, onClos
                       const k = `${row.code} ${row.path} ${row.message}`;
                       const isOpen = expanded.has(k);
                       const canRename = row.code === 'orphan-key' && isTopLevel(row.path);
+                      const canCoerce = row.code === 'value-type';
                       return (
                         <div key={k}>
                           <button type="button"
@@ -115,6 +122,15 @@ export function TypeAuditModal({ typeId, typeName, schemaFieldKeys, open, onClos
                                 {row.instances.map(i => <li key={i.id} className="text-xs text-fg3 truncate">{i.name}</li>)}
                               </ul>
                               <div className="flex flex-wrap items-center gap-2 pt-1">
+                                {/* Приведение (issue #643) идёт ПЕРВЫМ и без подтверждения: для
+                                    расхождения с типом это исправление, а удаление — потеря. */}
+                                {canCoerce && (
+                                  <Button variant="text" size="sm" icon={<Wand2 size={13} />}
+                                    disabled={applyFixes.isPending}
+                                    onClick={() => apply(row, 'coerce')}>
+                                    Привести во всех ({row.instances.length})
+                                  </Button>
+                                )}
                                 <Button variant="text" size="sm" danger icon={<Trash2 size={13} />}
                                   disabled={applyFixes.isPending}
                                   onClick={() => setConfirmRow(row)}>

--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -340,7 +340,7 @@ export function useAuditInstance(setId: string, instanceId: string | undefined, 
 export function useApplyInstanceAuditFixes(setId: string, instanceId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (fixes: { action: 'remove' | 'rename'; path: string; targetKey?: string }[]) =>
+    mutationFn: (fixes: { action: 'remove' | 'rename' | 'coerce'; path: string; targetKey?: string }[]) =>
       apiClient.post<import('./documentTypes').ApplyAuditFixesResult>(
         `/document-sets/${setId}/documents/${instanceId}/audit/apply`, { fixes }).then(r => r.data),
     onSuccess: () => {

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -110,7 +110,8 @@ export function useAuditDocumentType(id: string | undefined, enabled: boolean) {
   });
 }
 
-export interface AuditFix { instanceId: string; action: 'remove' | 'rename'; path: string; targetKey?: string }
+/** «coerce» — привести значение к объявленному типу поля (issue #643), только по команде человека. */
+export interface AuditFix { instanceId: string; action: 'remove' | 'rename' | 'coerce'; path: string; targetKey?: string }
 export interface AuditFixOutcome { instanceId: string; path: string; action: string; applied: boolean; reason?: string; oldValue?: string }
 export interface ApplyAuditFixesResult { applied: number; skipped: number; outcomes: AuditFixOutcome[] }
 

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -53,8 +53,9 @@ public record MigrateFieldKeyCommand(Guid TypeId, string OldKey, string NewKey) 
 /// (одна SaveChanges). Батч = список фиксов; фронт разворачивает «применить ко всем» в per-instance.
 public record ApplyAuditFixesCommand(IReadOnlyList<AuditFix> Fixes) : IRequest<ApplyAuditFixesResult>;
 
-/// Одно исправление: Action = "remove" (удалить осиротевший ключ / очистить невалидное) или
-/// "rename" (переместить значение в поле схемы TargetKey, только если цель пуста). Path — JSON-путь.
+/// Одно исправление: Action = "remove" (удалить осиротевший ключ / очистить невалидное),
+/// "rename" (переместить значение в поле схемы TargetKey, только если цель пуста) или
+/// "coerce" (привести значение к объявленному типу поля, issue #643). Path — JSON-путь.
 public record AuditFix(Guid InstanceId, string Action, string Path, string? TargetKey = null);
 
 public record ApplyAuditFixesResult(int Applied, int Skipped, IReadOnlyList<AuditFixOutcome> Outcomes);

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -76,6 +76,15 @@ public class DocumentTypeHandlers(
     {
         var outcomes = new List<AuditFixOutcome>();
         var touched = false;
+        // Справочники схемы нужны только приведению (issue #643) — оно должно знать, К ЧЕМУ приводить.
+        // Читаем лениво: пакет из одних удалений (обычный случай) не должен платить за два SELECT'а.
+        Dictionary<Guid, DocumentType>? typesById = null;
+        Dictionary<Guid, PrimitiveType>? primitivesById = null;
+        async Task LoadSchemaAsync()
+        {
+            typesById ??= (await repo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+            primitivesById ??= (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
+        }
         // Группируем по инстансу — одну загрузку/мутацию Data на инстанс. Осиротевшие пути — ключи
         // объектов (не индексы массива), поэтому порядок применения внутри инстанса не сдвигает пути.
         foreach (var grp in cmd.Fixes.GroupBy(f => f.InstanceId))
@@ -99,6 +108,11 @@ public class DocumentTypeHandlers(
                 }
                 else if (f.Action == "rename" && !string.IsNullOrWhiteSpace(f.TargetKey))
                     ok = Schema.JsonPathEditor.Rename(root, f.Path, f.TargetKey!, out oldVal, out reason);
+                else if (f.Action == "coerce")
+                {
+                    await LoadSchemaAsync();
+                    ok = TryCoerceAt(root, f.Path, inst.CompositeTypeId, typesById!, primitivesById!, out oldVal, out reason);
+                }
                 else { ok = false; reason = "Неизвестное действие."; }
                 outcomes.Add(new(f.InstanceId, f.Path, f.Action, ok, reason, oldVal));
                 changed |= ok;
@@ -112,6 +126,31 @@ public class DocumentTypeHandlers(
         }
         if (touched) await objectRepo.SaveChangesAsync(ct); // атомарно: один SaveChanges на все мутации
         return new(outcomes.Count(o => o.Applied), outcomes.Count(o => !o.Applied), outcomes);
+    }
+
+    /// <summary>
+    /// Приведение значения по пути к объявленному типу поля (issue #643). Поле находим по СХЕМЕ
+    /// (путь ведёт и внутрь строк таблиц), значение правим в дереве данных.
+    /// </summary>
+    private static bool TryCoerceAt(
+        System.Text.Json.Nodes.JsonNode root, string path, Guid rootTypeId,
+        IReadOnlyDictionary<Guid, DocumentType> typesById,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        out string? oldValue, out string? reason)
+    {
+        oldValue = null;
+        var field = Schema.SchemaPathResolver.FieldAt(path, rootTypeId, typesById);
+        if (field is null) { reason = "Поле не найдено в текущей схеме."; return false; }
+
+        var current = Schema.JsonPathEditor.ValueAt(root, path);
+        if (!Schema.ValueCoercion.TryCoerce(field, current, primitivesById, out var coerced, out reason))
+            return false;
+        if (!Schema.JsonPathEditor.Replace(root, path, coerced, out oldValue))
+        {
+            reason = "Значение по этому пути уже отсутствует.";
+            return false;
+        }
+        return true;
     }
 
     public async Task<DocumentTypeAuditReport> Handle(AuditDocumentTypeQuery q, CancellationToken ct)

--- a/src/server/BHS.CRG.Application/Schema/JsonPathEditor.cs
+++ b/src/server/BHS.CRG.Application/Schema/JsonPathEditor.cs
@@ -61,6 +61,42 @@ public static class JsonPathEditor
         }
     }
 
+    /// <summary>Значение по пути либо null, если путь не разрешается (issue #643).</summary>
+    public static JsonNode? ValueAt(JsonNode root, string path)
+    {
+        if (Navigate(root, path) is not var (parent, last)) return null;
+        return last switch
+        {
+            string key when parent is JsonObject o && o.TryGetPropertyValue(key, out var v) => v,
+            int idx when parent is JsonArray a && idx >= 0 && idx < a.Count => a[idx],
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Заменяет значение по пути (issue #643). <paramref name="oldValue"/> — сериализованное прежнее
+    /// значение для журнала. false — путь не разрешился: значение уже убрали или переименовали, и
+    /// создавать его заново исправлением аудита нечего.
+    /// </summary>
+    public static bool Replace(JsonNode root, string path, JsonNode? newValue, out string? oldValue)
+    {
+        oldValue = null;
+        if (Navigate(root, path) is not var (parent, last)) return false;
+        switch (last)
+        {
+            case string key when parent is JsonObject o && o.TryGetPropertyValue(key, out var v):
+                oldValue = v?.ToJsonString();
+                o[key] = newValue;
+                return true;
+            case int idx when parent is JsonArray a && idx >= 0 && idx < a.Count:
+                oldValue = a[idx]?.ToJsonString();
+                a[idx] = newValue;
+                return true;
+            default:
+                return false;
+        }
+    }
+
     /// <summary>Переименовывает КЛЮЧ на его уровне в <paramref name="targetKey"/> — только если цель
     /// отсутствует/пуста (не затираем данные). false + <paramref name="skipReason"/>, если нельзя.</summary>
     public static bool Rename(JsonNode root, string path, string targetKey, out string? oldValue, out string? skipReason)

--- a/src/server/BHS.CRG.Application/Schema/SchemaPathResolver.cs
+++ b/src/server/BHS.CRG.Application/Schema/SchemaPathResolver.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Schema;
+
+/// <summary>
+/// Поле схемы по пути аудита (issue #643): <c>Ключ</c>, <c>Ключ.Внутренний</c>, <c>Работы[0].Порядок</c>.
+///
+/// Обратная сторона <see cref="JsonPathEditor"/>: тот идёт по ДАННЫМ, этот — по СХЕМЕ. Нужен там, где
+/// исправление зависит от объявленного типа: чтобы привести значение, надо знать, к чему приводить, а
+/// в находке аудита есть только путь.
+///
+/// Индекс элемента массива схему не меняет — у всех строк таблицы один тип, — поэтому <c>[3]</c>
+/// просто пропускается.
+/// </summary>
+public static class SchemaPathResolver
+{
+    private static readonly Regex Segment = new(@"([^.\[\]]+)|\[(\d+)\]", RegexOptions.Compiled);
+
+    /// <summary>Глубина обхода — та же защита от патологически вложенных схем, что и у сканеров.</summary>
+    private const int MaxDepth = 6;
+
+    public static SchemaFieldInfo? FieldAt(string path, Guid rootTypeId, IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        var typeId = rootTypeId;
+        SchemaFieldInfo? field = null;
+        var depth = 0;
+
+        foreach (Match m in Segment.Matches(path))
+        {
+            if (m.Groups[2].Success) continue; // индекс строки таблицы: тип строк один на всю таблицу
+            if (++depth > MaxDepth) return null;
+
+            if (!byId.ContainsKey(typeId)) return null;
+            field = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).FirstOrDefault(f => f.Key == m.Groups[1].Value);
+            if (field is null) return null;
+            // Следующий сегмент читается по типу текущего поля; у скаляра его нет — значит путь
+            // ведёт внутрь того, что внутренностей не имеет.
+            if (field.TypeId is { } next) typeId = next;
+        }
+
+        return field;
+    }
+}

--- a/src/server/BHS.CRG.Application/Schema/ValueCoercion.cs
+++ b/src/server/BHS.CRG.Application/Schema/ValueCoercion.cs
@@ -20,6 +20,15 @@ namespace BHS.CRG.Application.Schema;
 public static class ValueCoercion
 {
     /// <summary>
+    /// Кнопка «Привести» стоит у ЛЮБОЙ находки о значении, а тонкий слой ловит и нарушения
+    /// ограничений типа — шаблон, длину, границы. Там значение уже нужного вида, и приведение
+    /// бессильно; сказать в ответ «значение уже нужного вида» значило бы возразить самой находке,
+    /// на которую человек и нажал.
+    /// </summary>
+    private const string NotACoercionReason =
+        "Значение нужного вида — расходится не вид, а ограничение типа (формат, длина, границы); приведением это не чинится.";
+
+    /// <summary>
     /// Приведённое значение для поля. <c>false</c> + <paramref name="reason"/>, если приводить нечего
     /// или не к чему: значение уже нужного вида, тип поля не скалярный, разбор не удался.
     /// </summary>
@@ -42,8 +51,8 @@ public static class ValueCoercion
         var (baseType, primitive) = BaseTypeOf(field, primitivesById);
         if (baseType is null) { reason = "Для этого типа поля приведение не определено."; return false; }
 
-        var raw = value.GetValue<object>()?.ToString();
         var element = value.GetValueKind();
+        var raw = RawText(value, element);
 
         switch (baseType)
         {
@@ -55,7 +64,7 @@ public static class ValueCoercion
                     // типе, а её приведением не чинят (см. IsIntegerOnly ниже).
                     reason = IsIntegerOnly(primitive) && !IsWhole(value.GetValue<double>())
                         ? FractionReason(value.GetValue<double>())
-                        : "Значение уже нужного вида.";
+                        : NotACoercionReason;
                     return false;
                 }
                 if (!TryParseNumber(raw, out var n))
@@ -71,7 +80,7 @@ public static class ValueCoercion
             case "bool" or "boolean":
             {
                 if (element is System.Text.Json.JsonValueKind.True or System.Text.Json.JsonValueKind.False)
-                { reason = "Значение уже нужного вида."; return false; }
+                { reason = NotACoercionReason; return false; }
                 if (TryParseBool(raw, out var b)) { coerced = JsonValue.Create(b); return true; }
                 reason = $"«{raw}» не разбирается как логическое значение.";
                 return false;
@@ -89,15 +98,22 @@ public static class ValueCoercion
                     return false;
                 }
                 var iso = d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-                if (iso == raw) { reason = "Значение уже нужного вида."; return false; }
+                if (iso == raw) { reason = NotACoercionReason; return false; }
                 coerced = JsonValue.Create(iso);
                 return true;
             }
 
-            default: // string / text / enum
+            case "enum":
+                // Приведением получился бы КОД, которого нет ни в одном варианте перечисления:
+                // находка исчезла бы, а значение осталось бы нерабочим — худший исход, потому что
+                // невидимый. Вариант выбирает человек.
+                reason = "Вариант перечисления выбирается вручную — приведением его не угадать.";
+                return false;
+
+            default: // string / text
             {
                 if (element == System.Text.Json.JsonValueKind.String)
-                { reason = "Значение уже нужного вида."; return false; }
+                { reason = NotACoercionReason; return false; }
                 coerced = JsonValue.Create(raw ?? "");
                 return true;
             }
@@ -142,6 +158,11 @@ public static class ValueCoercion
     /// Число целиком, без хвоста. Пробелы (в том числе неразрывный) — разряды, запятая — десятичный
     /// разделитель; когда встречаются оба, десятичным считается последний, что верно и для «1 234,5»,
     /// и для «1,234.5» (то же допущение, что в <c>QuantityParser</c>).
+    ///
+    /// Разделителей больше одного — только если предыдущие делят разряды ПО ТРИ цифры. Без этой
+    /// проверки «2.1.3» превращалось в 21.3, а «01.02.2026» — в 102.2026: приведение выдумывало
+    /// число из иерархической нумерации и из даты, отвечая при этом «Документ исправлен». Ровно тот
+    /// исход, ради недопущения которого целочисленность и не округляется.
     /// </summary>
     private static bool TryParseNumber(string? raw, out double value)
     {
@@ -150,12 +171,39 @@ public static class ValueCoercion
 
         var cleaned = new string([.. raw.Where(ch => !char.IsWhiteSpace(ch) && ch != ' ')]);
         var lastSep = Math.Max(cleaned.LastIndexOf(','), cleaned.LastIndexOf('.'));
-        var normalized = lastSep < 0
-            ? cleaned
-            : $"{cleaned[..lastSep].Replace(",", "").Replace(".", "")}.{cleaned[(lastSep + 1)..]}";
+        if (lastSep < 0)
+            return double.TryParse(cleaned, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
 
+        var head = cleaned[..lastSep];
+        if (!IsGrouped(head)) return false;
+
+        var normalized = $"{head.Replace(",", "").Replace(".", "")}.{cleaned[(lastSep + 1)..]}";
         return double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
     }
+
+    /// <summary>Целая часть: либо без разделителей вовсе, либо разряды по три одним и тем же знаком.</summary>
+    private static bool IsGrouped(string head)
+    {
+        // Мешать знаки нельзя: «1,234.567» — не запись числа, а следы двух разных соглашений.
+        if (head.Contains(',') && head.Contains('.')) return false;
+        var groups = head.Split(',', '.');
+        if (groups.Length == 1) return true;
+        if (groups[0].Length is 0 or > 3) return false;
+        return groups.Skip(1).All(g => g.Length == 3);
+    }
+
+    /// <summary>
+    /// Текст значения. Своими руками, а не <c>ToString()</c>: у <c>JsonElement</c> тот отдаёт для
+    /// логического значения «True» с большой буквы (<c>bool.TrueString</c>), и приведение к строке
+    /// клало в русский документ «True» вместо «true».
+    /// </summary>
+    private static string? RawText(JsonNode value, System.Text.Json.JsonValueKind kind) => kind switch
+    {
+        System.Text.Json.JsonValueKind.String => value.GetValue<string>(),
+        System.Text.Json.JsonValueKind.True => "true",
+        System.Text.Json.JsonValueKind.False => "false",
+        _ => value.ToJsonString(),
+    };
 
     /// <summary>Русские «да»/«нет» — то, что кладёт распознавание: в скане стоит слово, не флажок.</summary>
     private static bool TryParseBool(string? raw, out bool value)

--- a/src/server/BHS.CRG.Application/Schema/ValueCoercion.cs
+++ b/src/server/BHS.CRG.Application/Schema/ValueCoercion.cs
@@ -1,0 +1,172 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using BHS.CRG.Domain.Catalog;
+
+namespace BHS.CRG.Application.Schema;
+
+/// <summary>
+/// Приведение хранимого значения к объявленному типу поля — исправление аудита «привести» (issue #643).
+///
+/// Это «узкое B» из #641: приведение живёт в аудите и срабатывает по явной команде человека, а не на
+/// каждой записи. На пути записи его нет намеренно — иначе значение молча менялось бы в пяти разных
+/// местах (форма, распознавание, вставка, авто-маппер, привязка набора), и понять, кто его переписал,
+/// стало бы невозможно.
+///
+/// Разбор здесь СТРОГИЙ и этим отличается от <c>DataSetValueCoercion</c>/<c>QuantityParser</c>, где
+/// «10 м» законно читается как 10: в ячейке набора единица измерения — обычное дело, а здесь мы
+/// правим уже сохранённое значение, и выбросить из него «м» значит потерять то, что человек написал.
+/// Не разобралось целиком — не приводим и говорим почему.
+/// </summary>
+public static class ValueCoercion
+{
+    /// <summary>
+    /// Приведённое значение для поля. <c>false</c> + <paramref name="reason"/>, если приводить нечего
+    /// или не к чему: значение уже нужного вида, тип поля не скалярный, разбор не удался.
+    /// </summary>
+    public static bool TryCoerce(
+        SchemaFieldInfo field, JsonNode? value,
+        IReadOnlyDictionary<Guid, PrimitiveType> primitivesById,
+        out JsonNode? coerced, out string? reason)
+    {
+        coerced = null; reason = null;
+
+        if (value is null) { reason = "Значение отсутствует."; return false; }
+        if (value is JsonObject or JsonArray)
+        {
+            // Составное значение в скалярном поле — не приведение, а разбор содержимого: что из
+            // объекта считать значением, знает только человек.
+            reason = "Составное значение привести нельзя — исправьте вручную.";
+            return false;
+        }
+
+        var (baseType, primitive) = BaseTypeOf(field, primitivesById);
+        if (baseType is null) { reason = "Для этого типа поля приведение не определено."; return false; }
+
+        var raw = value.GetValue<object>()?.ToString();
+        var element = value.GetValueKind();
+
+        switch (baseType)
+        {
+            case "number":
+            {
+                if (element == System.Text.Json.JsonValueKind.Number)
+                {
+                    // Число уже число: единственное, чем оно бывает расхождением, — дробь в целом
+                    // типе, а её приведением не чинят (см. IsIntegerOnly ниже).
+                    reason = IsIntegerOnly(primitive) && !IsWhole(value.GetValue<double>())
+                        ? FractionReason(value.GetValue<double>())
+                        : "Значение уже нужного вида.";
+                    return false;
+                }
+                if (!TryParseNumber(raw, out var n))
+                {
+                    reason = $"«{raw}» не разбирается как число.";
+                    return false;
+                }
+                if (IsIntegerOnly(primitive) && !IsWhole(n)) { reason = FractionReason(n); return false; }
+                coerced = NumberNode(n);
+                return true;
+            }
+
+            case "bool" or "boolean":
+            {
+                if (element is System.Text.Json.JsonValueKind.True or System.Text.Json.JsonValueKind.False)
+                { reason = "Значение уже нужного вида."; return false; }
+                if (TryParseBool(raw, out var b)) { coerced = JsonValue.Create(b); return true; }
+                reason = $"«{raw}» не разбирается как логическое значение.";
+                return false;
+            }
+
+            case "date":
+            {
+                if (raw is null) { reason = "Значение отсутствует."; return false; }
+                // Дата хранится строкой ISO. Русский формат «01.02.2026» — то, что приходит от
+                // распознавания и из ячеек; инвариантная культура прочла бы его как 2 января.
+                if (!DateTime.TryParse(raw, CultureInfo.GetCultureInfo("ru-RU"), DateTimeStyles.None, out var d)
+                    && !DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out d))
+                {
+                    reason = $"«{raw}» не разбирается как дата.";
+                    return false;
+                }
+                var iso = d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                if (iso == raw) { reason = "Значение уже нужного вида."; return false; }
+                coerced = JsonValue.Create(iso);
+                return true;
+            }
+
+            default: // string / text / enum
+            {
+                if (element == System.Text.Json.JsonValueKind.String)
+                { reason = "Значение уже нужного вида."; return false; }
+                coerced = JsonValue.Create(raw ?? "");
+                return true;
+            }
+        }
+    }
+
+    /// <summary>Базовый тип поля и примитив, если поле объявлено примитивом. null — поле не скалярное.</summary>
+    private static (string? BaseType, PrimitiveType? Primitive) BaseTypeOf(
+        SchemaFieldInfo field, IReadOnlyDictionary<Guid, PrimitiveType> primitivesById) => field.Type switch
+    {
+        "primitive" => field.TypeId is { } id && primitivesById.TryGetValue(id, out var p)
+            ? (p.BaseType, p)
+            : (null, null),
+        "number" or "date" or "bool" or "boolean" or "string" or "text" or "enum" => (field.Type, null),
+        _ => (null, null),
+    };
+
+    private static bool IsIntegerOnly(PrimitiveType? primitive)
+        => primitive?.Constraints.RootElement is { } c
+           && c.ValueKind == System.Text.Json.JsonValueKind.Object
+           && c.TryGetProperty("integer", out var f)
+           && f.ValueKind == System.Text.Json.JsonValueKind.True;
+
+    private static bool IsWhole(double n) => Math.Abs(n - Math.Truncate(n)) < double.Epsilon;
+
+    /// <summary>
+    /// Целочисленность НЕ чиним: «2.1» в поле «Цело число» — это не опечатка формата, а либо
+    /// иерархическая нумерация (ровно случай #461), либо настоящая дробь. И округление, и отбрасывание
+    /// дробной части выдумали бы данные, которых никто не вводил; правильное решение здесь — либо
+    /// поправить объявление типа, либо переписать значение руками.
+    /// </summary>
+    private static string FractionReason(double n)
+        => $"{n.ToString(CultureInfo.InvariantCulture)} — дробное, а тип допускает только целые; округление придумало бы данные.";
+
+    /// <summary>Целое пишем целым: «1.0» в JSON выглядит опечаткой там, где счёт идёт штуками.</summary>
+    private static JsonNode NumberNode(double n)
+        => Math.Abs(n - Math.Truncate(n)) < double.Epsilon && Math.Abs(n) < 9.2e18
+            ? JsonValue.Create((long)n)
+            : JsonValue.Create(n);
+
+    /// <summary>
+    /// Число целиком, без хвоста. Пробелы (в том числе неразрывный) — разряды, запятая — десятичный
+    /// разделитель; когда встречаются оба, десятичным считается последний, что верно и для «1 234,5»,
+    /// и для «1,234.5» (то же допущение, что в <c>QuantityParser</c>).
+    /// </summary>
+    private static bool TryParseNumber(string? raw, out double value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        var cleaned = new string([.. raw.Where(ch => !char.IsWhiteSpace(ch) && ch != ' ')]);
+        var lastSep = Math.Max(cleaned.LastIndexOf(','), cleaned.LastIndexOf('.'));
+        var normalized = lastSep < 0
+            ? cleaned
+            : $"{cleaned[..lastSep].Replace(",", "").Replace(".", "")}.{cleaned[(lastSep + 1)..]}";
+
+        return double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    /// <summary>Русские «да»/«нет» — то, что кладёт распознавание: в скане стоит слово, не флажок.</summary>
+    private static bool TryParseBool(string? raw, out bool value)
+    {
+        value = false;
+        var s = raw?.Trim().ToLowerInvariant();
+        switch (s)
+        {
+            case "да" or "true" or "1" or "истина" or "yes": value = true; return true;
+            case "нет" or "false" or "0" or "ложь" or "no": return true;
+            default: return false;
+        }
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/AuditCoerceTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/AuditCoerceTests.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using BHS.CRG.Application.Catalog;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Приведение значения к типу как исправление аудита (issue #643) — от находки до чистого повтора.
+///
+/// Проверяется именно связка: находит расхождение аудит (#642), а чинит команда исправлений, и обе
+/// должны считать одно и то же одним и тем же. Разойдись они — кнопка «Привести» либо не появилась
+/// бы там, где нужно, либо не убирала бы находку, ради которой её нажали.
+/// </summary>
+[Collection("Integration")]
+public class AuditCoerceTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private IMediator Mediator(IServiceScope scope) => scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    /// <summary>Тип с полем «Количество листов» примитива «Цело число» — живой случай из #642.</summary>
+    private async Task<(Guid TypeId, Guid InstanceId)> SeedAsync(IServiceScope scope, string storedJson)
+    {
+        var m = Mediator(scope);
+        var prim = await m.Send(new CreatePrimitiveTypeCommand(
+            "Цело число", "int", "number", null, JsonDocument.Parse("{\"integer\":true}")));
+        var type = await m.Send(new CreateDocumentTypeCommand("Внешний документ", "EXT", DocumentTypeKind.Document, null,
+            JsonDocument.Parse($"{{\"fields\":[{{\"key\":\"КоличествоЛистов\",\"title\":\"Количество листов\"," +
+                               $"\"type\":\"primitive\",\"typeId\":\"{prim.Id}\"}}]}}")));
+
+        var c = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "Раздел"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, "Комплект"));
+        var inst = await m.Send(new AddDocumentToSetCommand(set.Id, type.Id));
+        await m.Send(new UpdateRequisitesCommand(inst.Id, JsonDocument.Parse(storedJson)));
+        return (type.Id, inst.Id);
+    }
+
+    [Fact]
+    public async Task Coerce_TurnsStoredStringIntoNumber_AndAuditGoesClean()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var (typeId, instanceId) = await SeedAsync(scope, "{\"КоличествоЛистов\":\"3\"}");
+
+        var before = await Mediator(scope).Send(new AuditDocumentTypeQuery(typeId));
+        var finding = Assert.Single(before.Findings, f => f.Code == SchemaDataAuditor.ValueType);
+
+        var result = await Mediator(scope).Send(new ApplyAuditFixesCommand(
+            [new AuditFix(instanceId, "coerce", finding.Path)]));
+
+        Assert.Equal(1, result.Applied);
+        // Прежнее значение возвращается в журнале — единственная возможность откатить руками.
+        Assert.Equal("\"3\"", Assert.Single(result.Outcomes).OldValue);
+
+        using var after = fixture.Services.CreateScope();
+        var report = await Mediator(after).Send(new AuditDocumentTypeQuery(typeId));
+        Assert.Empty(report.Findings);
+
+        var inst = await Mediator(after).Send(new GetDocumentInstanceQuery(instanceId));
+        Assert.Equal(JsonValueKind.Number, inst!.Data.RootElement.GetProperty("КоличествоЛистов").ValueKind);
+        Assert.Equal(3, inst.Data.RootElement.GetProperty("КоличествоЛистов").GetInt32());
+    }
+
+    [Fact]
+    public async Task Coerce_RefusesFraction_AndLeavesValueAlone()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var (typeId, instanceId) = await SeedAsync(scope, "{\"КоличествоЛистов\":\"2.1\"}");
+
+        var result = await Mediator(scope).Send(new ApplyAuditFixesCommand(
+            [new AuditFix(instanceId, "coerce", "КоличествоЛистов")]));
+
+        Assert.Equal(0, result.Applied);
+        Assert.Contains("округление придумало бы данные", Assert.Single(result.Outcomes).Reason);
+
+        using var after = fixture.Services.CreateScope();
+        var inst = await Mediator(after).Send(new GetDocumentInstanceQuery(instanceId));
+        Assert.Equal("2.1", inst!.Data.RootElement.GetProperty("КоличествоЛистов").GetString());
+        // Находка остаётся: расхождение никуда не делось, и молчать о нём было бы хуже всего.
+        var report = await Mediator(after).Send(new AuditDocumentTypeQuery(typeId));
+        Assert.Contains(report.Findings, f => f.Code == SchemaDataAuditor.ValueType);
+    }
+
+    [Fact]
+    public async Task Coerce_UnknownPath_IsSkippedWithReason()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var (_, instanceId) = await SeedAsync(scope, "{\"КоличествоЛистов\":\"3\"}");
+
+        var result = await Mediator(scope).Send(new ApplyAuditFixesCommand(
+            [new AuditFix(instanceId, "coerce", "НетТакогоПоля")]));
+
+        Assert.Equal(0, result.Applied);
+        Assert.Contains("не найдено", Assert.Single(result.Outcomes).Reason);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Schema/ValueCoercionTests.cs
+++ b/src/server/BHS.CRG.Tests/Schema/ValueCoercionTests.cs
@@ -101,11 +101,52 @@ public class ValueCoercionTests
         Assert.Equal("42", r!.GetValue<string>());
     }
 
-    [Fact]
-    public void Coerce_AlreadyCorrect_IsNotAChange()
+    [Theory]
+    [InlineData("2.1.3")]      // иерархическая нумерация — случай #461
+    [InlineData("01.02.2026")] // дата, попавшая в числовое поле
+    [InlineData("1,2,3")]
+    [InlineData("1.2,34.5")]   // знаки разрядов вперемешку — следы двух соглашений
+    public void Coerce_RefusesMultipleSeparators(string stored)
     {
+        // Нормализация «всё до последнего разделителя — разряды» без проверки групп превращала
+        // «2.1.3» в 21.3, а «01.02.2026» — в 102.2026, отвечая при этом «Документ исправлен».
+        Assert.False(Coerce(F("number"), JsonValue.Create(stored), out _, out var reason));
+        Assert.Contains("не разбирается как число", reason);
+    }
+
+    [Theory]
+    [InlineData("1.234.567,89", 1234567.89)] // разряды точками, десятичная запятая
+    [InlineData("1,234.567", 1234.567)]      // и обратное соглашение — как читает QuantityParser
+    public void Coerce_AcceptsGroupedThousands(string stored, double expected)
+    {
+        Assert.True(Coerce(F("number"), JsonValue.Create(stored), out var r, out _));
+        Assert.Equal(expected, r!.GetValue<double>());
+    }
+
+    [Fact]
+    public void Coerce_AlreadyCorrect_NamesTheRealObstacle()
+    {
+        // Кнопка «Привести» стоит у любой находки о значении, включая нарушение шаблона или длины.
+        // Ответ «значение уже нужного вида» возражал бы самой находке, на которую человек нажал.
         Assert.False(Coerce(F("string"), JsonValue.Create("уже строка"), out _, out var reason));
-        Assert.Equal("Значение уже нужного вида.", reason);
+        Assert.Contains("ограничение типа", reason);
+    }
+
+    [Fact]
+    public void Coerce_BooleanToString_WritesJsonLiteral()
+    {
+        // JsonElement.ToString() отдаёт «True» с большой буквы — в русском документе это мусор.
+        Assert.True(Coerce(F("string"), JsonValue.Create(true), out var r, out _));
+        Assert.Equal("true", r!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Coerce_RefusesEnum()
+    {
+        // Приведением получился бы код, которого нет ни в одном варианте: находка исчезла бы, а
+        // значение осталось бы нерабочим — и теперь уже невидимым.
+        Assert.False(Coerce(F("enum"), JsonValue.Create(3), out _, out var reason));
+        Assert.Contains("вручную", reason);
     }
 
     [Fact]

--- a/src/server/BHS.CRG.Tests/Schema/ValueCoercionTests.cs
+++ b/src/server/BHS.CRG.Tests/Schema/ValueCoercionTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Tests.Schema;
+
+/// <summary>
+/// Приведение значения к объявленному типу — исправление аудита «привести» (issue #643).
+///
+/// Повод — четыре записи «Внешний документ» на живой базе: «Количество листов» объявлено «Цело
+/// число», а хранит строку «1». Удаление такое расхождение не чинит, а теряет.
+/// </summary>
+public class ValueCoercionTests
+{
+    private static readonly Guid IntId = Guid.Parse("00000000-0000-0000-0000-0000000000c1");
+    private static readonly Guid AnyNumId = Guid.Parse("00000000-0000-0000-0000-0000000000c2");
+    private static readonly Guid DateId = Guid.Parse("00000000-0000-0000-0000-0000000000c3");
+
+    private static IReadOnlyDictionary<Guid, PrimitiveType> Prims() => new Dictionary<Guid, PrimitiveType>
+    {
+        [IntId] = P(IntId, "Цело число", "number", "{\"integer\":true}"),
+        [AnyNumId] = P(AnyNumId, "Число", "number", "{}"),
+        [DateId] = P(DateId, "Дата", "date", "{}"),
+    };
+
+    private static PrimitiveType P(Guid id, string name, string baseType, string constraints) =>
+        PrimitiveType.Restore(id, name, name, baseType, null, JsonDocument.Parse(constraints),
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private static SchemaFieldInfo F(string type, Guid? typeId = null) => new("Поле", type, typeId, "Поле");
+
+    private static bool Coerce(SchemaFieldInfo f, JsonNode? v, out JsonNode? result, out string? reason)
+        => ValueCoercion.TryCoerce(f, v, Prims(), out result, out reason);
+
+    [Fact]
+    public void Coerce_StringToInteger()
+    {
+        Assert.True(Coerce(F("primitive", IntId), JsonValue.Create("1"), out var r, out _));
+        Assert.Equal("1", r!.ToJsonString()); // именно 1, а не 1.0 — счёт идёт штуками
+    }
+
+    [Fact]
+    public void Coerce_RussianDecimalComma()
+    {
+        Assert.True(Coerce(F("primitive", AnyNumId), JsonValue.Create("12,5"), out var r, out _));
+        Assert.Equal(12.5, r!.GetValue<double>());
+    }
+
+    [Fact]
+    public void Coerce_ThousandSpaces()
+    {
+        Assert.True(Coerce(F("number"), JsonValue.Create("1 234,5"), out var r, out _));
+        Assert.Equal(1234.5, r!.GetValue<double>());
+    }
+
+    [Fact]
+    public void Coerce_RefusesTrailingUnits()
+    {
+        // Отличие от разбора ячейки набора (QuantityParser), где «10 м» законно читается как 10:
+        // здесь правится СОХРАНЁННОЕ значение, и выбросить «м» значит потерять написанное человеком.
+        Assert.False(Coerce(F("number"), JsonValue.Create("10 м"), out _, out var reason));
+        Assert.Contains("не разбирается как число", reason);
+    }
+
+    [Fact]
+    public void Coerce_RefusesFractionInIntegerType()
+    {
+        // Ровно случай #461: «2.1» — иерархическая нумерация, а не опечатка формата. И округление, и
+        // отбрасывание дробной части выдумали бы данные.
+        Assert.False(Coerce(F("primitive", IntId), JsonValue.Create("2.1"), out _, out var reason));
+        Assert.Contains("округление придумало бы данные", reason);
+    }
+
+    [Fact]
+    public void Coerce_FractionAllowedWhenTypeAllows()
+    {
+        Assert.True(Coerce(F("primitive", AnyNumId), JsonValue.Create("2.1"), out var r, out _));
+        Assert.Equal(2.1, r!.GetValue<double>());
+    }
+
+    [Fact]
+    public void Coerce_RussianDateToIso()
+    {
+        Assert.True(Coerce(F("primitive", DateId), JsonValue.Create("01.02.2026"), out var r, out _));
+        Assert.Equal("2026-02-01", r!.GetValue<string>()); // инвариантная культура прочла бы 2 января
+    }
+
+    [Fact]
+    public void Coerce_BooleanFromRussianYes()
+    {
+        Assert.True(Coerce(F("boolean"), JsonValue.Create("да"), out var r, out _));
+        Assert.True(r!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void Coerce_NumberToStringField()
+    {
+        Assert.True(Coerce(F("string"), JsonValue.Create(42), out var r, out _));
+        Assert.Equal("42", r!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Coerce_AlreadyCorrect_IsNotAChange()
+    {
+        Assert.False(Coerce(F("string"), JsonValue.Create("уже строка"), out _, out var reason));
+        Assert.Equal("Значение уже нужного вида.", reason);
+    }
+
+    [Fact]
+    public void Coerce_RefusesCompositeValue()
+    {
+        Assert.False(Coerce(F("number"), JsonNode.Parse("{\"a\":1}"), out _, out var reason));
+        Assert.Contains("вручную", reason);
+    }
+
+    [Fact]
+    public void Coerce_UnknownPrimitive_Refuses()
+    {
+        Assert.False(Coerce(F("primitive", Guid.NewGuid()), JsonValue.Create("1"), out _, out var reason));
+        Assert.Contains("не определено", reason);
+    }
+}
+
+/// <summary>Поле схемы по пути аудита (issue #643) — обратная сторона JsonPathEditor.</summary>
+public class SchemaPathResolverTests
+{
+    private static readonly Guid DocId = Guid.Parse("d0000000-0000-0000-0000-000000000002");
+    private static readonly Guid RowId = Guid.Parse("00000000-0000-0000-0000-0000000000d1");
+
+    private static DocumentType T(Guid id, string fieldsJson) =>
+        DocumentType.Restore(id, id.ToString(), id.ToString(), DocumentTypeKind.Composite, null,
+            JsonDocument.Parse($"{{\"fields\":{fieldsJson}}}"), JsonDocument.Parse("{}"), false,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private static IReadOnlyDictionary<Guid, DocumentType> Types() => new[]
+    {
+        T(DocId, $"[{{\"key\":\"Работы\",\"type\":\"array\",\"typeId\":\"{RowId}\"}},{{\"key\":\"Номер\",\"type\":\"string\"}}]"),
+        T(RowId, "[{\"key\":\"Порядок\",\"type\":\"number\"}]"),
+    }.ToDictionary(t => t.Id);
+
+    [Fact]
+    public void FieldAt_TopLevel() =>
+        Assert.Equal("Номер", SchemaPathResolver.FieldAt("Номер", DocId, Types())!.Key);
+
+    [Fact]
+    public void FieldAt_InsideArrayRow()
+    {
+        // Индекс строки схему не меняет — у всех строк таблицы тип один.
+        var f = SchemaPathResolver.FieldAt("Работы[3].Порядок", DocId, Types());
+        Assert.Equal("number", f!.Type);
+    }
+
+    [Fact]
+    public void FieldAt_UnknownKey_IsNull() =>
+        Assert.Null(SchemaPathResolver.FieldAt("Нет.Такого", DocId, Types()));
+
+    [Fact]
+    public void FieldAt_DeeperThanScalar_IsNull() =>
+        Assert.Null(SchemaPathResolver.FieldAt("Номер.Внутри", DocId, Types()));
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.77.1</Version>
+    <Version>0.78.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.78.0</Version>
+    <Version>0.78.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Фаза 2 варианта C по #641. Closes #643. Стек: поверх #645.

## Зачем

После #642 находка `value-type` видна, но чинить её нечем. Из двух существующих исправлений
удаление для неё — не исправление, а потеря: четыре записи «Внешний документ» на живой базе хранят
«Количество листов» строкой «1», «3», «2», «1».

## Что сделано

Третье действие `coerce` рядом с `remove`/`rename`:

| было | стало |
|---|---|
| `"3"` в поле «Цело число» | `3` |
| `"12,5"`, `"1 234,5"` в числовом | `12.5`, `1234.5` |
| `"01.02.2026"` в поле даты | `"2026-02-01"` |
| `"да"` в поле-флажке | `true` |
| `42` в строковом поле | `"42"` |

Не разобралось целиком — не приводим, возвращаем причину. Прежнее значение уходит в `OldValue`, как
у существующих исправлений (единственный способ откатить руками).

Кнопка «Привести во всех (N)» в аудите типа и «Привести к типу» в аудите документа — только у строк
с кодом `value-type`, первыми в ряду действий: удаление рядом с ними теперь худший из вариантов.

## Два решения, которые стоит заметить

**Разбор строже, чем `QuantityParser`.** Там «10 м» законно читается как 10 — в ячейке набора
единица измерения обычное дело. Здесь правится уже сохранённое значение, и молча выбросить «м»
значит потерять написанное человеком. Поэтому строка должна разбираться целиком.

**Целочисленность не чиним вовсе.** «2.1» в поле «Цело число» — либо иерархическая нумерация (ровно
случай #461), либо настоящая дробь. Округление и отбрасывание дробной части одинаково выдумали бы
данные, которых никто не вводил; находка остаётся, чинить её человеку.

**Приведения на пути записи по-прежнему нет.** Это «узкое B» из #641: оно живёт в аудите и
срабатывает по явной команде. Перенеси его в запись — значение молча менялось бы в пяти местах
сразу (форма, распознавание, вставка, авто-маппер, привязка набора).

## Проверка

- 987 backend-тестов (было 968): 16 модульных на приведение и разбор пути по схеме + 3
  интеграционных на связку «аудит нашёл → исправление починило → повтор чист».
- 353 frontend, `tsc -b` чист.
- Четыре живые записи намеренно НЕ тронуты: приведение — действие пользователя, не миграция.
