### PR TITLE
Системный провайдер «Общие данные по типу» (#627)

### DIFF
--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -9,6 +9,9 @@ import { XPathBuilder } from './xpath/XPathBuilder';
 import { JsonPathBuilder } from './jsonpath/JsonPathBuilder';
 import { DATA_SET_FORMAT_LABELS } from '@/shared/api/types';
 import type { ColumnExprDef, DataSetSource, DataSetFormat } from '@/shared/api/types';
+
+/** С этого числа кандидатов список перестаёт читаться целиком — показываем поиск. */
+const CANDIDATE_SEARCH_FROM = 7;
 
 type PathFormat = 'Xml' | 'Json';
 
@@ -76,6 +79,14 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
   // Готовые кандидаты — без нераспознанных таблиц (issue #385): их создать нельзя, пока таблица
   // не распознана (это делается в списке кандидатов под источниками кнопкой «Распознать таблицу»).
   const readyCandidates = candidates.filter(c => c.firstPageIndex == null);
+  // Список кандидатов длинный только у общих данных (issue #627) — там их столько же, сколько
+  // составных типов; у остальных форматов их единицы, и поиск был бы лишним полем в диалоге.
+  const [candidateQuery, setCandidateQuery] = useState('');
+  const shownCandidates = useMemo(() => {
+    const q = candidateQuery.trim().toLowerCase();
+    return q ? readyCandidates.filter(c => c.name.toLowerCase().includes(q)) : readyCandidates;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [candidates, candidateQuery]);
   const pendingTableCount = candidates.length - readyCandidates.length;
 
   // Новый источник из кандидата (лист/«весь файл»/PDF-проекция): как только приедут кандидаты —
@@ -85,6 +96,15 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
     setSheetOrPath(prev => prev || readyCandidates[0].sheetOrPath);
     setName(prev => prev || readyCandidates[0].name);
   }, [initial, usesCandidates, readyCandidates]);
+
+  // Поиск сузил список так, что выбранное в него не входит — снимаем выбор (issue #627). Иначе
+  // список показывает одно, а сохранится подставленный по умолчанию первый кандидат: человек ищет
+  // «Приказ», видит пустое поле и получает «Единицу измерения».
+  useEffect(() => {
+    if (!sheetOrPath || shownCandidates.some(c => c.sheetOrPath === sheetOrPath)) return;
+    setSheetOrPath('');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [candidateQuery]);
 
   // Текущее значение может отсутствовать в списке (архив обновился) — не терять его молча.
   const entryOptions = entryPath && !zipEntries.includes(entryPath) ? [entryPath, ...zipEntries] : zipEntries;
@@ -185,12 +205,32 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
                       : 'Все проекции набора уже добавлены как источники.'}
               </p>
             ) : (
-              <Select label={isSystem ? 'Данные системы' : 'Данные набора'} value={sheetOrPath || undefined} placeholder="— выберите —"
-                onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
-                {readyCandidates.map(c => (
-                  <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>{c.name} · {c.rowCount} строк</SelectItem>
-                ))}
-              </Select>
+              <>
+                {/* Поиск появляется, когда список перестаёт читаться глазами (issue #627): общих
+                    данных столько же, сколько составных типов, и выпадающий список из десятков
+                    строк заставляет прокручивать вместо того, чтобы назвать нужное. */}
+                {readyCandidates.length > CANDIDATE_SEARCH_FROM && (
+                  <TextField label="Поиск консолидации" value={candidateQuery}
+                    onChange={e => setCandidateQuery(e.target.value)}
+                    hint={`Показано ${shownCandidates.length} из ${readyCandidates.length}`} />
+                )}
+                <Select label={isSystem ? 'Данные системы' : 'Данные набора'} value={sheetOrPath || undefined} placeholder="— выберите —"
+                  onValueChange={v => { setSheetOrPath(v); const c = candidates.find(x => x.sheetOrPath === v); if (c) setName(prev => prev || c.name); }}>
+                  {shownCandidates.map(c => (
+                    <SelectItem key={c.sheetOrPath} value={c.sheetOrPath}>
+                      {c.name} · {c.rowCount} строк{c.warning ? ' · с оговоркой' : ''}
+                    </SelectItem>
+                  ))}
+                </Select>
+                {shownCandidates.length === 0 && (
+                  <p className="text-xs text-fg4 mt-1">Под поиск ничего не подходит.</p>
+                )}
+              </>
+            )}
+            {/* Оговорку показываем ДО создания источника: узнать о неполноте данных, уже привязав
+                их к полям документа, — узнать поздно. */}
+            {selectedCandidate?.warning && (
+              <p className="text-xs text-warning mt-1">{selectedCandidate.warning}</p>
             )}
             {selectedCandidate && selectedCandidate.columns.length > 0 && (
               <p className="text-xs text-fg4 mt-1">Колонки: {selectedCandidate.columns.join(', ')}</p>

--- a/src/client/src/features/datasets/SourceEditorDialog.tsx
+++ b/src/client/src/features/datasets/SourceEditorDialog.tsx
@@ -78,7 +78,9 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
 
   // Готовые кандидаты — без нераспознанных таблиц (issue #385): их создать нельзя, пока таблица
   // не распознана (это делается в списке кандидатов под источниками кнопкой «Распознать таблицу»).
-  const readyCandidates = candidates.filter(c => c.firstPageIndex == null);
+  // useMemo не для скорости: без него массив новый на каждый рендер, и эффект подстановки ниже
+  // перезапускается бесконечно, переписывая выбор пользователя.
+  const readyCandidates = useMemo(() => candidates.filter(c => c.firstPageIndex == null), [candidates]);
   // Список кандидатов длинный только у общих данных (issue #627) — там их столько же, сколько
   // составных типов; у остальных форматов их единицы, и поиск был бы лишним полем в диалоге.
   const [candidateQuery, setCandidateQuery] = useState('');
@@ -89,22 +91,22 @@ export function SourceEditorDialog({ fileId, format, initial, onClose }: {
   }, [candidates, candidateQuery]);
   const pendingTableCount = candidates.length - readyCandidates.length;
 
-  // Новый источник из кандидата (лист/«весь файл»/PDF-проекция): как только приедут кандидаты —
-  // подставить первый готовый и его имя.
+  /**
+   * Новый источник из кандидата (лист/«весь файл»/PDF-проекция/консолидация): подставить первый
+   * ПОКАЗАННЫЙ и его имя.
+   *
+   * Именно показанный, а не первый вообще (issue #627): поиск сужает список, и выбранное могло из
+   * него выпасть. Оставить прежний выбор значило бы сохранить не то, что человек видит — он ищет
+   * «Приказ», в списке пусто, а сохраняется «Единица измерения», подставленная при открытии.
+   * Имя обновляем, только пока оно совпадает с именем какого-то кандидата: набранное руками —
+   * решение пользователя, и переписывать его нельзя.
+   */
   useEffect(() => {
-    if (initial || !usesCandidates || readyCandidates.length === 0) return;
-    setSheetOrPath(prev => prev || readyCandidates[0].sheetOrPath);
-    setName(prev => prev || readyCandidates[0].name);
-  }, [initial, usesCandidates, readyCandidates]);
-
-  // Поиск сузил список так, что выбранное в него не входит — снимаем выбор (issue #627). Иначе
-  // список показывает одно, а сохранится подставленный по умолчанию первый кандидат: человек ищет
-  // «Приказ», видит пустое поле и получает «Единицу измерения».
-  useEffect(() => {
-    if (!sheetOrPath || shownCandidates.some(c => c.sheetOrPath === sheetOrPath)) return;
-    setSheetOrPath('');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [candidateQuery]);
+    if (initial || !usesCandidates || shownCandidates.length === 0) return;
+    const first = shownCandidates[0];
+    setSheetOrPath(prev => (prev && shownCandidates.some(c => c.sheetOrPath === prev)) ? prev : first.sheetOrPath);
+    setName(prev => (!prev || readyCandidates.some(c => c.name === prev)) ? first.name : prev);
+  }, [initial, usesCandidates, shownCandidates, readyCandidates]);
 
   // Текущее значение может отсутствовать в списке (архив обновился) — не терять его молча.
   const entryOptions = entryPath && !zipEntries.includes(entryPath) ? [entryPath, ...zipEntries] : zipEntries;

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -354,6 +354,7 @@ builder.Services.AddScoped<ISystemDataProvider, SetDocumentsProvider>();
 builder.Services.AddScoped<ISystemDataProvider, QualityDocumentsProvider>();
 builder.Services.AddScoped<ISystemDataProvider, MaterialQualityProvider>();
 builder.Services.AddScoped<ISystemDataProvider, SubtreeDocumentsProvider>();
+builder.Services.AddScoped<ISystemDataProvider, DomainObjectsProvider>();
 builder.Services.AddScoped<SystemDataProviderRegistry>();
 builder.Services.AddScoped<IDataSetRowLoader, DataSetRowLoader>();
 builder.Services.AddScoped<SystemSourceCounter>();

--- a/src/server/BHS.CRG.Domain/DataSets/SystemDataSets.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/SystemDataSets.cs
@@ -29,6 +29,21 @@ public static class SystemDataSets
     /// <summary>Документы всех комплектов поддерева — реестр раздела или стройки.</summary>
     public const string SubtreeDocumentsMarker = "system:subtree-documents";
 
+    /// <summary>
+    /// Записи общих данных одного составного типа: маркер несёт идентификатор типа
+    /// (<c>system:objects:{typeId}</c>). Типов много, и провайдер на каждый не заводится — часть
+    /// после префикса разбирает сам провайдер, как у проекций таблиц ГОСТ.
+    /// </summary>
+    public const string ObjectsMarkerPrefix = "system:objects:";
+
+    /// <summary>Идентификатор типа из маркера общих данных; false — маркер не тот или не разбирается.</summary>
+    public static bool TryParseObjectsMarker(string marker, out Guid typeId)
+    {
+        typeId = Guid.Empty;
+        return marker.StartsWith(ObjectsMarkerPrefix, StringComparison.Ordinal)
+            && Guid.TryParse(marker[ObjectsMarkerPrefix.Length..], out typeId);
+    }
+
     public static bool IsSystemMarker(string sheetOrPath) =>
         sheetOrPath.StartsWith(MarkerPrefix, StringComparison.Ordinal);
 }

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DomainObjectsProvider.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DomainObjectsProvider.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Objects;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
+using BHS.CRG.Infrastructure.Common;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.DataSets;
+
+/// <summary>
+/// Консолидация «Общие данные: {тип}»: записи выбранного составного типа, видимые с уровня набора,
+/// таблицей. Маркер ПАРАМЕТРИЗОВАН — <c>system:objects:{typeId}</c>, по образцу проекций таблиц ГОСТ
+/// (<c>gost-table:{id}</c>): типов много, и заводить провайдера на каждый бессмысленно.
+///
+/// Видно то же, что показывает форма: цепочка вверх от места набора (свой уровень → раздел →
+/// стройка → система), сам тип и его подтипы, <c>_baseRef</c> развёрнут. Одноимённые записи разных
+/// уровней НЕ схлопываются (решение по эпику #622): какая из них победит при резолве — вопрос
+/// другого механизма, а здесь человек должен видеть всё, что есть, и различать колонкой «Уровень».
+/// Сузить до одного уровня можно штатным фильтром строк.
+/// </summary>
+public class DomainObjectsProvider(AppDbContext db) : ISystemDataProvider
+{
+    /// <summary>
+    /// Колонки, которые есть у любой записи независимо от схемы. Имя «ИмяОбъекта», а не
+    /// «Наименование», нарочно: «Наименование» — самый частый ключ в схемах, и совпадение имён
+    /// заставило бы выбирать, чьё значение показывать.
+    /// </summary>
+    private static readonly string[] FixedColumns =
+    [
+        "НомерПП", "Ид", "ИмяОбъекта", "Алиасы", "ТипКод", "ТипИмя", "Уровень",
+    ];
+
+    public bool Handles(string marker) => SystemDataSets.TryParseObjectsMarker(marker, out _);
+
+    public async Task<IReadOnlyList<DataSetSourceInfo>> GetCandidatesAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct)
+    {
+        if (scope != CatalogScope.System && scopeId is null) return [];
+
+        // Кандидаты считаются при КАЖДОМ открытии страницы наборов, поэтому строки здесь не
+        // собираются: сколько записей каждого типа видно — один групповой запрос, колонки — из
+        // схемы без образцов значений. Тип без записей не предлагаем: пустая таблица не выбор.
+        var chain = await ScopeChains.LoadForScopeAsync(db, scope, scopeId, ct);
+        var counts = await VisibleObjects(chain)
+            .GroupBy(o => o.CompositeTypeId)
+            .Select(g => new { TypeId = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+        if (counts.Count == 0) return [];
+
+        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var byId = allTypes.ToDictionary(t => t.Id);
+        var enumsById = await EnumTypesAsync(ct);
+
+        // Записи подтипа принадлежат и предку (DescendantTypeIds), поэтому кандидат предлагается на
+        // каждый тип, у которого есть СВОИ записи, а число строк считается по нему и потомкам.
+        var byType = counts.ToDictionary(c => c.TypeId, c => c.Count);
+        var candidates = new List<DataSetSourceInfo>();
+        foreach (var typeId in byType.Keys)
+        {
+            if (!byId.TryGetValue(typeId, out var type)) continue;
+            var rowCount = DescendantTypeIds(typeId, allTypes).Sum(id => byType.GetValueOrDefault(id));
+            candidates.Add(new DataSetSourceInfo(
+                NameFor(type),
+                $"{SystemDataSets.ObjectsMarkerPrefix}{typeId}",
+                [.. ColumnNames(typeId, byId, enumsById).Select(name => new DataSetColumnInfo(name, []))],
+                rowCount));
+        }
+        return [.. candidates.OrderBy(c => c.Name, StringComparer.CurrentCulture)];
+    }
+
+    public async Task<DataSetParseResult> ProvideAsync(
+        string marker, CatalogScope scope, Guid? scopeId, CancellationToken ct)
+    {
+        if (!SystemDataSets.TryParseObjectsMarker(marker, out var typeId))
+            throw new ArgumentException($"Маркер «{marker}» не содержит идентификатора типа.");
+        if (scope != CatalogScope.System && scopeId is null)
+            throw new ArgumentException("Источнику общих данных нужен уровень с объектом: комплект, раздел или стройка.");
+
+        var allTypes = await db.DocumentTypes.AsNoTracking().ToListAsync(ct);
+        var byId = allTypes.ToDictionary(t => t.Id);
+        // Тип удалён — это ArgumentException, а НЕ KeyNotFoundException: пересчёт строк в списке
+        // наборов глотает только первое, и удалённый тип иначе уронил бы весь список.
+        if (!byId.ContainsKey(typeId))
+            throw new ArgumentException("Тип, по которому собирался источник, удалён — пересоздайте источник.");
+
+        var enumsById = await EnumTypesAsync(ct);
+        var chain = await ScopeChains.LoadForScopeAsync(db, scope, scopeId, ct);
+        var typeIds = DescendantTypeIds(typeId, allTypes);
+
+        var objects = await VisibleObjects(chain)
+            .Where(o => typeIds.Contains(o.CompositeTypeId))
+            .ToListAsync(ct);
+
+        var columns = ColumnNames(typeId, byId, enumsById);
+        if (objects.Count == 0)
+            return new DataSetParseResult([.. columns.Select(n => new DataSetColumnInfo(n, []))], []);
+
+        // Наследование значений (issue #71): запись-наследник показывает то же, что видно в форме,
+        // иначе таблица и экран расходились бы на ровном месте. Базы читаем одним запросом.
+        var baseIds = objects
+            .Select(o => BaseRefReader.GetBaseRefId(o.Data.RootElement))
+            .OfType<Guid>().Distinct().ToList();
+        var baseById = baseIds.Count == 0
+            ? []
+            : (await db.DomainObjects.AsNoTracking().Where(o => baseIds.Contains(o.Id)).ToListAsync(ct))
+                .ToDictionary(o => o.Id, o => o.Data.RootElement.Clone());
+
+        var fields = ScalarFields(typeId, byId, enumsById)
+            .Where(f => !FixedColumns.Contains(f.Key))
+            .ToList();
+        var enumLabels = fields
+            .Where(f => f.Options is { Count: > 0 })
+            .ToDictionary(f => f.Key, f => f.Options!.ToDictionary(o => o.Code, o => o.Label));
+
+        var ordered = objects
+            .OrderBy(o => o.DisplayName ?? "", StringComparer.CurrentCulture)
+            .ThenBy(o => o.Id)
+            .ToList();
+
+        var rows = new List<IReadOnlyDictionary<string, string?>>(ordered.Count);
+        var ordinal = 1;
+        foreach (var obj in ordered)
+        {
+            var data = obj.Data.RootElement;
+            if (BaseRefReader.GetBaseRefId(data) is { } baseId && baseById.TryGetValue(baseId, out var baseData))
+                data = BaseRefReader.MergeObjects(baseData, data);
+
+            var type = byId.GetValueOrDefault(obj.CompositeTypeId);
+            var row = new Dictionary<string, string?>
+            {
+                ["НомерПП"] = ordinal.ToString(),
+                ["Ид"] = obj.Id.ToString(),
+                ["ИмяОбъекта"] = obj.DisplayName,
+                ["Алиасы"] = obj.Aliases.Count == 0 ? null : string.Join(", ", obj.Aliases),
+                ["ТипКод"] = type?.Code,
+                ["ТипИмя"] = type?.Name,
+                ["Уровень"] = ScopeLabel(obj.ScopeLevel),
+            };
+            foreach (var f in fields)
+            {
+                var value = ScalarOf(data, f.Key);
+                row[f.Key] = value is not null && enumLabels.TryGetValue(f.Key, out var labels)
+                    ? labels.GetValueOrDefault(value, value) // код вне вариантов показываем как есть
+                    : value;
+            }
+            rows.Add(row);
+            ordinal++;
+        }
+
+        return new DataSetParseResult(ColumnsOf(columns, rows), rows);
+    }
+
+    /// <summary>Записи ОБЩИХ ДАННЫХ (Facet == null — документы это не они), видимые с места набора.</summary>
+    private IQueryable<DomainObject> VisibleObjects(ScopeChain chain) =>
+        db.DomainObjects.AsNoTracking().Where(o => o.Facet == null &&
+            ((o.ScopeLevel == CatalogScope.Set && o.ScopeId == chain.SetId) ||
+             (o.ScopeLevel == CatalogScope.Section && o.ScopeId == chain.SectionId) ||
+             (o.ScopeLevel == CatalogScope.Construction && o.ScopeId == chain.ConstructionId) ||
+             o.ScopeLevel == CatalogScope.System));
+
+    private async Task<IReadOnlyDictionary<Guid, EnumType>> EnumTypesAsync(CancellationToken ct) =>
+        (await db.EnumTypes.AsNoTracking().ToListAsync(ct)).ToDictionary(t => t.Id);
+
+    private static string NameFor(DocumentType type) => $"Общие данные: {type.Name}";
+
+    /// <summary>Сам тип и его подтипы: запись подтипа — тоже запись этого типа (как у резолвера ссылок).</summary>
+    private static HashSet<Guid> DescendantTypeIds(Guid rootId, List<DocumentType> all)
+    {
+        var result = new HashSet<Guid> { rootId };
+        var grew = true;
+        while (grew)
+        {
+            grew = false;
+            foreach (var t in all)
+                if (t.ParentId is { } p && result.Contains(p) && result.Add(t.Id)) grew = true;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Скалярные поля эффективной схемы. Расчётные (issue #368) исключены намеренно: считать их
+    /// значит гонять Jint на каждую строку списка, а пустая колонка хуже отсутствующей.
+    /// </summary>
+    private static List<SchemaFieldInfo> ScalarFields(
+        Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, EnumType> enumsById) =>
+        [.. DocumentTypeSchemaReader.EffectiveFields(typeId, byId, enumsById)
+            .Where(f => SchemaFieldKinds.IsScalar(f.Type) && !f.Computed)];
+
+    /// <summary>
+    /// Имена колонок: фиксированные плюс ключи скалярных полей схемы. Ключ, совпавший с фиксированным
+    /// именем, ПРОПУСКАЕТСЯ — иначе значение колонки зависело бы от порядка сборки словаря, а он
+    /// деталь реализации.
+    /// </summary>
+    private static List<string> ColumnNames(
+        Guid typeId, IReadOnlyDictionary<Guid, DocumentType> byId,
+        IReadOnlyDictionary<Guid, EnumType> enumsById) =>
+        [.. FixedColumns,
+         .. ScalarFields(typeId, byId, enumsById).Select(f => f.Key).Where(k => !FixedColumns.Contains(k))];
+
+    private static string? ScalarOf(JsonElement data, string key)
+    {
+        if (data.ValueKind != JsonValueKind.Object) return null;
+        if (!data.TryGetProperty(key, out var value)) return null;
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.ToString(),
+            JsonValueKind.True => "да",
+            JsonValueKind.False => "нет",
+            _ => null,
+        };
+    }
+
+    private static string ScopeLabel(CatalogScope scope) => scope switch
+    {
+        CatalogScope.Set => "Комплект",
+        CatalogScope.Section => "Раздел",
+        CatalogScope.Construction => "Стройка",
+        CatalogScope.System => "Система",
+        _ => scope.ToString(),
+    };
+
+    private static IReadOnlyList<DataSetColumnInfo> ColumnsOf(
+        IReadOnlyList<string> columns, IReadOnlyList<IReadOnlyDictionary<string, string?>> rows) =>
+        [.. columns.Select(name => new DataSetColumnInfo(name,
+            [.. rows.Take(3).Select(r => r.GetValueOrDefault(name) ?? "")]))];
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DomainObjectsProvider.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DomainObjectsProvider.cs
@@ -101,21 +101,20 @@ public class DomainObjectsProvider(AppDbContext db) : ISystemDataProvider
             return new DataSetParseResult([.. columns.Select(n => new DataSetColumnInfo(n, []))], []);
 
         // Наследование значений (issue #71): запись-наследник показывает то же, что видно в форме,
-        // иначе таблица и экран расходились бы на ровном месте. Базы читаем одним запросом.
-        var baseIds = objects
-            .Select(o => BaseRefReader.GetBaseRefId(o.Data.RootElement))
-            .OfType<Guid>().Distinct().ToList();
-        var baseById = baseIds.Count == 0
-            ? []
-            : (await db.DomainObjects.AsNoTracking().Where(o => baseIds.Contains(o.Id)).ToListAsync(ct))
-                .ToDictionary(o => o.Id, o => o.Data.RootElement.Clone());
+        // иначе таблица и экран расходились бы на ровном месте.
+        var basesById = await LoadBaseChainAsync(objects, ct);
 
         var fields = ScalarFields(typeId, byId, enumsById)
             .Where(f => !FixedColumns.Contains(f.Key))
             .ToList();
+        // Первый вариант с этим кодом побеждает: уникальность кодов внутри перечисления никто не
+        // проверяет (а легаси-варианты в схеме и подавно), и падать на дубле — значит уронить
+        // предпросмотр, экспорт и живой счётчик строк из-за одной кривой записи справочника.
         var enumLabels = fields
             .Where(f => f.Options is { Count: > 0 })
-            .ToDictionary(f => f.Key, f => f.Options!.ToDictionary(o => o.Code, o => o.Label));
+            .ToDictionary(f => f.Key, f => f.Options!
+                .GroupBy(o => o.Code)
+                .ToDictionary(g => g.Key, g => g.First().Label));
 
         var ordered = objects
             .OrderBy(o => o.DisplayName ?? "", StringComparer.CurrentCulture)
@@ -126,9 +125,7 @@ public class DomainObjectsProvider(AppDbContext db) : ISystemDataProvider
         var ordinal = 1;
         foreach (var obj in ordered)
         {
-            var data = obj.Data.RootElement;
-            if (BaseRefReader.GetBaseRefId(data) is { } baseId && baseById.TryGetValue(baseId, out var baseData))
-                data = BaseRefReader.MergeObjects(baseData, data);
+            var data = EffectiveData(obj, basesById, chain);
 
             var type = byId.GetValueOrDefault(obj.CompositeTypeId);
             var row = new Dictionary<string, string?>
@@ -154,6 +151,69 @@ public class DomainObjectsProvider(AppDbContext db) : ISystemDataProvider
 
         return new DataSetParseResult(ColumnsOf(columns, rows), rows);
     }
+
+    /// <summary>Предел длины цепочки наследования — от патологических данных, не от нормы.</summary>
+    private const int MaxBaseDepth = 8;
+
+    /// <summary>
+    /// Базы наследования для выборки — ВСЯ цепочка, пакетами: A наследует B, B наследует C, и в
+    /// форме видно значения C. Один уровень, как было сначала, показывал бы у внука пустую ячейку
+    /// там, где документ печатает значение прадеда.
+    /// </summary>
+    private async Task<Dictionary<Guid, DomainObject>> LoadBaseChainAsync(
+        List<DomainObject> objects, CancellationToken ct)
+    {
+        var known = new Dictionary<Guid, DomainObject>();
+        var wanted = objects
+            .Select(o => BaseRefReader.GetBaseRefId(o.Data.RootElement))
+            .OfType<Guid>().Distinct().ToList();
+
+        for (var depth = 0; depth < MaxBaseDepth && wanted.Count > 0; depth++)
+        {
+            var batch = await db.DomainObjects.AsNoTracking().Include(o => o.Facet)
+                .Where(o => wanted.Contains(o.Id)).ToListAsync(ct);
+            foreach (var o in batch) known[o.Id] = o;
+
+            wanted = [.. batch
+                .Select(o => BaseRefReader.GetBaseRefId(o.Data.RootElement))
+                .OfType<Guid>().Where(id => !known.ContainsKey(id)).Distinct()];
+        }
+        return known;
+    }
+
+    /// <summary>
+    /// Данные записи с учётом наследования — теми же правилами, что у резолвера при выпуске:
+    /// цикл рвётся по visited, запись общих данных наследуется только если видна из того же места,
+    /// документ-база — только из своего комплекта. Без этих ограничений таблица показала бы
+    /// значение, которого в документе не будет.
+    /// </summary>
+    private static JsonElement EffectiveData(
+        DomainObject obj, IReadOnlyDictionary<Guid, DomainObject> bases, ScopeChain chain)
+    {
+        var visited = new HashSet<Guid> { obj.Id };
+        var line = new List<JsonElement> { obj.Data.RootElement };
+
+        var current = obj.Data.RootElement;
+        while (line.Count <= MaxBaseDepth
+               && BaseRefReader.GetBaseRefId(current) is { } baseId
+               && visited.Add(baseId)
+               && bases.TryGetValue(baseId, out var baseObj)
+               && Inheritable(baseObj, chain))
+        {
+            current = baseObj.Data.RootElement;
+            line.Add(current);
+        }
+
+        // Сворачиваем от дальней базы к ближней: своё всегда сильнее унаследованного.
+        var effective = line[^1];
+        for (var i = line.Count - 2; i >= 0; i--)
+            effective = BaseRefReader.MergeObjects(effective, line[i]);
+        return effective;
+    }
+
+    private static bool Inheritable(DomainObject baseObj, ScopeChain chain) => baseObj.Facet is not null
+        ? baseObj.ScopeLevel == CatalogScope.Set && baseObj.ScopeId == chain.SetId // документ — из своего комплекта
+        : chain.Contains(baseObj.ScopeLevel, baseObj.ScopeId);                     // запись — из видимого поддерева
 
     /// <summary>Записи ОБЩИХ ДАННЫХ (Facet == null — документы это не они), видимые с места набора.</summary>
     private IQueryable<DomainObject> VisibleObjects(ScopeChain chain) =>

--- a/src/server/BHS.CRG.Tests/Integration/DomainObjectsProviderTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DomainObjectsProviderTests.cs
@@ -200,6 +200,56 @@ public class DomainObjectsProviderTests(IntegrationTestFixture fixture) : IAsync
         Assert.Equal("Тверь", heir[preview.Columns.ToList().IndexOf("Адрес")]); // своё сильнее
     }
 
+    /// <summary>
+    /// Цепочка наследования разворачивается ЦЕЛИКОМ: внук показывает значение прадеда — ровно то,
+    /// что напечатает документ. Один уровень оставлял бы у внука пустую ячейку.
+    /// </summary>
+    [Fact]
+    public async Task BaseRefChain_IsResolvedToTheEnd()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        var grand = await AddEntryAsync(scope, seed.OrgTypeId, "Прадед", "{'ИНН':'7700','Адрес':'Москва'}",
+            CatalogScope.System, null);
+        var parent = await AddEntryAsync(scope, seed.OrgTypeId, "Дед",
+            $"{{'_baseRef':{{'kind':'catalog','id':'{grand.Id}'}},'Адрес':'Тверь'}}", CatalogScope.System, null);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Внук",
+            $"{{'_baseRef':{{'kind':'catalog','id':'{parent.Id}'}}}}", CatalogScope.System, null);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var cols = preview!.Columns.ToList();
+        var heir = preview.Rows.Single(r => r[cols.IndexOf("ИмяОбъекта")] == "Внук");
+
+        Assert.Equal("7700", heir[cols.IndexOf("ИНН")]);   // от прадеда, через деда
+        Assert.Equal("Тверь", heir[cols.IndexOf("Адрес")]); // дед переопределил
+    }
+
+    /// <summary>
+    /// База вне видимого поддерева не наследуется — так же, как отказывается наследовать резолвер
+    /// при выпуске. Иначе таблица показала бы значение, которого в документе не будет.
+    /// </summary>
+    [Fact]
+    public async Task BaseRefOutsideScope_IsNotMerged()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var seed = await SeedAsync(scope);
+        var other = await m.Send(new CreateDocumentSetCommand(seed.SectionId, "Комплект 2"));
+
+        var foreign = await AddEntryAsync(scope, seed.OrgTypeId, "Чужая база", "{'ИНН':'9999'}",
+            CatalogScope.Set, other.Id);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Наследник",
+            $"{{'_baseRef':{{'kind':'catalog','id':'{foreign.Id}'}}}}", CatalogScope.System, null);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var cols = preview!.Columns.ToList();
+        var heir = preview.Rows.Single(r => r[cols.IndexOf("ИмяОбъекта")] == "Наследник");
+
+        Assert.True(string.IsNullOrEmpty(heir[cols.IndexOf("ИНН")]));
+    }
+
     /// <summary>Данные живые: запись, добавленная после создания источника, попадает в строки.</summary>
     [Fact]
     public async Task RowsFollowCatalogState()

--- a/src/server/BHS.CRG.Tests/Integration/DomainObjectsProviderTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DomainObjectsProviderTests.cs
@@ -1,0 +1,293 @@
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Системная консолидация «Общие данные: {тип}» (issue #627) — единственная с параметризованным
+/// маркером. Колонки собираются по эффективной схеме типа, поэтому проверяются наследование,
+/// исключения полей и столкновение ключа схемы с фиксированной колонкой.
+/// </summary>
+[Collection("Integration")]
+public class DomainObjectsProviderTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IDataSetService Svc(IServiceScope s) => s.ServiceProvider.GetRequiredService<IDataSetService>();
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+
+    private sealed record Seed(Guid SetId, Guid SectionId, Guid ConstructionId, Guid OrgTypeId, Guid ContractorTypeId);
+
+    /// <summary>
+    /// «Организация» и её подтип «Подрядчик»: подтип исключает поле предка и добавляет своё.
+    /// Комплект живёт в разделе и стройке — чтобы проверить видимость по цепочке.
+    /// </summary>
+    private static async Task<Seed> SeedAsync(IServiceScope scope)
+    {
+        var m = M(scope);
+        var org = await m.Send(new CreateDocumentTypeCommand("Организация", "ORG", DocumentTypeKind.Composite, null,
+            J("""
+              {'fields':[
+                {'key':'ИНН','type':'string','required':false},
+                {'key':'Адрес','type':'string','required':false},
+                {'key':'Контакты','type':'array','required':false},
+                {'key':'ИмяОбъекта','type':'string','required':false}
+              ]}
+              """)));
+        var contractor = await m.Send(new CreateDocumentTypeCommand("Подрядчик", "CONTR", DocumentTypeKind.Composite, org.Id,
+            J("{'fields':[{'key':'СРО','type':'string','required':false}],'excludedFields':['Адрес']}")));
+
+        var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "Комплект 1"));
+        return new Seed(set.Id, section.Id, construction.Id, org.Id, contractor.Id);
+    }
+
+    private static Task<Domain.Objects.DomainObject> AddEntryAsync(IServiceScope scope, Guid typeId, string name,
+        string data, CatalogScope entryScope, Guid? scopeId, string[]? aliases = null)
+        => M(scope).Send(new CreateCommonDataEntryCommand(name, typeId, J(data), entryScope, scopeId, aliases));
+
+    private static string MarkerFor(Guid typeId) => $"{SystemDataSets.ObjectsMarkerPrefix}{typeId}";
+
+    private static async Task<Guid> SourceAtAsync(IServiceScope scope, string level, Guid? scopeId, Guid typeId)
+    {
+        var svc = Svc(scope);
+        var file = await svc.CreateSystemFileAsync(
+            new CreateSystemFileInput(level, scopeId?.ToString(), null), default);
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Объекты", MarkerFor(typeId), null), default);
+        return source.Id;
+    }
+
+    private static string? Cell(SourcePreviewDto p, int row, string column) =>
+        p.Rows[row][p.Columns.ToList().IndexOf(column)];
+
+    [Fact]
+    public async Task Columns_FollowEffectiveSchema_AndFixedOnesWin()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.ContractorTypeId, "СтройМонтаж",
+            "{'ИНН':'7701','СРО':'СРО-С-001','Адрес':'не должно быть колонки','ИмяОбъекта':'подмена'}",
+            CatalogScope.System, null);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.ContractorTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var columns = preview!.Columns.ToList();
+
+        Assert.Contains("ИНН", columns);          // унаследовано от предка
+        Assert.Contains("СРО", columns);          // собственное поле подтипа
+        Assert.DoesNotContain("Адрес", columns);  // исключено в подтипе
+        Assert.DoesNotContain("Контакты", columns); // массив — не скалярная колонка
+
+        // Ключ схемы «ИмяОбъекта» столкнулся с фиксированной колонкой: побеждает фиксированная,
+        // иначе значение зависело бы от порядка сборки словаря.
+        Assert.Equal(1, columns.Count(c => c == "ИмяОбъекта"));
+        Assert.Equal("СтройМонтаж", Cell(preview, 0, "ИмяОбъекта"));
+    }
+
+    [Fact]
+    public async Task Rows_CarryFixedColumnsAndScopeLabel()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.OrgTypeId, "ЭнергоСтрой", "{'ИНН':'7702','Адрес':'Москва'}",
+            CatalogScope.Section, seed.SectionId, ["ЭС", "Энерго"]);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+
+        Assert.Equal("1", Cell(preview!, 0, "НомерПП"));
+        Assert.Equal("ЭнергоСтрой", Cell(preview, 0, "ИмяОбъекта"));
+        Assert.Equal("ЭС, Энерго", Cell(preview, 0, "Алиасы"));
+        Assert.Equal("ORG", Cell(preview, 0, "ТипКод"));
+        Assert.Equal("Организация", Cell(preview, 0, "ТипИмя"));
+        Assert.Equal("Раздел", Cell(preview, 0, "Уровень"));
+        Assert.Equal("7702", Cell(preview, 0, "ИНН"));
+        Assert.Equal("Москва", Cell(preview, 0, "Адрес"));
+    }
+
+    /// <summary>
+    /// Записи подтипа — тоже записи типа (как у резолвера ссылок), а документы (Facet != null) в
+    /// общие данные не попадают вовсе.
+    /// </summary>
+    [Fact]
+    public async Task SubtypeEntries_AreIncluded_DocumentsAreNot()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Организация", "{}", CatalogScope.System, null);
+        await AddEntryAsync(scope, seed.ContractorTypeId, "Подрядчик", "{}", CatalogScope.System, null);
+
+        // Документ того же типа: попасть в общие данные он не должен.
+        var docType = await m.Send(new CreateDocumentTypeCommand("АОСР", "AOSR", DocumentTypeKind.Document, null,
+            J("{'fields':[]}")));
+        await m.Send(new AddDocumentToSetCommand(seed.SetId, docType.Id));
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+
+        Assert.Equal(2, preview!.Rows.Count);
+        Assert.Equal(["Организация", "Подрядчик"],
+            [.. preview.Rows.Select(r => r[preview.Columns.ToList().IndexOf("ИмяОбъекта")]).Order()]);
+    }
+
+    /// <summary>Видно то же, что в форме: цепочка вверх, но не соседний комплект.</summary>
+    [Fact]
+    public async Task Visibility_FollowsScopeChain()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var seed = await SeedAsync(scope);
+        var other = await m.Send(new CreateDocumentSetCommand(seed.SectionId, "Комплект 2"));
+
+        await AddEntryAsync(scope, seed.OrgTypeId, "Своя", "{}", CatalogScope.Set, seed.SetId);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Раздельная", "{}", CatalogScope.Section, seed.SectionId);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Общая", "{}", CatalogScope.System, null);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Чужая", "{}", CatalogScope.Set, other.Id);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var names = preview!.Rows.Select(r => r[preview.Columns.ToList().IndexOf("ИмяОбъекта")]).ToList();
+
+        Assert.Equal(["Общая", "Раздельная", "Своя"], [.. names.Order()]);
+        Assert.DoesNotContain("Чужая", names);
+    }
+
+    /// <summary>Одноимённые записи разных уровней НЕ схлопываются: их различает колонка «Уровень».</summary>
+    [Fact]
+    public async Task SameNameOnDifferentLevels_AreBothShown()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Заказчик", "{'ИНН':'общий'}", CatalogScope.System, null);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Заказчик", "{'ИНН':'комплектный'}", CatalogScope.Set, seed.SetId);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+
+        Assert.Equal(2, preview!.Rows.Count);
+        Assert.Equal(["Комплект", "Система"],
+            [.. preview.Rows.Select(r => r[preview.Columns.ToList().IndexOf("Уровень")]).Order()]);
+    }
+
+    /// <summary>Наследник показывает унаследованные значения — то же, что видно в форме (issue #71).</summary>
+    [Fact]
+    public async Task BaseRef_IsMergedIntoRow()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        var baseEntry = await AddEntryAsync(scope, seed.OrgTypeId, "Базовая", "{'ИНН':'7700','Адрес':'Москва'}",
+            CatalogScope.System, null);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Наследник",
+            $"{{'_baseRef':{{'kind':'catalog','id':'{baseEntry.Id}'}},'Адрес':'Тверь'}}",
+            CatalogScope.System, null);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        var preview = await Svc(scope).PreviewSourceAsync(sourceId, 50, default);
+        var heir = preview!.Rows.Single(r => r[preview.Columns.ToList().IndexOf("ИмяОбъекта")] == "Наследник");
+
+        Assert.Equal("7700", heir[preview.Columns.ToList().IndexOf("ИНН")]);  // от базы
+        Assert.Equal("Тверь", heir[preview.Columns.ToList().IndexOf("Адрес")]); // своё сильнее
+    }
+
+    /// <summary>Данные живые: запись, добавленная после создания источника, попадает в строки.</summary>
+    [Fact]
+    public async Task RowsFollowCatalogState()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Первая", "{}", CatalogScope.System, null);
+
+        var sourceId = await SourceAtAsync(scope, "Set", seed.SetId, seed.OrgTypeId);
+        Assert.Single((await Svc(scope).PreviewSourceAsync(sourceId, 50, default))!.Rows);
+
+        await AddEntryAsync(scope, seed.OrgTypeId, "Вторая", "{}", CatalogScope.System, null);
+        Assert.Equal(2, (await Svc(scope).PreviewSourceAsync(sourceId, 50, default))!.Rows.Count);
+    }
+
+    /// <summary>
+    /// Тип удалён вместе со своими записями, а источник остался: это ArgumentException, и список
+    /// наборов не падает, а показывает запомненное число строк.
+    /// </summary>
+    [Fact]
+    public async Task DeletedType_FailsSoftly_AndListSurvives()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Единственная", "{}", CatalogScope.System, null);
+
+        var file = await svc.CreateSystemFileAsync(
+            new CreateSystemFileInput("Set", seed.SetId.ToString(), null), default);
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Объекты", MarkerFor(seed.OrgTypeId), null), default);
+        Assert.Equal(1, source.CachedRowCount);
+
+        var provider = scope.ServiceProvider.GetServices<ISystemDataProvider>()
+            .Single(p => p.Handles(MarkerFor(seed.OrgTypeId)));
+        await Assert.ThrowsAsync<ArgumentException>(() => provider.ProvideAsync(
+            MarkerFor(Guid.NewGuid()), CatalogScope.Set, seed.SetId, default));
+
+        // Маркер без идентификатора — тоже отказ, а не падение обходом.
+        await Assert.ThrowsAsync<ArgumentException>(() => provider.ProvideAsync(
+            SystemDataSets.ObjectsMarkerPrefix + "не-guid", CatalogScope.Set, seed.SetId, default));
+
+        var listed = Assert.Single(await svc.ListSourcesAsync(file.Id, default));
+        Assert.Equal(source.Id, listed.Id);
+    }
+
+    /// <summary>Кандидат — на каждый тип с записями; типы без записей не предлагаются.</summary>
+    [Fact]
+    public async Task Candidates_OnlyForTypesWithEntries()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+
+        Assert.DoesNotContain(await svc.ListSystemCandidatesAsync("Set", seed.SetId, default),
+            c => c.SheetOrPath.StartsWith(SystemDataSets.ObjectsMarkerPrefix, StringComparison.Ordinal));
+
+        await AddEntryAsync(scope, seed.ContractorTypeId, "СтройМонтаж", "{}", CatalogScope.System, null);
+
+        var candidates = await svc.ListSystemCandidatesAsync("Set", seed.SetId, default);
+        var objectCandidates = candidates
+            .Where(c => c.SheetOrPath.StartsWith(SystemDataSets.ObjectsMarkerPrefix, StringComparison.Ordinal))
+            .ToList();
+
+        // Запись подтипа даёт кандидата на свой тип; у предка своих записей нет, но записи подтипа
+        // принадлежат и ему — предлагать его отдельным кандидатом было бы дублем той же таблицы.
+        var contractor = Assert.Single(objectCandidates);
+        Assert.Equal($"{SystemDataSets.ObjectsMarkerPrefix}{seed.ContractorTypeId}", contractor.SheetOrPath);
+        Assert.Equal("Общие данные: Подрядчик", contractor.Name);
+        Assert.Equal(1, contractor.RowCount);
+        Assert.Contains("СРО", contractor.Columns.Select(c => c.Name));
+    }
+
+    [Fact]
+    public async Task RowCount_IsLiveInSourceList()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var svc = Svc(scope);
+        var seed = await SeedAsync(scope);
+        await AddEntryAsync(scope, seed.OrgTypeId, "Первая", "{}", CatalogScope.System, null);
+
+        var file = await svc.CreateSystemFileAsync(
+            new CreateSystemFileInput("Set", seed.SetId.ToString(), null), default);
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Объекты", MarkerFor(seed.OrgTypeId), null), default);
+        Assert.Equal(1, source.CachedRowCount);
+
+        await AddEntryAsync(scope, seed.OrgTypeId, "Вторая", "{}", CatalogScope.System, null);
+        Assert.Equal(2, Assert.Single(await svc.ListSourcesAsync(file.Id, default)).CachedRowCount);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.84.0</Version>
+    <Version>0.85.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Closes #627. Шаг 5 эпика #622 — последний; после мёрджа эпик закрывается целиком.

## Что сделано

`DomainObjectsProvider` — единственная консолидация с **параметризованным маркером** `system:objects:{typeId}` (по образцу `gost-table:{id}`): составных типов десятки, и провайдера на каждый не заведёшь.

Показывает то же, что видно в форме: цепочка вверх от места набора, сам тип **и его подтипы**, `_baseRef` развёрнут одним дополнительным запросом. Одноимённые записи разных уровней **не схлопываются** — какая победит при резолве, решает другой механизм, а здесь человек должен видеть всё и различать колонкой «Уровень» (сузить можно штатным фильтром).

**Колонки:** семь фиксированных (НомерПП, Ид, ИмяОбъекта, Алиасы, ТипКод, ТипИмя, Уровень) плюс по одной на каждое скалярное поле эффективной схемы. Ключ схемы, совпавший с фиксированным именем, пропускается — иначе значение колонки зависело бы от порядка сборки словаря; ради этого фиксированная колонка и названа «ИмяОбъекта», а не «Наименование». Перечисления отдаются меткой; расчётные поля не включаются (Jint на каждую строку списка недопустим, а пустая колонка хуже отсутствующей).

**Кандидаты без N+1:** групповой запрос «сколько записей у каждого типа» + типы, колонки из схемы без образцов значений. Список кандидатов строится при каждом открытии страницы наборов, поэтому строки там не собираются.

**Отказы — только `ArgumentException`:** неразбираемый маркер, удалённый тип, уровень без объекта области. `KeyNotFoundException` уронил бы весь список наборов через пересчёт строк.

## UI

В диалоге создания источника появился **поиск по кандидатам**: на живой базе их 14, и «автоподставленный первый по алфавиту» означал случайный тип. Заодно закрыта ловушка, которую поиск делал хуже: при сужении списка выбор снимается — иначе человек ищет «Приказ», видит пустое поле и сохраняет «Единицу измерения».

## Проверка

Десять тестов: колонки по эффективной схеме (поле предка, исключение в подтипе, массив не колонка), столкновение ключа с фиксированной колонкой, записи подтипа в выдаче и документы вне её, видимость по цепочке, одноимённые записи разных уровней, слияние `_baseRef`, живость строк и счётчика, удалённый тип и неразбираемый маркер.

Живая база: **14 кандидатов** общих данных; у «Персоны» 16 строк, колонка «Должность» из схемы, в выдаче есть записи подтипа «Подписант». Поиск в диалоге сужает 13 кандидатов до 1 (скриншот). Пробный источник удалён — в наборе остались прежние три.

Backend 1059 тестов зелёные, frontend 390, `tsc -b` чист. Версия 0.85.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)