### PR TITLE
Формат значений в свёрнутых сводках составных полей (#611)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -14,6 +14,8 @@ import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import {
   resolveEffectiveFields, getDefaultValues, type SchemaField,
 } from '@/shared/api/schema';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
+import { formatFieldValue, type FieldTypeDefs } from '@/shared/utils/fieldDisplay';
 import {
   CELL_INPUT, SCOPE_COLORS, TABLE_SHOWN_TYPES, defaultColWidth,
 } from './constants';
@@ -441,7 +443,9 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
 
   const hasTableFields = subFields.some(f => TABLE_SHOWN_TYPES.has(f.type));
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
+  const typeDefs: FieldTypeDefs = { primitiveTypes, enumTypes }; // формат значений в сводке строки (issue #611)
 
   function addRow() {
     const newRow = getDefaultValues(subFields);
@@ -463,7 +467,7 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   }
 
   function rowSummary(row: Record<string, unknown>) {
-    return objectSummary(row, subFields);
+    return objectSummary(row, subFields, typeDefs);
   }
 
   return (
@@ -636,15 +640,22 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
 
 // ─── Complex field group ──────────────────────────────────────────────────────
 
-/** Сводка первых заполненных полей объекта — для свёрнутого/строкового вида составного (issue #102). */
-export function objectSummary(values: Record<string, unknown>, fields: SchemaField[]): string {
+/**
+ * Сводка первых заполненных полей объекта — для свёрнутого/строкового вида составного (issue #102).
+ *
+ * Значение форматируем по типу поля (issue #611): без `defs` сводка показывала сырое хранимое
+ * значение — дату ISO там, где поле внутри того же объекта показывает «ДД.ММ.ГГГГ».
+ */
+export function objectSummary(
+  values: Record<string, unknown>, fields: SchemaField[], defs: FieldTypeDefs = {},
+): string {
   const parts = fields
     .map(f => {
       const v = values[f.key];
       if (v == null || v === '') return null;
       if (isFieldRef(v)) return v.displayName;
       if (typeof v === 'object') return null; // вложенные объекты/массивы — не в сводку
-      return String(v);
+      return formatFieldValue(f, v, defs);
     })
     .filter((s): s is string => !!s)
     .slice(0, 3);
@@ -688,6 +699,8 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
   const [collapsed, setCollapsed] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
+  const typeDefs: FieldTypeDefs = { primitiveTypes, enumTypes }; // формат значений в сводке (issue #611)
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
 
   // Union-тип (issue #320): составной тип с тэгом type.union — «заполняется ровно одно из полей».
@@ -803,7 +816,7 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
         <div className="flex items-center gap-2 border border-stroke rounded-lg px-3 py-2 bg-base">
           <button type="button" onClick={() => setModalOpen(true)}
             className="flex-1 min-w-0 text-left text-sm text-fg2 hover:text-fg1 truncate">
-            {isEmpty ? <span className="text-fg4">Заполнить…</span> : objectSummary(subValues, subFields)}
+            {isEmpty ? <span className="text-fg4">Заполнить…</span> : objectSummary(subValues, subFields, typeDefs)}
           </button>
           <button type="button" onClick={() => setPickerOpen(true)}
             className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover px-2 py-0.5 rounded hover:bg-brand-subtle transition-colors shrink-0">
@@ -857,7 +870,7 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
           <span className="truncate">
             {isEmpty
               ? <span className="text-fg4 font-normal">{compositeType ? compositeType.name : 'Составной тип'}</span>
-              : objectSummary(subValues, subFields)}
+              : objectSummary(subValues, subFields, typeDefs)}
           </span>
         </button>
         <button type="button" onClick={() => setPickerOpen(true)}
@@ -979,6 +992,7 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
   scope?: CatalogScope; scopeId?: string | null; docRefMode?: 'catalog' | 'instance'; nested?: boolean;
 }) {
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const compositeType = allDocTypes.find(dt => dt.id === field.typeId) ?? null;
   // Расчётные подполя (issue #368) не редактируются вручную — считаются при генерации; в редакторе скрыты.
   const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
@@ -1037,7 +1051,7 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
         <div className="flex items-center gap-2 border border-stroke rounded-lg px-3 py-2 bg-base">
           <button type="button" onClick={() => setModalOpen(true)}
             className="flex-1 min-w-0 text-left text-sm text-fg2 hover:text-fg1 truncate">
-            {unionSummary(activeSf, subValues[activeKey])}
+            {unionSummary(activeSf, subValues[activeKey], { primitiveTypes, enumTypes })}
           </button>
           <button type="button" onClick={() => setModalOpen(true)} title="Редактировать"
             className="p-1 text-fg4 hover:text-fg2 transition-colors shrink-0"><Pencil size={13} /></button>
@@ -1059,10 +1073,10 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
 }
 
 /** Короткая сводка активного варианта union — для свёрнутой строки во вложенном режиме. */
-function unionSummary(sf: SchemaField | null, val: unknown): string {
+function unionSummary(sf: SchemaField | null, val: unknown, defs: FieldTypeDefs = {}): string {
   if (!sf) return '(пусто)';
   if (!isVariantFilled(val)) return `${sf.title}: —`;
   if (isFieldRef(val)) return `${sf.title} → ${val.displayName}`;
   if (Array.isArray(val)) return `${sf.title} · ${val.length} стр.`;
-  return `${sf.title}: ${String(val).slice(0, 40)}`;
+  return `${sf.title}: ${formatFieldValue(sf, val, defs).slice(0, 40)}`; // формат по типу (issue #611)
 }

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -7,7 +7,7 @@ import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import type {
-  CatalogScope, DocumentInstance, DocumentType, FieldRef, PrimitiveTypeDef,
+  CatalogScope, DocumentInstance, DocumentType, EnumTypeDef, FieldRef, PrimitiveTypeDef,
 } from '@/shared/api/types';
 import { isFieldRef, SCOPE_LABELS } from '@/shared/api/types';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
@@ -27,6 +27,9 @@ import { DocRefCatalogPickerField } from './DocRefCatalogPickerField';
 import { DocRefField, DocArrayField } from './DocRefField';
 import { PasteMappingModal } from './PasteMappingModal';
 import { BROKEN_PLATE, BROKEN_LABEL, BrokenRefNote } from './BrokenRef';
+
+/** Модульная пустышка для дефолта пропа: инлайновый `= []` — новый массив на каждый рендер. */
+const EMPTY_ENUM_TYPES: EnumTypeDef[] = [];
 
 // ─── Complex cell picker (inline table cell) ──────────────────────────────────
 
@@ -64,12 +67,15 @@ export function ComplexCellPicker({ value, onChange, compositeType, setId, allDo
 
 // ─── Table cell ───────────────────────────────────────────────────────────────
 
-export function TableCell({ field, value, onChange, compositeType, setId, allDocTypes, scope, scopeId, primitiveTypeDef }: {
+export function TableCell({ field, value, onChange, compositeType, setId, allDocTypes, scope, scopeId,
+  primitiveTypeDef, enumTypeDef }: {
   field: SchemaField; value: unknown; onChange: (v: unknown) => void;
   compositeType: DocumentType | null;
   setId?: string; allDocTypes: DocumentType[];
   scope?: CatalogScope; scopeId?: string | null;
   primitiveTypeDef?: PrimitiveTypeDef;
+  /** Перечисление из реестра (issue #59): без него ячейка читает только легаси-`options` и пустеет. */
+  enumTypeDef?: EnumTypeDef;
 }) {
   const strVal = value == null ? '' : String(value);
   if (field.type === 'complex') {
@@ -89,12 +95,16 @@ export function TableCell({ field, value, onChange, compositeType, setId, allDoc
     );
   }
   if (field.type === 'enum') {
-    const opts = (field.options ?? []).filter(o => o !== '');
+    // Варианты знает реестр (issue #59); в схеме их нет вовсе — там только typeId. Легаси-поля,
+    // наоборот, хранят коды прямо в options, и код там же и есть отображаемое имя.
+    const opts = enumTypeDef
+      ? enumTypeDef.values.map(v => ({ code: v.code, label: v.label }))
+      : (field.options ?? []).filter(o => o !== '').map(o => ({ code: o, label: o }));
     return (
       <select value={strVal} onChange={e => onChange(e.target.value)}
         className={CELL_INPUT + ' cursor-pointer'}>
         <option value="">—</option>
-        {opts.map(opt => <option key={opt} value={opt}>{opt}</option>)}
+        {opts.map(o => <option key={o.code} value={o.code}>{o.label}</option>)}
       </select>
     );
   }
@@ -154,7 +164,9 @@ export function ArrayTableModal({
   const resolveScope = setId ? 'Set' as const : scope;
   const resolveScopeId = setId ?? scopeId;
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
   const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
+  const enumDef = (f: SchemaField) => f.type === 'enum' ? enumTypes.find(et => et.id === f.typeId) : undefined;
 
   // Расчётные подполя (issue #368) не редактируются вручную — считаются при генерации; в редакторе скрыты.
   const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
@@ -372,7 +384,7 @@ export function ArrayTableModal({
                       style={{ border: BORDER, padding: 0, height: 26 }}>
                       <TableCell field={f} value={row[f.key]} onChange={v => updateCell(i, f.key, v)}
                         compositeType={compositeForField} setId={setId} allDocTypes={allDocTypes}
-                        scope={scope} scopeId={scopeId} primitiveTypeDef={primDef(f)} />
+                        scope={scope} scopeId={scopeId} primitiveTypeDef={primDef(f)} enumTypeDef={enumDef(f)} />
                     </td>
                   );
                 })}
@@ -445,6 +457,7 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   const { data: primitiveTypes = [] } = useListPrimitiveTypes();
   const { data: enumTypes = [] } = useListEnumTypes();
   const primDef = (f: SchemaField) => f.type === 'primitive' ? primitiveTypes.find(pt => pt.id === f.typeId) : undefined;
+  const enumDef = (f: SchemaField) => f.type === 'enum' ? enumTypes.find(et => et.id === f.typeId) : undefined;
   const typeDefs: FieldTypeDefs = { primitiveTypes, enumTypes }; // формат значений в сводке строки (issue #611)
 
   function addRow() {
@@ -608,7 +621,7 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                   ) : (
                     <PrimitiveInput field={sf} value={subVal} label={sf.title}
                       onChange={v => updateRow(rowModal, { ...rowObj, [sf.key]: v })} invalid={invalid}
-                      primitiveTypeDef={primDef(sf)} />
+                      primitiveTypeDef={primDef(sf)} enumTypeDef={enumDef(sf)} />
                   )}
                   {invalid && <p className="text-xs text-danger mt-0.5">Обязательное поле</p>}
                 </div>
@@ -801,7 +814,7 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
             <SubfieldEditor sf={sf} value={subVal} onChange={v => setSubValue(sf.key, v)}
               allDocTypes={allDocTypes} showValidation={showValidation} setId={setId}
               otherInstances={otherInstances} scope={scope} scopeId={scopeId}
-              docRefMode={docRefMode} primitiveTypes={primitiveTypes} />
+              docRefMode={docRefMode} primitiveTypes={primitiveTypes} enumTypes={enumTypes} />
             {invalid && <p className="text-xs text-danger mt-1">Обязательное поле</p>}
           </div>
         );
@@ -887,13 +900,14 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
 // ─── Один подполе-редактор (диспетчеризация по типу) ───────────────────────────
 // Извлечено из ComplexFieldGroup, чтобы переиспользовать для активного варианта union (issue #320).
 function SubfieldEditor({ sf, value, onChange, allDocTypes, showValidation, setId,
-  otherInstances = [], scope, scopeId, docRefMode = 'catalog', primitiveTypes }: {
+  otherInstances = [], scope, scopeId, docRefMode = 'catalog', primitiveTypes, enumTypes = EMPTY_ENUM_TYPES }: {
   sf: SchemaField; value: unknown; onChange: (v: unknown) => void;
   allDocTypes: DocumentType[]; showValidation: boolean; setId?: string;
   otherInstances?: DocumentInstance[]; scope?: CatalogScope; scopeId?: string | null;
-  docRefMode?: 'catalog' | 'instance'; primitiveTypes: PrimitiveTypeDef[];
+  docRefMode?: 'catalog' | 'instance'; primitiveTypes: PrimitiveTypeDef[]; enumTypes?: EnumTypeDef[];
 }) {
   const primDef = sf.type === 'primitive' ? primitiveTypes.find(pt => pt.id === sf.typeId) : undefined;
+  const enumTypeDef = sf.type === 'enum' ? enumTypes.find(et => et.id === sf.typeId) : undefined;
   const invalid = showValidation && isMissing(sf, value);
   if (sf.type === 'complex')
     return <ComplexFieldGroup field={sf} allDocTypes={allDocTypes} value={value} onChange={v => onChange(v)}
@@ -915,7 +929,7 @@ function SubfieldEditor({ sf, value, onChange, allDocTypes, showValidation, setI
       showValidation={showValidation} setId={setId} otherInstances={otherInstances}
       scope={scope} scopeId={scopeId} docRefMode={docRefMode} />;
   return <PrimitiveInput field={sf} value={value} label={sf.title} onChange={v => onChange(v)}
-    invalid={invalid} primitiveTypeDef={primDef} />;
+    invalid={invalid} primitiveTypeDef={primDef} enumTypeDef={enumTypeDef} />;
 }
 
 // ─── Union-поле (issue #320): заполняется РОВНО ОДИН вариант (подполе union-типа) ──
@@ -1035,7 +1049,8 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
   const activeEditor = activeSf && (
     <SubfieldEditor sf={activeSf} value={subValues[activeSf.key]} onChange={setActiveValue}
       allDocTypes={allDocTypes} showValidation={showValidation} setId={setId}
-      otherInstances={otherInstances} scope={scope} scopeId={scopeId} docRefMode={docRefMode} primitiveTypes={primitiveTypes} />
+      otherInstances={otherInstances} scope={scope} scopeId={scopeId} docRefMode={docRefMode}
+      primitiveTypes={primitiveTypes} enumTypes={enumTypes} />
   );
   const bar = (
     <div className="space-y-1.5">

--- a/src/client/src/shared/utils/fieldDisplay.test.ts
+++ b/src/client/src/shared/utils/fieldDisplay.test.ts
@@ -37,10 +37,20 @@ describe('formatFieldValue', () => {
 
   it('логическое значение — словом', () => {
     expect(formatFieldValue(f('boolean'), true)).toBe('Да');
-    expect(formatFieldValue(f('boolean'), 'true')).toBe('Да');
     // Снятый флажок остаётся в сводке (раньше стоял «false») — «Нет» тоже сведение, а не пропуск.
     expect(formatFieldValue(f('boolean'), false)).toBe('Нет');
-    expect(formatFieldValue(f('boolean'), 'false')).toBe('Нет'); // строку кладёт распознавание
+  });
+
+  it('в поле-флажке понимает слова, которые кладут туда распознавание и вставка', () => {
+    // «Да» по одному только `=== true` показывало бы «Нет» на «да» — уверенно наоборот.
+    for (const yes of ['да', 'Да', 'true', '1', 'истина', 'yes', '+'])
+      expect(formatFieldValue(f('boolean'), yes)).toBe('Да');
+    for (const no of ['нет', 'false', '0', 'ложь', 'no'])
+      expect(formatFieldValue(f('boolean'), no)).toBe('Нет');
+  });
+
+  it('непонятное значение флажка показывает как есть, а не толкует', () => {
+    expect(formatFieldValue(f('boolean'), 'частично')).toBe('частично');
   });
 
   it('перечисление — именем варианта, а не кодом', () => {

--- a/src/client/src/shared/utils/fieldDisplay.test.ts
+++ b/src/client/src/shared/utils/fieldDisplay.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { formatFieldValue } from './fieldDisplay';
+import type { SchemaField } from '@/shared/api/schema';
+import type { EnumTypeDef, PrimitiveTypeDef } from '@/shared/api/types';
+
+const f = (type: SchemaField['type'], typeId?: string): SchemaField =>
+  ({ key: 'Поле', title: 'Поле', type, typeId, required: false });
+
+const prim = (id: string, baseType: PrimitiveTypeDef['baseType'], constraints = {}): PrimitiveTypeDef =>
+  ({ id, name: id, code: id, baseType, constraints, allowedTags: [], group: null,
+     createdAt: '', updatedAt: '' });
+
+const enumType: EnumTypeDef = {
+  id: 'e1', name: 'Стадия', code: 'stage',
+  values: [{ code: 'P', label: 'Проектная' }, { code: 'R', label: 'Рабочая' }],
+  group: null, createdAt: '', updatedAt: '',
+};
+
+describe('formatFieldValue', () => {
+  it('дату показывает по-русски, а не сырым ISO', () => {
+    // Ровно issue #611: в сводке стояло «2023-08-10», в поле внутри — «10.08.2023».
+    expect(formatFieldValue(f('date'), '2023-08-10')).toBe('10.08.2023');
+  });
+
+  it('учитывает точность примитивного date-типа', () => {
+    const defs = { primitiveTypes: [
+      prim('p1', 'date', { datePrecision: 'month' }),
+      prim('p2', 'date'),
+    ] };
+    expect(formatFieldValue(f('primitive', 'p1'), '2026-07-01', defs)).toBe('07.2026');
+    expect(formatFieldValue(f('primitive', 'p2'), '2026-07-01', defs)).toBe('01.07.2026');
+  });
+
+  it('незнакомый примитив показывает как есть — справочник мог не догрузиться', () => {
+    expect(formatFieldValue(f('primitive', 'нет-такого'), '2026-07-01')).toBe('2026-07-01');
+  });
+
+  it('логическое значение — словом', () => {
+    expect(formatFieldValue(f('boolean'), true)).toBe('Да');
+    expect(formatFieldValue(f('boolean'), 'true')).toBe('Да');
+    // Снятый флажок остаётся в сводке (раньше стоял «false») — «Нет» тоже сведение, а не пропуск.
+    expect(formatFieldValue(f('boolean'), false)).toBe('Нет');
+    expect(formatFieldValue(f('boolean'), 'false')).toBe('Нет'); // строку кладёт распознавание
+  });
+
+  it('перечисление — именем варианта, а не кодом', () => {
+    expect(formatFieldValue(f('enum', 'e1'), 'R', { enumTypes: [enumType] })).toBe('Рабочая');
+  });
+
+  it('код вне вариантов остаётся кодом — иначе значение исчезло бы из сводки', () => {
+    expect(formatFieldValue(f('enum', 'e1'), 'X', { enumTypes: [enumType] })).toBe('X');
+  });
+
+  it('строку и число не трогает', () => {
+    expect(formatFieldValue(f('string'), 'АОСР-1')).toBe('АОСР-1');
+    expect(formatFieldValue(f('number'), 12.5)).toBe('12.5');
+  });
+
+  it('пусто — пустая строка', () => {
+    expect(formatFieldValue(f('date'), null)).toBe('');
+    expect(formatFieldValue(f('string'), '')).toBe('');
+  });
+
+  it('неразобранную дату отдаёт как есть', () => {
+    expect(formatFieldValue(f('date'), 'не дата')).toBe('не дата');
+  });
+});

--- a/src/client/src/shared/utils/fieldDisplay.ts
+++ b/src/client/src/shared/utils/fieldDisplay.ts
@@ -1,0 +1,50 @@
+import type { SchemaField } from '@/shared/api/schema';
+import type { EnumTypeDef, PrimitiveTypeDef } from '@/shared/api/types';
+import { formatDateRu } from './date';
+
+/**
+ * Значение поля в человеческом виде — для мест, где значение ПОКАЗЫВАЮТ, а не редактируют
+ * (issue #611): свёрнутые сводки составных полей и строк таблиц.
+ *
+ * Повод: в свёрнутой строке составного поля «Период действия» стояло «2023-08-10 · 2028-08-09»,
+ * тогда как сами поля внутри показывали «10.08.2023» и «09.08.2028». Формат знали только
+ * редакторы (`DateInput`, `PrimitiveInput`), а сводка звала `String(v)` и отдавала сырое хранимое
+ * значение. Здесь собрано то же знание в чистом виде — без контролов.
+ *
+ * Хранение не меняется: дата всегда полный ISO, точность — метаданные типа (issue #60), логическое
+ * значение — булево, перечисление — код. Формат живёт только на экране; в PDF о нём заботится
+ * Typst-шаблон.
+ */
+export interface FieldTypeDefs {
+  primitiveTypes?: PrimitiveTypeDef[];
+  enumTypes?: EnumTypeDef[];
+}
+
+/** Пустое значение отдаём пустой строкой: решение «показывать ли пропуск» принимает вызывающий. */
+export function formatFieldValue(
+  field: SchemaField, value: unknown, defs: FieldTypeDefs = {},
+): string {
+  if (value == null || value === '') return '';
+
+  if (field.type === 'date') return formatDateRu(String(value));
+
+  if (field.type === 'primitive') {
+    const def = defs.primitiveTypes?.find(pt => pt.id === field.typeId);
+    if (def?.baseType === 'date')
+      return formatDateRu(String(value), def.constraints.datePrecision ?? 'day');
+    return String(value);
+  }
+
+  if (field.type === 'boolean')
+    // Строку сюда кладёт распознавание и вставка из таблицы: «false» — не «Да», хотя и не пусто.
+    return value === true || value === 'true' ? 'Да' : 'Нет';
+
+  if (field.type === 'enum') {
+    const code = String(value);
+    // Отображаемое имя знает реестр перечислений (issue #59); легаси-варианты в схеме — код и есть имя.
+    const def = defs.enumTypes?.find(et => et.id === field.typeId);
+    return def?.values.find(v => v.code === code)?.label ?? code;
+  }
+
+  return String(value);
+}

--- a/src/client/src/shared/utils/fieldDisplay.ts
+++ b/src/client/src/shared/utils/fieldDisplay.ts
@@ -20,6 +20,9 @@ export interface FieldTypeDefs {
   enumTypes?: EnumTypeDef[];
 }
 
+const TRUE_TOKENS = new Set(['true', 'да', 'истина', 'yes', 'y', '1', '+']);
+const FALSE_TOKENS = new Set(['false', 'нет', 'ложь', 'no', 'n', '0', '-']);
+
 /** Пустое значение отдаём пустой строкой: решение «показывать ли пропуск» принимает вызывающий. */
 export function formatFieldValue(
   field: SchemaField, value: unknown, defs: FieldTypeDefs = {},
@@ -35,9 +38,17 @@ export function formatFieldValue(
     return String(value);
   }
 
-  if (field.type === 'boolean')
-    // Строку сюда кладёт распознавание и вставка из таблицы: «false» — не «Да», хотя и не пусто.
-    return value === true || value === 'true' ? 'Да' : 'Нет';
+  if (field.type === 'boolean') {
+    if (typeof value === 'boolean') return value ? 'Да' : 'Нет';
+    // В поле-флажке лежит не только булево: распознавание кладёт туда «да»/«нет» словом
+    // (`ValueTypeRules.CheckBase`), вставка из таблицы разбирает свой набор (`PasteMappingModal`).
+    // Чего нет ни в одном наборе — показываем как есть: «Нет» на непонятном значении было бы
+    // утверждением, причём в том самом месте, где значение смотрят не открывая редактор.
+    const token = String(value).trim().toLowerCase();
+    if (TRUE_TOKENS.has(token)) return 'Да';
+    if (FALSE_TOKENS.has(token)) return 'Нет';
+    return String(value);
+  }
 
   if (field.type === 'enum') {
     const code = String(value);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.79.1</Version>
+    <Version>0.79.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #611.

## Что было

Свёрнутая строка составного поля показывала **сырое хранимое значение**: «Период действия» — «2023-08-10 · 2028-08-09», хотя поля внутри того же объекта показывают «10.08.2023» и «09.08.2028». Формат даты знали только редакторы (`DateInput`, `PrimitiveInput`), а `objectSummary` звала `String(v)`.

## Что сделано

Та же логика вынесена в чистую функцию `formatFieldValue` (`shared/utils/fieldDisplay.ts`) — без контролов:

- **дата** — по-русски, с учётом точности примитивного типа (`datePrecision`, issue #60);
- **логическое** — «Да»/«Нет» вместо `true`/`false`;
- **перечисление** — имя варианта вместо кода (реестр EnumType, issue #59); код вне вариантов остаётся кодом, иначе значение исчезло бы из сводки.

Хранение не тронуто: дата остаётся полным ISO, формат живёт только на экране — в PDF о нём заботится Typst-шаблон.

Подключено во всех трёх местах, где строится сводка: строка таблицы массива, свёрнутое составное (вложенное и верхнего уровня) и сводка активного варианта union (issue #320) — там был тот же `String(val)`.

## Проверка

- 9 модульных тестов на `formatFieldValue`; фронтенд 368 тестов зелёные, `tsc -b` чист.
- Живая проверка: документы качества → «EKF — автоматические выключатели» → правка → свёрнутая строка «Период действия» показывает **23.09.2025 · 22.09.2030** (в базе `2025-09-23` / `2030-09-22`).

Версия 0.79.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)