### PR TITLE
Системный провайдер «Документы качества» (#623)

### DIFF
--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -351,6 +351,7 @@ builder.Services.AddSingleton<IDataSetParser, ZipDataSetParser>();
 builder.Services.AddSingleton<IDataSetParser, PdfDataSetParser>();
 builder.Services.AddSingleton<DataSetParserFactory>();
 builder.Services.AddScoped<ISystemDataProvider, SetDocumentsProvider>();
+builder.Services.AddScoped<ISystemDataProvider, QualityDocumentsProvider>();
 builder.Services.AddScoped<SystemDataProviderRegistry>();
 builder.Services.AddScoped<IDataSetRowLoader, DataSetRowLoader>();
 builder.Services.AddScoped<SystemSourceCounter>();

--- a/src/server/BHS.CRG.Domain/DataSets/SystemDataSets.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/SystemDataSets.cs
@@ -20,6 +20,9 @@ public static class SystemDataSets
     /// <summary>Документы комплекта, в границах которого живёт набор.</summary>
     public const string SetDocumentsMarker = "system:set-documents";
 
+    /// <summary>Библиотека документов качества, видимых с уровня набора (цепочка вверх).</summary>
+    public const string QualityDocumentsMarker = "system:quality-documents";
+
     public static bool IsSystemMarker(string sheetOrPath) =>
         sheetOrPath.StartsWith(MarkerPrefix, StringComparison.Ordinal);
 }

--- a/src/server/BHS.CRG.Infrastructure/DataSets/QualityDocumentsProvider.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/QualityDocumentsProvider.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Schema;
+using BHS.CRG.Infrastructure.Common;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.DataSets;
+
+/// <summary>
+/// Консолидация «Документы качества»: строка на каждый документ библиотеки, ВИДИМЫЙ с уровня
+/// набора — по цепочке вверх (свой уровень → раздел → стройка → система). Тот же предикат
+/// видимости, что у резолвера связок при генерации (<c>QualityLinkResolver</c>): иначе набор
+/// показывал бы одно, а в PDF подставлялось другое.
+///
+/// Реквизиты у подтипов разные (сертификат, декларация, паспорт), поэтому номер, дата, срок и
+/// изготовитель ищутся по функциональным тэгам, а не по именам полей. Незаполненное поле или тип
+/// без тэга дают пустую ячейку — строка документа при этом не пропадает.
+///
+/// Тип берётся из реестра типов по <c>DocumentTypeId</c>, а НЕ из реквизита «ТипДокумента»: на
+/// живой базе реквизит противоречит собственному типу документа (см. комментарий в
+/// <c>QualityDocHandlers.Handle(ListMaterialLinksQuery)</c>), и доверять надо тому, что определяет
+/// схему.
+/// </summary>
+public class QualityDocumentsProvider(AppDbContext db) : ISystemDataProvider
+{
+    private const string Name = "Документы качества";
+
+    /// <summary>Колонки в порядке отображения. Значения — строки, как и у всех источников.</summary>
+    private static readonly string[] Columns =
+    [
+        "НомерПП", "Ид", "Наименование", "ТипКод", "ТипИмя",
+        "НомерДокумента", "ДатаДокумента", "СрокДействия", "Изготовитель",
+        "Уровень", "Источник", "ЕстьСкан", "ИмяФайлаСкана",
+    ];
+
+    public bool Handles(string marker) => marker == SystemDataSets.QualityDocumentsMarker;
+
+    public async Task<IReadOnlyList<DataSetSourceInfo>> GetCandidatesAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct)
+    {
+        // Уровни все, но кандидата предлагаем только при живых строках: иначе кнопка «Данные
+        // системы» появлялась бы и там, где модулем качества не пользуются вовсе.
+        if (scope != CatalogScope.System && scopeId is null) return [];
+        var rows = await RowsAsync(scope, scopeId, ct);
+        return rows.Count == 0
+            ? []
+            : [new DataSetSourceInfo(Name, SystemDataSets.QualityDocumentsMarker, ColumnsOf(rows), rows.Count)];
+    }
+
+    public async Task<DataSetParseResult> ProvideAsync(
+        string marker, CatalogScope scope, Guid? scopeId, CancellationToken ct)
+    {
+        // Единственный вид отказа — ArgumentException: KeyNotFoundException из провайдера уронил бы
+        // весь список наборов, а не одну строку в нём.
+        if (scope != CatalogScope.System && scopeId is null)
+            throw new ArgumentException(
+                $"Источнику «{Name}» нужен уровень с объектом: комплект, раздел или стройка.");
+
+        var rows = await RowsAsync(scope, scopeId, ct);
+        return new DataSetParseResult(ColumnsOf(rows), rows);
+    }
+
+    private async Task<List<IReadOnlyDictionary<string, string?>>> RowsAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct)
+    {
+        // Цепочка вверх от места набора: с комплекта видны и его раздел, и стройка, и система.
+        var chain = await ScopeChains.LoadForScopeAsync(db, scope, scopeId, ct);
+
+        var visible = await db.QualityDocuments.AsNoTracking()
+            .Where(d => d.Scope == CatalogScope.System
+                        || (d.Scope == CatalogScope.Set && d.ScopeId == chain.SetId)
+                        || (d.Scope == CatalogScope.Section && d.ScopeId == chain.SectionId)
+                        || (d.Scope == CatalogScope.Construction && d.ScopeId == chain.ConstructionId))
+            .OrderBy(d => d.DisplayName).ThenBy(d => d.Id)   // как в ListQualityDocumentsQuery
+            .ToListAsync(ct);
+        if (visible.Count == 0) return [];
+
+        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var typeById = allTypes.ToDictionary(t => t.Id);
+
+        // Ключ тэгированного поля зависит от ТИПА (у каждого своя схема) — карта строится на тип,
+        // а не на документ.
+        var taggedKeys = new Dictionary<Guid, Dictionary<string, string>>();
+        Dictionary<string, string> KeysOf(Guid typeId)
+        {
+            if (taggedKeys.TryGetValue(typeId, out var cached)) return cached;
+            var map = new Dictionary<string, string>();
+            if (typeById.TryGetValue(typeId, out var type))
+                foreach (var (key, tag) in SchemaTags.TaggedFields(type, allTypes))
+                    map.TryAdd(tag, key); // ближний тип в цепочке наследования уже победил
+            taggedKeys[typeId] = map;
+            return map;
+        }
+
+        var rows = new List<IReadOnlyDictionary<string, string?>>(visible.Count);
+        var ordinal = 1;
+        foreach (var doc in visible)
+        {
+            var type = typeById.GetValueOrDefault(doc.DocumentTypeId);
+            var keys = KeysOf(doc.DocumentTypeId);
+
+            string? Tagged(string tag) =>
+                keys.TryGetValue(tag, out var key) ? ScalarOf(doc.Requisites, key) : null;
+
+            rows.Add(new Dictionary<string, string?>
+            {
+                ["НомерПП"] = ordinal.ToString(),
+                ["Ид"] = doc.Id.ToString(),
+                ["Наименование"] = doc.DisplayName,
+                ["ТипКод"] = type?.Code,
+                ["ТипИмя"] = type?.Name,
+                ["НомерДокумента"] = Tagged(FunctionalTag.DocNumber),
+                ["ДатаДокумента"] = Tagged(FunctionalTag.DocDate),
+                ["СрокДействия"] = Tagged(FunctionalTag.QualityValidUntil),
+                ["Изготовитель"] = Tagged(FunctionalTag.QualityManufacturer),
+                ["Уровень"] = ScopeLabel(doc.Scope),
+                ["Источник"] = SourceLabel(doc.Source),
+                ["ЕстьСкан"] = string.IsNullOrWhiteSpace(doc.ScanBlobPath) ? "нет" : "да",
+                ["ИмяФайлаСкана"] = doc.ScanFileName,
+            });
+            ordinal++;
+        }
+        return rows;
+    }
+
+    /// <summary>Значение реквизита как строка. Составное/массив — не ячейка таблицы, пропускаем.</summary>
+    private static string? ScalarOf(JsonDocument data, string key)
+    {
+        if (data.RootElement.ValueKind != JsonValueKind.Object) return null;
+        if (!data.RootElement.TryGetProperty(key, out var value)) return null;
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.ToString(),
+            JsonValueKind.True => "да",
+            JsonValueKind.False => "нет",
+            _ => null,
+        };
+    }
+
+    private static string ScopeLabel(CatalogScope scope) => scope switch
+    {
+        CatalogScope.Set => "Комплект",
+        CatalogScope.Section => "Раздел",
+        CatalogScope.Construction => "Стройка",
+        CatalogScope.System => "Система",
+        _ => scope.ToString(),
+    };
+
+    private static string SourceLabel(QualityDocSource source) => source switch
+    {
+        QualityDocSource.Manual => "Вручную",
+        QualityDocSource.Fgis => "ФГИС",
+        QualityDocSource.Manufacturer => "Изготовитель",
+        QualityDocSource.Web => "Веб",
+        _ => source.ToString(),
+    };
+
+    private static IReadOnlyList<DataSetColumnInfo> ColumnsOf(
+        IReadOnlyList<IReadOnlyDictionary<string, string?>> rows) =>
+        [.. Columns.Select(name => new DataSetColumnInfo(name,
+            [.. rows.Take(3).Select(r => r.GetValueOrDefault(name) ?? "")]))];
+}

--- a/src/server/BHS.CRG.Tests/Integration/QualityDocumentsProviderTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/QualityDocumentsProviderTests.cs
@@ -1,0 +1,293 @@
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.DataSnapshots;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Системная консолидация «Документы качества» (issue #623): библиотека сертификатов, видимая с
+/// уровня набора по цепочке вверх. Проверяется тот же сквозной путь, что у документов комплекта:
+/// кандидат → источник → живые строки, — и видимость по уровням, ради которой всё и делается.
+/// </summary>
+[Collection("Integration")]
+public class QualityDocumentsProviderTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IDataSetService Svc(IServiceScope s) => s.ServiceProvider.GetRequiredService<IDataSetService>();
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+
+    private sealed record Seed(Guid SetId, Guid SectionId, Guid ConstructionId, Guid CertTypeId, Guid LetterTypeId);
+
+    /// <summary>
+    /// Комплект в разделе и стройке + два подтипа документа качества с РАЗНЫМИ именами полей:
+    /// провайдер обязан находить номер и срок по тэгам, а не по именам.
+    /// </summary>
+    private static async Task<Seed> SeedAsync(IServiceScope scope)
+    {
+        var m = M(scope);
+
+        var cert = await m.Send(new CreateDocumentTypeCommand("Сертификат", "CERT", DocumentTypeKind.Document, null,
+            J("""
+              {'fields':[
+                {'key':'НомерДок','type':'string','required':false,'tags':['doc.number']},
+                {'key':'ДатаВыдачи','type':'date','required':false,'tags':['doc.date']},
+                {'key':'Действителен','type':'date','required':false,'tags':['quality.validUntil']},
+                {'key':'Завод','type':'string','required':false,'tags':['quality.manufacturer']}
+              ]}
+              """)));
+
+        // Информационное письмо: срока действия у него нет вовсе — тэга quality.validUntil в схеме нет.
+        var letter = await m.Send(new CreateDocumentTypeCommand("Письмо", "LETTER", DocumentTypeKind.Document, null,
+            J("{'fields':[{'key':'Рег','type':'string','required':false,'tags':['doc.number']}]}")));
+
+        var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "Комплект 1"));
+
+        return new Seed(set.Id, section.Id, construction.Id, cert.Id, letter.Id);
+    }
+
+    private static Task<QualityDocument> AddDocAsync(
+        IServiceScope scope, Guid typeId, string name, string requisites,
+        CatalogScope docScope, Guid? scopeId, QualityDocSource source = QualityDocSource.Manual,
+        string? scanBlobPath = null, string? scanFileName = null)
+        => M(scope).Send(new CreateQualityDocumentCommand(
+            typeId, name, J(requisites), docScope, scopeId, source, scanBlobPath, scanFileName, null));
+
+    private static async Task<Guid> SourceAtAsync(IServiceScope scope, string level, Guid? scopeId)
+    {
+        var svc = Svc(scope);
+        var file = await svc.CreateSystemFileAsync(
+            new CreateSystemFileInput(level, scopeId?.ToString(), null), default);
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Качество", SystemDataSets.QualityDocumentsMarker, null), default);
+        return source.Id;
+    }
+
+    [Fact]
+    public async Task Candidate_BecomesSourceWithLiveRows()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+
+        var cert = await AddDocAsync(scope, seed.CertTypeId, "EKF — автоматы",
+            "{'НомерДок':'ЕАЭС RU С-CN.1','ДатаВыдачи':'2024-03-01','Действителен':'2029-02-28','Завод':'EKF'}",
+            CatalogScope.Set, seed.SetId, QualityDocSource.Fgis, "blob/scan.pdf", "скан.pdf");
+
+        var file = await svc.CreateSystemFileAsync(
+            new CreateSystemFileInput("Set", seed.SetId.ToString(), null), default);
+        var candidate = Assert.Single(await svc.DetectSourceCandidatesAsync(file.Id, default),
+            c => c.SheetOrPath == SystemDataSets.QualityDocumentsMarker);
+        Assert.Equal("Документы качества", candidate.Name);
+
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Качество", candidate.SheetOrPath, null), default);
+        var preview = await svc.PreviewSourceAsync(source.Id, 50, default);
+        Assert.NotNull(preview);
+
+        string? Cell(int row, string column) => preview.Rows[row][preview.Columns.ToList().IndexOf(column)];
+
+        Assert.Single(preview.Rows);
+        Assert.Equal("1", Cell(0, "НомерПП"));
+        Assert.Equal(cert.Id.ToString(), Cell(0, "Ид"));
+        Assert.Equal("EKF — автоматы", Cell(0, "Наименование"));
+        Assert.Equal("CERT", Cell(0, "ТипКод"));
+        Assert.Equal("Сертификат", Cell(0, "ТипИмя"));
+        // Тэгированные поля найдены в чужой схеме: имена полей провайдеру неизвестны.
+        Assert.Equal("ЕАЭС RU С-CN.1", Cell(0, "НомерДокумента"));
+        Assert.Equal("2024-03-01", Cell(0, "ДатаДокумента"));
+        Assert.Equal("2029-02-28", Cell(0, "СрокДействия"));
+        Assert.Equal("EKF", Cell(0, "Изготовитель"));
+        Assert.Equal("Комплект", Cell(0, "Уровень"));
+        Assert.Equal("ФГИС", Cell(0, "Источник"));
+        Assert.Equal("да", Cell(0, "ЕстьСкан"));
+        Assert.Equal("скан.pdf", Cell(0, "ИмяФайлаСкана"));
+    }
+
+    /// <summary>Данные живые: документ, заведённый после создания источника, попадает в строки.</summary>
+    [Fact]
+    public async Task RowsFollowLibraryState()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddDocAsync(scope, seed.CertTypeId, "Первый", "{}", CatalogScope.Set, seed.SetId);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId);
+        Assert.Single((await Svc(scope).PreviewSourceAsync(sourceId, 50, default))!.Rows);
+
+        await AddDocAsync(scope, seed.CertTypeId, "Второй", "{}", CatalogScope.Set, seed.SetId);
+        Assert.Equal(2, (await Svc(scope).PreviewSourceAsync(sourceId, 50, default))!.Rows.Count);
+    }
+
+    /// <summary>
+    /// Ради чего консолидация и нужна: с комплекта видна вся цепочка вверх. Документ соседнего
+    /// комплекта при этом не виден — иначе набор показывал бы одно, а генерация подставляла другое.
+    /// </summary>
+    [Fact]
+    public async Task VisibilityFollowsScopeChainUpwards()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var seed = await SeedAsync(scope);
+        var otherSet = await m.Send(new CreateDocumentSetCommand(seed.SectionId, "Комплект 2"));
+
+        await AddDocAsync(scope, seed.CertTypeId, "Свой", "{}", CatalogScope.Set, seed.SetId);
+        await AddDocAsync(scope, seed.CertTypeId, "Раздельный", "{}", CatalogScope.Section, seed.SectionId);
+        await AddDocAsync(scope, seed.CertTypeId, "Строечный", "{}", CatalogScope.Construction, seed.ConstructionId);
+        await AddDocAsync(scope, seed.CertTypeId, "Общий", "{}", CatalogScope.System, null);
+        await AddDocAsync(scope, seed.CertTypeId, "Чужой", "{}", CatalogScope.Set, otherSet.Id);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var names = preview!.Rows.Select(r => r[preview.Columns.ToList().IndexOf("Наименование")]).ToList();
+
+        Assert.Equal(["Общий", "Раздельный", "Свой", "Строечный"], [.. names.Order()]);
+        Assert.DoesNotContain("Чужой", names);
+    }
+
+    /// <summary>Общесистемный документ виден и с уровня «Система», где объекта области нет вовсе.</summary>
+    [Fact]
+    public async Task SystemLevel_SeesOnlySystemWideDocuments()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddDocAsync(scope, seed.CertTypeId, "Общий", "{}", CatalogScope.System, null);
+        await AddDocAsync(scope, seed.CertTypeId, "Комплектный", "{}", CatalogScope.Set, seed.SetId);
+
+        var sourceId = await SourceAtAsync(scope, "System", null);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        Assert.Equal("Общий", Assert.Single(preview!.Rows)[preview.Columns.ToList().IndexOf("Наименование")]);
+    }
+
+    /// <summary>
+    /// Тип без тэга «срок действия» даёт пустую ячейку, а не выпадает из выдачи: у информационного
+    /// письма срока нет по природе, и молча прятать его было бы хуже пустой клетки.
+    /// </summary>
+    [Fact]
+    public async Task DocumentWithoutValidUntilTag_KeepsRowWithEmptyCell()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddDocAsync(scope, seed.LetterTypeId, "Письмо о продукции", "{'Рег':'исх-17'}",
+            CatalogScope.Set, seed.SetId);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var row = Assert.Single(preview!.Rows);
+        var columns = preview.Columns.ToList();
+
+        Assert.Equal("исх-17", row[columns.IndexOf("НомерДокумента")]);
+        Assert.True(string.IsNullOrEmpty(row[columns.IndexOf("СрокДействия")]));
+        Assert.Equal("нет", row[columns.IndexOf("ЕстьСкан")]);
+    }
+
+    /// <summary>Число строк живое везде, где показывается: в списке источников и в MCP-срезе (#613).</summary>
+    [Fact]
+    public async Task RowCount_IsLiveEverywhereItIsShown()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+        await AddDocAsync(scope, seed.CertTypeId, "Первый", "{}", CatalogScope.Set, seed.SetId);
+
+        var file = await svc.CreateSystemFileAsync(
+            new CreateSystemFileInput("Set", seed.SetId.ToString(), null), default);
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Качество", SystemDataSets.QualityDocumentsMarker, null), default);
+        Assert.Equal(1, source.CachedRowCount);
+
+        await AddDocAsync(scope, seed.CertTypeId, "Второй", "{}", CatalogScope.System, null);
+
+        Assert.Equal(2, Assert.Single(await svc.ListSourcesAsync(file.Id, default)).CachedRowCount);
+
+        var snapshots = scope.ServiceProvider.GetRequiredService<IDataSnapshotService>();
+        Assert.Equal(2, (await snapshots.GetSourceAsync(source.Id))!.RowCount);
+        Assert.Equal(2, (await snapshots.GetRowsAsync(source.Id, 0, 50))!.TotalRows);
+    }
+
+    /// <summary>
+    /// Уровень без объекта области (кроме «Системы») — отказ ArgumentException, и только он:
+    /// KeyNotFoundException из провайдера уронил бы весь список наборов, а не одну строку в нём.
+    /// Отказ срабатывает уже при СОЗДАНИИ источника: число строк пишется в тот же момент.
+    /// </summary>
+    [Fact]
+    public async Task LevelWithoutScopeId_IsRefusedWithArgumentException()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+        await AddDocAsync(scope, seed.CertTypeId, "Общий", "{}", CatalogScope.System, null);
+
+        var provider = scope.ServiceProvider.GetServices<ISystemDataProvider>()
+            .Single(p => p.Handles(SystemDataSets.QualityDocumentsMarker));
+        await Assert.ThrowsAsync<ArgumentException>(() => provider.ProvideAsync(
+            SystemDataSets.QualityDocumentsMarker, CatalogScope.Section, null, default));
+
+        var file = await svc.CreateSystemFileAsync(new CreateSystemFileInput("Section", null, null), default);
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Качество", SystemDataSets.QualityDocumentsMarker, null), default));
+    }
+
+    /// <summary>
+    /// А источник, СОХРАНЁННЫЙ на таком уровне (остался от версий до гейта #606 или уровень набора
+    /// изменили), список наборов не роняет: счётчик ловит отказ и показывает запомненное число.
+    /// </summary>
+    [Fact]
+    public async Task LegacySourceOnLevelWithoutScopeId_DoesNotBreakTheList()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        await SeedAsync(scope);
+
+        var file = await svc.CreateSystemFileAsync(new CreateSystemFileInput("Section", null, null), default);
+
+        // Мимо сервиса: сегодня такой источник создать нельзя — тем и ценен случай.
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var entity = await db.DataSetFiles.FirstAsync(f => f.Id == file.Id);
+        var source = entity.AddSource("Качество", SystemDataSets.QualityDocumentsMarker, "[]", 7);
+        db.DataSetSources.Add(source);
+        await db.SaveChangesAsync();
+
+        var listed = Assert.Single(await svc.ListSourcesAsync(file.Id, default));
+        Assert.Equal(source.Id, listed.Id);
+        Assert.Equal(7, listed.CachedRowCount); // запомненное число, а не падение
+    }
+
+    /// <summary>
+    /// Пустая библиотека кандидата не даёт: иначе кнопка «Данные системы» появлялась бы и в
+    /// установках, где модулем качества не пользуются.
+    /// </summary>
+    [Fact]
+    public async Task NoDocuments_NoCandidate()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+
+        Assert.DoesNotContain(await svc.ListSystemCandidatesAsync("Set", seed.SetId, default),
+            c => c.SheetOrPath == SystemDataSets.QualityDocumentsMarker);
+
+        await AddDocAsync(scope, seed.CertTypeId, "Появился", "{}", CatalogScope.System, null);
+
+        Assert.Contains(await svc.ListSystemCandidatesAsync("Set", seed.SetId, default),
+            c => c.SheetOrPath == SystemDataSets.QualityDocumentsMarker);
+        // И на уровнях, где документов комплекта нет и быть не может.
+        Assert.Contains(await svc.ListSystemCandidatesAsync("Construction", seed.ConstructionId, default),
+            c => c.SheetOrPath == SystemDataSets.QualityDocumentsMarker);
+        Assert.Contains(await svc.ListSystemCandidatesAsync("System", null, default),
+            c => c.SheetOrPath == SystemDataSets.QualityDocumentsMarker);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/SystemDataSetTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/SystemDataSetTests.cs
@@ -215,7 +215,10 @@ public class SystemDataSetTests(IntegrationTestFixture fixture) : IAsyncLifetime
         var svc = Svc(scope);
 
         var file = await svc.CreateSystemFileAsync(new CreateSystemFileInput("System", null, null), default);
-        Assert.Empty(await svc.DetectSourceCandidatesAsync(file.Id, default));
+        // Не «пусто вообще»: с #623 на любом уровне может предложиться библиотека документов
+        // качества. Проверяем ровно то, о чём тест, — документов КОМПЛЕКТА вне комплекта нет.
+        Assert.DoesNotContain(await svc.DetectSourceCandidatesAsync(file.Id, default),
+            c => c.SheetOrPath == SystemDataSets.SetDocumentsMarker);
     }
 
     /// <summary>
@@ -232,10 +235,13 @@ public class SystemDataSetTests(IntegrationTestFixture fixture) : IAsyncLifetime
         var inSet = await svc.ListSystemCandidatesAsync("Set", setId, default);
         Assert.Equal(SystemDataSets.SetDocumentsMarker, Assert.Single(inSet).SheetOrPath);
 
-        // Раздел/стройка/система: консолидировать нечего — кнопку показывать незачем.
-        Assert.Empty(await svc.ListSystemCandidatesAsync("Section", Guid.NewGuid(), default));
-        Assert.Empty(await svc.ListSystemCandidatesAsync("Construction", Guid.NewGuid(), default));
-        Assert.Empty(await svc.ListSystemCandidatesAsync("System", null, default));
+        // Раздел/стройка/система: документов комплекта там нет. Проверяем именно их отсутствие, а
+        // не пустоту списка: библиотека качества (#623) предлагается на любом уровне, если в ней
+        // есть хоть один документ, — здесь их не заводили, поэтому список пока пуст и целиком.
+        foreach (var (level, id) in ((string, Guid?)[])
+                 [("Section", Guid.NewGuid()), ("Construction", Guid.NewGuid()), ("System", null)])
+            Assert.DoesNotContain(await svc.ListSystemCandidatesAsync(level, id, default),
+                c => c.SheetOrPath == SystemDataSets.SetDocumentsMarker);
 
         await Assert.ThrowsAsync<ArgumentException>(
             () => svc.ListSystemCandidatesAsync("Ерунда", null, default));

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.81.1</Version>
+    <Version>0.82.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #623. Шаг 1 эпика #622 — второй вид системной консолидации после «Документов комплекта».

## Что сделано

`QualityDocumentsProvider` (маркер `system:quality-documents`): строка на каждый документ библиотеки качества, **видимый с уровня набора** по цепочке вверх — свой уровень → раздел → стройка → система. Предикат видимости тот же, что у `QualityLinkResolver` при генерации: иначе набор показывал бы одно, а в PDF подставлялось другое.

**13 колонок:** НомерПП, Ид, Наименование, ТипКод, ТипИмя, НомерДокумента, ДатаДокумента, СрокДействия, Изготовитель, Уровень, Источник, ЕстьСкан, ИмяФайлаСкана.

- Номер, дата, срок и изготовитель — по функциональным тэгам, а не по именам полей: у сертификата, декларации и информационного письма схемы разные. Тип без такого тэга даёт пустую ячейку, но строка не пропадает.
- Тип — из реестра по `DocumentTypeId`, **не** из реквизита «ТипДокумента»: на живой базе реквизит противоречит собственному типу документа.
- Кандидат предлагается на любом уровне, но только при непустой выдаче — иначе кнопка «Данные системы» появлялась бы и в установках, где модулем качества не пользуются.
- Единственный вид отказа — `ArgumentException` (уровень без объекта области, кроме «Системы»).

## Правка существующих тестов

`SystemCandidates_KnownBeforeFileExists` и `SetDocuments_NotOfferedOutsideSetScope` проверяли «кандидатов нет вовсе». Теперь проверяют то, о чём они на самом деле: что нет кандидата **документов комплекта**. Иначе первый же заведённый документ качества ронял бы их по причине, к ним не относящейся.

## Проверка

Девять тестов: ячейки конкретных колонок, живость строк, видимость по всей цепочке (свой/раздельный/строечный/общий видны, документ соседнего комплекта — нет), уровень «Система» видит только общесистемные, тип без тэга срока даёт пустую ячейку и остаётся в выдаче, живой счётчик строк в списках и MCP-срезе, отказ при уровне без объекта области и сохранённый источник на таком уровне не роняет список наборов.

Живая база (18 общесистемных документов, 2 комплектных): у своего комплекта **20** строк, у соседнего **18**, на уровне «Система» **18**. Тэгированные значения найдены в реальных схемах:

```
НомерДокумента  ['', 'ЕАЭС КG417/045.CN.02.00828', 'RU C-CN.HA46.B.06753/23']
Изготовитель    ['', 'CECF Electric Trading (Shanghai) Co.Ltd', …]
Уровень         ['Система', 'Комплект', 'Система']
ЕстьСкан        ['да', 'да', 'да']
```

`СрокДействия` пуст — известное ограничение #558: тэга `quality.validUntil` в данных пока нет ни у одного поля.

Backend 1029 тестов зелёные. Версия 0.82.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)