### PR TITLE
Селектор типа: код не вытесняет имя и не вылезает за рамку (#668)

### DIFF
--- a/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
+++ b/src/client/src/features/document-sets/editor/QualityLinksTab.tsx
@@ -233,13 +233,17 @@ export function LinkPickerModal({ open, onClose, allDocTypes, scope, scopeId, ma
       {tab === 'search' && (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <TypePickerField className="w-52" aria-label="Тип документа качества" title="Тип документа качества"
+            {/* w-64, а не w-52 (issue #668): «Сертификат соответствия» — типичное значение, и в
+                208 px оно обрезалось многоточием почти сразу даже без кода типа. */}
+            <TypePickerField className="w-64" aria-label="Тип документа качества" title="Тип документа качества"
               placeholder="Тип"
               types={qualityTypes.map<PickType>(t => ({ id: t.id, name: t.name, code: t.code, section: 'Документы качества' }))}
               value={searchType || undefined}
               onChange={id => { if (id) setSearchType(id); }} />
+            {/* Ведущей лупы здесь нет (issue #668): рядом стоял селектор типа со своей замыкающей
+                лупой — обещанием модалки поиска (#565), — и два одинаковых значка подряд означали
+                разное. У самой строки намерение уже названо кнопкой «Найти» справа. */}
             <div className="flex-1 flex items-center gap-2 border border-stroke-strong rounded-md px-2 transition-colors focus-within:border-brand focus-within:ring-1 focus-within:ring-brand">
-              <Search size={14} className="text-fg4" />
               <input value={query} onChange={e => setQuery(e.target.value)}
                 onKeyDown={e => { if (e.key === 'Enter') void runSearch(); }}
                 placeholder="строка поиска" className="flex-1 py-2 text-sm bg-transparent focus:outline-none" />

--- a/src/client/src/shared/ui/TypePickerField.tsx
+++ b/src/client/src/shared/ui/TypePickerField.tsx
@@ -5,7 +5,7 @@ import { OutlinedField } from './OutlinedField';
 
 /**
  * Триггер-поле над `TypePicker` (issue #266): закрытый вид читается как поле формы (значок
- * семейства + имя выбранного типа + код по showCode + лупа), клик/Enter/Space открывают богатую
+ * семейства + имя выбранного типа + код в слое формы + лупа), клик/Enter/Space открывают богатую
  * модалку выбора. Единый контрол для ЛЮБОГО выбора типа (документа/поля/родителя), чтобы не плодить
  * свои триггеры на каждом сайте. Триггер — настоящий `<button aria-haspopup>`, фокус возвращается
  * на него по Esc (Radix Dialog). Не-типовые короткие списки (роль/scope) — обычный Select.
@@ -34,7 +34,8 @@ export function TypePickerField({
   recentKey?: string;
   title?: string;
   placeholder?: string;
-  /** `sm` — компактный триггер для шапок (без кода); `md` — обычное поле формы. */
+  /** Высота компактного триггера: `sm` для шапок, `md` для фильтров. Кода нет ни там, ни там —
+   *  его показывает только слой формы (см. `showCode`, issue #668). */
   size?: 'sm' | 'md';
   /** Подпись поля. Задана — контрол переходит в слой формы (outlined-рамка с вырезом). */
   label?: string;
@@ -52,8 +53,16 @@ export function TypePickerField({
   const selected = value ? types.find(t => t.id === value) : undefined;
   const Icon = selected ? typeIcon(selected) : Boxes;
   const code = selected?.code.trim();
-  const showCode = size !== 'sm' && !!code && code.toLowerCase() !== selected!.name.trim().toLowerCase();
   const framed = label !== undefined;
+  /**
+   * Код показываем только в СЛОЕ ФОРМЫ (issue #668). Раньше условием был размер, и компактный
+   * триггер размера `md` код получал — а места под него там нет: имя стоит `flex-1 truncate`, код
+   * `shrink-0`, и при нехватке ширины сжималось имя, вплоть до нуля. В поле оставался один код
+   * («СетрификатСоответствия» вместо «Сертификат соответствия») — то есть исчезало ровно то, ради
+   * чего поле существует. Коды в проекте пишутся слитно, имена с пробелами, так что проверка на
+   * несовпадение почти всегда истинна и от этого не спасала.
+   */
+  const showCode = framed && !!code && code.toLowerCase() !== selected!.name.trim().toLowerCase();
   const showClear = !!clearable && !!selected && !disabled;
 
   // В слое формы рамку и фон рисует оболочка — триггер внутри неё прозрачный и без своей границы,
@@ -66,13 +75,15 @@ export function TypePickerField({
       `text-sm text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand ` +
       `data-[state=open]:ring-2 disabled:opacity-50 disabled:pointer-events-none`;
 
+  // `overflow-hidden` на триггере — страховка впредь (issue #668): её не было, и несжимаемый
+  // элемент (код типа) не обрезался, а выходил за рамку поля и наезжал на замыкающую лупу.
   const trigger = (
     <button
       ref={triggerRef}
       type="button" disabled={disabled} onClick={() => setOpen(true)}
       aria-haspopup="dialog" aria-expanded={open}
       aria-label={framed ? undefined : ariaLabel} aria-labelledby={framed ? labelId : undefined}
-      className={`inline-flex items-center gap-2 ${triggerClass}`}
+      className={`inline-flex items-center gap-2 overflow-hidden ${triggerClass}`}
       data-state={open ? 'open' : 'closed'}
     >
       <Icon size={16} className={`shrink-0 ${selected ? 'text-fg3' : 'text-fg4'}`} />

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.87.1</Version>
+    <Version>0.87.2</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Закрывает #668. Разбор в issue точный — сверил все четыре пункта с `master`, ничего не разошлось.

## Правки

1. **`showCode` привязан к слою формы, а не к размеру.** Было `size !== 'sm'`, стало `framed` (то есть «задан `label`»). Компактный триггер размера `md` код получал, а места под него там нет by design: имя `flex-1 truncate`, код `shrink-0` — при нехватке ширины сжималось **имя**, вплоть до нуля. Проверка «код ≠ имя» не спасала: коды пишутся слитно, имена с пробелами, условие почти всегда истинно.
2. **`overflow-hidden` на кнопке-триггере** — чтобы впредь ни один `shrink-0`-элемент не мог выйти за рамку, а не только этот.
3. **`w-52` → `w-64`** в `QualityLinksTab`: «Сертификат соответствия» обрезалось многоточием почти сразу даже без кода.
4. **Убрана ведущая лупа строки веб-поиска.** Рядом стоял селектор со своей замыкающей лупой — обещанием модалки (#565), — и два одинаковых значка означали разное. У строки намерение уже названо кнопкой «Найти».

Заодно поправлены два доккоммента, разошедшихся с кодом: описание `size` («без кода» теперь относится к обоим размерам) и строка про «код по showCode» в шапке файла.

## Проверка

**Живьём, обе ветки нового условия** — это главный риск правки (код мог исчезнуть там, где он нужен):

| Контекст | `code` в DOM | `overflow` |
|---|---|---|
| Слой формы — создание документа качества | `«ОтказноеПисьмо»` — **на месте** | `hidden` |
| Компактный — шапка списка шаблонов (`size="sm"`) | **нет** | `hidden` |

Сам экран со скриншота (модалка связывания → «Поиск в интернете») кликом не открыл: до неё нужно выбрать материал, а в комплекте «250701.ЭОМ-1» скрипт до отмеченного материала не добрался. Но этот селектор — **та же ветка**, что и проверенный компактный (`label` не задан), так что поведение у них теперь общее и проверенное.

- `npx tsc -b --force` — чисто. `npm test` — **430/430**. `npm run lint` — новых замечаний нет (репозиторий как был, 130).
- Остальные пять вызовов `TypePickerField` не затронуты: `TemplateSidebar` — `size="sm"` (кода не было), `QualityDocForm` / `MaterializationDialog` / `DocumentTypesPage` ×2 — слой формы с `label`, там код остаётся.

⚠️ **Поправка к плану:** в issue указан бамп `0.85.0 → 0.85.1`, но `master` уже на `0.87.1` — взял **`0.87.2`** (PATCH).

Опечатку в коде типа (`СетрификатСоответствия`) не трогал — это данные, правятся админом в настройках типов, как и написано в issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
