### PR TITLE
Уровень связи материала: значок, аномалии, единый словарь (#649)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -536,7 +536,9 @@ export function QualityLinksTab({ instance, setId, allDocTypes }: {
             <SelectItem value="Set">Только этот комплект</SelectItem>
             {sectionId && <SelectItem value="Section">Весь раздел</SelectItem>}
             {constructionId && <SelectItem value="Construction">Вся стройка</SelectItem>}
-            <SelectItem value="System">Общая (System)</SelectItem>
+            {/* Слово «Система» — из общего словаря областей (issue #649): экран контроля называет
+                этот уровень так же, и выбирать одним словом, а читать другое человек не должен. */}
+            <SelectItem value="System">Все стройки (Система)</SelectItem>
           </Select>
         </div>
       </div>

--- a/src/client/src/features/quality-docs/QualityDocLinks.tsx
+++ b/src/client/src/features/quality-docs/QualityDocLinks.tsx
@@ -28,8 +28,11 @@ import { SCOPE_LABELS, type CatalogScope, type DocumentType } from '@/shared/api
  *       это артикулы, где сопоставлять нечего. Ноль означает «непроверяемо», а не «неверно».</li>
  * </ul>
  */
-export function QualityDocLinks({ links, allDocTypes, search }: {
+export function QualityDocLinks({ links, allLinks, allDocTypes, search }: {
   links: MaterialQualityLink[];
+  /** Связки ВСЕЙ библиотеки — для поиска спора двух документов за один материал (issue #649):
+   *  внутри одного документа такой спор безвреден, в PDF всё равно попадёт он же. */
+  allLinks: MaterialQualityLink[];
   allDocTypes: DocumentType[];
   /** Строка поиска — строки фильтруются на клиенте (113 связок фильтруются мгновенно). */
   search: string;
@@ -72,6 +75,8 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
   function toggle(id: string) {
     setSelected(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
   }
+
+  const anomalyOf = (link: MaterialQualityLink) => linkAnomaly(link, { inDocument: links, all: allLinks });
 
   async function relinkMany(docId: string) {
     // Перепривязка идёт ПО ГРУППАМ ОБЛАСТЕЙ. Команда апсертит по тройке (область, объект области,
@@ -155,8 +160,8 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
           </div>
           {/* Знак аномалии — рядом со значком уровня, но цветом: он говорит не «какой уровень»,
               а «здесь что-то не так». Тот же приём, что у коллизий идентичности в QualityLinksTab. */}
-          {linkAnomaly(link, links) && (
-            <span title={linkAnomaly(link, links)!} aria-label={linkAnomaly(link, links)!} role="img"
+          {anomalyOf(link) && (
+            <span title={anomalyOf(link)!} aria-label={anomalyOf(link)!} role="img"
               className="mt-1 shrink-0 text-warning"><AlertTriangle size={13} /></span>
           )}
           <div className="flex items-center gap-1 shrink-0">

--- a/src/client/src/features/quality-docs/QualityDocLinks.tsx
+++ b/src/client/src/features/quality-docs/QualityDocLinks.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
-import { Link2, Unlink, Replace } from 'lucide-react';
+import { AlertTriangle, Link2, Unlink, Replace } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
+import { ScopeIcon } from '@/shared/ui/ScopeIcon';
+import { linkAnomaly, scopeBreakdownText, widerThanSet } from './linkScopes';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { useToast } from '@/shared/ui/Toast';
@@ -9,7 +11,7 @@ import {
   useRemoveMaterialLink, useRemoveMaterialLinks, useSetMaterialLinks, type MaterialQualityLink,
 } from '@/shared/api/qualityDocs';
 import { LinkPickerModal } from '@/features/document-sets/editor/QualityLinksTab';
-import type { CatalogScope, DocumentType } from '@/shared/api/types';
+import { SCOPE_LABELS, type CatalogScope, type DocumentType } from '@/shared/api/types';
 
 /**
  * Связки материалов документа качества — правая часть экрана контроля (issue #555).
@@ -139,6 +141,9 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
         <div key={link.id} className="group flex items-start gap-3 rounded-md px-3 py-2 hover:bg-base">
           <input type="checkbox" checked={selected.has(link.id)} onChange={() => toggle(link.id)}
             aria-label={`Выбрать ${nameOf(link)}`} className="mt-1 shrink-0" />
+          {/* Уровень связи (issue #649): до этого он не показывался вовсе, хотя управляет и
+              перепривязкой (она идёт по группам областей), и тем, какая связка победит в PDF. */}
+          <ScopeIcon scope={link.scope as CatalogScope} className="mt-1" />
           <div className="min-w-0 flex-1">
             {/* Метка первой строкой во всю ширину: имена материалов доходят до сотни знаков,
                 колонки на четверть экрана здесь противопоказаны. Ключ — второй строкой и
@@ -148,6 +153,12 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
               <p className="text-xs text-fg4 font-mono break-all">{link.materialKey}</p>
             )}
           </div>
+          {/* Знак аномалии — рядом со значком уровня, но цветом: он говорит не «какой уровень»,
+              а «здесь что-то не так». Тот же приём, что у коллизий идентичности в QualityLinksTab. */}
+          {linkAnomaly(link, links) && (
+            <span title={linkAnomaly(link, links)!} aria-label={linkAnomaly(link, links)!} role="img"
+              className="mt-1 shrink-0 text-warning"><AlertTriangle size={13} /></span>
+          )}
           <div className="flex items-center gap-1 shrink-0">
             <Button variant="text" size="sm" icon={<Replace size={13} />}
               onClick={() => setRelinking(link)}>Перепривязать</Button>
@@ -174,8 +185,11 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
       <ConfirmDialog
         open={bulkBreak} onOpenChange={setBulkBreak}
         title={`Разорвать связи: ${chosen.length}?`}
-        description={<p>Выбранные материалы останутся без документов качества — при генерации поле
-          документа качества будет пустым.</p>}
+        description={<>
+          <p>Выбранные материалы останутся без документов качества — при генерации поле
+            документа качества будет пустым.</p>
+          <ScopeReachNote links={chosen} />
+        </>}
         confirmLabel="Разорвать"
         onConfirm={() => breakMany()}
       />
@@ -200,6 +214,7 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
             <p className="mb-2">{breaking ? nameOf(breaking) : ''}</p>
             <p>Материал останется без документа качества — при генерации поле документа качества
               будет пустым.</p>
+            <ScopeReachNote links={breaking ? [breaking] : []} />
           </>
         }
         confirmLabel="Разорвать"
@@ -215,6 +230,33 @@ export function QualityDocLinks({ links, allDocTypes, search }: {
         />
       )}
     </div>
+  );
+}
+
+/**
+ * Что зацепит действие над связками — состав по уровням и предупреждение про широкие (issue #649).
+ *
+ * Разрыв и перепривязка идут поперёк уровней, а до этого в подтверждении стояло одно число. Связка
+ * уровня «Стройка» или «Система» действует далеко за пределами комплекта, из которого её завели, —
+ * и человек узнавал об этом только по последствиям.
+ */
+export function ScopeReachNote({ links }: { links: MaterialQualityLink[] }) {
+  if (links.length === 0) return null;
+  const wide = widerThanSet(links);
+  const breakdown = scopeBreakdownText(links);
+  const mixed = links.some(l => l.scope !== links[0].scope);
+  if (wide.length === 0 && !mixed) return null; // всё в одном комплекте — говорить не о чем
+
+  return (
+    <p className="mt-2 text-warning">
+      {links.length > 1 && <>По уровням: {breakdown}. </>}
+      {wide.length > 0 && (
+        links.length === 1
+          ? <>Связка уровня «{SCOPE_LABELS[links[0].scope]}» — она действует не только в этом
+              комплекте, но и всюду, куда распространяется этот уровень.</>
+          : <>Из них шире комплекта: {wide.length} — они действуют и в других комплектах.</>
+      )}
+    </p>
   );
 }
 

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -16,17 +16,18 @@ import {
   useListQualityDocs, useDeleteQualityDoc, useListMaterialLinks, useRemoveMaterialLinks, searchQualityDocs,
   importQualityDocFromUrl, type QualityDocument, type SearchCandidate, type MaterialQualityLink,
 } from '@/shared/api/qualityDocs';
-import type { CatalogScope } from '@/shared/api/types';
+import { SCOPE_LABELS, type CatalogScope } from '@/shared/api/types';
 import { resolveEffectiveFields, typeHasTag } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import type { DocumentType } from '@/shared/api/types';
 import { QualityDocForm } from './QualityDocForm';
 import { ambiguousDocNames, docFieldByTag, docNumberOf, isAmbiguous } from './docIdentity';
 import { recognizeAndUpdate } from './recognizeImported';
-import { QualityDocLinks, matchesLink } from './QualityDocLinks';
+import { QualityDocLinks, ScopeReachNote, matchesLink } from './QualityDocLinks';
 import { docState, EXPIRING_SOON_DAYS, type DocState } from './docState';
 
-const SCOPE_LABEL: Record<string, string> = { System: 'Общая', Construction: 'Стройка', Section: 'Раздел', Set: 'Комплект' };
+// Метки областей — только из общего словаря (issue #649). Локальный дубль называл System «Общей»,
+// и на одном экране уровень документа и уровень его связок читались бы разными словами.
 const SOURCE_LABEL: Record<string, string> = { file: 'Файл', fgis: 'ФГИС', manufacturer: 'Произв.', web: 'Веб' };
 
 /** Значение реквизита по функциональному тэгу — общий модуль опознания документа (issue #588):
@@ -190,7 +191,7 @@ export function QualityDocsPage() {
               byTag(current, docTypes, FUNCTIONAL_TAG.docNumber) && `№ ${byTag(current, docTypes, FUNCTIONAL_TAG.docNumber)}`,
               byTag(current, docTypes, FUNCTIONAL_TAG.qualityValidUntil) && `до ${formatDate(byTag(current, docTypes, FUNCTIONAL_TAG.qualityValidUntil))}`,
               byTag(current, docTypes, FUNCTIONAL_TAG.qualityManufacturer),
-              SCOPE_LABEL[current.scope] ?? current.scope,
+              SCOPE_LABELS[current.scope as CatalogScope] ?? current.scope,
             ].filter(Boolean).join(' · ')}
           </p>
         </div>
@@ -253,8 +254,13 @@ export function QualityDocsPage() {
           <ConfirmDialog
             open={!!breakAll} onOpenChange={o => { if (!o) setBreakAll(null); }}
             title={`Разорвать все связки документа (${breakAll ? linksByDoc.get(breakAll.id)?.length ?? 0 : 0})?`}
-            description={<p>Материалы останутся без документа качества — при генерации поле документа
-              качества будет пустым. Сам документ останется в библиотеке.</p>}
+            description={<>
+              <p>Материалы останутся без документа качества — при генерации поле документа
+                качества будет пустым. Сам документ останется в библиотеке.</p>
+              {/* Действие идёт поперёк уровней (issue #649): среди связок бывают общесистемные,
+                  действующие на другие стройки, и одного числа для решения мало. */}
+              <ScopeReachNote links={breakAll ? linksByDoc.get(breakAll.id) ?? [] : []} />
+            </>}
             confirmLabel="Разорвать все"
             onConfirm={async () => {
               if (!breakAll) return;

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -209,7 +209,7 @@ export function QualityDocsPage() {
             его собственному имени, увидел бы «ни одна связка не подходит» под заголовком «Связки · 69». */}
         {/* key — чтобы выбор строк не переезжал на другой документ: иначе панель показывала бы
             «Выбрано: 3» без единой отмеченной строки, а разрыв ушёл бы с пустым списком. */}
-        <QualityDocLinks key={current.id} links={linksByDoc.get(current.id) ?? []} allDocTypes={docTypes}
+        <QualityDocLinks key={current.id} links={linksByDoc.get(current.id) ?? []} allLinks={links} allDocTypes={docTypes}
           search={(linksByDoc.get(current.id) ?? []).some(l => matchesLink(l, search.trim().toLowerCase())) ? search : ''} />
       </div>
     </div>

--- a/src/client/src/features/quality-docs/linkScopes.test.ts
+++ b/src/client/src/features/quality-docs/linkScopes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { linkAnomaly, scopeBreakdown, scopeBreakdownText, widerThanSet } from './linkScopes';
+import type { MaterialQualityLink } from '@/shared/api/qualityDocs';
+import type { CatalogScope } from '@/shared/api/types';
+
+let seq = 0;
+function link(scope: CatalogScope, materialKey = `m${++seq}`): MaterialQualityLink {
+  return {
+    id: `l${++seq}`, scope, scopeId: null, materialKey, materialLabel: null,
+    qualityDocumentId: 'q1', qualityDocumentName: 'Сертификат', qualityDocumentType: null,
+    createdAt: '', updatedAt: '',
+  } as MaterialQualityLink;
+}
+
+describe('состав связок по уровням', () => {
+  it('считает и упорядочивает от узкого к широкому', () => {
+    const links = [link('System'), link('Set'), link('Set'), link('Construction')];
+    expect(scopeBreakdown(links)).toEqual([
+      { scope: 'Set', count: 2 },
+      { scope: 'Construction', count: 1 },
+      { scope: 'System', count: 1 },
+    ]);
+    expect(scopeBreakdownText(links)).toBe('Комплект 2, Стройка 1, Система 1');
+  });
+
+  it('шире комплекта — всё, кроме уровня «Комплект»', () => {
+    const links = [link('Set'), link('Section'), link('System')];
+    expect(widerThanSet(links).map(l => l.scope)).toEqual(['Section', 'System']);
+  });
+
+  it('пустой список не даёт ни состава, ни текста', () => {
+    expect(scopeBreakdown([])).toEqual([]);
+    expect(scopeBreakdownText([])).toBe('');
+  });
+});
+
+describe('аномалии связки', () => {
+  it('однородный список аномалий не даёт', () => {
+    const links = [link('Set'), link('Set')];
+    expect(linkAnomaly(links[0], links)).toBeNull();
+  });
+
+  it('однородный список из общесистемных — тоже не аномалия', () => {
+    // Живой случай #587: все 113 связок на System. Это могло быть и осознанным решением; аномалия —
+    // когда связка выбивается из остальных, а не когда весь список одинаков.
+    const links = [link('System'), link('System')];
+    expect(linkAnomaly(links[0], links)).toBeNull();
+  });
+
+  it('связка шире остальных помечается', () => {
+    const wide = link('System');
+    const links = [link('Set'), link('Set'), wide];
+    expect(linkAnomaly(wide, links)).toContain('шире остальных');
+    expect(linkAnomaly(links[0], links)).toBeNull();
+  });
+
+  it('два уровня на один материал: победителя называем прямо', () => {
+    const narrow = link('Set', 'кабель | ');
+    const wide = link('System', 'кабель | ');
+    const links = [narrow, wide];
+    expect(linkAnomaly(narrow, links)).toContain('подставится ЭТА');
+    expect(linkAnomaly(wide, links)).toContain('«Комплект»');
+  });
+
+  it('конфликт уровней важнее, чем «шире остальных»', () => {
+    // У широкой связки верны обе претензии, но неразличимый дубль — та, о которой надо сказать:
+    // она объясняет, почему в PDF попадает не то, что человек видит первым.
+    const narrow = link('Set', 'кабель | ');
+    const wide = link('System', 'кабель | ');
+    const links = [narrow, wide, link('Set')];
+    expect(linkAnomaly(wide, links)).toContain('на разных уровнях');
+  });
+});

--- a/src/client/src/features/quality-docs/linkScopes.test.ts
+++ b/src/client/src/features/quality-docs/linkScopes.test.ts
@@ -4,13 +4,20 @@ import type { MaterialQualityLink } from '@/shared/api/qualityDocs';
 import type { CatalogScope } from '@/shared/api/types';
 
 let seq = 0;
-function link(scope: CatalogScope, materialKey = `m${++seq}`): MaterialQualityLink {
+function link(
+  scope: CatalogScope,
+  materialKey = `m${++seq}`,
+  { docId = 'q1', docName = 'Сертификат', scopeId = null as string | null } = {},
+): MaterialQualityLink {
   return {
-    id: `l${++seq}`, scope, scopeId: null, materialKey, materialLabel: null,
-    qualityDocumentId: 'q1', qualityDocumentName: 'Сертификат', qualityDocumentType: null,
+    id: `l${++seq}`, scope, scopeId, materialKey, materialLabel: null,
+    qualityDocumentId: docId, qualityDocumentName: docName, qualityDocumentType: null,
     createdAt: '', updatedAt: '',
   } as MaterialQualityLink;
 }
+
+/** Один и тот же список и как «связки документа», и как «вся библиотека» — обычный случай. */
+const same = (links: MaterialQualityLink[]) => ({ inDocument: links, all: links });
 
 describe('состав связок по уровням', () => {
   it('считает и упорядочивает от узкого к широкому', () => {
@@ -37,37 +44,66 @@ describe('состав связок по уровням', () => {
 describe('аномалии связки', () => {
   it('однородный список аномалий не даёт', () => {
     const links = [link('Set'), link('Set')];
-    expect(linkAnomaly(links[0], links)).toBeNull();
+    expect(linkAnomaly(links[0], same(links))).toBeNull();
   });
 
   it('однородный список из общесистемных — тоже не аномалия', () => {
     // Живой случай #587: все 113 связок на System. Это могло быть и осознанным решением; аномалия —
     // когда связка выбивается из остальных, а не когда весь список одинаков.
     const links = [link('System'), link('System')];
-    expect(linkAnomaly(links[0], links)).toBeNull();
+    expect(linkAnomaly(links[0], same(links))).toBeNull();
   });
 
   it('связка шире остальных помечается', () => {
     const wide = link('System');
     const links = [link('Set'), link('Set'), wide];
-    expect(linkAnomaly(wide, links)).toContain('шире остальных');
-    expect(linkAnomaly(links[0], links)).toBeNull();
+    expect(linkAnomaly(wide, same(links))).toContain('шире остальных');
+    expect(linkAnomaly(links[0], same(links))).toBeNull();
   });
 
-  it('два уровня на один материал: победителя называем прямо', () => {
-    const narrow = link('Set', 'кабель | ');
-    const wide = link('System', 'кабель | ');
-    const links = [narrow, wide];
-    expect(linkAnomaly(narrow, links)).toContain('подставится ЭТА');
-    expect(linkAnomaly(wide, links)).toContain('«Комплект»');
+  it('за материал спорят два документа: победителя называем по имени', () => {
+    const mine = link('System', 'кабель | ', { docId: 'A', docName: 'Сертификат A' });
+    const rival = link('Set', 'кабель | ', { docId: 'B', docName: 'Декларация B', scopeId: 's1' });
+    const all = [mine, rival];
+    expect(linkAnomaly(mine, { inDocument: [mine], all })).toContain('«Декларация B»');
+    expect(linkAnomaly(rival, { inDocument: [rival], all })).toContain('подставится ЭТА');
   });
 
-  it('конфликт уровней важнее, чем «шире остальных»', () => {
-    // У широкой связки верны обе претензии, но неразличимый дубль — та, о которой надо сказать:
-    // она объясняет, почему в PDF попадает не то, что человек видит первым.
-    const narrow = link('Set', 'кабель | ');
-    const wide = link('System', 'кабель | ');
-    const links = [narrow, wide, link('Set')];
-    expect(linkAnomaly(wide, links)).toContain('на разных уровнях');
+  it('спор внутри ОДНОГО документа аномалией не считается', () => {
+    // Кто бы из двух связок ни победил, в PDF попадёт этот же документ — предупреждать не о чем.
+    const links = [
+      link('Set', 'кабель | ', { docId: 'A' }),
+      link('System', 'кабель | ', { docId: 'A' }),
+    ];
+    expect(linkAnomaly(links[0], same(links))).toBeNull();
+    // У широкой связки остаётся своя, отдельная претензия — она шире соседей по документу; про
+    // спор документов не говорится ничего, потому что документ один.
+    expect(linkAnomaly(links[1], same(links))).not.toContain('другому документу');
+  });
+
+  it('один ключ в двух РАЗНЫХ комплектах спором не считается', () => {
+    // Уникальность в базе — по тройке (область, объект области, ключ), поэтому один материал
+    // законно живёт в двух комплектах. Резолвер читает связки только своей цепочки: они не
+    // встречаются никогда, и треугольник здесь был бы ложной тревогой.
+    const a = link('Set', 'кабель | ', { docId: 'A', docName: 'Сертификат A', scopeId: 'setA' });
+    const b = link('Set', 'кабель | ', { docId: 'B', docName: 'Декларация B', scopeId: 'setB' });
+    const all = [a, b];
+    expect(linkAnomaly(a, { inDocument: [a], all })).toBeNull();
+    expect(linkAnomaly(b, { inDocument: [b], all })).toBeNull();
+  });
+
+  it('пара «комплект — раздел» молчит: содержит ли раздел этот комплект, экран не знает', () => {
+    const set = link('Set', 'кабель | ', { docId: 'A', scopeId: 'setA' });
+    const section = link('Section', 'кабель | ', { docId: 'B', scopeId: 'sec1' });
+    const all = [set, section];
+    expect(linkAnomaly(set, { inDocument: [set], all })).toBeNull();
+    expect(linkAnomaly(section, { inDocument: [section], all })).toBeNull();
+  });
+
+  it('спор важнее, чем «шире остальных»', () => {
+    const wide = link('System', 'кабель | ', { docId: 'A' });
+    const rival = link('Set', 'кабель | ', { docId: 'B', docName: 'Декларация B', scopeId: 's1' });
+    const inDocument = [wide, link('Set', 'другое', { docId: 'A' })];
+    expect(linkAnomaly(wide, { inDocument, all: [...inDocument, rival] })).toContain('Декларация B');
   });
 });

--- a/src/client/src/features/quality-docs/linkScopes.ts
+++ b/src/client/src/features/quality-docs/linkScopes.ts
@@ -35,27 +35,44 @@ export function widerThanSet(links: MaterialQualityLink[]): MaterialQualityLink[
   return links.filter(l => SCOPE_PRIORITY[l.scope] > SCOPE_PRIORITY.Set);
 }
 
-/** Аномалия строки: почему на связке стоит предупреждающий знак. null — всё в порядке. */
-export function linkAnomaly(link: MaterialQualityLink, all: MaterialQualityLink[]): string | null {
-  const conflict = scopeConflict(link, all);
-  if (conflict) return conflict;
-  return widerThanRest(link, all);
+/**
+ * Аномалия строки: почему на связке стоит предупреждающий знак. null — всё в порядке.
+ *
+ * Два вопроса задаются РАЗНЫМ спискам: «шире остальных» — про связки этого документа (`inDocument`),
+ * «за материал спорят два документа» — про всю библиотеку (`all`). Считать спор внутри одного
+ * документа бессмысленно: кто бы ни победил, в PDF попадёт он же.
+ */
+export function linkAnomaly(
+  link: MaterialQualityLink,
+  { inDocument, all }: { inDocument: MaterialQualityLink[]; all: MaterialQualityLink[] },
+): string | null {
+  return documentConflict(link, all) ?? widerThanRest(link, inDocument);
 }
 
 /**
- * Один материал привязан на двух уровнях — строки неразличимы, а в PDF попадёт ровно одна.
- * Победителя называем прямо: догадаться о правиле «узкий побеждает» по экрану нельзя.
+ * За один материал спорят ДВА РАЗНЫХ документа качества, и в PDF попадёт ровно один. По экрану
+ * догадаться нельзя: на карточке проигравшего связка выглядит совершенно здоровой.
+ *
+ * Соперниками считаем только те связки, чьи области заведомо пересекаются, — то есть когда одна из
+ * них общесистемная. Про пару «Комплект — Раздел» сказать нечего: содержит ли ТОТ раздел ЭТОТ
+ * комплект, знает дерево объектов, а его мы на этот экран намеренно не тянем (решение по #649).
+ * Ложная тревога здесь хуже молчания: экран и заведён ради поиска настоящих дефектов.
  */
-function scopeConflict(link: MaterialQualityLink, all: MaterialQualityLink[]): string | null {
-  const rivals = all.filter(l => l.materialKey === link.materialKey && l.id !== link.id);
+function documentConflict(link: MaterialQualityLink, all: MaterialQualityLink[]): string | null {
+  const rivals = all.filter(l =>
+    l.materialKey === link.materialKey
+    && l.id !== link.id
+    && l.qualityDocumentId !== link.qualityDocumentId
+    && (l.scope === 'System' || link.scope === 'System')); // области пересекаются заведомо
   if (rivals.length === 0) return null;
 
   const winner = [...rivals, link].reduce((a, b) => (SCOPE_PRIORITY[a.scope] <= SCOPE_PRIORITY[b.scope] ? a : b));
-  const levels = scopeBreakdown([...rivals, link]).map(s => SCOPE_LABELS[s.scope]).join(' и ');
-  const verdict = winner.id === link.id
-    ? 'при генерации подставится ЭТА — уровень уже'
-    : `при генерации подставится связка уровня «${SCOPE_LABELS[winner.scope]}» — он уже`;
-  return `Материал привязан на разных уровнях (${levels}): ${verdict}.`;
+  const rivalNames = [...new Set(rivals.map(r => r.qualityDocumentName))].join(', ');
+  return winner.id === link.id
+    ? `Тот же материал привязан и к другому документу (${rivalNames}) на уровне «${SCOPE_LABELS[rivals[0].scope]}»: `
+      + 'при генерации подставится ЭТА связка — её уровень уже.'
+    : `Тот же материал привязан к документу «${winner.qualityDocumentName}» на уровне `
+      + `«${SCOPE_LABELS[winner.scope]}»: при генерации подставится ОН, а не этот документ.`;
 }
 
 /**

--- a/src/client/src/features/quality-docs/linkScopes.ts
+++ b/src/client/src/features/quality-docs/linkScopes.ts
@@ -1,0 +1,70 @@
+import { SCOPE_LABELS, SCOPE_PRIORITY, type CatalogScope } from '@/shared/api/types';
+import type { MaterialQualityLink } from '@/shared/api/qualityDocs';
+
+/**
+ * Уровень связки материала: разбор состава и аномалий (issue #649).
+ *
+ * Экран документов качества грузит связки ВСЕХ областей одним запросом, а на строке уровень до сих
+ * пор не показывался вовсе — при том что он управляет и поведением экрана (перепривязка идёт по
+ * группам областей), и результатом генерации: при совпадении ключа побеждает более узкий уровень
+ * (Set=1 … System=5, `QualityLinkResolver`). Две связки одного материала на разных уровнях давали
+ * две визуально НЕРАЗЛИЧИМЫЕ строки.
+ *
+ * Здесь только счёт и сравнение — без React, чтобы правила проверялись тестами, а не глазами.
+ */
+
+/** Сколько связок на каждом уровне, от узкого к широкому. Пустые уровни не попадают. */
+export function scopeBreakdown(links: MaterialQualityLink[]): { scope: CatalogScope; count: number }[] {
+  const counts = new Map<CatalogScope, number>();
+  for (const l of links) counts.set(l.scope, (counts.get(l.scope) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => SCOPE_PRIORITY[a[0]] - SCOPE_PRIORITY[b[0]])
+    .map(([scope, count]) => ({ scope, count }));
+}
+
+/** «Комплект 9, Система 2» — состав словами. Пустой список даёт пустую строку. */
+export function scopeBreakdownText(links: MaterialQualityLink[]): string {
+  return scopeBreakdown(links).map(({ scope, count }) => `${SCOPE_LABELS[scope]} ${count}`).join(', ');
+}
+
+/**
+ * Связки шире комплекта — те, чей разрыв или перепривязка заденет не только текущий комплект.
+ * Ради них и заведено предупреждение в подтверждениях: «Система» действует на все стройки.
+ */
+export function widerThanSet(links: MaterialQualityLink[]): MaterialQualityLink[] {
+  return links.filter(l => SCOPE_PRIORITY[l.scope] > SCOPE_PRIORITY.Set);
+}
+
+/** Аномалия строки: почему на связке стоит предупреждающий знак. null — всё в порядке. */
+export function linkAnomaly(link: MaterialQualityLink, all: MaterialQualityLink[]): string | null {
+  const conflict = scopeConflict(link, all);
+  if (conflict) return conflict;
+  return widerThanRest(link, all);
+}
+
+/**
+ * Один материал привязан на двух уровнях — строки неразличимы, а в PDF попадёт ровно одна.
+ * Победителя называем прямо: догадаться о правиле «узкий побеждает» по экрану нельзя.
+ */
+function scopeConflict(link: MaterialQualityLink, all: MaterialQualityLink[]): string | null {
+  const rivals = all.filter(l => l.materialKey === link.materialKey && l.id !== link.id);
+  if (rivals.length === 0) return null;
+
+  const winner = [...rivals, link].reduce((a, b) => (SCOPE_PRIORITY[a.scope] <= SCOPE_PRIORITY[b.scope] ? a : b));
+  const levels = scopeBreakdown([...rivals, link]).map(s => SCOPE_LABELS[s.scope]).join(' и ');
+  const verdict = winner.id === link.id
+    ? 'при генерации подставится ЭТА — уровень уже'
+    : `при генерации подставится связка уровня «${SCOPE_LABELS[winner.scope]}» — он уже`;
+  return `Материал привязан на разных уровнях (${levels}): ${verdict}.`;
+}
+
+/**
+ * Связка шире всех остальных в списке. Самый тихий класс ошибок привязки — «заведено шире, чем
+ * нужно»: на живых данных все 113 связок сидели на уровне «Система» (#587), и по экрану это никак
+ * не читалось. Когда весь список однороден, аномалии нет — предупреждать не о чем.
+ */
+function widerThanRest(link: MaterialQualityLink, all: MaterialQualityLink[]): string | null {
+  const narrowest = Math.min(...all.map(l => SCOPE_PRIORITY[l.scope]));
+  if (SCOPE_PRIORITY[link.scope] <= narrowest) return null;
+  return `Связка заведена шире остальных: уровень «${SCOPE_LABELS[link.scope]}» — она действует и за пределами этого комплекта.`;
+}

--- a/src/client/src/shared/ui/ScopeIcon.tsx
+++ b/src/client/src/shared/ui/ScopeIcon.tsx
@@ -1,0 +1,35 @@
+import { Boxes, Building2, FolderOpen, Layers } from 'lucide-react';
+import { SCOPE_LABELS, type CatalogScope } from '@/shared/api/types';
+
+/**
+ * Значок уровня области (issue #649).
+ *
+ * Иконки не выдуманы заново, а взяты те, которыми уровни уже подписаны в приложении: стройка —
+ * `Building2` (`ConstructionsList`/`ConstructionDetail`), раздел — `Layers` (`SectionDetail`),
+ * комплект — `FolderOpen` (`SetDetail`). Своей иконки у «Системы» не было; `Globe` занят на экране
+ * документов качества кнопкой «Найти в интернете», поэтому взят `Boxes` — «всё сразу».
+ *
+ * Уровень — порядковая шкала из четырёх значений, и одной картинкой она не выучивается, поэтому
+ * слово всегда рядом: `title` для мыши и `aria-label` для чтения с экрана. Цвет приглушённый:
+ * в типичном списке уровень у всех строк один, и яркий значок, повторённый десятки раз, стал бы
+ * фоном — как повторённый номер документа, о котором говорит комментарий в `QualityDocsPage`.
+ */
+const SCOPE_ICONS: Record<CatalogScope, typeof Boxes> = {
+  Set: FolderOpen,
+  Section: Layers,
+  Construction: Building2,
+  System: Boxes,
+};
+
+export function ScopeIcon({ scope, size = 13, className = '' }: {
+  scope: CatalogScope; size?: number; className?: string;
+}) {
+  const Icon = SCOPE_ICONS[scope];
+  const label = SCOPE_LABELS[scope];
+  return (
+    <span title={`Уровень связи: ${label}`} aria-label={`Уровень связи: ${label}`} role="img"
+      className={`inline-flex items-center shrink-0 text-fg4 ${className}`}>
+      <Icon size={size} />
+    </span>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.80.2</Version>
+    <Version>0.81.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #649 (первая итерация — пункты 2–4 плана; фильтр по уровню, пункт 5, не входит).

Решения приняты пользователем, зафиксированы [комментарием в issue](https://github.com/pavru/bhs.crg/issues/649#issuecomment-5162498400).

## Что сделано

**Уровень — значком на каждой строке.** Иконки не выдуманы заново: `Building2` — стройка, `Layers` — раздел, `FolderOpen` — комплект, ровно как эти уровни уже подписаны на своих экранах. Своей иконки у «Системы» не было, а `Globe` занят на этом же экране кнопкой «Найти в интернете» — поэтому `Boxes`. Слово всегда рядом (`title` + `aria-label`): одной картинкой порядковая шкала из четырёх значений не выучивается, и значок приглушён, чтобы повторённый десять раз не стал фоном.

**Имя объекта области не показываем**, `ScopeName` в DTO не добавляем. Взамен — предупреждение в подтверждениях: одиночный разрыв, массовый и «Разорвать все связки» теперь говорят, что зацепит («По уровням: Комплект 3, Система 2. Из них шире комплекта: 2 — они действуют и в других комплектах»).

**Единый словарь меток.** Локальный дубль в `QualityDocsPage.tsx` называл System «Общей», общий `SCOPE_LABELS` — «Системой»; на одном экране уровень документа и уровень его связок читались бы разными словами. Дубль убран.

**Аномалии — предупреждающим знаком.** Два случая: связка шире остальных в списке (самый тихий класс ошибок, #587 — все 113 связок сидели на System) и два уровня на один `materialKey` — с прямым указанием, какая победит при генерации. Однородный список аномалией не считается: одинаковый уровень у всех может быть и осознанным решением.

Счёт и сравнение — в чистом `linkScopes.ts`, 8 тестов (в том числе: конфликт уровней важнее, чем «шире остальных»).

## Проверка

На живых данных: временно завёл две связки уровня «Система» — одну на тот же материал (конфликт), одну на новый ключ (шире остальных). Значки и подсказки прочитаны из DOM:

```
• Уровень связи: Комплект
• Материал привязан на разных уровнях (Комплект и Система): при генерации подставится ЭТА — уровень уже.
• Уровень связи: Система
• Материал привязан на разных уровнях (Комплект и Система): при генерации подставится связка уровня «Комплект» — он уже.
• Связка заведена шире остальных: уровень «Система» — она действует и за пределами этого комплекта.
```

Диалог «Разорвать все связки документа (5)» показал состав по уровням. Пробные связки удалены — в базе снова 11 исходных, все уровня «Комплект».

Frontend 387 тестов зелёные, `tsc -b` чист. Версия 0.81.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)