### PR TITLE
Распознавание знает типы полей, форма качества проверяет ограничения (#654, #655)

### DIFF
--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -21,7 +21,8 @@ import {
 } from '@/shared/api/schema';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
 import { recognizeDocument } from '@/shared/api/qualityDocs';
-import { flattenLeaves, applyRecognized } from '@/features/quality-docs/QualityDocForm';
+import { applyRecognized } from '@/features/quality-docs/QualityDocForm';
+import { buildRecognitionFields, codesFromLabels } from '@/features/quality-docs/recognitionFields';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
 import { computeBoundFieldKeys, mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
@@ -287,12 +288,15 @@ export function CatalogEntryForm({
     if (!attachment || !selectedType) return;
     setRecognizing(true); setError('');
     try {
+      // Тот же контракт типов, что и у документов качества (issue #654): модель видит варианты
+      // перечислений и базовый тип примитива, а её ответ отображается обратно в коды.
+      const plan = buildRecognitionFields(effectiveFields, allDocTypes, { primitiveTypes, enumTypes });
       const rec = await recognizeDocument({
         blobPath: attachment.blobPath, mimeType: attachment.mimeType,
-        fields: flattenLeaves(effectiveFields, allDocTypes),
+        fields: plan.fields,
         promptKind: 'titleblock',
       });
-      let next = applyRecognized(values, rec.values);
+      let next = applyRecognized(values, codesFromLabels(rec.values, plan.enumCodes));
       // Число страниц надёжнее брать из самого файла, чем просить модель прочитать его на штампе.
       if (rec.pageCount != null) {
         const p = findTaggedFieldPath(selectedType, FUNCTIONAL_TAG.docPageCount, allDocTypes);

--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -19,6 +19,8 @@ import {
   typeHasTag, findTaggedFieldPath, collectMaterialRows, materialIdentityKeys,
 } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
+import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
 import { identityKey, isIdentityKeyEmpty, normalizeKey } from '@/shared/api/identityKey';
 import {
   assessBulkLink, collectStrings, collidingIdentities, docHaystackStems, relevance, weighted,
@@ -99,6 +101,9 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
   const [searching, setSearching] = useState(false);
   const [importingUrl, setImportingUrl] = useState<string | null>(null);
   const [searchError, setSearchError] = useState('');
+  // Определения типов полей нужны распознаванию импортированного скана (issue #654).
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
 
   // Сброс и инициализация при открытии: строку поиска заполняем материалом.
   useEffect(() => {
@@ -148,7 +153,10 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
     try {
       let doc = await importQualityDocFromUrl({ url: c.url, title: c.title, documentTypeId: searchType, scope, scopeId });
       // Автоматически распознаём скан импортированного документа (best-effort).
-      try { doc = await recognizeAndUpdate(doc, allDocTypes); } catch { /* распознавание не критично */ }
+      // Определения типов — чтобы распознавание увидело варианты перечислений и вернуло КОДЫ,
+      // а не подписи (issue #654): формы здесь нет, расхождение показать некому.
+      try { doc = await recognizeAndUpdate(doc, allDocTypes, { primitiveTypes, enumTypes }); }
+      catch { /* распознавание не критично */ }
       onPick(doc);
     } catch (e: unknown) {
       setSearchError(e instanceof Error ? e.message : 'Не удалось импортировать');

--- a/src/client/src/features/quality-docs/QualityDocForm.tsx
+++ b/src/client/src/features/quality-docs/QualityDocForm.tsx
@@ -7,8 +7,9 @@ import type { PickType } from '@/shared/ui/TypePicker';
 import { TextField } from '@/shared/ui/TextField';
 import {
   useCreateQualityDoc, useUpdateQualityDoc, useSetQualityDocScan, recognizeDocument,
-  type QualityDocument, type RecognitionFieldReq,
+  type QualityDocument,
 } from '@/shared/api/qualityDocs';
+import { buildRecognitionFields, codesFromLabels } from './recognitionFields';
 import { uploadAttachment, openAttachmentInNewTab } from '@/shared/api/attachments';
 import type { DocumentType, CatalogScope } from '@/shared/api/types';
 import { resolveEffectiveFields, typeHasTag, findTaggedFieldPath, type SchemaField } from '@/shared/api/schema';
@@ -17,29 +18,12 @@ import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
 import {
   PrimitiveInput, ComplexFieldGroup, ArrayFieldEditor, DocRefCatalogPickerField, ImageField, FileField,
+  validateConstraint, collectConstraintViolations, describeViolationPath,
 } from '@/features/document-sets/fields';
 import { useUploadsInFlight } from '@/shared/ui/uploadsInFlight';
 
 /** Поля, занимающие обе колонки сетки — тот же набор, что в редакторе реквизитов (`RequisitesTab`). */
 const WIDE_TYPES = new Set(['complex', 'array', 'doc-ref', 'doc-array', 'image', 'file', 'text']);
-
-/** Разворачивает поля типа в плоские «листья» (путь через точку) для распознавания. */
-export function flattenLeaves(fields: SchemaField[], allDocTypes: DocumentType[], prefix = '', depth = 0): RecognitionFieldReq[] {
-  if (depth > 3) return [];
-  const out: RecognitionFieldReq[] = [];
-  for (const f of fields) {
-    const path = prefix ? `${prefix}.${f.key}` : f.key;
-    if (f.type === 'complex' && f.typeId) {
-      const ct = allDocTypes.find(d => d.id === f.typeId);
-      if (ct) out.push(...flattenLeaves(resolveEffectiveFields(ct, allDocTypes), allDocTypes, path, depth + 1));
-    } else if (['array', 'doc-ref', 'doc-array', 'image', 'file'].includes(f.type)) {
-      // для распознавания пропускаем
-    } else {
-      out.push({ path, title: f.title, type: f.type, options: f.options });
-    }
-  }
-  return out;
-}
 
 /** Раскладывает плоские значения (путь через точку) во вложенный объект и сливает с текущими. */
 export function applyRecognized(values: Record<string, unknown>, flat: Record<string, string>): Record<string, unknown> {
@@ -76,6 +60,9 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
   );
   const [uploading, setUploading] = useState(false);
   const [recognizing, setRecognizing] = useState(false);
+  // Нарушения ограничений по путям («ПериодДействия.До»); сбрасываются при правке значения, иначе
+  // претензия висела бы на исправленном поле (issue #655).
+  const [constraintErrors, setConstraintErrors] = useState<Record<string, string>>({});
   const scanInputRef = useRef<HTMLInputElement>(null);
   // Картинка поля ещё едет в хранилище — сохранять рано: значение появится только после (issue #522).
   // Своё `uploading` выше — про скан документа качества, это разные загрузки.
@@ -100,7 +87,23 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
   const enumDef = (f: SchemaField) =>
     f.type === 'enum' ? enumTypes.find(et => et.id === f.typeId) : undefined;
 
-  function setValue(key: string, v: unknown) { setValues(p => ({ ...p, [key]: v })); }
+  /**
+   * Правка значения сразу и проверяется, и снимает прежнюю претензию (issue #655) — как в двух
+   * соседних формах. Проверка на изменение ловит ввод, сбор при сохранении — всё остальное:
+   * распознавание, вставку, значение, пришедшее с базового документа.
+   */
+  function setValue(key: string, v: unknown) {
+    setValues(p => ({ ...p, [key]: v }));
+    const f = fields.find(x => x.key === key);
+    const def = f && f.type === 'primitive' ? primitiveDef(f) : undefined;
+    const err = def ? validateConstraint(v, def) : null;
+    setConstraintErrors(prev => {
+      if (!err && !prev[key]) return prev;              // ничего не менялось — не будим рендер
+      const next = { ...prev };
+      if (err) next[key] = err; else delete next[key];
+      return next;
+    });
+  }
 
   async function handleScan(file: File) {
     setUploading(true); setError('');
@@ -134,14 +137,17 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
       const SUMMARY = '__summary__';
       const activeType = allDocTypes.find(d => d.id === activeTypeId);
       const activeFields = activeType ? resolveEffectiveFields(activeType, allDocTypes) : fields;
+      // Модели показываем варианты перечислений и базовый тип примитива, ответ отображаем обратно
+      // в коды (issue #654) — иначе в реквизиты ложится подпись, которой нет ни в одном пункте.
+      const plan = buildRecognitionFields(activeFields, allDocTypes, { primitiveTypes, enumTypes });
       const rec = await recognizeDocument({
         blobPath: scan.blobPath, mimeType: scan.mimeType,
         fields: [
-          ...flattenLeaves(activeFields, allDocTypes),
+          ...plan.fields,
           { path: SUMMARY, title: 'Краткое наименование документа: краткое имя (бренд) производителя и тип продукции, например «EKF — автоматические выключатели»', type: 'string' },
         ],
       });
-      const recognized = rec.values;
+      const recognized = codesFromLabels(rec.values, plan.enumCodes);
       const summary = (recognized[SUMMARY] ?? '').trim();
       const { [SUMMARY]: _omitSummary, ...fieldValues } = recognized;
       // Число страниц берём из файла → в поле с тэгом doc.pageCount (напр. «КоличествоЛистов»).
@@ -161,6 +167,20 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
   async function handleSave() {
     setError('');
     const name = displayName.trim() || String(values['НомерДокумента'] ?? '').trim() || docType?.name || 'Документ качества';
+
+    // Ограничения примитивов эта форма не проверяла никогда (issue #655), в отличие от редактора
+    // реквизитов и формы общих данных. Тем же сбором, что и они: вторая реализация правил разошлась
+    // бы с первой, а серверной проверки нет вовсе — значение уходит в базу как набрали.
+    const violations = collectConstraintViolations(values, fields, allDocTypes, primitiveTypes);
+    const firstBad = Object.entries(violations)[0];
+    if (firstBad) {
+      const [path, message] = firstBad;
+      setConstraintErrors(violations);
+      setError(`${describeViolationPath(path, fields, allDocTypes)} — ${message}`);
+      return;
+    }
+    setConstraintErrors({});
+
     try {
       let doc: QualityDocument;
       if (isEdit && initial) {
@@ -245,9 +265,16 @@ export function QualityDocForm({ allDocTypes, scope, scopeId, initial, onSaved, 
             return <div key={f.key} className={cls}>{label}<ImageField value={v} onChange={x => setValue(f.key, x)} /></div>;
           if (f.type === 'file')
             return <div key={f.key} className={cls}>{label}<FileField value={v} onChange={x => setValue(f.key, x ?? undefined)} /></div>;
-          return <div key={f.key} className={cls}><PrimitiveInput field={f} value={v} label={f.title}
-            onChange={x => setValue(f.key, x)} invalid={false}
-            primitiveTypeDef={primitiveDef(f)} enumTypeDef={enumDef(f)} /></div>;
+          return (
+            <div key={f.key} className={cls}>
+              <PrimitiveInput field={f} value={v} label={f.title}
+                onChange={x => setValue(f.key, x)} invalid={!!constraintErrors[f.key]}
+                primitiveTypeDef={primitiveDef(f)} enumTypeDef={enumDef(f)} />
+              {constraintErrors[f.key] && (
+                <p className="text-xs text-danger mt-0.5">{constraintErrors[f.key]}</p>
+              )}
+            </div>
+          );
         })}
       </div>
 

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -19,6 +19,8 @@ import {
 import { SCOPE_LABELS, type CatalogScope } from '@/shared/api/types';
 import { resolveEffectiveFields, typeHasTag } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
+import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
+import { useListEnumTypes } from '@/shared/api/enumTypes';
 import type { DocumentType } from '@/shared/api/types';
 import { QualityDocForm } from './QualityDocForm';
 import { ambiguousDocNames, docFieldByTag, docNumberOf, isAmbiguous } from './docIdentity';
@@ -338,6 +340,9 @@ function WebSearchModal({ open, onClose, docTypes }: {
   const [searching, setSearching] = useState(false);
   const [importingUrl, setImportingUrl] = useState<string | null>(null);
   const [error, setError] = useState('');
+  // Определения типов полей нужны распознаванию импортированного скана (issue #654).
+  const { data: primitiveTypes = [] } = useListPrimitiveTypes();
+  const { data: enumTypes = [] } = useListEnumTypes();
 
   // Тип берём ТОЛЬКО среди помеченных тэгом «документ качества»: без него q[0] это первый попавшийся
   // тип документа (например АОСР), и импорт молча создал бы «документ качества» чужого типа, чья
@@ -371,7 +376,8 @@ function WebSearchModal({ open, onClose, docTypes }: {
       // Распознавание — best-effort: документ уже импортирован, и падение распознавателя (например,
       // выключенная Ollama) не должно выглядеть как «не удалось импортировать» — человек нажал бы ещё
       // раз и завёл дубль.
-      try { await recognizeAndUpdate(created, docTypes); } catch { /* распознавание не критично */ }
+      try { await recognizeAndUpdate(created, docTypes, { primitiveTypes, enumTypes }); }
+      catch { /* распознавание не критично */ }
       // Без инвалидации список слева не обновится до перефокуса окна (staleTime 30 с), и тот же
       // документ импортировали бы повторно.
       qc.invalidateQueries({ queryKey: ['quality-docs'] });

--- a/src/client/src/features/quality-docs/recognitionFields.test.ts
+++ b/src/client/src/features/quality-docs/recognitionFields.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { buildRecognitionFields, codesFromLabels } from './recognitionFields';
+import type { SchemaField } from '@/shared/api/schema';
+import type { DocumentType, EnumTypeDef, PrimitiveTypeDef } from '@/shared/api/types';
+
+/**
+ * Что распознаванию рассказывают про поля и как читают ответ (issue #654).
+ *
+ * Оба класса ошибки тихие: подпись перечисления вместо кода даёт пустой на вид `Select` при
+ * заполненном реквизите, а «primitive» вместо базового типа лишает промпт единственной предметной
+ * подсказки про формат. По безголовому пути импорта не видно ни того, ни другого.
+ */
+
+const field = (key: string, type: string, extra: Partial<SchemaField> = {}): SchemaField =>
+  ({ key, type, title: key, required: false, ...extra } as unknown as SchemaField);
+
+const docType = (id: string, fields: SchemaField[]): DocumentType =>
+  ({ id, name: id, schema: { fields }, parentId: null } as unknown as DocumentType);
+
+const enumTypes = [{
+  id: 'e-kind', name: 'Вид документа', code: 'DocKind',
+  values: [{ code: 'СС', label: 'Сертификат соответствия' }, { code: 'ДС', label: 'Декларация о соответствии' }],
+}] as unknown as EnumTypeDef[];
+
+const primitiveTypes = [
+  { id: 'p-date', name: 'Дата', code: 'Date', baseType: 'date', constraints: {} },
+  { id: 'p-num', name: 'Номер', code: 'Num', baseType: 'number', constraints: {} },
+] as unknown as PrimitiveTypeDef[];
+
+const defs = { enumTypes, primitiveTypes };
+
+describe('buildRecognitionFields', () => {
+  it('перечислению из реестра подставляет ПОДПИСИ — их модель и увидит в скане', () => {
+    const t = docType('t', [field('Вид', 'enum', { typeId: 'e-kind' })]);
+    const plan = buildRecognitionFields(t.schema.fields as SchemaField[], [t], defs);
+
+    expect(plan.fields[0].options).toEqual(['Сертификат соответствия', 'Декларация о соответствии']);
+  });
+
+  it('без определений перечисление осталось бы без вариантов — ровно прежний дефект', () => {
+    const t = docType('t', [field('Вид', 'enum', { typeId: 'e-kind' })]);
+    expect(buildRecognitionFields(t.schema.fields as SchemaField[], [t], {}).fields[0].options)
+      .toEqual([]);
+  });
+
+  it('legacy-список вариантов прямо в схеме продолжает работать', () => {
+    const t = docType('t', [field('Вид', 'enum', { options: ['А', 'Б', ''] })]);
+    const plan = buildRecognitionFields(t.schema.fields as SchemaField[], [t], defs);
+
+    expect(plan.fields[0].options).toEqual(['А', 'Б']); // пустая строка вариантом не является
+    expect(plan.enumCodes['Вид']).toMatchObject({ 'а': 'А', 'б': 'Б' });
+  });
+
+  it('примитив отдаёт БАЗОВЫЙ тип, а не бесполезное «primitive»', () => {
+    const t = docType('t', [
+      field('Выдан', 'primitive', { typeId: 'p-date' }),
+      field('Номер', 'primitive', { typeId: 'p-num' }),
+      field('Ничей', 'primitive', { typeId: 'нет-такого' }),
+    ]);
+    expect(buildRecognitionFields(t.schema.fields as SchemaField[], [t], defs).fields.map(f => f.type))
+      .toEqual(['date', 'number', 'primitive']); // неизвестный тип — как было, врать нечем
+  });
+
+  it('спускается в составные поля и собирает пути через точку', () => {
+    const inner = docType('inner', [field('Вид', 'enum', { typeId: 'e-kind' })]);
+    const outer = docType('outer', [field('Период', 'complex', { typeId: 'inner' })]);
+    const plan = buildRecognitionFields(outer.schema.fields as SchemaField[], [inner, outer], defs);
+
+    expect(plan.fields.map(f => f.path)).toEqual(['Период.Вид']);
+    expect(plan.enumCodes['Период.Вид']).toBeDefined(); // карта кодов вложенного поля не теряется
+  });
+
+  it('массивы, ссылки и вложения распознаванию не отдаются', () => {
+    const t = docType('t', [
+      field('Строки', 'array'), field('Ссылка', 'doc-ref'), field('Список', 'doc-array'),
+      field('Картинка', 'image'), field('Файл', 'file'), field('Номер', 'string'),
+    ]);
+    expect(buildRecognitionFields(t.schema.fields as SchemaField[], [t], defs).fields.map(f => f.path))
+      .toEqual(['Номер']);
+  });
+});
+
+describe('codesFromLabels', () => {
+  const t = docType('t', [field('Вид', 'enum', { typeId: 'e-kind' })]);
+  const plan = buildRecognitionFields(t.schema.fields as SchemaField[], [t], defs);
+
+  it('подпись, которой ответила модель, становится КОДОМ', () => {
+    expect(codesFromLabels({ 'Вид': 'Сертификат соответствия' }, plan.enumCodes))
+      .toEqual({ 'Вид': 'СС' });
+  });
+
+  it('регистр, лишние пробелы и «ё» совпадению не мешают', () => {
+    expect(codesFromLabels({ 'Вид': '  декларация   О  СООТВЕТСТВИИ ' }, plan.enumCodes))
+      .toEqual({ 'Вид': 'ДС' });
+  });
+
+  it('ответ кодом остаётся кодом — модель вправе ответить и так', () => {
+    expect(codesFromLabels({ 'Вид': 'сс' }, plan.enumCodes)).toEqual({ 'Вид': 'СС' });
+  });
+
+  it('неопознанное значение сохраняется как есть, а не выбрасывается', () => {
+    // Распознавание — единственное, что прочитало скан; терять его ответ хуже, чем показать
+    // расхождение. Расхождение и покажут: форма подсветит, аудит значений (#644) найдёт.
+    expect(codesFromLabels({ 'Вид': 'Свидетельство' }, plan.enumCodes))
+      .toEqual({ 'Вид': 'Свидетельство' });
+  });
+
+  it('поля без перечисления проходят нетронутыми', () => {
+    expect(codesFromLabels({ 'Номер': 'РОСС RU.0001', '__summary__': 'EKF' }, plan.enumCodes))
+      .toEqual({ 'Номер': 'РОСС RU.0001', '__summary__': 'EKF' });
+  });
+});

--- a/src/client/src/features/quality-docs/recognitionFields.ts
+++ b/src/client/src/features/quality-docs/recognitionFields.ts
@@ -1,0 +1,119 @@
+import type { DocumentType } from '@/shared/api/types';
+import { resolveEffectiveFields, type SchemaField } from '@/shared/api/schema';
+import type { FieldTypeDefs } from '@/shared/utils/fieldDisplay';
+import type { RecognitionFieldReq } from '@/shared/api/qualityDocs';
+
+/**
+ * Что распознаванию рассказывают про поля типа и как читают его ответ (issue #654).
+ *
+ * Прежде уходило `{ path, title, type, options: f.options }`, и двум видам полей этого не хватало:
+ *
+ * 1. **Перечисление из реестра** (#59). Варианты живут в `EnumType`, у поля в схеме только `typeId`,
+ *    а `options` там пусто — клиентский `resolveEffectiveFields` варианты не подставляет. Промпт
+ *    оставался без строки «(варианты: …)», и модель отвечала свободной формулировкой вроде
+ *    «Сертификат соответствия». В реквизиты попадала ПОДПИСЬ вместо КОДА: `Select` показывал
+ *    плейсхолдер (значение не совпадало ни с одним пунктом), человек видел пустое обязательное поле,
+ *    а в данных лежала подпись и сохранялась дальше — в том числе по безголовому пути импорта, где
+ *    формы нет вовсе. В PDF это не всплывало: резолвер меток не трогает значения вне списка кодов.
+ * 2. **Примитив** (#60). Уходило `type: 'primitive'` — по нему не понять, дата за ним, число или
+ *    строка с шаблоном, и единственным ориентиром оставалась общая фраза «Даты возвращай в ISO».
+ *
+ * Модель видит ПОДПИСИ (их же она прочитает в скане), а в данные кладём КОДЫ — обратное отображение
+ * и есть вторая половина контракта.
+ */
+export interface RecognitionPlan {
+  fields: RecognitionFieldReq[];
+  /**
+   * Путь поля → «нормализованная подпись → код». Только для перечислений; пусто, если их нет.
+   * Коды тоже кладём ключами: модель вправе ответить и кодом, и его же подписью.
+   */
+  enumCodes: Record<string, Record<string, string>>;
+}
+
+const SKIPPED_TYPES = new Set(['array', 'doc-ref', 'doc-array', 'image', 'file']);
+
+/** Разворачивает поля типа в плоские «листья» (путь через точку) для распознавания. */
+export function buildRecognitionFields(
+  fields: SchemaField[], allDocTypes: DocumentType[], defs: FieldTypeDefs = {},
+  prefix = '', depth = 0,
+): RecognitionPlan {
+  if (depth > 3) return { fields: [], enumCodes: {} };
+
+  const out: RecognitionFieldReq[] = [];
+  const enumCodes: RecognitionPlan['enumCodes'] = {};
+
+  for (const f of fields) {
+    const path = prefix ? `${prefix}.${f.key}` : f.key;
+
+    if (f.type === 'complex' && f.typeId) {
+      const ct = allDocTypes.find(d => d.id === f.typeId);
+      if (!ct) continue;
+      const inner = buildRecognitionFields(
+        resolveEffectiveFields(ct, allDocTypes), allDocTypes, defs, path, depth + 1);
+      out.push(...inner.fields);
+      Object.assign(enumCodes, inner.enumCodes);
+      continue;
+    }
+
+    if (SKIPPED_TYPES.has(f.type)) continue;
+
+    if (f.type === 'enum') {
+      const options = enumOptionsOf(f, defs);
+      // Модели показываем подписи — их она и увидит в скане; пустой список промпт всё равно
+      // пропустит, и поле останется без подсказки, как было.
+      out.push({ path, title: f.title, type: f.type, options: options.map(o => o.label) });
+      if (options.length > 0) enumCodes[path] = codeIndex(options);
+      continue;
+    }
+
+    if (f.type === 'primitive') {
+      // Базовый тип вместо бесполезного «primitive»: за ним стоит дата, число или строка, и общая
+      // подсказка про формат становится предметной.
+      const def = defs.primitiveTypes?.find(pt => pt.id === f.typeId);
+      out.push({ path, title: f.title, type: def?.baseType ?? f.type });
+      continue;
+    }
+
+    out.push({ path, title: f.title, type: f.type, options: f.options });
+  }
+
+  return { fields: out, enumCodes };
+}
+
+/**
+ * Ответ модели → значения для реквизитов: подписи перечислений заменяются кодами.
+ *
+ * Неопознанное значение оставляем КАК ЕСТЬ, а не выбрасываем: распознавание — единственное, что
+ * прочитало скан, и терять его результат из-за расхождения формулировок хуже, чем показать
+ * расхождение. Его и покажут — форма подсветит несоответствие типу, аудит значений (#644) найдёт
+ * его же в сохранённой записи.
+ */
+export function codesFromLabels(
+  values: Record<string, string>, enumCodes: RecognitionPlan['enumCodes'],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [path, value] of Object.entries(values)) {
+    const index = enumCodes[path];
+    out[path] = index ? index[normalize(value)] ?? value : value;
+  }
+  return out;
+}
+
+/** Варианты перечисления: из реестра типов (#59), иначе из legacy-списка в самой схеме. */
+function enumOptionsOf(f: SchemaField, defs: FieldTypeDefs): { code: string; label: string }[] {
+  const def = f.typeId ? defs.enumTypes?.find(et => et.id === f.typeId) : undefined;
+  if (def) return def.values.map(v => ({ code: v.code, label: v.label }));
+  return (f.options ?? []).filter(o => o !== '').map(o => ({ code: o, label: o }));
+}
+
+/** Подпись И код ведут к коду: модель вправе ответить любым из них. Подпись выигрывает при совпадении. */
+function codeIndex(options: { code: string; label: string }[]): Record<string, string> {
+  const index: Record<string, string> = {};
+  for (const o of options) index[normalize(o.code)] = o.code;
+  for (const o of options) index[normalize(o.label)] = o.code;
+  return index;
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ').replace(/ё/g, 'е');
+}

--- a/src/client/src/features/quality-docs/recognizeImported.ts
+++ b/src/client/src/features/quality-docs/recognizeImported.ts
@@ -3,7 +3,9 @@ import { recognizeDocument, type QualityDocument } from '@/shared/api/qualityDoc
 import type { DocumentType } from '@/shared/api/types';
 import { resolveEffectiveFields, findTaggedFieldPath } from '@/shared/api/schema';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
-import { flattenLeaves, applyRecognized } from './QualityDocForm';
+import type { FieldTypeDefs } from '@/shared/utils/fieldDisplay';
+import { applyRecognized } from './QualityDocForm';
+import { buildRecognitionFields, codesFromLabels } from './recognitionFields';
 
 const SUMMARY = '__summary__';
 
@@ -11,24 +13,31 @@ const SUMMARY = '__summary__';
  * Распознаёт скан импортированного документа качества и обновляет его реквизиты,
  * краткое наименование и количество листов. Тип документа уже задан при импорте
  * (классификация не нужна). Best-effort: при ошибке распознавания возвращает исходный документ.
+ *
+ * `defs` (определения примитивов и перечислений) обязательны по смыслу, хотя и не по сигнатуре:
+ * без них модель не увидит вариантов перечисления, а её подпись некому будет отобразить в код —
+ * и здесь это опаснее, чем в форме, потому что формы тут нет и расхождение никто не увидит (#654).
  */
-export async function recognizeAndUpdate(doc: QualityDocument, allDocTypes: DocumentType[]): Promise<QualityDocument> {
+export async function recognizeAndUpdate(
+  doc: QualityDocument, allDocTypes: DocumentType[], defs: FieldTypeDefs = {},
+): Promise<QualityDocument> {
   if (!doc.scanBlobPath || !doc.scanMimeType) return doc;
   const type = allDocTypes.find(t => t.id === doc.documentTypeId);
   if (!type) return doc;
 
-  const fields = flattenLeaves(resolveEffectiveFields(type, allDocTypes), allDocTypes);
+  const plan = buildRecognitionFields(resolveEffectiveFields(type, allDocTypes), allDocTypes, defs);
   const rec = await recognizeDocument({
     blobPath: doc.scanBlobPath,
     mimeType: doc.scanMimeType,
     fields: [
-      ...fields,
+      ...plan.fields,
       { path: SUMMARY, title: 'Краткое наименование документа: краткое имя (бренд) производителя и тип продукции, например «EKF — автоматические выключатели»', type: 'string' },
     ],
   });
 
-  const summary = (rec.values[SUMMARY] ?? '').trim();
-  const { [SUMMARY]: _omit, ...fieldValues } = rec.values;
+  const values = codesFromLabels(rec.values, plan.enumCodes);
+  const summary = (values[SUMMARY] ?? '').trim();
+  const { [SUMMARY]: _omit, ...fieldValues } = values;
   if (rec.pageCount != null) {
     const p = findTaggedFieldPath(type, FUNCTIONAL_TAG.docPageCount, allDocTypes);
     if (p) fieldValues[p.join('.')] = String(rec.pageCount);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.87.0</Version>
+    <Version>0.87.1</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #654 и #655. Одним PR: обе правки в одной форме и обе про один контракт — что система знает о типе поля и что с этим знанием делает. #655 без #654 всё равно ругалась бы на подпись, пришедшую от модели.

## #654 — распознавание не знало про перечисления и примитивы

Уходило `{ path, title, type, options: f.options }`. Двум видам полей этого мало:

- **Перечисление из реестра** (#59) держит варианты в `EnumType`, у поля в схеме только `typeId`, а `options` пусто. Промпт оставался без «(варианты: …)», модель отвечала свободной формулировкой — и в реквизиты попадала **подпись вместо кода**. `Select` показывал плейсхолдер (значение не совпадает ни с одним пунктом), человек видел пустое обязательное поле, а в данных лежала подпись и сохранялась дальше. В PDF не всплывало: резолвер меток не трогает значения вне списка кодов.
- **Примитив** уходил как `type: 'primitive'` — по нему не понять, дата за ним, число или строка с шаблоном.

Теперь модель видит **подписи** (их она и прочитает в скане) и **базовый тип** примитива, а ответ отображается обратно в **коды**. Совпадение по нормализованному значению: регистр, лишние пробелы и «ё» не мешают, ответ кодом тоже принимается.

**Неопознанное значение сохраняется как есть**, а не выбрасывается: распознавание — единственное, что прочитало скан, и терять его ответ хуже, чем показать расхождение. Расхождение и покажут — форма подсветит несоответствие типу, аудит значений (#644) найдёт его в сохранённой записи.

### Третье место, которого не было в плане

Контракт вынесен в чистый модуль `recognitionFields.ts` и подключён во **всех трёх** местах, собиравших поля для распознавания:

| Место | Было |
|---|---|
| Форма документа качества | описано в issue |
| Безголовый импорт (`recognizeImported`) | описано в issue |
| **Распознавание штампа в форме общих данных** (`catalog/index.tsx`) | **не было в issue** |

Третье нашлось при правке: оно звало ту же `flattenLeaves` и несло ровно тот же дефект. Определения типов у той формы уже были на руках — подключение стоило одной строки.

## #655 — форма качества не проверяла ограничения

Рисовала скалярные поля с `invalid={false}` и не звала `validateConstraint` никогда — в отличие от `RequisitesTab` и формы общих данных. Примитив с `pattern`/`maxLength` или числовой с `min`/`max` принимался и молча сохранялся.

Теперь две проверки, как у соседей: на изменение (ловит ввод, снимает прежнюю претензию с исправленного поля) и `collectConstraintViolations` при сохранении (ловит всё остальное — распознавание, вставку, значение от базового документа). Тем же сбором, что и они: вторая реализация правил разошлась бы с первой, а серверной проверки нет вовсе.

### Что осталось за рамками

В комментарии к #655 я отмечал, что форма не показывает и `ValueIssueHint` — подсказку аудита значений (#644), которая есть в двух соседних формах. Здесь её не сделал: она читает `/common-data/{id}/audit`, а для документов качества такого эндпоинта нет — есть только сет-уровневый `/quality-docs/audit/{setId}` (#589). Это отдельная задача с серверной частью, и заводить её внутрь «формы, которая не проверяет ограничения» неправильно. Опишу follow-up в issue.

## Проверка

- `npm test` — **430/430** (32 файла), из них 11 новых в `recognitionFields.test.ts`: подстановка подписей, работа legacy-списка, базовый тип примитива, спуск в составные поля, обратное отображение с нормализацией, сохранение неопознанного.
- `npx tsc -b --force` — чисто. `npm run lint` — новых замечаний ноль (репозиторий 131 → **130**: экспорт `flattenLeaves` убран).
- Backend не менялся: сервер печатает `type` в промпт и не ветвится по нему.
- Версия `0.87.0` → `0.87.1` (PATCH — оба пункта фиксы).

⚠️ Оба дефекта **латентны**: типов документов качества с `primitive`/`enum` на верхнем уровне в базе пока нет, так что живьём разницу увидеть не на чем — проверял тестами и типами, кликом не гонял.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
