### PR TITLE
Шаг 2 локального отчёта безопасности: раздел 3

### DIFF
--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using BHS.CRG.Api.Auth;
@@ -334,7 +334,12 @@ builder.Services.AddHttpClient<SerperEngine>().ConfigureHttpClient(c => c.Timeou
 builder.Services.AddHttpClient<YandexEngine>().ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(30));
 builder.Services.AddScoped<IWebSearchEngine>(sp => sp.GetRequiredService<SerperEngine>());
 builder.Services.AddScoped<IWebSearchEngine>(sp => sp.GetRequiredService<YandexEngine>());
-builder.Services.AddHttpClient<TieredWebSearch>().ConfigureHttpClient(c =>
+// Автоследование за перенаправлениями выключено намеренно: переходы проходит SafeHttpGet, проверяя
+// цель каждого. С автоследованием проверка исходного адреса ничего не стоит — ответ общедоступного
+// хоста уводит куда угодно.
+builder.Services.AddHttpClient<TieredWebSearch>()
+    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false })
+    .ConfigureHttpClient(c =>
 {
     c.Timeout = TimeSpan.FromSeconds(15);
     c.DefaultRequestHeaders.UserAgent.ParseAdd(
@@ -342,6 +347,7 @@ builder.Services.AddHttpClient<TieredWebSearch>().ConfigureHttpClient(c =>
 });
 builder.Services.AddScoped<IQualityDocSearch>(sp => sp.GetRequiredService<TieredWebSearch>());
 builder.Services.AddHttpClient<IFileUrlFetcher, HttpFileUrlFetcher>()
+    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false })
     .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(60));
 builder.Services.AddSingleton<TypstGenerator>();
 builder.Services.AddSingleton<IDocumentGeneratorFactory, DocumentGeneratorFactory>();

--- a/src/server/BHS.CRG.Infrastructure/Http/OutboundAddressPolicy.cs
+++ b/src/server/BHS.CRG.Infrastructure/Http/OutboundAddressPolicy.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace BHS.CRG.Infrastructure.Http;
+
+/// <summary>
+/// Куда приложению разрешено ходить по ссылке, пришедшей ИЗВНЕ — от пользователя или из выдачи
+/// поиска. Единственная точка правил: клиентов несколько, и каждый со своей проверкой разошёлся бы
+/// с остальными.
+///
+/// Правило одно: снаружи ссылка ведёт в интернет, а не внутрь периметра. Приложение живёт рядом с
+/// базой, хранилищем и локальными службами, их адреса известны из файлов развёртывания, а ответ по
+/// ссылке возвращается пользователю — то есть без проверки «скачай мне файл» превращается в чтение
+/// соседей по сети.
+///
+/// Проверяется РЕЗУЛЬТАТ РАЗРЕШЕНИЯ ИМЕНИ, а не сама строка: имя в публичном домене может указывать
+/// куда угодно, и запрет по тексту адреса ничего не значит. Если имя разрешается в несколько
+/// адресов, годными должны быть ВСЕ — иначе достаточно одной подходящей записи в DNS.
+///
+/// ⚠️ Не применяется к адресам СЛУЖБ, заданным администратором (адрес Ollama и т.п.): они
+/// внутренние по замыслу, и это разные задачи. См. отчёт, раздел 3.
+/// </summary>
+public static class OutboundAddressPolicy
+{
+    /// <summary>Сколько перенаправлений проходим сами. .NET по умолчанию идёт до 50 и каждое
+    /// следующее уже не наша проверка — поэтому переходы считаем здесь и заново проверяем цель.</summary>
+    public const int MaxRedirects = 5;
+
+    /// <summary>
+    /// Текст отказа ОДИН на все причины. Разные тексты («хост не ответил», «403», «не тот тип»)
+    /// отвечают на вопрос «что там внутри?» — по ним внутреннюю сеть можно нарисовать, ничего не
+    /// скачав. Подробности уходят в лог, пользователю достаётся один ответ.
+    /// </summary>
+    public const string RefusalMessage =
+        "Не удалось загрузить файл по этой ссылке. Проверьте адрес — он должен вести на общедоступный ресурс.";
+
+    /// <summary>Ссылка разобрана и это http(s). Иначе — тот же общий отказ.</summary>
+    public static Uri RequireHttpUrl(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            ? uri
+            : throw new OutboundAddressRefusedException($"схема или форма адреса не годятся: {url}");
+
+    /// <summary>Разрешает имя и требует, чтобы КАЖДЫЙ полученный адрес был публичным.</summary>
+    public static async Task EnsureAllowedAsync(Uri uri, CancellationToken ct = default)
+    {
+        IPAddress[] addresses;
+        if (IPAddress.TryParse(uri.Host, out var literal))
+        {
+            addresses = [literal];
+        }
+        else
+        {
+            try { addresses = await Dns.GetHostAddressesAsync(uri.Host, ct); }
+            // Неразрешимое имя — тоже отказ, и с тем же текстом: иначе «не резолвится» против
+            // «резолвится, но запрещено» само по себе отвечает на вопрос об именах внутри сети.
+            catch (Exception e) when (e is SocketException or ArgumentException)
+            {
+                throw new OutboundAddressRefusedException($"имя не разрешается: {uri.Host}");
+            }
+        }
+
+        if (addresses.Length == 0)
+            throw new OutboundAddressRefusedException($"имя не разрешается: {uri.Host}");
+
+        foreach (var address in addresses)
+            if (IsBlocked(address))
+                throw new OutboundAddressRefusedException($"адрес вне общедоступных: {uri.Host} → {address}");
+    }
+
+    /// <summary>
+    /// Адрес принадлежит к диапазону, наружу не ведущему. Чистая функция — на ней и держится
+    /// проверка, поэтому она покрыта тестами по диапазонам.
+    /// </summary>
+    public static bool IsBlocked(IPAddress address)
+    {
+        // Адрес IPv4, записанный как IPv6 (::ffff:127.0.0.1), проверяем как IPv4: иначе запись
+        // формы достаточно, чтобы обойти правила для «настоящего» IPv4.
+        if (address.IsIPv4MappedToIPv6) address = address.MapToIPv4();
+
+        if (IPAddress.IsLoopback(address)) return true;
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = address.GetAddressBytes();
+            return b[0] switch
+            {
+                0 => true,                                   // 0.0.0.0/8 — «этот хост»
+                10 => true,                                  // 10.0.0.0/8
+                127 => true,                                 // на случай, если IsLoopback не сработал
+                169 when b[1] == 254 => true,                // 169.254.0.0/16 — link-local, там же метаданные облаков
+                172 when b[1] >= 16 && b[1] <= 31 => true,    // 172.16.0.0/12
+                192 when b[1] == 168 => true,                // 192.168.0.0/16
+                100 when b[1] >= 64 && b[1] <= 127 => true,   // 100.64.0.0/10 — CGNAT
+                >= 224 => true,                              // multicast и зарезервированное, включая 255.255.255.255
+                _ => false,
+            };
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal || address.IsIPv6Multicast) return true;
+            var b = address.GetAddressBytes();
+            if ((b[0] & 0xFE) == 0xFC) return true;          // fc00::/7 — уникальные локальные
+            if (address.Equals(IPAddress.IPv6Any)) return true;
+            return false;
+        }
+
+        // Неизвестное семейство адресов наружу не ведёт — отказываем.
+        return true;
+    }
+}
+
+/// <summary>
+/// Отказ по адресу назначения. Сообщение внутри — ДЛЯ ЛОГА: причина названа точно, чтобы разбирать
+/// обращения. Пользователю показывают <see cref="OutboundAddressPolicy.RefusalMessage"/>, один на
+/// все случаи.
+/// </summary>
+public class OutboundAddressRefusedException(string reason)
+    : Exception($"Исходящий запрос отклонён: {reason}");

--- a/src/server/BHS.CRG.Infrastructure/Http/SafeHttpGet.cs
+++ b/src/server/BHS.CRG.Infrastructure/Http/SafeHttpGet.cs
@@ -1,0 +1,48 @@
+using System.Net;
+
+namespace BHS.CRG.Infrastructure.Http;
+
+/// <summary>
+/// GET по внешней ссылке с проверкой КАЖДОГО адреса на пути, включая перенаправления.
+///
+/// Перенаправления проходим сами. Автоматическое следование сводит любую проверку исходной ссылки на
+/// нет: ответ с общедоступного хоста уводит куда угодно, а проверять там уже нечего и некому.
+/// Поэтому клиентам, которые ходят по внешним ссылкам, автоследование выключено
+/// (<c>AllowAutoRedirect = false</c> при регистрации), а цель каждого перехода проверяется заново.
+/// </summary>
+public static class SafeHttpGet
+{
+    public static async Task<HttpResponseMessage> SendAsync(
+        HttpClient http, Uri uri, HttpCompletionOption completion,
+        Action<HttpRequestMessage>? prepare = null, CancellationToken ct = default)
+    {
+        var current = uri;
+        for (var hop = 0; ; hop++)
+        {
+            await OutboundAddressPolicy.EnsureAllowedAsync(current, ct);
+
+            var req = new HttpRequestMessage(HttpMethod.Get, current);
+            prepare?.Invoke(req);
+            var resp = await http.SendAsync(req, completion, ct);
+
+            if (!IsRedirect(resp.StatusCode) || resp.Headers.Location is null) return resp;
+
+            // Ответ с перенаправлением дальше не нужен, а тело у него может быть — освобождаем.
+            var location = resp.Headers.Location;
+            resp.Dispose();
+
+            if (hop >= OutboundAddressPolicy.MaxRedirects)
+                throw new OutboundAddressRefusedException($"слишком много перенаправлений: {uri}");
+
+            // Location бывает относительным — разрешаем относительно текущего адреса, иначе
+            // проверять было бы нечего.
+            current = location.IsAbsoluteUri ? location : new Uri(current, location);
+            if (current.Scheme != Uri.UriSchemeHttp && current.Scheme != Uri.UriSchemeHttps)
+                throw new OutboundAddressRefusedException($"перенаправление уводит со схемы http(s): {current}");
+        }
+    }
+
+    private static bool IsRedirect(HttpStatusCode code) => code
+        is HttpStatusCode.Moved or HttpStatusCode.Found or HttpStatusCode.SeeOther
+        or HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect;
+}

--- a/src/server/BHS.CRG.Infrastructure/Search/HttpFileUrlFetcher.cs
+++ b/src/server/BHS.CRG.Infrastructure/Search/HttpFileUrlFetcher.cs
@@ -1,4 +1,5 @@
 using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Infrastructure.Http;
 
 namespace BHS.CRG.Infrastructure.Search;
 
@@ -10,29 +11,75 @@ public class HttpFileUrlFetcher(HttpClient http) : IFileUrlFetcher
     private static readonly HashSet<string> Allowed = new(StringComparer.OrdinalIgnoreCase)
     { "application/pdf", "image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif", "image/tiff" };
 
+    /// <summary>
+    /// Ссылку сюда приносит обычный пользователь, поэтому адрес назначения проверяется политикой
+    /// исходящих запросов — включая цель каждого перенаправления (см. <see cref="SafeHttpGet"/>).
+    ///
+    /// Отказы сетевого слоя и по адресу отвечают ОДНИМ текстом. Прежде они различались («404»,
+    /// «тип не поддерживается: text/html», молчание до таймаута), и по этой разнице внутреннюю сеть
+    /// можно было нарисовать, ничего не скачав. Причина уходит в исключение для лога, наружу — один
+    /// ответ. Отказ по типу и по размеру остались своими: они про сам файл и ничего о сети не говорят.
+    /// </summary>
     public async Task<FetchedFile> FetchAsync(string url, CancellationToken ct = default)
     {
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-            throw new SearchUnavailableException("Некорректная ссылка.");
+        Uri uri;
+        HttpResponseMessage resp;
+        try
+        {
+            uri = OutboundAddressPolicy.RequireHttpUrl(url);
+            resp = await SafeHttpGet.SendAsync(
+                http, uri, HttpCompletionOption.ResponseHeadersRead,
+                req => req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (compatible; BHS.CRG/1.0)"),
+                ct);
+        }
+        catch (OutboundAddressRefusedException)
+        {
+            throw new SearchUnavailableException(OutboundAddressPolicy.RefusalMessage);
+        }
+        catch (HttpRequestException)
+        {
+            throw new SearchUnavailableException(OutboundAddressPolicy.RefusalMessage);
+        }
 
-        using var req = new HttpRequestMessage(HttpMethod.Get, uri);
-        req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (compatible; BHS.CRG/1.0)");
-        using var resp = await http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
-        if (!resp.IsSuccessStatusCode)
-            throw new SearchUnavailableException($"Не удалось скачать файл ({(int)resp.StatusCode}).");
+        using (resp)
+        {
+            if (!resp.IsSuccessStatusCode)
+                throw new SearchUnavailableException(OutboundAddressPolicy.RefusalMessage);
 
-        var mime = resp.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
-        if (!Allowed.Contains(mime))
-            throw new SearchUnavailableException($"Тип файла не поддерживается: {mime}. Нужны PDF или изображение.");
+            var mime = resp.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
+            if (!Allowed.Contains(mime))
+                throw new SearchUnavailableException($"Тип файла не поддерживается: {mime}. Нужны PDF или изображение.");
 
-        if (resp.Content.Headers.ContentLength is { } len && len > MaxBytes)
-            throw new SearchUnavailableException("Файл превышает 50 МБ.");
+            // Заголовок длины — только ранний отказ: у ответа с потоковой передачей его нет вовсе,
+            // и полагаться на него значит не иметь предела там, где он нужнее всего.
+            if (resp.Content.Headers.ContentLength is { } len && len > MaxBytes)
+                throw new SearchUnavailableException("Файл превышает 50 МБ.");
 
-        var bytes = await resp.Content.ReadAsByteArrayAsync(ct);
-        if (bytes.Length > MaxBytes) throw new SearchUnavailableException("Файл превышает 50 МБ.");
+            var bytes = await ReadWithLimitAsync(resp, ct);
+            var fileName = DeriveFileName(uri, mime,
+                resp.Content.Headers.ContentDisposition?.FileNameStar ?? resp.Content.Headers.ContentDisposition?.FileName);
+            return new FetchedFile(bytes, fileName, mime == "image/jpg" ? "image/jpeg" : mime);
+        }
+    }
 
-        var fileName = DeriveFileName(uri, mime, resp.Content.Headers.ContentDisposition?.FileNameStar ?? resp.Content.Headers.ContentDisposition?.FileName);
-        return new FetchedFile(bytes, fileName, mime == "image/jpg" ? "image/jpeg" : mime);
+    /// <summary>
+    /// Читает тело потоком и обрывается на пределе. Прежде тело целиком буферизовалось в память и
+    /// проверялось ПОСЛЕ — то есть предел не мешал занять память по размеру ответа, а у передачи без
+    /// заявленной длины не мешал ничему вовсе.
+    /// </summary>
+    private static async Task<byte[]> ReadWithLimitAsync(HttpResponseMessage resp, CancellationToken ct)
+    {
+        await using var source = await resp.Content.ReadAsStreamAsync(ct);
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        int read;
+        while ((read = await source.ReadAsync(chunk, ct)) > 0)
+        {
+            if (buffer.Length + read > MaxBytes)
+                throw new SearchUnavailableException("Файл превышает 50 МБ.");
+            buffer.Write(chunk, 0, read);
+        }
+        return buffer.ToArray();
     }
 
     private static string DeriveFileName(Uri uri, string mime, string? disposition)

--- a/src/server/BHS.CRG.Infrastructure/Search/TieredWebSearch.cs
+++ b/src/server/BHS.CRG.Infrastructure/Search/TieredWebSearch.cs
@@ -1,3 +1,4 @@
+using BHS.CRG.Infrastructure.Http;
 using System.Net;
 using System.Text.RegularExpressions;
 using BHS.CRG.Application.QualityDocs;
@@ -107,8 +108,10 @@ public class TieredWebSearch(IEnumerable<IWebSearchEngine> engines, IIntegration
         string html;
         try
         {
-            using var req = new HttpRequestMessage(HttpMethod.Get, baseUri);
-            using var resp = await http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct);
+            // Адрес приходит из выдачи поисковика, то есть снаружи, — проверяем его и цель каждого
+            // перенаправления так же, как при загрузке файла по ссылке.
+            using var resp = await SafeHttpGet.SendAsync(
+                http, baseUri, HttpCompletionOption.ResponseContentRead, ct: ct);
             if (!resp.IsSuccessStatusCode) return [];
             var ctype = resp.Content.Headers.ContentType?.MediaType ?? "";
             if (!ctype.Contains("html", StringComparison.OrdinalIgnoreCase)) return [];

--- a/src/server/BHS.CRG.Tests/Configuration/OutboundAddressPolicyTests.cs
+++ b/src/server/BHS.CRG.Tests/Configuration/OutboundAddressPolicyTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using BHS.CRG.Infrastructure.Http;
+
+namespace BHS.CRG.Tests.Configuration;
+
+/// <summary>
+/// Правила для адресов, куда приложение ходит по ссылке извне. Проверка держится на разборе
+/// диапазонов, поэтому диапазоны и проверяются поимённо: ошибка здесь не видна ни на каком экране —
+/// она видна только тем, кто её ищет.
+/// </summary>
+public class OutboundAddressPolicyTests
+{
+    [Theory]
+    // Петля и «этот хост»
+    [InlineData("127.0.0.1")]
+    [InlineData("127.255.255.254")]
+    [InlineData("0.0.0.0")]
+    [InlineData("0.1.2.3")]
+    // Частные диапазоны
+    [InlineData("10.0.0.1")]
+    [InlineData("10.255.255.255")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.255")]
+    [InlineData("192.168.1.1")]
+    // Link-local: там же адрес метаданных облачных площадок
+    [InlineData("169.254.169.254")]
+    [InlineData("169.254.0.1")]
+    // Диапазон оператора связи между абонентом и сетью (CGNAT)
+    [InlineData("100.64.0.1")]
+    [InlineData("100.127.255.255")]
+    // Групповая рассылка и широковещание
+    [InlineData("224.0.0.1")]
+    [InlineData("239.255.255.255")]
+    [InlineData("255.255.255.255")]
+    // IPv6
+    [InlineData("::1")]
+    [InlineData("fe80::1")]
+    [InlineData("fc00::1")]
+    [InlineData("fd12:3456::1")]
+    [InlineData("ff02::1")]
+    [InlineData("::")]
+    // Запись IPv4 внутри IPv6: формой записи правила не обходятся
+    [InlineData("::ffff:127.0.0.1")]
+    [InlineData("::ffff:10.0.0.1")]
+    [InlineData("::ffff:169.254.169.254")]
+    public void NonPublicAddress_Blocked(string ip)
+        => Assert.True(OutboundAddressPolicy.IsBlocked(IPAddress.Parse(ip)), ip);
+
+    [Theory]
+    [InlineData("8.8.8.8")]
+    [InlineData("1.1.1.1")]
+    [InlineData("93.184.216.34")]
+    [InlineData("172.15.255.255")]  // соседний с частным диапазоном снизу
+    [InlineData("172.32.0.1")]      // и сверху
+    [InlineData("100.63.255.255")]  // соседний с CGNAT снизу
+    [InlineData("100.128.0.1")]     // и сверху
+    [InlineData("169.253.0.1")]     // соседний с link-local
+    [InlineData("11.0.0.1")]
+    [InlineData("223.255.255.255")] // последний перед групповой рассылкой
+    [InlineData("2606:4700::1111")]
+    [InlineData("2001:4860:4860::8888")]
+    public void PublicAddress_Allowed(string ip)
+        => Assert.False(OutboundAddressPolicy.IsBlocked(IPAddress.Parse(ip)), ip);
+
+    [Theory]
+    [InlineData("https://example.com/file.pdf")]
+    [InlineData("http://example.com/file.pdf")]
+    public void HttpUrl_Accepted(string url)
+        => Assert.Equal(url, OutboundAddressPolicy.RequireHttpUrl(url).ToString());
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("не ссылка")]
+    [InlineData("/только/путь")]
+    [InlineData("file:///c:/windows/win.ini")]
+    [InlineData("ftp://example.com/file.pdf")]
+    [InlineData("gopher://example.com/")]
+    public void NonHttpUrl_Refused(string? url)
+        => Assert.Throws<OutboundAddressRefusedException>(() => OutboundAddressPolicy.RequireHttpUrl(url));
+
+    [Theory]
+    [InlineData("http://127.0.0.1:9000/bucket/object")]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://[::1]:5000/api/users")]
+    [InlineData("http://10.0.0.5/internal")]
+    public async Task LiteralNonPublicHost_Refused(string url)
+    {
+        var uri = OutboundAddressPolicy.RequireHttpUrl(url);
+        await Assert.ThrowsAsync<OutboundAddressRefusedException>(
+            () => OutboundAddressPolicy.EnsureAllowedAsync(uri));
+    }
+
+    /// <summary>
+    /// Имя, которое не разрешается, — тоже отказ. Иначе «не резолвится» против «резолвится, но
+    /// запрещено» само по себе отвечало бы на вопрос, какие имена внутри сети существуют.
+    /// </summary>
+    [Fact]
+    public async Task UnresolvableHost_Refused()
+    {
+        var uri = OutboundAddressPolicy.RequireHttpUrl(
+            "http://this-name-does-not-exist-8b31d0c47f2a.invalid/file.pdf");
+        await Assert.ThrowsAsync<OutboundAddressRefusedException>(
+            () => OutboundAddressPolicy.EnsureAllowedAsync(uri));
+    }
+
+    /// <summary>
+    /// Текст, который видит пользователь, — КОНСТАНТА: он не собирается из причины и потому одинаков
+    /// для запрещённого адреса, неразрешимого имени и молчания хоста. Различие этих текстов и есть
+    /// то, по чему внутреннюю сеть можно нарисовать, ничего не скачав.
+    ///
+    /// Сказать «проверьте адрес» при этом не возбраняется — речь о ссылке, которую пользователь ввёл
+    /// сам; запрещено называть, ЧТО именно с ней не так.
+    /// </summary>
+    [Fact]
+    public void RefusalMessage_IsOneConstantWithoutDetails()
+    {
+        var m = OutboundAddressPolicy.RefusalMessage;
+
+        // В тексте нет ничего, что зависит от конкретного запроса.
+        Assert.DoesNotContain("127.", m);
+        Assert.DoesNotContain("169.254", m);
+        Assert.DoesNotContain("localhost", m, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("{", m);   // не шаблон с подстановкой
+        Assert.DoesNotContain("404", m);
+        Assert.DoesNotContain("timeout", m, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Причина остаётся ВНУТРИ исключения — для лога и разбора обращений. Наружу её выносит
+    /// вызывающий, подставляя общий текст; здесь фиксируем, что причина вообще есть и она разная.
+    /// </summary>
+    [Fact]
+    public async Task RefusalReason_IsKeptForTheLog()
+    {
+        var blocked = await Assert.ThrowsAsync<OutboundAddressRefusedException>(
+            () => OutboundAddressPolicy.EnsureAllowedAsync(new Uri("http://10.0.0.5/x")));
+        var badScheme = Assert.Throws<OutboundAddressRefusedException>(
+            () => OutboundAddressPolicy.RequireHttpUrl("ftp://example.com/x"));
+
+        Assert.Contains("10.0.0.5", blocked.Message);
+        Assert.NotEqual(blocked.Message, badScheme.Message);
+        // И ни одна из причин не равна тому, что покажут пользователю.
+        Assert.NotEqual(OutboundAddressPolicy.RefusalMessage, blocked.Message);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.88.0</Version>
+    <Version>0.89.0</Version>
   </PropertyGroup>
 
   <!-- Проставляем короткий git-хеш в SourceRevisionId, если он ещё не задан — SDK допишет его в


### PR DESCRIPTION
Шаг 2 «Порядка работ» из локального отчёта `docs/security/SECURITY-AUDIT-2026-08-04.md`, раздел 3 (#673).

**Описания и обоснования — в отчёте, не здесь.**

## Что сделано

Появились две единицы в `Infrastructure/Http/`: правила для адресов назначения и запрос, проверяющий каждый переход. Одна точка на всех исходящих клиентов — своя проверка у каждого разошлась бы с остальными.

- проверяется **результат разрешения имени**, а не текст адреса; при нескольких адресах годными должны быть все;
- автоследование за перенаправлениями выключено, переходы проходятся вручную с пределом и проверкой цели каждого;
- тело читается потоком со счётчиком и обрывается на пределе — заголовок длины больше не опора;
- отказы сетевого слоя отвечают одним текстом-константой, причина остаётся для лога;
- скрейпинг страниц выдачи переведён на тот же путь.

## Два пункта плана отклонены — это решения, а не недоделки

**Адрес Ollama.** План предписывал применить проверку и к нему. Не сделал: умолчание `http://localhost:11434`, в поставке `ollama:11434` — ровно те адреса, которые проверка обязана запрещать, то есть распознавание сломалось бы у всех, у кого служба стоит рядом. Плюс это не ссылка извне, а адрес службы, заданный администратором, и по модели угроз самого отчёта «Admin дотянулся до внутренней сети» находкой не считается. Что там уместно вместо — записано в отчёт и отнесено к разделу 6.

**Белый список доменов.** Списки в настройках существуют, но они про релевантность выдачи, а не про допуск. Сделав их белым списком, мы молча запретили бы импорт с сайта производителя, которого в списке нет — а список ведёт человек и он неполон по определению, — и связали бы правку ранжирования с правами. Проверка по диапазонам закрывает то, ради чего пункт заведён, и не зависит от полноты чьего-то списка.

Оба обоснования — в отчёте; если решения не устраивают, они обратимы.

## Проверка

- `dotnet test` — **1134/1134** (+53 новых). Тесты по диапазонам включают **соседние с запрещёнными** адреса с обеих сторон: границы диапазонов ошибаются молча.
- Сборка чиста, версия `0.88.0` → `0.89.0`.

⚠️ Живьём по сети не проверял: проверка адресов и разбор перенаправлений покрыты тестами, но реальный импорт с внешнего сайта и ответ с перенаправлением внутрь я не прогонял — для этого нужен внешний ресурс. Раздел «Проверка после починки» в отчёте описывает, что стоит прощёлкать.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
