### PR TITLE
Материалы за union-обёрткой: закладка, список, генерация, диагностика (#648)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/shared/api/qualityDocs';
 import type { DocumentInstance, DocumentType, CatalogScope } from '@/shared/api/types';
 import {
-  typeHasTag, findTaggedFieldPath, resolveEffectiveFields, isMaterialType, materialIdentityKeys,
+  typeHasTag, findTaggedFieldPath, collectMaterialRows, materialIdentityKeys,
 } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { identityKey, isIdentityKeyEmpty, normalizeKey } from '@/shared/api/identityKey';
@@ -388,14 +388,10 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
         if (r.mode === 'tabular' && Array.isArray(r.data))
           for (const row of r.data as Record<string, unknown>[]) add(row);
     const docType = allDocTypes.find(t => t.id === instance.documentTypeId);
+    // По всей глубине реквизитов (issue #648): в АОСР материалы лежат внутри union-обёртки
+    // «массив ИЛИ ссылка на реестр» (#320), и обход только верхнего уровня их не видел.
     if (docType)
-      for (const f of resolveEffectiveFields(docType, allDocTypes)) {
-        if (f.type !== 'array' || !f.typeId) continue;
-        const ct = allDocTypes.find(t => t.id === f.typeId);
-        if (!ct || !isMaterialType(ct, allDocTypes)) continue;
-        const arr = instance.requisites[f.key];
-        if (Array.isArray(arr)) for (const el of arr) if (el && typeof el === 'object') add(el as Record<string, unknown>);
-      }
+      for (const row of collectMaterialRows(docType, allDocTypes, instance.requisites)) add(row);
     return rows;
   }, [preview, identityKeys, allDocTypes, instance]);
 

--- a/src/client/src/shared/api/schema.test.ts
+++ b/src/client/src/shared/api/schema.test.ts
@@ -10,6 +10,8 @@ import {
   isScalarField,
   isMaterialType,
   materialIdentityKeys,
+  compositeFieldHasTag,
+  collectMaterialRows,
   type SchemaField,
 } from './schema';
 import type { DocumentType } from './types';
@@ -303,5 +305,79 @@ describe('materialIdentityKeys', () => {
     const cable = { ...dt({ fields: [field('МаркаКабеля', { tags: ['identity'] })] }, 'dt-base2', 'dt-cable2'),
       kind: 'Composite' as const };
     expect(materialIdentityKeys([base, cable])).toEqual(['Наименование', 'МаркаКабеля']);
+  });
+});
+
+// ── Материалы через union-обёртку (issue #648) ────────────────────────────────
+
+describe('материалы за составной обёрткой', () => {
+  /**
+   * Живой случай: пользователь внёс материалы прямо в АОСР — inline-ветка union-поля «Материалы»
+   * (#320), а не ссылку на реестр. Обход «ровно на один уровень» до типа «Материал» не доходил:
+   * закладки «Документы качества» у документа не было вовсе, подобрать сертификаты негде.
+   *
+   *   АОСР → «Материалы» (complex, тип «МатериалыАОСР», тэг union)
+   *        → «Материалы» (array, тип «Материал») | «Реестр» (doc-ref)
+   *        → «ДокументПодтверждающийКачество» (тэг material.qualityDocLink)
+   */
+  const material = dt({ fields: [
+    field('Наименование', { tags: ['identity'] }),
+    field('Артикул', { tags: ['identity'] }),
+    field('ДокументПодтверждающийКачество', { type: 'complex', tags: ['material.qualityDocLink'] }),
+  ] }, null, 'material');
+  const wrapper = dt({ tags: ['type.union'], fields: [
+    field('Материалы', { type: 'array', typeId: 'material' }),
+    field('Реестр', { type: 'doc-ref', typeId: 'registry' }),
+  ] }, null, 'wrapper');
+  const aosr = dt({ fields: [
+    field('Номер'),
+    field('Материалы', { type: 'complex', typeId: 'wrapper' }),
+  ] }, null, 'aosr');
+  const registry = dt({ fields: [field('Материалы', { type: 'array', typeId: 'material' })] }, null, 'registry');
+  const all = [material, wrapper, aosr, registry];
+
+  it('тэг находится через обёртку — закладка у АОСР появляется', () => {
+    expect(compositeFieldHasTag(aosr, 'material.qualityDocLink', all)).toBe(true);
+  });
+
+  it('прямой массив материалов (реестр) работает как работал', () => {
+    expect(compositeFieldHasTag(registry, 'material.qualityDocLink', all)).toBe(true);
+  });
+
+  it('тип без материалов остаётся без закладки', () => {
+    const plain = dt({ fields: [field('Работы', { type: 'array', typeId: 'work' })] }, null, 'plain');
+    const work = dt({ fields: [field('Наименование')] }, null, 'work');
+    expect(compositeFieldHasTag(plain, 'material.qualityDocLink', [plain, work])).toBe(false);
+  });
+
+  it('тип, ссылающийся сам на себя, не зацикливает обход', () => {
+    const selfRef = dt({ fields: [field('Вложенное', { type: 'complex', typeId: 'self' })] }, null, 'self');
+    expect(compositeFieldHasTag(selfRef, 'material.qualityDocLink', [selfRef])).toBe(false);
+  });
+
+  // ── collectMaterialRows ─────────────────────────────────────────────────────
+
+  it('строки материалов достаются из-под обёртки', () => {
+    const requisites = { Номер: '1', Материалы: { Материалы: [
+      { Наименование: 'проверка', Артикул: '2342' },
+      { Наименование: 'кабель', Артикул: '77' },
+    ] } };
+    expect(collectMaterialRows(aosr, all, requisites).map(r => r.Артикул)).toEqual(['2342', '77']);
+  });
+
+  it('прямой массив материалов собирается как прежде', () => {
+    const requisites = { Материалы: [{ Наименование: 'кабель', Артикул: '77' }] };
+    expect(collectMaterialRows(registry, all, requisites)).toHaveLength(1);
+  });
+
+  it('выбранная ветка union со ссылкой на реестр материалов не даёт', () => {
+    // Ссылку не разворачиваем: материалы чужой записи приходят на вкладку набором данных.
+    const requisites = { Материалы: { Реестр: { $ref: 'instance:123', displayName: 'Реестр ЭОМ-1' } } };
+    expect(collectMaterialRows(aosr, all, requisites)).toEqual([]);
+  });
+
+  it('пустая обёртка и отсутствующие ключи материалов не дают', () => {
+    expect(collectMaterialRows(aosr, all, {})).toEqual([]);
+    expect(collectMaterialRows(aosr, all, { Материалы: {} })).toEqual([]);
   });
 });

--- a/src/client/src/shared/api/schema.test.ts
+++ b/src/client/src/shared/api/schema.test.ts
@@ -355,6 +355,19 @@ describe('материалы за составной обёрткой', () => {
     expect(compositeFieldHasTag(selfRef, 'material.qualityDocLink', [selfRef])).toBe(false);
   });
 
+
+  it('глубоко вложенный тэг находится — предел глубины не отсекает ветку', () => {
+    // Цепочка длиннее прежнего предела (6): тип, срезанный по глубине, помечался посещённым, и
+    // соседняя ветка, где тэг нашёлся бы, получала «нет» без проверки.
+    const chain = Array.from({ length: 9 }, (_, i) => dt({ fields: [
+      i === 8
+        ? field('ДокументПодтверждающийКачество', { type: 'complex', tags: ['material.qualityDocLink'] })
+        : field('Дальше', { type: 'complex', typeId: `lvl${i + 1}` }),
+    ] }, null, `lvl${i}`));
+    const root = dt({ fields: [field('Вложенное', { type: 'complex', typeId: 'lvl0' })] }, null, 'deep-root');
+    expect(compositeFieldHasTag(root, 'material.qualityDocLink', [root, ...chain])).toBe(true);
+  });
+
   // ── collectMaterialRows ─────────────────────────────────────────────────────
 
   it('строки материалов достаются из-под обёртки', () => {

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -246,21 +246,25 @@ export function isSubtypeOf(childId: string, parentId: string, allDocTypes: Docu
  * тэг материала стоит на строке материала, а не на поле, которое их содержит.
  */
 export function compositeFieldHasTag(docType: DocumentType, tag: string, allDocTypes: DocumentType[]): boolean {
-  const visited = new Set<string>(); // защита от циклов: тип, ссылающийся на себя, — законная схема
-  function descend(typeId: string, depth: number): boolean {
-    if (depth > MAX_COMPOSITE_DEPTH || visited.has(typeId)) return false;
+  // Глубину НЕ ограничиваем: обход конечен сам по себе — каждый тип посещается один раз, а типов
+  // конечное число. Предел глубины вместе с этой пометкой давал бы неверный ответ: тип, срезанный
+  // по глубине в одной ветке, считался бы «проверенным» и в другой, где тэг нашёлся бы.
+  const visited = new Set<string>(); // цикл (тип, ссылающийся на себя) — законная схема
+  function descend(typeId: string): boolean {
+    if (visited.has(typeId)) return false;
     visited.add(typeId);
     const ct = allDocTypes.find(d => d.id === typeId);
     if (!ct) return false;
     return resolveEffectiveFields(ct, allDocTypes).some(cf =>
       hasTag(cf.tags, tag)
-      || ((cf.type === 'array' || cf.type === 'complex') && !!cf.typeId && descend(cf.typeId, depth + 1)));
+      || ((cf.type === 'array' || cf.type === 'complex') && !!cf.typeId && descend(cf.typeId)));
   }
   return resolveEffectiveFields(docType, allDocTypes).some(f =>
-    (f.type === 'array' || f.type === 'complex') && !!f.typeId && descend(f.typeId, 1));
+    (f.type === 'array' || f.type === 'complex') && !!f.typeId && descend(f.typeId));
 }
 
-/** Предел вложенности составных типов при обходе схемы — от патологических схем, не от нормы. */
+/** Предел вложенности при обходе ДАННЫХ по схеме — от патологических данных, не от нормы.
+ *  (Обходу самой схемы предел не нужен: там каждый тип посещается один раз.) */
 const MAX_COMPOSITE_DEPTH = 6;
 
 /**

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -235,15 +235,33 @@ export function isSubtypeOf(childId: string, parentId: string, allDocTypes: Docu
  * True if the type has an array/complex field whose row composite type (incl. inheritance)
  * carries a field with the given functional tag. Used e.g. to detect documents that require
  * quality documents (material.qualityDocLink on a material row type).
+ *
+ * Обход рекурсивный, ВСЕЙ цепочкой составных полей (issue #648). Спуск ровно на один уровень
+ * пропускал материалы в АОСР: union-обёртка «массив ИЛИ ссылка на реестр» (#320) добавила
+ * промежуточный составной тип, и «Материалы» стали лежать на два уровня — АОСР → «МатериалыАОСР»
+ * → массив «Материал». Тэг не находился, закладки «Документы качества» у документа не было вовсе,
+ * и подобрать сертификаты к внесённым вручную материалам было негде.
+ *
+ * Тэг ищется на полях ВЛОЖЕННЫХ типов, а не на собственных полях документа — как и раньше:
+ * тэг материала стоит на строке материала, а не на поле, которое их содержит.
  */
 export function compositeFieldHasTag(docType: DocumentType, tag: string, allDocTypes: DocumentType[]): boolean {
-  return resolveEffectiveFields(docType, allDocTypes).some(f => {
-    if ((f.type !== 'array' && f.type !== 'complex') || !f.typeId) return false;
-    const ct = allDocTypes.find(d => d.id === f.typeId);
+  const visited = new Set<string>(); // защита от циклов: тип, ссылающийся на себя, — законная схема
+  function descend(typeId: string, depth: number): boolean {
+    if (depth > MAX_COMPOSITE_DEPTH || visited.has(typeId)) return false;
+    visited.add(typeId);
+    const ct = allDocTypes.find(d => d.id === typeId);
     if (!ct) return false;
-    return resolveEffectiveFields(ct, allDocTypes).some(cf => hasTag(cf.tags, tag));
-  });
+    return resolveEffectiveFields(ct, allDocTypes).some(cf =>
+      hasTag(cf.tags, tag)
+      || ((cf.type === 'array' || cf.type === 'complex') && !!cf.typeId && descend(cf.typeId, depth + 1)));
+  }
+  return resolveEffectiveFields(docType, allDocTypes).some(f =>
+    (f.type === 'array' || f.type === 'complex') && !!f.typeId && descend(f.typeId, 1));
 }
+
+/** Предел вложенности составных типов при обходе схемы — от патологических схем, не от нормы. */
+const MAX_COMPOSITE_DEPTH = 6;
 
 /**
  * Path (dotted segments) to the first effective field carrying the given functional tag,
@@ -349,4 +367,47 @@ export function materialIdentityKeys(allDocTypes: DocumentType[]): string[] {
 
   found.sort((a, b) => a.order - b.order || a.typeIndex - b.typeIndex || a.fieldIndex - b.fieldIndex);
   return Array.from(new Set(found.map(f => f.key)));
+}
+
+/**
+ * Все строки материалов, лежащие в реквизитах, — по схеме и по всей глубине вложенности (issue #648).
+ *
+ * Раньше вкладка собирала материалы только из массивов ВЕРХНЕГО уровня, и inline-ветка union
+ * «массив ИЛИ ссылка на реестр» (#320) выпадала: в АОСР материалы лежат в `Материалы.Материалы`,
+ * то есть внутри составной обёртки. Закладка оставалась пустой ровно там, где материалы внесли
+ * руками, — в мелком акте без отдельного реестра.
+ *
+ * Материалом считается строка массива материального типа (см. {@link isMaterialType}); одиночное
+ * составное поле материального типа — тоже строка, случай «в документе один материал». Ссылки
+ * (`doc-ref`/`doc-array`) не разворачиваем: материалы чужой записи приходят на вкладку набором
+ * данных, а не отсюда.
+ */
+export function collectMaterialRows(
+  docType: DocumentType, allDocTypes: DocumentType[], requisites: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = [];
+
+  function walk(type: DocumentType, values: Record<string, unknown>, depth: number) {
+    if (depth > MAX_COMPOSITE_DEPTH) return;
+    for (const f of resolveEffectiveFields(type, allDocTypes)) {
+      if ((f.type !== 'array' && f.type !== 'complex') || !f.typeId) continue;
+      const ct = allDocTypes.find(t => t.id === f.typeId);
+      if (!ct) continue;
+      const value = values[f.key];
+      const material = isMaterialType(ct, allDocTypes);
+      const items = f.type === 'array'
+        ? (Array.isArray(value) ? value : [])
+        : [value];
+      for (const item of items) {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+        const record = item as Record<string, unknown>;
+        if ('$ref' in record) continue; // ссылка на запись каталога — не инлайн-материал
+        if (material) rows.push(record);
+        else walk(ct, record, depth + 1); // обёртка (в т.ч. union) — материалы могут быть глубже
+      }
+    }
+  }
+
+  walk(docType, requisites, 0);
+  return rows;
 }

--- a/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
+++ b/src/server/BHS.CRG.Application/Generation/GenerateDocumentHandler.cs
@@ -103,8 +103,7 @@ public class GenerateDocumentHandler(
             // Материалы без документа качества (issue #585) — предупреждением: выпуск не блокируем
             // (на живом комплекте таких было 75 из 151), но и молчать нельзя — сегодня документ
             // выходит без сертификатов, не оставляя следа.
-            QualityLinkScanner.Scan(context, MaterialIdentity.KeysOf(allDocTypes),
-                MaterialIdentity.QualityDocFieldOf(allDocTypes), diagnostics);
+            QualityLinkScanner.Scan(context, instance.CompositeTypeId, allDocTypes, diagnostics);
 
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 throw new ResolutionValidationException(diagnostics);

--- a/src/server/BHS.CRG.Application/Generation/InstanceResolutionValidator.cs
+++ b/src/server/BHS.CRG.Application/Generation/InstanceResolutionValidator.cs
@@ -81,8 +81,7 @@ public class InstanceResolutionValidator(
         ValueTypeScanner.Scan(context, fields, catalog.DocumentTypes, catalog.Primitives, diagnostics);
 
         // Материалы без документа качества (issue #585) — предупреждениями, как и при выпуске.
-        QualityLinkScanner.Scan(context, MaterialIdentity.KeysOf(catalog.AllTypes),
-            MaterialIdentity.QualityDocFieldOf(catalog.AllTypes), diagnostics);
+        QualityLinkScanner.Scan(context, instance.CompositeTypeId, catalog.AllTypes, diagnostics);
 
         return diagnostics;
     }

--- a/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Application.Generation;
 
@@ -23,65 +25,117 @@ public static class QualityLinkScanner
     /// <summary>Документ есть, но материал не упоминается в его области продукции (issue #586).</summary>
     public const string ImplausibleCode = "quality-doc-implausible";
 
+    /// <summary>Предел глубины обхода — тот же, что у подмешивания: от патологических данных.</summary>
+    private const int MaxDepth = 8;
+
     /// <summary>
-    /// Ищет в массивах контекста элементы-материалы (опознаются полями идентичности — тем же
-    /// способом, что и сопоставление) с пустым полем документа качества.
+    /// Ищет объекты-материалы с пустым полем документа качества.
+    ///
+    /// Обход идёт ПО СХЕМЕ документа, а не по всему контексту (issue #648), и вглубь — по всей
+    /// цепочке составных полей. Почему по схеме: контекст, кроме реквизитов, содержит подмешанные
+    /// общие данные и записи каталога, а «Наименование» с тэгом идентичности есть и у объекта
+    /// строительства. Свободный обход выдал на живом документе предупреждение «Материал
+    /// «комплексная застройка «ДНС Сити»…» без документа качества» — претензию к стройке. Схема
+    /// отвечает на вопрос точно: материал — объект типа, СПОСОБНОГО нести документ качества
+    /// (<see cref="MaterialIdentity.IsMaterial" />, тот же критерий, что у клиента).
+    ///
+    /// Глубина понадобилась потому, что материалы бывают не только массивом верхнего уровня: в АОСР
+    /// они лежат внутри union-обёртки «массив ИЛИ ссылка на реестр» (#320). Иначе сертификат
+    /// подставлялся бы, а сказать, что его нет, было бы некому — предупреждение молчало бы ровно
+    /// там, где оно и нужно.
     ///
     /// Запускать ПОСЛЕ <see cref="IQualityLinkResolver.InjectAsync" />: до неё пусты вообще все, и
     /// предупреждение говорило бы о порядке шагов, а не о данных.
     /// </summary>
     public static void Scan(
         GenerationContext ctx,
-        IReadOnlyList<string> identityFields,
-        string? targetField,
+        Guid documentTypeId,
+        IReadOnlyList<DocumentType> allTypes,
         List<ResolutionDiagnostic> diagnostics)
     {
-        if (identityFields.Count == 0 || string.IsNullOrEmpty(targetField)) return; // тэги не настроены
+        var identityFields = MaterialIdentity.KeysOf(allTypes);
+        var targetField = MaterialIdentity.QualityDocFieldOf(allTypes);
+        if (identityFields.Length == 0 || string.IsNullOrEmpty(targetField)) return; // тэги не настроены
 
-        foreach (var (key, value) in ctx.Data)
+        var byId = allTypes.ToDictionary(t => t.Id);
+        if (!byId.ContainsKey(documentTypeId)) return;
+
+        foreach (var f in DocumentTypeSchemaReader.EffectiveFields(documentTypeId, byId))
         {
-            if (value is not JsonElement el || el.ValueKind != JsonValueKind.Array) continue;
-
-            var index = -1;
-            foreach (var item in el.EnumerateArray())
-            {
-                index++;
-                if (item.ValueKind != JsonValueKind.Object) continue;
-
-                // Материал ли это: у элемента есть хоть одно непустое поле идентичности. Тот же
-                // признак, по которому строка получает ключ, — иначе предупреждение доставалось бы
-                // строкам, которые сопоставлять и не собирались.
-                var identity = IdentityKey.From(identityFields, f => Text(item, f));
-                if (IdentityKey.IsEmpty(identity)) continue;
-
-                if (!HasValue(item, targetField))
-                {
-                    diagnostics.Add(new ResolutionDiagnostic(
-                        DiagnosticSeverity.Warning,
-                        $"{key}[{index}].{targetField}",
-                        $"Материал «{identity}» без документа качества: привязка не найдена.",
-                        Code));
-                    continue;
-                }
-
-                // Документ есть — правдоподобен ли он (issue #586). Реквизиты документа уже
-                // подмешаны в строку, отдельного запроса не нужно.
-                if (!item.TryGetProperty(targetField, out var doc)) continue;
-
-                var docTexts = new List<string>();
-                ProductScopeMatcher.CollectStrings(doc, docTexts);
-                // Человеческие значения, а не ключ: сравнивать надо со словами, а ключ — машинный.
-                var materialText = string.Join(' ', identityFields.Select(f => Text(item, f)).Where(v => !string.IsNullOrWhiteSpace(v)));
-
-                if (ProductScopeMatcher.Assess(materialText, docTexts) == ProductScopeVerdict.Mismatched)
-                    diagnostics.Add(new ResolutionDiagnostic(
-                        DiagnosticSeverity.Warning,
-                        $"{key}[{index}].{targetField}",
-                        $"Материал «{identity}» не упоминается в области продукции привязанного документа — "
-                        + "возможно, сертификат не тот.",
-                        ImplausibleCode));
-            }
+            if (f.TypeId is not { } typeId || !byId.ContainsKey(typeId)) continue;
+            if (!ctx.Data.TryGetValue(f.Key, out var raw) || raw is not JsonElement value) continue;
+            Walk(value, f.Key, typeId, byId, allTypes, identityFields, targetField, diagnostics, 0);
         }
+    }
+
+    private static void Walk(
+        JsonElement value, string path, Guid typeId,
+        IReadOnlyDictionary<Guid, DocumentType> byId, IReadOnlyList<DocumentType> allTypes,
+        string[] identityFields, string targetField,
+        List<ResolutionDiagnostic> diagnostics, int depth)
+    {
+        if (depth >= MaxDepth) return;
+
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            var index = -1;
+            foreach (var item in value.EnumerateArray())
+                Walk(item, $"{path}[{++index}]", typeId, byId, allTypes, identityFields, targetField, diagnostics, depth + 1);
+            return;
+        }
+        if (value.ValueKind != JsonValueKind.Object) return;
+
+        if (MaterialIdentity.IsMaterial(byId[typeId], allTypes))
+        {
+            Check(value, path, identityFields, targetField, diagnostics);
+            return; // внутрь материала не идём: сертификат в его подполях искать нечего
+        }
+
+        // Обёртка (в том числе union): материалы могут лежать глубже.
+        foreach (var inner in DocumentTypeSchemaReader.EffectiveFields(typeId, byId))
+        {
+            if (inner.TypeId is not { } innerTypeId || !byId.ContainsKey(innerTypeId)) continue;
+            if (!value.TryGetProperty(inner.Key, out var innerValue)) continue;
+            Walk(innerValue, $"{path}.{inner.Key}", innerTypeId, byId, allTypes, identityFields, targetField, diagnostics, depth + 1);
+        }
+    }
+
+    private static void Check(
+        JsonElement item, string path, string[] identityFields, string targetField,
+        List<ResolutionDiagnostic> diagnostics)
+    {
+        // Материал ли это: у элемента есть хоть одно непустое поле идентичности. Тот же признак, по
+        // которому строка получает ключ, — иначе предупреждение доставалось бы строкам, которые
+        // сопоставлять и не собирались.
+        var identity = IdentityKey.From(identityFields, f => Text(item, f));
+        if (IdentityKey.IsEmpty(identity)) return;
+
+        if (!HasValue(item, targetField))
+        {
+            diagnostics.Add(new ResolutionDiagnostic(
+                DiagnosticSeverity.Warning,
+                $"{path}.{targetField}",
+                $"Материал «{identity}» без документа качества: привязка не найдена.",
+                Code));
+            return;
+        }
+
+        // Документ есть — правдоподобен ли он (issue #586). Реквизиты документа уже подмешаны в
+        // строку, отдельного запроса не нужно.
+        if (!item.TryGetProperty(targetField, out var doc)) return;
+
+        var docTexts = new List<string>();
+        ProductScopeMatcher.CollectStrings(doc, docTexts);
+        // Человеческие значения, а не ключ: сравнивать надо со словами, а ключ — машинный.
+        var materialText = string.Join(' ', identityFields.Select(f => Text(item, f)).Where(v => !string.IsNullOrWhiteSpace(v)));
+
+        if (ProductScopeMatcher.Assess(materialText, docTexts) == ProductScopeVerdict.Mismatched)
+            diagnostics.Add(new ResolutionDiagnostic(
+                DiagnosticSeverity.Warning,
+                $"{path}.{targetField}",
+                $"Материал «{identity}» не упоминается в области продукции привязанного документа — "
+                + "возможно, сертификат не тот.",
+                ImplausibleCode));
     }
 
     private static string? Text(JsonElement item, string field)

--- a/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/QualityLinkScanner.cs
@@ -44,6 +44,13 @@ public static class QualityLinkScanner
     /// подставлялся бы, а сказать, что его нет, было бы некому — предупреждение молчало бы ровно
     /// там, где оно и нужно.
     ///
+    /// Вглубь идут только ИНЛАЙН-составные поля (complex/array), но не ссылки (doc-ref/doc-array):
+    /// правило «предупреждаем лишь о том, что человек видит на закладке и может привязать». Материалы
+    /// чужой записи закладка показывает набором данных, а не разворотом ссылки (клиентский
+    /// <c>collectMaterialRows</c> пропускает <c>$ref</c> по той же причине), и разворот ссылки здесь
+    /// дал бы по предупреждению на каждую несопоставленную строку ЧУЖОГО реестра — в каждом
+    /// документе, который на него ссылается, и без единой строки, к которой их приложить.
+    ///
     /// Запускать ПОСЛЕ <see cref="IQualityLinkResolver.InjectAsync" />: до неё пусты вообще все, и
     /// предупреждение говорило бы о порядке шагов, а не о данных.
     /// </summary>
@@ -60,17 +67,19 @@ public static class QualityLinkScanner
         var byId = allTypes.ToDictionary(t => t.Id);
         if (!byId.ContainsKey(documentTypeId)) return;
 
-        foreach (var f in DocumentTypeSchemaReader.EffectiveFields(documentTypeId, byId))
+        // Схему одного типа разрешаем один раз на документ, а не на каждую строку: у реестра их 151,
+        // и IsMaterial сам по себе обходит всю цепочку наследования.
+        var schema = new SchemaMemo(byId, allTypes);
+
+        foreach (var f in schema.InlineComposites(documentTypeId))
         {
-            if (f.TypeId is not { } typeId || !byId.ContainsKey(typeId)) continue;
             if (!ctx.Data.TryGetValue(f.Key, out var raw) || raw is not JsonElement value) continue;
-            Walk(value, f.Key, typeId, byId, allTypes, identityFields, targetField, diagnostics, 0);
+            Walk(value, f.Key, f.TypeId!.Value, schema, identityFields, targetField, diagnostics, 0);
         }
     }
 
     private static void Walk(
-        JsonElement value, string path, Guid typeId,
-        IReadOnlyDictionary<Guid, DocumentType> byId, IReadOnlyList<DocumentType> allTypes,
+        JsonElement value, string path, Guid typeId, SchemaMemo schema,
         string[] identityFields, string targetField,
         List<ResolutionDiagnostic> diagnostics, int depth)
     {
@@ -80,23 +89,52 @@ public static class QualityLinkScanner
         {
             var index = -1;
             foreach (var item in value.EnumerateArray())
-                Walk(item, $"{path}[{++index}]", typeId, byId, allTypes, identityFields, targetField, diagnostics, depth + 1);
+                Walk(item, $"{path}[{++index}]", typeId, schema, identityFields, targetField, diagnostics, depth + 1);
             return;
         }
         if (value.ValueKind != JsonValueKind.Object) return;
 
-        if (MaterialIdentity.IsMaterial(byId[typeId], allTypes))
+        if (schema.IsMaterial(typeId))
         {
             Check(value, path, identityFields, targetField, diagnostics);
             return; // внутрь материала не идём: сертификат в его подполях искать нечего
         }
 
         // Обёртка (в том числе union): материалы могут лежать глубже.
-        foreach (var inner in DocumentTypeSchemaReader.EffectiveFields(typeId, byId))
+        foreach (var inner in schema.InlineComposites(typeId))
         {
-            if (inner.TypeId is not { } innerTypeId || !byId.ContainsKey(innerTypeId)) continue;
             if (!value.TryGetProperty(inner.Key, out var innerValue)) continue;
-            Walk(innerValue, $"{path}.{inner.Key}", innerTypeId, byId, allTypes, identityFields, targetField, diagnostics, depth + 1);
+            Walk(innerValue, $"{path}.{inner.Key}", inner.TypeId!.Value, schema, identityFields, targetField, diagnostics, depth + 1);
+        }
+    }
+
+    /// <summary>
+    /// Ответы схемы, посчитанные один раз на тип: «этот тип — материал?» и «какие у него инлайн-
+    /// составные поля». Оба зависят только от типа, а спрашивают их на каждый узел данных.
+    /// </summary>
+    private sealed class SchemaMemo(IReadOnlyDictionary<Guid, DocumentType> byId, IReadOnlyList<DocumentType> allTypes)
+    {
+        private readonly Dictionary<Guid, bool> _material = [];
+        private readonly Dictionary<Guid, SchemaFieldInfo[]> _composites = [];
+
+        public bool IsMaterial(Guid typeId)
+        {
+            if (_material.TryGetValue(typeId, out var known)) return known;
+            var result = byId.TryGetValue(typeId, out var t) && MaterialIdentity.IsMaterial(t, allTypes);
+            _material[typeId] = result;
+            return result;
+        }
+
+        /// <summary>Поля-составные, лежащие В САМОМ документе: complex/array с известным типом.</summary>
+        public SchemaFieldInfo[] InlineComposites(Guid typeId)
+        {
+            if (_composites.TryGetValue(typeId, out var known)) return known;
+            var result = byId.ContainsKey(typeId)
+                ? [.. DocumentTypeSchemaReader.EffectiveFields(typeId, byId)
+                    .Where(f => f.Type is "complex" or "array" && f.TypeId is { } id && byId.ContainsKey(id))]
+                : Array.Empty<SchemaFieldInfo>();
+            _composites[typeId] = result;
+            return result;
         }
     }
 
@@ -110,7 +148,7 @@ public static class QualityLinkScanner
         var identity = IdentityKey.From(identityFields, f => Text(item, f));
         if (IdentityKey.IsEmpty(identity)) return;
 
-        if (!HasValue(item, targetField))
+        if (!MaterialIdentity.HasQualityDoc(item, targetField))
         {
             diagnostics.Add(new ResolutionDiagnostic(
                 DiagnosticSeverity.Warning,
@@ -141,18 +179,4 @@ public static class QualityLinkScanner
     private static string? Text(JsonElement item, string field)
         => item.TryGetProperty(field, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 
-    /// <summary>Заполнено ли целевое поле — тот же предикат, что у резолвера: он не перетирает
-    /// заданное вручную, и предупреждать о заполненном вручную было бы ложной тревогой.</summary>
-    private static bool HasValue(JsonElement item, string field)
-    {
-        if (!item.TryGetProperty(field, out var v)) return false;
-        return v.ValueKind switch
-        {
-            JsonValueKind.Null or JsonValueKind.Undefined => false,
-            JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
-            JsonValueKind.Object => v.EnumerateObject().Any(),
-            JsonValueKind.Array => v.GetArrayLength() > 0,
-            _ => true,
-        };
-    }
 }

--- a/src/server/BHS.CRG.Application/QualityDocs/MaterialIdentity.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/MaterialIdentity.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Documents;
 using BHS.CRG.Domain.Schema;
@@ -60,6 +61,28 @@ public static class MaterialIdentity
             .ThenBy(x => x.fieldIndex)   // стабильность: поля без номера идут в порядке схемы
             .Select(x => x.Key)
             .Distinct()];
+
+    /// <summary>
+    /// Заполнено ли у материала поле документа качества.
+    ///
+    /// Один предикат на подмешивание и на проверку: резолвер по нему решает, не перетереть ли
+    /// заданное вручную, а сканер — не предупредить ли о пропаже. Пока копий было две, они
+    /// разошлись на пустом массиве — тот считался заполненным у резолвера и пустым у сканера, то
+    /// есть материал одновременно получал предупреждение «привязка не найдена» и пропускался при
+    /// подмешивании существующей связки.
+    /// </summary>
+    public static bool HasQualityDoc(JsonElement item, string field)
+    {
+        if (!item.TryGetProperty(field, out var v)) return false;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => false,
+            JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
+            JsonValueKind.Object => v.EnumerateObject().Any(),
+            JsonValueKind.Array => v.GetArrayLength() > 0,
+            _ => true,
+        };
+    }
 
     /// <summary>Ключ поля, в которое подмешивается документ качества (тэг material.qualityDocLink).</summary>
     public static string? QualityDocFieldOf(IReadOnlyList<DocumentType> allTypes)

--- a/src/server/BHS.CRG.Application/QualityDocs/MaterialQualityInjector.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/MaterialQualityInjector.cs
@@ -13,8 +13,14 @@ namespace BHS.CRG.Application.QualityDocs;
 ///
 /// Совпадение ищем по составному ключу идентичности (issue #582) у КАЖДОГО встреченного объекта,
 /// а не только у элементов массива: одиночное составное поле материального типа — тот же материал,
-/// просто в единственном числе. Ключ обязан совпасть целиком, включая пустые слоты, поэтому
-/// посторонний объект под совпадение не подходит — у него нет тех же полей.
+/// просто в единственном числе.
+///
+/// Обход НЕ ограничен схемой — в отличие от <c>QualityLinkScanner</c>, и это намеренно. Сканер
+/// высказывает человеку претензию, поэтому обязан молчать там, где не уверен; подмешивание же лишь
+/// подставляет то, что человек уже связал своими руками, и цена ошибок здесь обратная: пропустить
+/// материал значит потерять сертификат в PDF. Пропуском грозили бы пути, которых схема не описывает
+/// (данные плагина, привязка набора на переименованное поле). Защитой служит сам ключ: он составной
+/// и обязан совпасть целиком, включая пустые слоты, — у постороннего объекта нет тех же полей.
 /// </summary>
 public static class MaterialQualityInjector
 {
@@ -77,7 +83,7 @@ public static class MaterialQualityInjector
 
                 if (TryMatch(value, identityFields, byKey, out var docId)
                     && reqByDoc.TryGetValue(docId, out var reqs)
-                    && !HasValue(value, targetField)) // не перетираем заданное вручную
+                    && !MaterialIdentity.HasQualityDoc(value, targetField)) // не перетираем заданное вручную
                 {
                     props[targetField] = reqs;
                     changed = true;
@@ -107,17 +113,5 @@ public static class MaterialQualityInjector
 
         docId = default;
         return false;
-    }
-
-    private static bool HasValue(JsonElement elem, string field)
-    {
-        if (!elem.TryGetProperty(field, out var v)) return false;
-        return v.ValueKind switch
-        {
-            JsonValueKind.Null or JsonValueKind.Undefined => false,
-            JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
-            JsonValueKind.Object => v.EnumerateObject().Any(),
-            _ => true,
-        };
     }
 }

--- a/src/server/BHS.CRG.Application/QualityDocs/MaterialQualityInjector.cs
+++ b/src/server/BHS.CRG.Application/QualityDocs/MaterialQualityInjector.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+
+namespace BHS.CRG.Application.QualityDocs;
+
+/// <summary>
+/// Подмешивание документа качества в строки материалов контекста генерации — чистое ядро
+/// <c>QualityLinkResolver</c>: связки и реквизиты сертификатов ищет он, а по данным ходит эта часть.
+///
+/// Обход РЕКУРСИВНЫЙ (issue #648). Прежний проходил только по ключам верхнего уровня, значение
+/// которых само является массивом, и inline-ветка union «массив ИЛИ ссылка на реестр» (#320)
+/// выпадала: в АОСР материалы лежат в <c>Материалы.Материалы</c>, то есть внутри составной
+/// обёртки, — заведённая связка в PDF не попадала вовсе.
+///
+/// Совпадение ищем по составному ключу идентичности (issue #582) у КАЖДОГО встреченного объекта,
+/// а не только у элементов массива: одиночное составное поле материального типа — тот же материал,
+/// просто в единственном числе. Ключ обязан совпасть целиком, включая пустые слоты, поэтому
+/// посторонний объект под совпадение не подходит — у него нет тех же полей.
+/// </summary>
+public static class MaterialQualityInjector
+{
+    /// <summary>Предел глубины: защита от патологических данных, а не от нормальной вложенности.</summary>
+    private const int MaxDepth = 8;
+
+    /// <param name="value">Значение ключа контекста генерации.</param>
+    /// <param name="identityFields">Поля идентичности материала, в порядке компонентов ключа.</param>
+    /// <param name="targetField">Ключ поля, в которое кладётся документ качества.</param>
+    /// <param name="byKey">Ключ материала → идентификатор документа (уже с учётом приоритета scope).</param>
+    /// <param name="reqByDoc">Реквизиты документов качества по идентификатору.</param>
+    /// <param name="injected">Значение с подмешанными документами; исходное, если ничего не совпало.</param>
+    /// <returns>Изменилось ли значение — вызывающий не переписывает контекст зря.</returns>
+    public static bool TryInject(
+        JsonElement value,
+        string[] identityFields,
+        string targetField,
+        IReadOnlyDictionary<string, Guid> byKey,
+        IReadOnlyDictionary<Guid, JsonElement> reqByDoc,
+        out JsonElement injected)
+    {
+        injected = Walk(value, identityFields, targetField, byKey, reqByDoc, 0, out var changed);
+        return changed;
+    }
+
+    private static JsonElement Walk(
+        JsonElement value, string[] identityFields, string targetField,
+        IReadOnlyDictionary<string, Guid> byKey, IReadOnlyDictionary<Guid, JsonElement> reqByDoc,
+        int depth, out bool changed)
+    {
+        changed = false;
+        if (depth >= MaxDepth) return value;
+
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Array:
+            {
+                var items = new List<JsonElement>();
+                foreach (var item in value.EnumerateArray())
+                {
+                    items.Add(Walk(item, identityFields, targetField, byKey, reqByDoc, depth + 1, out var itemChanged));
+                    changed |= itemChanged;
+                }
+                return changed ? JsonSerializer.SerializeToElement(items) : value;
+            }
+
+            case JsonValueKind.Object:
+            {
+                // Сначала вглубь, потом сопоставление: подмешанные реквизиты сертификата — уже
+                // результат, и обходить их как данные материала незачем.
+                var props = new Dictionary<string, JsonElement>();
+                foreach (var p in value.EnumerateObject())
+                {
+                    // Внутрь уже стоящего документа качества не идём: его реквизиты — не данные
+                    // материала, и искать в них материалы значит подмешивать сертификат в сертификат.
+                    if (p.Name == targetField) { props[p.Name] = p.Value.Clone(); continue; }
+                    props[p.Name] = Walk(p.Value, identityFields, targetField, byKey, reqByDoc, depth + 1, out var propChanged);
+                    changed |= propChanged;
+                }
+
+                if (TryMatch(value, identityFields, byKey, out var docId)
+                    && reqByDoc.TryGetValue(docId, out var reqs)
+                    && !HasValue(value, targetField)) // не перетираем заданное вручную
+                {
+                    props[targetField] = reqs;
+                    changed = true;
+                }
+
+                return changed ? JsonSerializer.SerializeToElement(props) : value;
+            }
+
+            default:
+                return value;
+        }
+    }
+
+    // Ключ материала СОСТАВНОЙ: все поля идентичности разом, в порядке параметра тэга (#582).
+    // Прежний перебор «совпало любое поле» допускал две связки на один материал с разными
+    // сертификатами и выбирал между ними по порядку полей — то есть молча и не в пользу более
+    // точной привязки. Здесь выбирать не из чего: у материала ровно один ключ.
+    private static bool TryMatch(JsonElement elem, string[] identityFields,
+        IReadOnlyDictionary<string, Guid> byKey, out Guid docId)
+    {
+        var key = IdentityKey.From(identityFields, field =>
+            elem.TryGetProperty(field, out var v) && v.ValueKind == JsonValueKind.String
+                ? v.GetString()
+                : null);
+
+        if (!IdentityKey.IsEmpty(key) && byKey.TryGetValue(key, out docId)) return true;
+
+        docId = default;
+        return false;
+    }
+
+    private static bool HasValue(JsonElement elem, string field)
+    {
+        if (!elem.TryGetProperty(field, out var v)) return false;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => false,
+            JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
+            JsonValueKind.Object => v.EnumerateObject().Any(),
+            _ => true,
+        };
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/QualityLinkResolver.cs
@@ -57,64 +57,15 @@ public class QualityLinkResolver(AppDbContext db) : IQualityLinkResolver
             .ToListAsync(ct);
         var reqByDoc = docs.ToDictionary(d => d.Id, d => d.Requisites.RootElement.Clone());
 
-        // 4) проход по массивам контекста: для каждого элемента с совпавшей идентичностью
-        //    проставляем TargetField = реквизиты документа (вложенные $ref разрешит второй проход)
+        // 4) проход по контексту: каждому объекту с совпавшей идентичностью проставляем
+        //    TargetField = реквизиты документа (вложенные $ref разрешит второй проход).
+        //    Сам обход — в MaterialQualityInjector: он рекурсивный, потому что материалы бывают
+        //    не только массивом верхнего уровня (union-обёртка АОСР, issue #648).
         foreach (var key in ctx.Data.Keys.ToList())
         {
-            if (ctx.Data[key] is not JsonElement el || el.ValueKind != JsonValueKind.Array) continue;
-
-            var changed = false;
-            var newItems = new List<JsonElement>();
-            foreach (var elem in el.EnumerateArray())
-            {
-                if (elem.ValueKind != JsonValueKind.Object) { newItems.Add(elem.Clone()); continue; }
-
-                if (TryMatch(elem, identityFields, byKey, out var docId)
-                    && reqByDoc.TryGetValue(docId, out var reqs)
-                    && !HasValue(elem, targetField)) // не перетираем заданное вручную
-                {
-                    var dict = new Dictionary<string, JsonElement>();
-                    foreach (var p in elem.EnumerateObject()) dict[p.Name] = p.Value.Clone();
-                    dict[targetField] = reqs;
-                    newItems.Add(JsonSerializer.SerializeToElement(dict));
-                    changed = true;
-                }
-                else
-                {
-                    newItems.Add(elem.Clone());
-                }
-            }
-            if (changed) ctx.Set(key, JsonSerializer.SerializeToElement(newItems));
+            if (ctx.Data[key] is not JsonElement el) continue;
+            if (MaterialQualityInjector.TryInject(el, identityFields, targetField, byKey, reqByDoc, out var injected))
+                ctx.Set(key, injected);
         }
-    }
-
-    // Ключ материала СОСТАВНОЙ: все поля идентичности разом, в порядке параметра тэга (#582).
-    // Прежний перебор «совпало любое поле» допускал две связки на один материал с разными
-    // сертификатами и выбирал между ними по порядку полей — то есть молча и не в пользу более
-    // точной привязки. Здесь выбирать не из чего: у материала ровно один ключ.
-    private static bool TryMatch(JsonElement elem, string[] identityFields,
-        IReadOnlyDictionary<string, Guid> byKey, out Guid docId)
-    {
-        var key = IdentityKey.From(identityFields, field =>
-            elem.TryGetProperty(field, out var v) && v.ValueKind == JsonValueKind.String
-                ? v.GetString()
-                : null);
-
-        if (!IdentityKey.IsEmpty(key) && byKey.TryGetValue(key, out docId)) return true;
-
-        docId = default;
-        return false;
-    }
-
-    private static bool HasValue(JsonElement elem, string field)
-    {
-        if (!elem.TryGetProperty(field, out var v)) return false;
-        return v.ValueKind switch
-        {
-            JsonValueKind.Null or JsonValueKind.Undefined => false,
-            JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
-            JsonValueKind.Object => v.EnumerateObject().Any(),
-            _ => true,
-        };
     }
 }

--- a/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BHS.CRG.Application.Generation;
+using BHS.CRG.Domain.Documents;
 
 namespace BHS.CRG.Tests.Generation;
 
@@ -10,15 +11,57 @@ namespace BHS.CRG.Tests.Generation;
 /// </summary>
 public class QualityLinkScannerTests
 {
-    private static readonly string[] IdentityFields = ["Наименование", "Артикул"];
     private const string Target = "ДокументПодтверждающийКачество";
 
+    private static DocumentType Composite(string name, string schema)
+        => DocumentType.Create(name, name, DocumentTypeKind.Composite, null, JsonDocument.Parse(schema), false);
+
+    private static DocumentType Document(string name, string schema)
+        => DocumentType.Create(name, name, DocumentTypeKind.Document, null, JsonDocument.Parse(schema), false);
+
+    private static readonly DocumentType Material = Composite("Материал", $$"""
+        { "fields": [
+            { "key": "Наименование", "tags": ["identity"] },
+            { "key": "Артикул", "tags": ["identity"] },
+            { "key": "{{Target}}", "type": "complex", "tags": ["material.qualityDocLink"] } ] }
+        """);
+
+    /// <summary>Объект строительства: «Наименование» с тэгом идентичности есть и у него, но нести
+    /// документ качества он не может — материалом он не является (issue #569).</summary>
+    private static readonly DocumentType Site = Composite("Объект строительства", """
+        { "fields": [ { "key": "Наименование", "tags": ["identity"] } ] }
+        """);
+
+    /// <summary>Union-обёртка «массив ИЛИ ссылка на реестр» (#320) — из-за неё материалы АОСР лежат
+    /// на два уровня вглубь.</summary>
+    private static readonly DocumentType Wrapper = Composite("МатериалыАОСР", $$"""
+        { "tags": ["type.union"], "fields": [
+            { "key": "Материалы", "type": "array", "typeId": "{{Material.Id}}" } ] }
+        """);
+
+    private static readonly DocumentType Registry = Document("Реестр материалов", $$"""
+        { "fields": [ { "key": "Материалы", "type": "array", "typeId": "{{Material.Id}}" } ] }
+        """);
+
+    private static readonly DocumentType Aosr = Document("АОСР", $$"""
+        { "fields": [
+            { "key": "Материалы", "type": "complex", "typeId": "{{Wrapper.Id}}" },
+            { "key": "Объект", "type": "complex", "typeId": "{{Site.Id}}" } ] }
+        """);
+
+    private static readonly DocumentType[] AllTypes = [Material, Site, Wrapper, Registry, Aosr];
+
+    /// <summary>Материалы прямым массивом — сценарий реестра.</summary>
     private static List<ResolutionDiagnostic> Scan(string materialsJson)
+        => ScanContext(Registry, ("Материалы", materialsJson));
+
+    private static List<ResolutionDiagnostic> ScanContext(DocumentType docType, params (string Key, string Json)[] data)
     {
         var ctx = new GenerationContext();
-        ctx.Set("Материалы", JsonDocument.Parse(materialsJson).RootElement.Clone());
+        foreach (var (key, json) in data)
+            ctx.Set(key, JsonDocument.Parse(json).RootElement.Clone());
         var diagnostics = new List<ResolutionDiagnostic>();
-        QualityLinkScanner.Scan(ctx, IdentityFields, Target, diagnostics);
+        QualityLinkScanner.Scan(ctx, docType.Id, AllTypes, diagnostics);
         return diagnostics;
     }
 
@@ -62,11 +105,15 @@ public class QualityLinkScannerTests
     [Fact]
     public void TagsNotConfigured_ScannerStaysQuiet()
     {
+        // Ни один тип не несёт тэгов материала — сопоставлять нечем, и молчание единственно верно.
+        var plainRow = Composite("Позиция", """{ "fields": [ { "key": "Наименование" } ] }""");
+        var plainDoc = Document("Ведомость", $$"""
+            { "fields": [ { "key": "Материалы", "type": "array", "typeId": "{{plainRow.Id}}" } ] }
+            """);
         var ctx = new GenerationContext();
         ctx.Set("Материалы", JsonDocument.Parse("""[ { "Наименование": "Трубка" } ]""").RootElement.Clone());
         var diagnostics = new List<ResolutionDiagnostic>();
-        QualityLinkScanner.Scan(ctx, [], Target, diagnostics);
-        QualityLinkScanner.Scan(ctx, IdentityFields, null, diagnostics);
+        QualityLinkScanner.Scan(ctx, plainDoc.Id, [plainRow, plainDoc], diagnostics);
         Assert.Empty(diagnostics);
     }
 
@@ -110,4 +157,39 @@ public class QualityLinkScannerTests
             """);
         Assert.Equal($"Материалы[1].{Target}", Assert.Single(diagnostics).Path);
     }
+
+    // ── материалы за составной обёрткой (issue #648) ───────────────────────────
+
+    /// <summary>
+    /// Inline-материалы АОСР лежат в «Материалы.Материалы» — внутри union-обёртки (#320). Обход
+    /// только верхнего уровня их не видел: сертификат подставлялся бы, а сказать, что его нет, было
+    /// бы некому.
+    /// </summary>
+    [Fact]
+    public void MaterialInsideCompositeWrapper_IsReported()
+    {
+        var d = Assert.Single(ScanContext(Aosr,
+            ("Материалы", """{ "Материалы": [ { "Наименование": "проверка", "Артикул": "2342" } ] }""")));
+        Assert.Equal($"Материалы.Материалы[0].{Target}", d.Path);
+    }
+
+    /// <summary>
+    /// Живой ложный вызов: обход по всему контексту (а не по схеме) выдал предупреждение «Материал
+    /// «комплексная застройка «ДНС Сити»…» без документа качества» — претензию к объекту
+    /// строительства. Тэг идентичности у него законный, а нести сертификат он не может.
+    /// </summary>
+    [Fact]
+    public void ObjectOfNonMaterialType_IsNotAMaterial()
+        => Assert.Empty(ScanContext(Aosr,
+            ("Объект", """{ "Наименование": "комплексная застройка «ДНС Сити»" }""")));
+
+    /// <summary>Реквизиты подмешанного сертификата — не данные документа: искать материалы внутри
+    /// них значит предъявлять претензии не по адресу.</summary>
+    [Fact]
+    public void InsideQualityDocRequisites_NotScanned()
+        => Assert.Empty(Scan($$"""
+            [ { "Наименование": "Выключатель автоматический AV-125 3P 63А EKF",
+                "{{Target}}": { "Наименование": "EKF — автоматические выключатели",
+                                "Продукция": "Выключатели автоматические, торговой марки «EKF», модель: AV-125" } } ]
+            """));
 }

--- a/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/QualityLinkScannerTests.cs
@@ -32,15 +32,16 @@ public class QualityLinkScannerTests
         { "fields": [ { "key": "Наименование", "tags": ["identity"] } ] }
         """);
 
+    private static readonly DocumentType Registry = Document("Реестр материалов", $$"""
+        { "fields": [ { "key": "Материалы", "type": "array", "typeId": "{{Material.Id}}" } ] }
+        """);
+
     /// <summary>Union-обёртка «массив ИЛИ ссылка на реестр» (#320) — из-за неё материалы АОСР лежат
     /// на два уровня вглубь.</summary>
     private static readonly DocumentType Wrapper = Composite("МатериалыАОСР", $$"""
         { "tags": ["type.union"], "fields": [
-            { "key": "Материалы", "type": "array", "typeId": "{{Material.Id}}" } ] }
-        """);
-
-    private static readonly DocumentType Registry = Document("Реестр материалов", $$"""
-        { "fields": [ { "key": "Материалы", "type": "array", "typeId": "{{Material.Id}}" } ] }
+            { "key": "Материалы", "type": "array", "typeId": "{{Material.Id}}" },
+            { "key": "Реестр", "type": "doc-ref", "typeId": "{{Registry.Id}}" } ] }
         """);
 
     private static readonly DocumentType Aosr = Document("АОСР", $$"""
@@ -182,6 +183,19 @@ public class QualityLinkScannerTests
     public void ObjectOfNonMaterialType_IsNotAMaterial()
         => Assert.Empty(ScanContext(Aosr,
             ("Объект", """{ "Наименование": "комплексная застройка «ДНС Сити»" }""")));
+
+    /// <summary>
+    /// Вторая ветка того же union — ССЫЛКА на реестр. После резолва ссылок её реквизиты лежат в
+    /// контексте целиком, но предупреждать по ним нельзя: закладка документа этих строк не
+    /// показывает (клиент пропускает $ref), и человеку было бы некуда приложить сертификат. Свой
+    /// список реестр проверяет сам, а иначе он повторялся бы в каждом ссылающемся документе.
+    /// </summary>
+    [Fact]
+    public void MaterialsBehindDocRef_AreNotThisDocumentsProblem()
+        => Assert.Empty(ScanContext(Aosr,
+            ("Материалы", """
+             { "Реестр": { "Материалы": [ { "Наименование": "Трубка", "Артикул": "T-1" } ] } }
+             """)));
 
     /// <summary>Реквизиты подмешанного сертификата — не данные документа: искать материалы внутри
     /// них значит предъявлять претензии не по адресу.</summary>

--- a/src/server/BHS.CRG.Tests/QualityDocs/MaterialQualityInjectorTests.cs
+++ b/src/server/BHS.CRG.Tests/QualityDocs/MaterialQualityInjectorTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using BHS.CRG.Application.QualityDocs;
+
+namespace BHS.CRG.Tests.QualityDocs;
+
+/// <summary>
+/// Подмешивание сертификата в строки материалов при генерации (issue #648).
+///
+/// Разбор живого случая: в АОСР материалы внесены прямо в документ (inline-ветка union «массив ИЛИ
+/// ссылка на реестр», #320), то есть лежат в <c>Материалы.Материалы</c> — внутри составной обёртки.
+/// Прежний обход брал только ключи верхнего уровня, значение которых само массив, и связка,
+/// заведённая на такой материал, в PDF не попадала вовсе.
+/// </summary>
+public class MaterialQualityInjectorTests
+{
+    private static readonly string[] IdentityFields = ["Наименование", "Артикул"];
+    private const string Target = "ДокументПодтверждающийКачество";
+    private static readonly Guid DocId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private static readonly Dictionary<string, Guid> ByKey = new() { ["проверка | 2342"] = DocId };
+    private static readonly Dictionary<Guid, JsonElement> Reqs = new()
+    {
+        [DocId] = JsonDocument.Parse("""{ "Номер": "ЕАЭС-1" }""").RootElement.Clone(),
+    };
+
+    private static bool Inject(string json, out JsonElement result)
+        => MaterialQualityInjector.TryInject(
+            JsonDocument.Parse(json).RootElement.Clone(), IdentityFields, Target, ByKey, Reqs, out result);
+
+    /// <summary>Ссылка на подмешанный сертификат по пути; null — на этом пути ничего нет.</summary>
+    private static string? CertNumberAt(JsonElement root, params string[] path)
+    {
+        var cur = root;
+        foreach (var seg in path)
+        {
+            if (int.TryParse(seg, out var i))
+            {
+                if (cur.ValueKind != JsonValueKind.Array || cur.GetArrayLength() <= i) return null;
+                cur = cur[i];
+            }
+            else if (!cur.TryGetProperty(seg, out cur)) return null;
+        }
+        return cur.TryGetProperty(Target, out var d) && d.TryGetProperty("Номер", out var n) ? n.GetString() : null;
+    }
+
+    [Fact]
+    public void Injects_IntoTopLevelArray()
+    {
+        // Штатный сценарий «материалы через реестр» — он работал и раньше; проверяем, что остался.
+        Assert.True(Inject("""[ { "Наименование": "проверка", "Артикул": "2342" } ]""", out var r));
+        Assert.Equal("ЕАЭС-1", CertNumberAt(r, "0"));
+    }
+
+    [Fact]
+    public void Injects_ThroughUnionWrapper()
+    {
+        // Ровно случай #648: массив материалов лежит внутри составной обёртки union.
+        Assert.True(Inject("""{ "Материалы": [ { "Наименование": "проверка", "Артикул": "2342" } ] }""", out var r));
+        Assert.Equal("ЕАЭС-1", CertNumberAt(r, "Материалы", "0"));
+    }
+
+    [Fact]
+    public void Injects_IntoSingleCompositeMaterial()
+    {
+        // Материал в единственном числе — тот же материал, просто не массивом.
+        Assert.True(Inject("""{ "Материал": { "Наименование": "проверка", "Артикул": "2342" } }""", out var r));
+        Assert.Equal("ЕАЭС-1", CertNumberAt(r, "Материал"));
+    }
+
+    [Fact]
+    public void Skips_WhenTargetAlreadyFilled()
+    {
+        // Заданное вручную не перетираем: человек мог выбрать другой сертификат осознанно.
+        Assert.False(Inject("""
+            [ { "Наименование": "проверка", "Артикул": "2342",
+                "ДокументПодтверждающийКачество": { "Номер": "своё" } } ]
+            """, out var r));
+        Assert.Equal("своё", CertNumberAt(r, "0"));
+    }
+
+    [Fact]
+    public void Skips_WhenKeyDiffers()
+    {
+        // Ключ составной и обязан совпасть целиком (#582): один артикул мимо — материал не тот.
+        Assert.False(Inject("""[ { "Наименование": "проверка", "Артикул": "9999" } ]""", out var r));
+        Assert.Null(CertNumberAt(r, "0"));
+    }
+
+    [Fact]
+    public void DoesNotDescend_IntoInjectedRequisites()
+    {
+        // Подмешанные реквизиты сертификата — уже результат: если бы обход шёл по ним, сертификат
+        // с теми же полями идентичности получил бы сертификат сам себе.
+        Assert.True(Inject("""[ { "Наименование": "проверка", "Артикул": "2342" } ]""", out var r));
+        var cert = r[0].GetProperty(Target);
+        Assert.False(cert.TryGetProperty(Target, out _));
+    }
+
+    [Fact]
+    public void Unchanged_WhenNothingMatched()
+    {
+        // Ничего не совпало — вызывающий не должен переписывать контекст.
+        Assert.False(Inject("""{ "Работы": [ { "Наименование": "монтаж" } ] }""", out _));
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.79.2</Version>
+    <Version>0.80.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #648 (Closes #648).

## Что было

Материалы, внесённые прямо в АОСР (inline-ветка union «массив ИЛИ ссылка на реестр», #320), не имели закладки «Документы качества» вовсе. Union добавил промежуточный составной уровень, а посылка «массив материалов лежит наверху» была зашита не в трёх местах, как в issue, а в **четырёх**.

## Что сделано

| Место | Было | Стало |
|---|---|---|
| Гейт закладки (`compositeFieldHasTag`) | спуск ровно на один уровень | рекурсия по цепочке составных полей, visited-защита от циклов, предел глубины |
| Список на закладке | массивы верхнего уровня | чистая `collectMaterialRows` — обход по схеме на всю глубину |
| Генерация (`QualityLinkResolver`) | только ключи-массивы | обход вынесен в чистый `MaterialQualityInjector`, рекурсивный |
| Диагностика #585/#586 (`QualityLinkScanner`) | только верхний уровень | обход по схеме документа, на всю глубину |

Четвёртое место нашлось при проверке: без него сертификат подставлялся бы, а сказать, что его нет, было бы некому — предупреждение молчало бы ровно там, где оно нужно.

**Сканер ходит по схеме, а не по всему контексту.** Свободный обход на живом документе выдал «Материал «комплексная застройка «ДНС Сити»…» без документа качества» — претензию к объекту строительства: тэг идентичности у него законный, а нести сертификат он не может. Критерий тот же, что у клиента: тип, способный нести документ качества (`MaterialIdentity.IsMaterial`, #569). Побочно это чинит и класс ложных срабатываний на подмешанных общих данных.

Ссылки (`$ref`) не разворачиваем: материалы чужой записи приходят на вкладку набором данных. Внутрь уже стоящего сертификата не идём — его реквизиты не данные материала.

## Проверка

Живьём на документе «Копия 250701.ЭОМ-1.АОСР» (комплект ОВиК-1):

- закладка «Документы качества» появилась и показывает inline-материал «проверка · оывфла · 2342»;
- заведённая связка доехала до `data.json` отладочного пакета — в строке материала появился `ДокументПодтверждающийКачество`;
- проверка документа даёт путь `Материалы.Материалы[0].ДокументПодтверждающийКачество` — и «без документа качества» без связки, и «сертификат не тот» с чужим;
- ложное предупреждение про объект строительства исчезло.

Временная связка после проверки удалена, данные вернулись в исходное состояние.

Тесты: backend 1011 (+10: 7 инжектор, 3 сканер), frontend 378 (+8), `tsc -b` чист. Версия 0.80.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)