### PR TITLE
Предел глубины считаем по цепочке ссылок, а не по вложенности JSON (#723)

### DIFF
--- a/src/client/src/shared/api/documentSets.ts
+++ b/src/client/src/shared/api/documentSets.ts
@@ -274,7 +274,10 @@ export interface ResolutionDiagnostic {
   severity: 'error' | 'warning';
   path: string;
   message: string;
-  /** Вид проблемы (issue #332): "leftover-ref" — висячая ссылка (цель удалена), "missing-required" — пустое обязательное. */
+  /**
+   * Вид проблемы (issue #332): "leftover-ref" — висячая ссылка (цель удалена), "ref-depth-limit" —
+   * ссылка цела, но резолвер до неё не дошёл (issue #723), "missing-required" — пустое обязательное.
+   */
   code?: string;
 }
 
@@ -292,9 +295,15 @@ export function useResolutionDiagnostics(instanceId: string | undefined, enabled
   });
 }
 
-/** Пути битых ссылок (leftover-ref) из диагностики — для пометки полей. */
+/**
+ * Пути неразрешённых ссылок из диагностики — для пометки полей. Оба вида: цель удалена
+ * (leftover-ref) и резолвер не дошёл (ref-depth-limit, issue #723). Причины разные, а поле в обоих
+ * случаях показывает не то, что в нём должно быть, — значит помечаем.
+ */
+const BROKEN_REF_CODES = new Set(['leftover-ref', 'ref-depth-limit']);
+
 export function brokenRefPaths(diagnostics: ResolutionDiagnostic[] | undefined): Set<string> {
-  return new Set((diagnostics ?? []).filter(d => d.code === 'leftover-ref').map(d => d.path));
+  return new Set((diagnostics ?? []).filter(d => BROKEN_REF_CODES.has(d.code ?? '')).map(d => d.path));
 }
 
 export type PreviewResult =

--- a/src/server/BHS.CRG.Api/Mcp/DocumentActionTools.cs
+++ b/src/server/BHS.CRG.Api/Mcp/DocumentActionTools.cs
@@ -17,7 +17,8 @@ namespace BHS.CRG.Api.Mcp;
 /// вывода: это то, что с ним делают в любом случае.
 /// </summary>
 /// <param name="Severity">Error / Warning. Error блокирует генерацию, Warning — нет.</param>
-/// <param name="Code">Вид проблемы: <c>missing-required</c>, <c>leftover-ref</c>, <c>value-type</c> и т.п.</param>
+/// <param name="Code">Вид проблемы: <c>missing-required</c>, <c>leftover-ref</c> (цель ссылки
+/// удалена), <c>ref-depth-limit</c> (цель цела, резолвер не дошёл), <c>value-type</c> и т.п.</param>
 /// <param name="Count">Сколько раз проблема встретилась — по нему видно, это единичный случай или
 /// системная беда всей таблицы.</param>
 /// <param name="Paths">Адреса проблемных мест. По умолчанию несколько первых: путей столько же,

--- a/src/server/BHS.CRG.Application/Generation/RefProvenance.cs
+++ b/src/server/BHS.CRG.Application/Generation/RefProvenance.cs
@@ -19,3 +19,19 @@ public static class RefProvenance
     /// <summary>Идентификатор документа, развёрнутого на этом месте.</summary>
     public const string InstanceIdKey = "_instanceId";
 }
+
+/// <summary>
+/// Почему ссылка осталась неразвёрнутой (issue #723). Сканеру нельзя выдавать одну причину за
+/// другую: «цель удалена» и «резолвер сам не пошёл дальше» требуют от человека противоположных
+/// действий, а внешне сырой <c>$ref</c> в обоих случаях один и тот же.
+///
+/// Пометку ставит резолвер в момент отказа; отсутствие пометки означает «цель не нашлась».
+/// </summary>
+public static class RefUnresolved
+{
+    /// <summary>Ключ пометки на самом $ref-узле.</summary>
+    public const string Key = "$unresolved";
+
+    /// <summary>Резолвер упёрся в предел глубины и оставил ссылку как есть.</summary>
+    public const string DepthLimit = "depth-limit";
+}

--- a/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
+++ b/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
@@ -8,7 +8,8 @@ public enum DiagnosticSeverity { Warning, Error }
 /// <summary>
 /// Одна проблема, найденная при проверке разрешения ссылок контекста генерации.
 /// <paramref name="Code"/> различает вид (issue #332): "leftover-ref" — висячая ссылка (цель удалена),
-/// "missing-required" — незаполненное обязательное. Фронт по нему рисует разные индикаторы.
+/// "ref-depth-limit" — ссылка цела, но резолвер до неё не дошёл (issue #723), "missing-required" —
+/// незаполненное обязательное. Фронт по нему рисует разные индикаторы.
 /// </summary>
 public record ResolutionDiagnostic(DiagnosticSeverity Severity, string Path, string Message, string Code = "");
 
@@ -86,10 +87,19 @@ public static class ResolutionScanner
                         "catalog" => "запись каталога",
                         _ => $"объект типа «{kind}»",
                     };
-                    diagnostics.Add(new ResolutionDiagnostic(
-                        DiagnosticSeverity.Error, path,
-                        $"Ссылка на {kindHuman}{(target is null ? "" : $" (id {target})")} не разрешена — целевая запись не найдена или удалена.",
-                        "leftover-ref"));
+                    var id = target is null ? "" : $" (id {target})";
+                    // Резолвер помечает СВОЙ отказ (issue #723). Без пометки причина одна — цели нет;
+                    // с пометкой цель, скорее всего, на месте, и звать человека её искать — враньё.
+                    var stoppedByDepth = el.TryGetProperty(RefUnresolved.Key, out var why)
+                        && why.GetString() == RefUnresolved.DepthLimit;
+                    diagnostics.Add(stoppedByDepth
+                        ? new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
+                            $"Ссылка на {kindHuman}{id} не развёрнута — исчерпан предел длины цепочки ссылок. " +
+                            "Целевая запись при этом может существовать: укоротите цепочку либо поднимите предел.",
+                            "ref-depth-limit")
+                        : new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
+                            $"Ссылка на {kindHuman}{id} не разрешена — целевая запись не найдена или удалена.",
+                            "leftover-ref"));
                     return; // глубже не идём — внутренность ссылки не данные
                 }
                 foreach (var p in el.EnumerateObject())

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -221,9 +221,19 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     private static JsonElement MarkDepthLimited(JsonElement node)
         => WithMeta(node, RefUnresolved.Key, RefUnresolved.DepthLimit);
 
+    /// <summary>Снимает пометку предела: этот проход до ссылки дошёл, и прежняя причина неверна.</summary>
+    private static JsonElement WithoutDepthMark(JsonElement node)
+        => node.TryGetProperty(RefUnresolved.Key, out _) ? WithoutMeta(node, RefUnresolved.Key) : node;
+
     private async Task<JsonElement> ResolveRefObject(JsonElement node, string? refType, ScopeChain scope,
         int refDepth, int nodeDepth, bool allowInstanceRefs, bool keepRefProvenance, CancellationToken ct)
     {
+        // Пометку прошлого прохода снимаем НА ВХОДЕ: генерация и проверка гоняют резолв дважды, и
+        // второй проход стартует с нулевой цепочкой. Он может дойти до узла, который первый пометил
+        // пределом, — и упереться уже в другое: цель удалена. Донеси пометку до `node.Clone()` в
+        // ветках ниже, сканер сказал бы «укоротите цепочку» про запись, которой попросту нет.
+        node = WithoutDepthMark(node);
+
         switch (refType)
         {
             // Запись каталога (с _baseRef-наследованием) → заходим внутрь, её собственные ссылки тоже разворачиваем.
@@ -313,6 +323,16 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
         foreach (var p in obj.EnumerateObject())
             if (p.Name != key) dict[p.Name] = p.Value.Clone();
         dict[key] = JsonSerializer.SerializeToElement(value);
+        return JsonSerializer.SerializeToElement(dict);
+    }
+
+    /// <summary>Копия объекта без служебного ключа.</summary>
+    private static JsonElement WithoutMeta(JsonElement obj, string key)
+    {
+        if (obj.ValueKind != JsonValueKind.Object) return obj;
+        var dict = new Dictionary<string, JsonElement>();
+        foreach (var p in obj.EnumerateObject())
+            if (p.Name != key) dict[p.Name] = p.Value.Clone();
         return JsonSerializer.SerializeToElement(dict);
     }
 

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -16,9 +16,18 @@ namespace BHS.CRG.Infrastructure.Generation;
 /// </summary>
 public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEvaluator) : IEntityResolver
 {
-    // Максимальная глубина рекурсивного разворачивания вложенных ссылок (защита от патологически
-    // глубоких структур). Ортогональна allowInstanceRefs (защита от циклов по документам).
+    // Предел ЦЕПОЧКИ ССЫЛОК: сколько переходов ref→ref разворачиваем подряд. Считается только на
+    // переходах, а не на вложенности JSON (issue #723): раньше счётчик был один на оба, и каждая
+    // развёрнутая ссылка съедала две единицы (заход внутрь резолвнутого объекта + обход его полей),
+    // из-за чего живая цепочка «строка источника → документ → персона → приказ → организация»
+    // упиралась в предел на последнем звене, а сканер выдавал обрыв за удалённую запись.
+    // Ортогонален allowInstanceRefs (защита от циклов по документам).
     private const int MaxRefDepth = 8;
+
+    // Предел вложенности САМОГО JSON — защита от патологически глубоких структур (рекурсия обхода).
+    // Отдельный и с большим запасом: обычные реквизиты в него не упираются, и расходовать на него
+    // бюджет ссылок незачем.
+    private const int MaxNodeDepth = 64;
 
     public async Task<GenerationContext> ResolveAsync(DocumentView instance, bool keepRefProvenance = false,
         CancellationToken ct = default)
@@ -95,7 +104,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
         foreach (var key in ctx.Data.Keys.ToList())
         {
             if (ctx.Data[key] is not JsonElement el) continue;
-            ctx.Set(key, await ResolveNode(el, scope, depth: 0, allowInstanceRefs: true, keepRefProvenance, ct));
+            ctx.Set(key, await ResolveNode(el, scope, refDepth: 0, nodeDepth: 0, allowInstanceRefs: true,
+                keepRefProvenance, ct));
         }
     }
 
@@ -157,28 +167,33 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
 
     /// <summary>
     /// Единая точка разбора $ref: обходит произвольное JSON-дерево (объекты/массивы на любой
-    /// глубине — раньше это были три разошедшиеся копии). <paramref name="depth"/> — общий предел
-    /// глубины графа; <paramref name="allowInstanceRefs"/> — разрешено ли на этом шаге разворачивать
-    /// instance-ссылки (становится false внутри уже развёрнутого instance — один переход по
-    /// документу, защита от циклов A→B→C).
+    /// глубине — раньше это были три разошедшиеся копии). <paramref name="refDepth"/> — длина уже
+    /// пройденной цепочки ссылок, <paramref name="nodeDepth"/> — вложенность самого JSON (пределы
+    /// раздельные, см. константы); <paramref name="allowInstanceRefs"/> — разрешено ли на этом шаге
+    /// разворачивать instance-ссылки (становится false внутри уже развёрнутого instance — один
+    /// переход по документу, защита от циклов A→B→C).
     /// </summary>
-    private async Task<JsonElement> ResolveNode(JsonElement node, ScopeChain scope, int depth,
+    private async Task<JsonElement> ResolveNode(JsonElement node, ScopeChain scope, int refDepth, int nodeDepth,
         bool allowInstanceRefs, bool keepRefProvenance, CancellationToken ct)
     {
-        if (depth >= MaxRefDepth) return node.Clone();
+        if (nodeDepth >= MaxNodeDepth) return MarkIfRef(node);
 
         switch (node.ValueKind)
         {
             case JsonValueKind.Object when node.TryGetProperty("$ref", out var refTypeProp):
-                return await ResolveRefObject(node, refTypeProp.GetString(), scope, depth, allowInstanceRefs,
-                    keepRefProvenance, ct);
+                // Бюджет цепочки исчерпан — ссылку оставляем сырой, но помечаем ПОЧЕМУ: иначе сканер
+                // прочтёт её как ссылку на удалённую запись и пошлёт искать то, чего не терялось.
+                return refDepth >= MaxRefDepth
+                    ? MarkDepthLimited(node)
+                    : await ResolveRefObject(node, refTypeProp.GetString(), scope, refDepth, nodeDepth,
+                        allowInstanceRefs, keepRefProvenance, ct);
 
             case JsonValueKind.Object:
             {
                 var dict = new Dictionary<string, JsonElement>();
                 foreach (var prop in node.EnumerateObject())
-                    dict[prop.Name] = await ResolveNode(prop.Value, scope, depth + 1, allowInstanceRefs,
-                        keepRefProvenance, ct);
+                    dict[prop.Name] = await ResolveNode(prop.Value, scope, refDepth, nodeDepth + 1,
+                        allowInstanceRefs, keepRefProvenance, ct);
                 return JsonSerializer.SerializeToElement(dict);
             }
 
@@ -186,7 +201,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
             {
                 var list = new List<JsonElement>();
                 foreach (var item in node.EnumerateArray())
-                    list.Add(await ResolveNode(item, scope, depth + 1, allowInstanceRefs, keepRefProvenance, ct));
+                    list.Add(await ResolveNode(item, scope, refDepth, nodeDepth + 1, allowInstanceRefs,
+                        keepRefProvenance, ct));
                 return JsonSerializer.SerializeToElement(list);
             }
 
@@ -195,8 +211,18 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
         }
     }
 
+    /// <summary>Пометка «дальше не пошли сами» — только на $ref-узле (остальное не ссылка).</summary>
+    private static JsonElement MarkIfRef(JsonElement node)
+        => node.ValueKind == JsonValueKind.Object && node.TryGetProperty("$ref", out _)
+            ? MarkDepthLimited(node)
+            : node.Clone();
+
+    /// <summary>Сырая ссылка + причина отказа (issue #723) — её читает <c>ResolutionScanner</c>.</summary>
+    private static JsonElement MarkDepthLimited(JsonElement node)
+        => WithMeta(node, RefUnresolved.Key, RefUnresolved.DepthLimit);
+
     private async Task<JsonElement> ResolveRefObject(JsonElement node, string? refType, ScopeChain scope,
-        int depth, bool allowInstanceRefs, bool keepRefProvenance, CancellationToken ct)
+        int refDepth, int nodeDepth, bool allowInstanceRefs, bool keepRefProvenance, CancellationToken ct)
     {
         switch (refType)
         {
@@ -206,7 +232,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
             {
                 var resolved = await ResolveEntryByIdAsync(entryId, scope, [], ct);
                 if (resolved.ValueKind == JsonValueKind.Undefined) return node.Clone();
-                var recursed = await ResolveNode(resolved, scope, depth + 1, allowInstanceRefs, keepRefProvenance, ct);
+                var recursed = await ResolveNode(resolved, scope, refDepth + 1, nodeDepth + 1, allowInstanceRefs,
+                    keepRefProvenance, ct);
                 // Фактический тип записи каталога (issue #344) — для корректного instance-of на подтипах
                 // (поле «Организация», запись «Подрядчик»). Application развернёт _typeId в _type.
                 var typeId = await db.DomainObjects.Where(o => o.Id == entryId)
@@ -237,7 +264,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
                 when allowInstanceRefs
                      && node.TryGetProperty("instanceId", out var docInstIdProp) && Guid.TryParse(docInstIdProp.GetString(), out var docInstId):
             {
-                var resolved = await ResolveDocumentInstanceAsync(docInstId, scope, depth, keepRefProvenance, ct);
+                var resolved = await ResolveDocumentInstanceAsync(docInstId, scope, refDepth, nodeDepth,
+                    keepRefProvenance, ct);
                 if (resolved.ValueKind == JsonValueKind.Undefined) return node.Clone();
                 return keepRefProvenance
                     ? WithMeta(resolved, RefProvenance.InstanceIdKey, docInstId.ToString())
@@ -293,8 +321,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     /// <c>allowInstanceRefs: false</c> — вложенные instance-ссылки дальше не разворачиваются
     /// (защита от циклов), а массивы/таблицы внутри обрабатываются как везде (это чинит баг B).
     /// </summary>
-    private async Task<JsonElement> ResolveDocumentInstanceAsync(Guid instanceId, ScopeChain scope, int depth,
-        bool keepRefProvenance, CancellationToken ct)
+    private async Task<JsonElement> ResolveDocumentInstanceAsync(Guid instanceId, ScopeChain scope, int refDepth,
+        int nodeDepth, bool keepRefProvenance, CancellationToken ct)
     {
         var obj = await db.DomainObjects.AsNoTracking().Include(o => o.Facet)
             .FirstOrDefaultAsync(o => o.Id == instanceId && o.ScopeLevel == CatalogScope.Set
@@ -306,7 +334,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
         var dict = new Dictionary<string, JsonElement>();
         foreach (var (k, v) in subCtx.Data)
             if (v is JsonElement je)
-                dict[k] = await ResolveNode(je, scope, depth + 1, allowInstanceRefs: false, keepRefProvenance, ct);
+                dict[k] = await ResolveNode(je, scope, refDepth + 1, nodeDepth + 1, allowInstanceRefs: false,
+                    keepRefProvenance, ct);
 
         // Фактический тип развёрнутого документа-ссылки (issue #344) — Application развернёт в _type.
         dict[TypeStamper.TypeIdKey] = JsonSerializer.SerializeToElement(obj.CompositeTypeId.ToString());

--- a/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ResolutionScannerTests.cs
@@ -59,5 +59,25 @@ public class ResolutionScannerTests
         Assert.Equal("Подрядчик", d.Path);
         Assert.Equal(DiagnosticSeverity.Error, d.Severity);
         Assert.Equal("leftover-ref", d.Code);
+        Assert.Contains("не найдена или удалена", d.Message);
+    }
+
+    [Fact]
+    public void ScanLeftoverRefs_RefStoppedByDepth_ReportedAsDepthLimit_NotDeletedTarget()
+    {
+        // issue #723: резолвер пометил СВОЙ отказ — про удаление говорить нельзя, цель обычно цела.
+        var ctx = new GenerationContext();
+        ctx.Set("Приказ", Json((
+            "{'ВыпустившаяОрганизация':{'$ref':'catalog','entryId':'00000000-0000-0000-0000-000000000001',"
+            + "'" + RefUnresolved.Key + "':'" + RefUnresolved.DepthLimit + "'}}").Replace('\'', '"')));
+
+        var diags = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diags);
+
+        var d = Assert.Single(diags);
+        Assert.Equal("Приказ.ВыпустившаяОрганизация", d.Path);
+        Assert.Equal(DiagnosticSeverity.Error, d.Severity);
+        Assert.Equal("ref-depth-limit", d.Code);
+        Assert.DoesNotContain("удалена", d.Message);
     }
 }

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -481,4 +481,33 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         // «Хвост» за пределом — до него не дошли, и это ровно то, о чём сказано в диагностике.
         Assert.DoesNotContain("Хвост", JsonSerializer.Serialize(ctx.Data));
     }
+
+    [Fact] // Пометка предела не должна пережить проход, который до ссылки таки дошёл
+    public async Task RefMarkedByLimit_TargetDeleted_SecondPassReportsLeftoverRef()
+    {
+        // Генерация и проверка гоняют ResolveContextRefsAsync ВТОРЫМ проходом (ссылки из наборов
+        // данных), и он стартует с нулевой цепочкой. Дойдя до помеченного узла, резолвер идёт в БД —
+        // и если цели там нет, причина уже другая: удаление, а не предел. Иначе подмена диагнозов,
+        // против которой затевался #723, просто меняет направление.
+        var setId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_DEPTH_DEL");
+        var refType = await TypeAsync(DocumentTypeKind.Composite, "ORG_DEPTH_DEL");
+        // Последнее звено указывает в никуда и стоит ровно за пределом первого прохода.
+        var currentId = await EntryAsync(refType, "{'След':{'$ref':'catalog','entryId':'" + Guid.NewGuid() + "'}}");
+        for (var i = 0; i < 7; i++)
+            currentId = await EntryAsync(refType, "{'След':{'$ref':'catalog','entryId':'" + currentId + "'}}");
+        var docId = await DocAsync(setId, docType, "{'Орг':{'$ref':'catalog','entryId':'" + currentId + "'}}");
+
+        var ctx = await ResolveAsync(docId);
+        using (var scope = fixture.Services.CreateScope())
+            await scope.ServiceProvider.GetRequiredService<IEntityResolver>()
+                .ResolveContextRefsAsync(ctx, setId);
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diagnostics);
+
+        var d = Assert.Single(diagnostics);
+        Assert.Equal("leftover-ref", d.Code);
+        Assert.Contains("не найдена или удалена", d.Message);
+    }
 }

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverTests.cs
@@ -434,4 +434,51 @@ public class EntityResolverTests(IntegrationTestFixture fixture) : IAsyncLifetim
         Assert.False(org.TryGetProperty("Наименование", out _)); // scope-guard на цепочке: чужая орг не подмешана
         Assert.Equal("Подрядчик", org.GetProperty("Роль").GetString()); // собственные поля прокси остаются
     }
+
+    // ── Пределы глубины: цепочка ссылок отдельно от вложенности JSON (issue #723) ─
+
+    [Fact] // Живой случай: документ → массив → объект → персона → приказ → организация
+    public async Task CatalogRefChain_UnderDeepNesting_ResolvedToLastLink()
+    {
+        // Раньше счётчик был один на оба измерения, и каждая развёрнутая ссылка съедала ДВЕ единицы:
+        // на этой структуре последнее звено обрывалось, а сканер выдавал обрыв за удалённую запись.
+        var setId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_DEPTH");
+        var refType = await TypeAsync(DocumentTypeKind.Composite, "ORG_DEPTH");
+        var orgId = await EntryAsync(refType, "{'Наименование':'ООО Ромашка'}");
+        var orderId = await EntryAsync(refType, "{'Орг':{'$ref':'catalog','entryId':'" + orgId + "'}}");
+        var personId = await EntryAsync(refType, "{'Приказ':{'$ref':'catalog','entryId':'" + orderId + "'}}");
+        var docId = await DocAsync(setId, docType,
+            "{'Строки':[{'Блок':{'Подписи':[{'$ref':'catalog','entryId':'" + personId + "'}]}}]}");
+
+        var ctx = await ResolveAsync(docId);
+
+        var org = E(ctx, "Строки")[0].GetProperty("Блок").GetProperty("Подписи")[0]
+            .GetProperty("Приказ").GetProperty("Орг");
+        Assert.Equal("ООО Ромашка", org.GetProperty("Наименование").GetString());
+    }
+
+    [Fact] // Предел цепочки обязан срабатывать — и говорить о себе, а не о «удалённой записи»
+    public async Task CatalogRefChain_BeyondLimit_LeavesMarkedRef_ReportedAsDepthLimit()
+    {
+        var setId = await SetupSetAsync();
+        var docType = await TypeAsync(DocumentTypeKind.Document, "DOC_DEPTH_MAX");
+        var refType = await TypeAsync(DocumentTypeKind.Composite, "ORG_DEPTH_MAX");
+        // Цепочка заведомо длиннее предела (8 переходов): последнее звено развернуться не должно.
+        var tailId = await EntryAsync(refType, "{'Наименование':'Хвост'}");
+        var currentId = tailId;
+        for (var i = 0; i < 12; i++)
+            currentId = await EntryAsync(refType, "{'След':{'$ref':'catalog','entryId':'" + currentId + "'}}");
+        var docId = await DocAsync(setId, docType, "{'Орг':{'$ref':'catalog','entryId':'" + currentId + "'}}");
+
+        var ctx = await ResolveAsync(docId);
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diagnostics);
+
+        var d = Assert.Single(diagnostics);
+        Assert.Equal("ref-depth-limit", d.Code);
+        Assert.DoesNotContain("удалена", d.Message);
+        // «Хвост» за пределом — до него не дошли, и это ровно то, о чём сказано в диагностике.
+        Assert.DoesNotContain("Хвост", JsonSerializer.Serialize(ctx.Data));
+    }
 }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.105.1</Version>
+    <Version>0.105.2</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Закрывает #723.

## Что было

«Проверить ссылки» на «250701.ЭОМ-1.Реестр исполнительной документации» давал 6 ошибок «целевая запись не найдена или удалена» — при том, что обе записи (ООО «Инвест Строй», ООО «ДНС СТРОЙ») на месте и в области видимости документа.

Причина не в данных: `MaxRefDepth` считался по вложенности JSON, а не по переходам между ссылками, хотя комментарий над константой обещал второе. Каждая развёрнутая ссылка стоила две единицы (заход внутрь резолвнутого объекта + обход его полей) против одного сегмента в пути, и живая цепочка упиралась в предел на последнем звене:

```
ОсновнойДокументы (строка материализованного источника)  -> 1
  .ТитульныйЛист   — doc-ref на документ комплекта        -> 3
  .Подписи[1]      — $ref на персону                      -> 5
  .Приказ          — $ref на приказ                       -> 7
  .ВыпустившаяОрганизация — $ref на организацию           -> 8  обрыв
```

Сырой `$ref` после обрыва внешне неотличим от ссылки на удалённую цель, и сканер сообщал единственное, что умел.

## Что сделано

**Два счётчика вместо одного.** `MaxRefDepth = 8` теперь считает ровно переходы по ссылкам (по смыслу своего комментария); вложенность самого JSON ограничена отдельным `MaxNodeDepth = 64` — защита от патологических структур, которой незачем расходовать бюджет ссылок.

**Отказ по пределу называет себя.** Резолвер помечает узел, на котором остановился (`$unresolved: depth-limit`), сканер докладывает отдельным кодом `ref-depth-limit` и другим текстом: цель, скорее всего, цела. Прежний `leftover-ref` остаётся ровно за случаем «цели нет».

**Фронт метит поля по обоим кодам.** Причины разные, а поле в обоих случаях показывает не то, что должно, — значит индикатор нужен. Иначе новый код тихо погасил бы пометки на полях.

## Проверено

- Комплект 250701.ЭОМ-1: было 6 ошибок на «Реестре», стало **0 по всем девяти документам** (через `/api/generate/validate/{id}`, тот же путь, что у кнопки «Проверить ссылки»).
- Регрессионный тест на живую форму данных (документ → массив → объект → персона → приказ → организация) **падает на прежней семантике счётчика** — проверено подменой.
- Тест на срабатывание самого предела: цепочка длиннее 8 переходов оставляет помеченную ссылку и диагностику `ref-depth-limit`, за предел резолвер не заходит.
- `dotnet test` — 1356 passed; `npx tsc -b` — чисто; `npm test` — 470 passed.

Версия поднята до 0.105.2.
