### PR TITLE
Материализация в тип-документ: режим «Существующий документ по Ид» (#725)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -152,8 +152,14 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
           id => allDocTypes.find(t => t.id === id)?.name ?? id)
       : null;
 
+  // Типы ещё не приехали, а тип у источника задан: тело диалога скрыто, и «Сохранить» отправила бы
+  // настройку, собранную из невыясненного, — режим «по Ид» и правило варианта потерялись бы молча,
+  // оставив источник в состоянии «материализован, но маппинг пуст», на которое ругается он же сам.
+  // Не «проблема» (человек ничего не сделал не так), а просто не время сохранять.
+  const typesPending = !!typeId && !selectedType;
+
   function handleSave() {
-    if (problem) return;
+    if (problem || typesPending) return;
     save.mutate(
       {
         sourceId: source.id,
@@ -189,7 +195,8 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
       footer={
         <div className="flex justify-end gap-2">
           <Button type="button" variant="text" onClick={onClose}>Отмена</Button>
-          <Button type="button" variant="filled" onClick={handleSave} loading={save.isPending} disabled={!!problem}>
+          <Button type="button" variant="filled" onClick={handleSave} loading={save.isPending}
+            disabled={!!problem || typesPending}>
             {save.isPending ? 'Сохранение…' : 'Сохранить'}
           </Button>
         </div>

--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -11,6 +11,7 @@ import { MappingEditor } from '@/features/document-sets/editor/DataSetsTab';
 import { VariantPicker } from '@/features/document-sets/fields/ComplexFields';
 import { UnionDiscriminatorEditor, discriminatorProblem } from './UnionDiscriminatorEditor';
 import { resolveEffectiveFields } from '@/shared/api/schema';
+import { parseSourceColumnNames } from '@/shared/api/datasetHelpers';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
 import type { DataSetSource, MaterializeDiscriminator } from '@/shared/api/types';
@@ -36,7 +37,20 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
   const [singleModeStash, setSingleModeStash] = useState<Record<string, string> | null>(null);
   const [byTypeStash, setByTypeStash] = useState<Record<string, string> | null>(null);
 
+  // Режим «существующий документ по Ид» (issue #725): строка целиком — ссылка на документ, маппинга
+  // в нём нет. Как и у режимов union'а, переключение недеструктивно — маппинг ждёт в стэше.
+  const [byIdMode, setByIdMode] = useState(!!source.materializeByIdColumn);
+  const [byIdColumn, setByIdColumn] = useState(source.materializeByIdColumn ?? '');
+  const [mappingModeStash, setMappingModeStash] = useState<Record<string, string> | null>(null);
+
   const selectedType = allDocTypes.find(t => t.id === typeId);
+  // Ссылаться можно только на экземпляр документа: у составного типа (в т.ч. union'а) их нет.
+  const isDocumentType = selectedType?.kind === 'Document';
+
+  const columnNames = useMemo(() => {
+    const computed = (source.computedColumns ?? []).map(c => c.alias).filter(Boolean);
+    return [...new Set([...parseSourceColumnNames(source.cachedSchema), ...computed])];
+  }, [source.cachedSchema, source.computedColumns]);
   const effectiveFields = selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : [];
   // Union-тип (issue #320/#391): «заполняется ровно один вариант» — маппим один активный вариант,
   // а не все поля union разом. Материализатор кладёт один ключ на строку → корректный union-экземпляр.
@@ -84,6 +98,22 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
     setByRowType(next);
   }
 
+  /**
+   * Переключение «собрать из колонок» ↔ «существующий документ по Ид». Маппинг не выбрасываем, а
+   * прячем в стэш: человек, заглянувший в другой режим, не должен терять уже настроенные колонки.
+   * Сохраняется при этом ровно один режим — в «по Ид» на сервер уходит пустой маппинг.
+   */
+  function switchByIdMode(next: boolean) {
+    if (next === byIdMode) return;
+    if (next) {
+      setMappingModeStash(mapping);
+      setMapping({});
+    } else {
+      setMapping(mappingModeStash ?? {});
+    }
+    setByIdMode(next);
+  }
+
   // Легаси-настройка union'а с НЕСКОЛЬКИМИ ключами (до issue #716 такое сохранялось молча, а union
   // при этом заполнялся весь сразу). Схлопываем до одного — того, что диалог и показывает. Иначе
   // человек правит видимую колонку, жмёт «Сохранить» и получает отказ про ключ, которого на экране
@@ -99,7 +129,8 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
   // Live-превью по ТЕКУЩИМ (несохранённым) типу+маппингу и правилу (issue #294, #716): обновляется
   // на каждую правку. Объявлено ПОСЛЕ isUnion/discriminator — раньше их значения ещё не существуют.
   const preview = useMaterializePreview(source.id, typeId || undefined, mapping, showPreview && !!typeId,
-    isUnion && byRowType && discriminator.column ? discriminator : null);
+    isUnion && byRowType && discriminator.column ? discriminator : null,
+    byIdMode && isDocumentType ? byIdColumn : null);
 
   function switchVariant(key: string) {
     if (key === activeVariant) return;
@@ -110,11 +141,16 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
     setActiveVariant(key);
   }
 
-  const useDiscriminator = isUnion && byRowType;
-  const problem = useDiscriminator
-    ? discriminatorProblem(effectiveFields, mapping, discriminator,
-        id => allDocTypes.find(t => t.id === id)?.name ?? id)
-    : null;
+  const useByIdMode = isDocumentType && byIdMode;
+  const useDiscriminator = isUnion && byRowType && !useByIdMode;
+  const problem = useByIdMode
+    // Режим без колонки сохранился бы как «материализация без маппинга» — то есть молчаливым
+    // массивом пустышек, ради которого и заведён issue #715. Отказываем здесь, а не там.
+    ? (byIdColumn ? null : 'Выберите колонку с идентификатором документа.')
+    : useDiscriminator
+      ? discriminatorProblem(effectiveFields, mapping, discriminator,
+          id => allDocTypes.find(t => t.id === id)?.name ?? id)
+      : null;
 
   function handleSave() {
     if (problem) return;
@@ -122,8 +158,11 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
       {
         sourceId: source.id,
         typeId: typeId || null,
-        mapping: typeId ? mapping : null,
+        // В режиме «по Ид» маппинга нет вовсе: строка целиком — ссылка. Отправить и то и другое
+        // значит сохранить две разные настройки одного и того же (сервер такое и не примет).
+        mapping: typeId && !useByIdMode ? mapping : {},
         discriminator: typeId && useDiscriminator ? discriminator : null,
+        byIdColumn: typeId && useByIdMode ? byIdColumn : null,
       },
       { onSuccess: onClose },
     );
@@ -181,13 +220,51 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
             setSingleModeStash(null);
             setByTypeStash(null);
             setByRowType(false);
+            setByIdMode(false);
+            setByIdColumn('');
+            setMappingModeStash(null);
           }} />
 
         {selectedType && (
-          effectiveFields.length === 0 ? (
-            <p className="text-xs text-warning">У типа «{selectedType.name}» нет полей — задайте поля типу, чтобы было куда маппить.</p>
-          ) : (
-            <div className="rounded-lg border border-stroke p-3 space-y-3">
+          <div className="rounded-lg border border-stroke p-3 space-y-3">
+            {/* Тип-документ можно не собирать, а назвать: строка ссылается на уже существующий
+                документ комплекта (issue #725). Составным типам выбирать не из чего. */}
+            {isDocumentType && (
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                <label className="flex items-center gap-1.5 cursor-pointer">
+                  <input type="radio" name="materialize-source-mode" checked={!byIdMode}
+                    onChange={() => switchByIdMode(false)} />
+                  <span className={byIdMode ? 'text-fg3' : 'text-fg1'}>собрать из колонок</span>
+                </label>
+                <label className="flex items-center gap-1.5 cursor-pointer">
+                  <input type="radio" name="materialize-source-mode" checked={byIdMode}
+                    onChange={() => switchByIdMode(true)} />
+                  <span className={byIdMode ? 'text-fg1' : 'text-fg3'}>существующий документ по Ид</span>
+                </label>
+              </div>
+            )}
+
+            {useByIdMode ? (
+              <div className="space-y-1.5">
+                <label className="block">
+                  <span className="block text-xs font-medium mb-1 text-fg3">Колонка с идентификатором документа</span>
+                  <select
+                    value={byIdColumn}
+                    onChange={e => setByIdColumn(e.target.value)}
+                    className="w-full border border-stroke rounded-md px-2 py-1.5 text-sm bg-surface text-fg1"
+                  >
+                    <option value="">— не выбрана —</option>
+                    {columnNames.map(c => <option key={c} value={c}>{c}</option>)}
+                  </select>
+                </label>
+                <span className="text-[11px] text-fg4 flex items-center gap-1">
+                  <Info size={11} /> строка целиком становится ссылкой на документ — поля берутся из него самого
+                </span>
+              </div>
+            ) : effectiveFields.length === 0 ? (
+              <p className="text-xs text-warning">У типа «{selectedType.name}» нет полей — задайте поля типу, чтобы было куда маппить.</p>
+            ) : (
+            <>
               {isUnion && (
                 <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
                   <label className="flex items-center gap-1.5 cursor-pointer">
@@ -237,14 +314,15 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
                   allowDocRef
                 />
               )}
+            </>
+            )}
 
-              {problem && (
-                <p className="text-xs text-danger flex items-start gap-1">
-                  <AlertTriangle size={13} className="shrink-0 mt-px" /> {problem}
-                </p>
-              )}
-            </div>
-          )
+            {problem && (
+              <p className="text-xs text-danger flex items-start gap-1">
+                <AlertTriangle size={13} className="shrink-0 mt-px" /> {problem}
+              </p>
+            )}
+          </div>
         )}
 
         {typeId && (

--- a/src/client/src/features/datasets/SourcesExpander.tsx
+++ b/src/client/src/features/datasets/SourcesExpander.tsx
@@ -216,9 +216,13 @@ function SourceRow({ src, isPdf, fixedExtraction, canManageExtraction, templates
               </span>
             )}
             {src.materializeTypeId && (
-              <span title="Источник материализуется в тип — маппинг задан на источнике (issue #19)."
+              <span title={src.materializeByIdColumn
+                // Режим «по Ид» (issue #725) виден чипом: маппинга у такого источника нет, и подпись
+                // про «маппинг на источнике» отправляла бы искать настройку, которой там не бывает.
+                ? `Строки источника — ссылки на существующие документы по колонке «${src.materializeByIdColumn}».`
+                : 'Источник материализуется в тип — маппинг задан на источнике (issue #19).'}
                 className="ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-brand/10 text-brand align-middle">
-                <Boxes size={10} /> материализация
+                <Boxes size={10} /> материализация{src.materializeByIdColumn ? ' · по Ид' : ''}
               </span>
             )}
             {/* Счётчик привязок (issue #417): удаление источника не должно быть вслепую.

--- a/src/client/src/features/document-sets/editor/ContainerFieldBinding.tsx
+++ b/src/client/src/features/document-sets/editor/ContainerFieldBinding.tsx
@@ -178,7 +178,12 @@ export function ContainerFieldBinding({ instanceId, setId, field, allDocTypes, b
               {selectedSource && (isMaterialized ? (
                 <div className="rounded-lg border border-brand/40 bg-brand/5 p-3 text-xs text-fg3">
                   Источник материализуется в тип <b>{allDocTypes.find(t => t.id === selectedSource.materializeTypeId)?.name ?? '—'}</b> —
-                  маппинг задан на источнике, поле заполнится напрямую.
+                  {selectedSource.materializeByIdColumn
+                    // Режим «по Ид» (issue #725): маппинга нет вовсе, и обещать его здесь значило бы
+                    // отправить человека искать несуществующую настройку.
+                    ? <> строки ссылаются на существующие документы (колонка «{selectedSource.materializeByIdColumn}»),
+                        поле заполнится их живыми данными.</>
+                    : <> маппинг задан на источнике, поле заполнится напрямую.</>}
                 </div>
               ) : (
                 <div className="rounded-lg border border-stroke p-3">

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -168,12 +168,15 @@ export function useSetMaterialization() {
     mapping: Record<string, string> | null;
     /** Правило выбора варианта union'а (issue #716); null — один вариант на все строки. */
     discriminator?: MaterializeDiscriminator | null;
+    /** Колонка с Ид существующего документа (issue #725); null — сборка объекта из колонок. */
+    byIdColumn?: string | null;
   }>({
     // Настройка сохраняется ЦЕЛИКОМ: маппинг и правило связаны, и отправить одно без другого
     // значит оставить источник в состоянии, которого сервер не пропустит.
-    mutationFn: ({ sourceId, typeId, mapping, discriminator }) =>
+    mutationFn: ({ sourceId, typeId, mapping, discriminator, byIdColumn }) =>
       apiClient.put(`/datasets/sources/${sourceId}/materialization`,
-        { typeId, mapping, discriminator: discriminator ?? null }).then(r => r.data),
+        { typeId, mapping, discriminator: discriminator ?? null, byIdColumn: byIdColumn ?? null })
+        .then(r => r.data),
     onSuccess: () => invalidateSources(qc),
   });
 }
@@ -202,14 +205,16 @@ export function useMaterializePreview(
   sourceId: string | undefined, typeId: string | undefined,
   mapping: Record<string, string>, enabled: boolean,
   discriminator?: MaterializeDiscriminator | null,
+  byIdColumn?: string | null,
 ) {
   return useQuery<MaterializePreview>({
     queryKey: ['datasets', 'materialize-preview', sourceId, typeId ?? '',
-      JSON.stringify(mapping), JSON.stringify(discriminator ?? null)],
+      JSON.stringify(mapping), JSON.stringify(discriminator ?? null), byIdColumn ?? ''],
     queryFn: () =>
       apiClient
         .post(`/datasets/sources/${sourceId}/materialization/preview`,
-          { typeId: typeId || null, mapping, discriminator: discriminator ?? null })
+          { typeId: typeId || null, mapping, discriminator: discriminator ?? null,
+            byIdColumn: byIdColumn ?? null })
         .then(r => r.data),
     enabled: !!sourceId && enabled,
     placeholderData: keepPreviousData,

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -336,6 +336,9 @@ export interface DataSetSource {
   materializeMapping: Record<string, string> | null;
   /** Правило выбора варианта union'а по строке (issue #716); null — один вариант на все строки. */
   materializeDiscriminator?: MaterializeDiscriminator | null;
+  /** Колонка с Ид существующего документа (issue #725): непустая = строка целиком становится
+   *  ссылкой на документ (маппинг в этом режиме не задаётся). Null — сборка объекта из колонок. */
+  materializeByIdColumn?: string | null;
 }
 
 /** Как читать колонку-признак: код типа документа либо идентификатор самого документа. */

--- a/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/DataSets/DataSetEndpoints.cs
@@ -194,7 +194,8 @@ public static class DataSetEndpoints
         g.MapPut("/sources/{sourceId:guid}/materialization", async (
             Guid sourceId, MaterializationRequest req, IDataSetService svc, CancellationToken ct) =>
         {
-            var result = await svc.SetMaterializationAsync(sourceId, req.TypeId, req.Mapping, req.Discriminator, ct);
+            var result = await svc.SetMaterializationAsync(
+                sourceId, req.TypeId, req.Mapping, req.Discriminator, req.ByIdColumn, ct);
             return result is null ? Results.NotFound() : Results.Ok(result);
         });
 
@@ -204,7 +205,7 @@ public static class DataSetEndpoints
             Guid sourceId, MaterializePreviewRequest req, IDataSetService svc, CancellationToken ct) =>
         {
             var result = await svc.MaterializePreviewAsync(
-                sourceId, req.MaxRows ?? 50, req.TypeId, req.Mapping, req.Discriminator, ct);
+                sourceId, req.MaxRows ?? 50, req.TypeId, req.Mapping, req.Discriminator, req.ByIdColumn, ct);
             return result is null ? Results.NotFound() : Results.Ok(result);
         });
 
@@ -434,10 +435,12 @@ public static class DataSetEndpoints
     private record SourceRequest(string Name, string SheetOrPath, ColumnExprDto[]? ColumnExpressions);
     private record RenameSourceRequest(string Name);
     private record DuplicateSourceRequest(string? Name);
+    /// <param name="ByIdColumn">Колонка с Ид существующего документа (issue #725): непустая = строка
+    /// целиком становится ссылкой на документ, маппинг в этом режиме не задаётся.</param>
     private record MaterializationRequest(Guid? TypeId, Dictionary<string, string>? Mapping,
-        MaterializeDiscriminatorConfig? Discriminator);
+        MaterializeDiscriminatorConfig? Discriminator, string? ByIdColumn);
     private record MaterializePreviewRequest(Guid? TypeId, Dictionary<string, string>? Mapping, int? MaxRows,
-        MaterializeDiscriminatorConfig? Discriminator);
+        MaterializeDiscriminatorConfig? Discriminator, string? ByIdColumn);
     private record ProcessingRequest(object? RowFilter, object? ComputedColumns, object? SortSpec);
     private record ProcessingTemplateRequest(
         string Name, string? SheetOrPath, ColumnExprDto[]? ColumnExpressions,

--- a/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
+++ b/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
@@ -17,7 +17,10 @@ public record DataSetSourceDto(
     string? Warning = null,
     /// <summary>Правило выбора варианта union'а по строке (issue #716); null — материализация
     /// статична, один вариант на все строки.</summary>
-    MaterializeDiscriminatorConfig? MaterializeDiscriminator = null);
+    MaterializeDiscriminatorConfig? MaterializeDiscriminator = null,
+    /// <summary>Колонка с Ид существующего документа (issue #725): непустая = строка целиком
+    /// становится ссылкой на документ, маппинг при этом пуст. Null — обычная сборка из колонок.</summary>
+    string? MaterializeByIdColumn = null);
 
 /// <summary>
 /// Материализованный предпросмотр источника: строки, развёрнутые в объекты формы типа (issue #19).

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -35,14 +35,18 @@ public interface IDataSetService
     /// <summary>Ручное создание источника (для XML — единственный способ, авто-детект не используется).</summary>
     Task<DataSetSourceDto> CreateSourceAsync(Guid fileId, CreateSourceInput input, CancellationToken ct);
     /// <summary>Настроить/снять материализацию источника в тип (issue #19). typeId=null снимает;
-    /// маппинг и правило выбора варианта (issue #716) задаются целиком, замещением.</summary>
+    /// маппинг, правило выбора варианта (issue #716) и колонка режима «по Ид» (issue #725) задаются
+    /// целиком, замещением.</summary>
     Task<DataSetSourceDto?> SetMaterializationAsync(Guid sourceId, Guid? typeId,
-        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator, CancellationToken ct);
+        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator,
+        string? byIdColumn, CancellationToken ct);
     /// <summary>Предпросмотр материализации источника (строки → объекты формы типа).
     /// <paramref name="mapping"/> задан — настройку ведёт диалог, и <paramref name="discriminator"/>
-    /// авторитетен (null значит «правила нет», issue #294/#716); mapping=null → сохранённые на источнике.</summary>
+    /// с <paramref name="byIdColumn"/> авторитетны (null значит «нет», issue #294/#716/#725);
+    /// mapping=null → сохранённые на источнике.</summary>
     Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, Guid? typeId,
-        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator, CancellationToken ct);
+        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator,
+        string? byIdColumn, CancellationToken ct);
     Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct);
     /// <summary>Лёгкое переименование источника (issue #43) — только имя, без extraction/кэша; для любого
     /// источника, включая PDF-проекции.</summary>

--- a/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
@@ -81,6 +81,23 @@ public class DataSetSource : Entity
     /// </summary>
     public string? MaterializeDiscriminator { get; private set; }
 
+    /// <summary>
+    /// Режим «существующий документ по Ид» (issue #725): имя колонки, несущей идентификатор уже
+    /// существующего документа. Строка источника целиком становится ссылкой
+    /// <c>{"$ref":"instance","instanceId":…}</c>, а не объектом, собранным из колонок; живые данные
+    /// подставляет второй проход <c>EntityResolver</c>. Null — материализация обычная (сборка).
+    ///
+    /// <para><b>Почему отдельной колонкой.</b> Та же причина, что у <see cref="MaterializeDiscriminator"/>:
+    /// «вся строка» — не поле типа, и служебный ключ внутри <see cref="MaterializeMapping"/> пришлось
+    /// бы объяснять всем, кто читает маппинг циклом (генерация, предпросмотр привязки, предпросмотр
+    /// материализации, редактор маппинга). Первый забывший получил бы «всю строку» в качестве поля.</para>
+    ///
+    /// <para>Применим только к типу-документу: у составного типа экземпляров-документов нет, ссылаться
+    /// не на что. Вместе с непустым <see cref="MaterializeMapping"/> не сохраняется — это две разные
+    /// настройки одного и того же (см. <c>MaterializeConfigValidator</c>).</para>
+    /// </summary>
+    public string? MaterializeByIdColumn { get; private set; }
+
     public DataSetFile File { get; private set; } = null!;
     private readonly List<DataSetBinding> _bindings = [];
     public IReadOnlyList<DataSetBinding> Bindings => _bindings.AsReadOnly();
@@ -158,12 +175,17 @@ public class DataSetSource : Entity
     /// строке; null означает «один вариант на все строки». Задаётся ЦЕЛИКОМ вместе с маппингом:
     /// правила и маппинг связаны (правило варианта без маппинга бессмысленно), и раздельное
     /// сохранение оставляло бы источник в состоянии, которого валидатор не пропустил бы.
+    ///
+    /// <paramref name="byIdColumn" /> (issue #725) — колонка с идентификатором существующего
+    /// документа; непустая означает режим «вся строка = ссылка», при котором маппинг пуст.
     /// </summary>
-    public void SetMaterialization(Guid? typeId, string? mappingJson, string? discriminatorJson = null)
+    public void SetMaterialization(Guid? typeId, string? mappingJson, string? discriminatorJson = null,
+        string? byIdColumn = null)
     {
         MaterializeTypeId = typeId;
         MaterializeMapping = typeId is null ? null : (mappingJson ?? "{}");
         MaterializeDiscriminator = typeId is null ? null : discriminatorJson;
+        MaterializeByIdColumn = typeId is null || string.IsNullOrWhiteSpace(byIdColumn) ? null : byIdColumn.Trim();
         TouchUpdatedAt();
     }
 }

--- a/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
+++ b/src/server/BHS.CRG.Domain/DataSets/DataSetSource.cs
@@ -185,7 +185,10 @@ public class DataSetSource : Entity
         MaterializeTypeId = typeId;
         MaterializeMapping = typeId is null ? null : (mappingJson ?? "{}");
         MaterializeDiscriminator = typeId is null ? null : discriminatorJson;
-        MaterializeByIdColumn = typeId is null || string.IsNullOrWhiteSpace(byIdColumn) ? null : byIdColumn.Trim();
+        // Имя колонки НЕ подрезаем: ключи строк — заголовки файла как есть (CSV-парсер подрезает
+        // значения, не заголовки). Подрезанное «Ид » не совпало бы ни с одной строкой, и реестр
+        // молча опустел бы с сообщением про пустую колонку. Дискриминатор (#716) хранит имя так же.
+        MaterializeByIdColumn = typeId is null || string.IsNullOrWhiteSpace(byIdColumn) ? null : byIdColumn;
         TouchUpdatedAt();
     }
 }

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.Json;
 using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -70,6 +72,13 @@ public class DataSetBindingService(
             .AsNoTracking()
             .ToListAsync(ct);
 
+        // Владелец нужен дважды: чтобы знать комплект, в котором будут разворачиваться ссылки строк
+        // (в другом комплекте резолвер документ не возьмёт), и чтобы вывести тип строки табличной
+        // привязки. Читаем один раз на весь предпросмотр, а не по привязке.
+        var owner = await db.DomainObjects.AsNoTracking().Include(o => o.Facet)
+            .FirstOrDefaultAsync(o => o.Id == ownerId, ct);
+        var ownerSetId = owner is { IsDocument: true, ScopeLevel: CatalogScope.Set } ? owner.ScopeId : null;
+
         var results = new List<BindingPreviewDto>();
         foreach (var binding in bindings)
         {
@@ -84,7 +93,7 @@ public class DataSetBindingService(
                     && DataSetMappingValue.IsEmptyMapping(binding.Mapping)
                     && MaterializeByIdMode.IsOn(binding.Source.MaterializeByIdColumn))
                 {
-                    results.Add(await PreviewDocumentRefsAsync(binding, rows, ct));
+                    results.Add(await PreviewDocumentRefsAsync(binding, rows, ownerSetId, ct));
                     continue;
                 }
 
@@ -126,6 +135,9 @@ public class DataSetBindingService(
                         if (!string.IsNullOrEmpty(colName))
                             data[fieldKey] = await DataSetDtoMapper.PreviewCellAsync(colName, row, ct);
 
+                    // Тип строки скалярной привязки — сам тип владельца: маппинг ложится на его поля.
+                    await DocRefPreviewLabeler.LabelAsync(db, [data], owner?.CompositeTypeId, ownerSetId, ct);
+
                     results.Add(new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
                         "scalar", null, rows.Count, data, null));
                 }
@@ -143,6 +155,12 @@ public class DataSetBindingService(
                                 obj[fieldKey] = await DataSetDtoMapper.PreviewCellAsync(colName, row, ct);
                         mapped.Add(obj);
                     }
+
+                    // Тип строки: у материализованного источника — его тип, иначе — тип элемента
+                    // целевого поля. Без этого doc-ref-ячейки остались бы сырыми идентификаторами
+                    // на экране, куда идут проверять, ТЕ ЛИ документы приедут.
+                    await DocRefPreviewLabeler.LabelAsync(db, mapped,
+                        await RowTypeIdAsync(binding, owner?.CompositeTypeId, ct), ownerSetId, ct);
 
                     results.Add(new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
                         "tabular", binding.TargetFieldKey, mapped.Count, mapped,
@@ -171,6 +189,7 @@ public class DataSetBindingService(
     private async Task<BindingPreviewDto> PreviewDocumentRefsAsync(
         DataSetBinding binding,
         IReadOnlyList<IReadOnlyDictionary<string, string?>> rows,
+        Guid? ownerSetId,
         CancellationToken ct)
     {
         var column = binding.Source.MaterializeByIdColumn!;
@@ -190,7 +209,7 @@ public class DataSetBindingService(
             else ids.Add(id.Value);
         }
 
-        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, ids.Distinct().ToList(), ct);
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, ids.Distinct().ToList(), ownerSetId, ct);
         var mapped = ids
             .Select(id => new Dictionary<string, object?>
             {
@@ -206,6 +225,23 @@ public class DataSetBindingService(
 
         return new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
             "tabular", binding.TargetFieldKey, mapped.Count, mapped, warning);
+    }
+
+    /// <summary>
+    /// Тип, в форму которого разворачивается строка табличной привязки: у материализованного
+    /// источника — его тип материализации (маппинг взят оттуда), иначе — тип элемента целевого поля.
+    /// null — вывести не удалось (тип владельца неизвестен либо поле не найдено).
+    /// </summary>
+    private async Task<Guid?> RowTypeIdAsync(DataSetBinding binding, Guid? ownerTypeId, CancellationToken ct)
+    {
+        if (binding.Source.MaterializeTypeId is { } materialized
+            && DataSetMappingValue.IsEmptyMapping(binding.Mapping))
+            return materialized;
+
+        if (ownerTypeId is not { } typeId || binding.TargetFieldKey is null) return null;
+
+        var typesById = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
+        return DocumentTypeSchemaReader.Field(typeId, binding.TargetFieldKey, typesById)?.TypeId;
     }
 
     /// <summary>Тот же выбор варианта, что у генерации (issue #716); null — правила нет.</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Infrastructure.Persistence;
@@ -77,6 +77,17 @@ public class DataSetBindingService(
             {
                 var rows = await rowLoader.LoadRowsAsync(binding.Source, ct);
 
+                // Материализация ссылкой на существующий документ (issue #725) — до маппинга, его в
+                // этом режиме нет. Показываем НАИМЕНОВАНИЯ документов: идентификатор в таблице не
+                // говорит человеку ничего, а именно сюда он идёт проверять, те ли документы уедут.
+                if (binding.Source.MaterializeTypeId is not null
+                    && DataSetMappingValue.IsEmptyMapping(binding.Mapping)
+                    && MaterializeByIdMode.IsOn(binding.Source.MaterializeByIdColumn))
+                {
+                    results.Add(await PreviewDocumentRefsAsync(binding, rows, ct));
+                    continue;
+                }
+
                 // Материализованный источник (issue #19/#23): привязка без своего маппинга берёт маппинг
                 // с источника — как и резолвер генерации. Иначе превью пустое и материалы/сертификаты не
                 // извлекаются на вкладке «Документы качества».
@@ -150,6 +161,51 @@ public class DataSetBindingService(
             }
         }
         return results;
+    }
+
+    /// <summary>
+    /// Предпросмотр материализации ссылкой на существующий документ (issue #725): по строке на
+    /// документ, значение — наименование, а для отсутствующего документа сказано, что его нет.
+    /// Пропущенные строки (пустая ячейка, не-Ид) показываются числом с причиной — как и у генерации.
+    /// </summary>
+    private async Task<BindingPreviewDto> PreviewDocumentRefsAsync(
+        DataSetBinding binding,
+        IReadOnlyList<IReadOnlyDictionary<string, string?>> rows,
+        CancellationToken ct)
+    {
+        var column = binding.Source.MaterializeByIdColumn!;
+
+        if (binding.TargetFieldKey is null)
+            return new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
+                "error", null, rows.Count, new { },
+                $"Источник «{binding.Source.Name}» материализован ссылкой на существующий документ — " +
+                "такую строку можно положить только в поле-документ или в список документов, а не в отдельные поля.");
+
+        var ids = new List<Guid>();
+        var skipped = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            var (id, reason, _) = MaterializeByIdMode.ReadId(row, column);
+            if (id is null) skipped[reason!] = skipped.GetValueOrDefault(reason!) + 1;
+            else ids.Add(id.Value);
+        }
+
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, ids.Distinct().ToList(), ct);
+        var mapped = ids
+            .Select(id => new Dictionary<string, object?>
+            {
+                ["Документ"] = labels.TryGetValue(id, out var label) ? label : MaterializeByIdMode.NotFoundLabel,
+            })
+            .ToList();
+
+        var warning = skipped.Count == 0
+            ? null
+            : "Строк пропущено при материализации: " + skipped.Values.Sum() + " — "
+              + string.Join("; ", skipped.OrderByDescending(p => p.Value)
+                  .Select(p => $"{p.Value} — {MaterializeSkipReason.Describe(p.Key)}"));
+
+        return new BindingPreviewDto(binding.Id, binding.Source.Name, binding.Source.File.Name,
+            "tabular", binding.TargetFieldKey, mapped.Count, mapped, warning);
     }
 
     /// <summary>Тот же выбор варианта, что у генерации (issue #716); null — правила нет.</summary>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetDtoMapper.cs
@@ -83,7 +83,8 @@ public static class DataSetDtoMapper
         s.MaterializeTypeId,
         s.MaterializeMapping is null ? null : JsonSerializer.Deserialize<Dictionary<string, string>>(s.MaterializeMapping),
         bindingCount, live?.Warning,
-        MaterializeVariantSelector.ParseConfig(s.MaterializeDiscriminator));
+        MaterializeVariantSelector.ParseConfig(s.MaterializeDiscriminator),
+        s.MaterializeByIdColumn);
 
     /// <summary>null, если счётчики не запрашивали (одиночная мутация), иначе 0 для источника без привязок.</summary>
     private static int? BindingCountOf(IReadOnlyDictionary<Guid, int>? counts, Guid sourceId)

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -55,11 +55,13 @@ public class DataSetService(
     public Task<DataSetSourceDto> CreateSourceAsync(Guid fileId, CreateSourceInput input, CancellationToken ct) =>
         sources.CreateSourceAsync(fileId, input, ct);
     public Task<DataSetSourceDto?> SetMaterializationAsync(Guid sourceId, Guid? typeId,
-        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator, CancellationToken ct) =>
-        sources.SetMaterializationAsync(sourceId, typeId, mapping, discriminator, ct);
+        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator,
+        string? byIdColumn, CancellationToken ct) =>
+        sources.SetMaterializationAsync(sourceId, typeId, mapping, discriminator, byIdColumn, ct);
     public Task<MaterializePreviewDto?> MaterializePreviewAsync(Guid sourceId, int maxRows, Guid? typeId,
-        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator, CancellationToken ct) =>
-        sources.MaterializePreviewAsync(sourceId, maxRows, typeId, mapping, discriminator, ct);
+        Dictionary<string, string>? mapping, MaterializeDiscriminatorConfig? discriminator,
+        string? byIdColumn, CancellationToken ct) =>
+        sources.MaterializePreviewAsync(sourceId, maxRows, typeId, mapping, discriminator, byIdColumn, ct);
     public Task<DataSetSourceDto?> UpdateSourceAsync(Guid sourceId, UpdateSourceInput input, CancellationToken ct) =>
         sources.UpdateSourceAsync(sourceId, input, ct);
     public Task<DataSetSourceDto?> RenameSourceAsync(Guid sourceId, string name, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -339,7 +339,7 @@ public class DataSetSourceService(
             var page = rows.Take(take).ToList();
 
             if (MaterializeByIdMode.IsOn(effByIdColumn))
-                return await ByIdPreviewAsync(effTypeId, effByIdColumn!, page, rows.Count, ct);
+                return await ByIdPreviewAsync(effTypeId, effByIdColumn!, page, rows.Count, SetOf(source.File), ct);
 
             MaterializeVariantSelector? selector = null;
             if (effDiscriminator is not null && !string.IsNullOrWhiteSpace(effDiscriminator.Column))
@@ -397,8 +397,7 @@ public class DataSetSourceService(
             // Ссылки на документы — наименованиями, а не идентификаторами (issue #715, пункт проверки,
             // и issue #725). Пока превью отдавало сырой GUID, «ссылка на удалённый документ» выглядела
             // здесь ровно так же, как рабочая, — и расходились они только при генерации.
-            if (effTypeId is { } previewTypeId)
-                await LabelDocRefCellsAsync(mapped, previewTypeId, ct);
+            await DocRefPreviewLabeler.LabelAsync(db, mapped, effTypeId, SetOf(source.File), ct);
 
             return new MaterializePreviewDto(effTypeId, rows.Count, mapped, null, variants, skipped);
         }
@@ -415,7 +414,7 @@ public class DataSetSourceService(
     /// </summary>
     private async Task<MaterializePreviewDto> ByIdPreviewAsync(
         Guid? typeId, string column,
-        IReadOnlyList<IReadOnlyDictionary<string, string?>> page, int totalRows, CancellationToken ct)
+        IReadOnlyList<IReadOnlyDictionary<string, string?>> page, int totalRows, Guid? setId, CancellationToken ct)
     {
         var ids = new List<Guid>();
         var skipped = new List<MaterializeSkippedRowDto>();
@@ -431,7 +430,7 @@ public class DataSetSourceService(
             else ids.Add(id.Value);
         }
 
-        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [.. ids.Distinct()], ct);
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [.. ids.Distinct()], setId, ct);
         var rows = ids
             .Select(id => new Dictionary<string, object?>
             {
@@ -442,46 +441,9 @@ public class DataSetSourceService(
         return new MaterializePreviewDto(typeId, totalRows, rows, null, null, skipped);
     }
 
-    /// <summary>
-    /// Ячейки <c>doc-ref</c>-полей — наименованием документа вместо идентификатора. Значения, не
-    /// разобравшиеся в идентификатор, остаются как есть: «в колонке не то» видно только так
-    /// (философия issue #466), и подменять это на «не найден» значило бы назвать другую беду.
-    /// </summary>
-    private async Task LabelDocRefCellsAsync(
-        List<Dictionary<string, object?>> rows, Guid typeId, CancellationToken ct)
-    {
-        if (rows.Count == 0) return;
-
-        var typesById = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
-        if (!typesById.ContainsKey(typeId)) return;
-
-        var docRefKeys = DocumentTypeSchemaReader.EffectiveFields(typeId, typesById)
-            .Where(f => f.Type == "doc-ref")
-            .Select(f => f.Key)
-            .ToHashSet(StringComparer.Ordinal);
-        if (docRefKeys.Count == 0) return;
-
-        // Идентификаторы всей страницы разрешаются ОДНИМ запросом — построчный дал бы по запросу на
-        // каждый документ реестра.
-        var ids = new List<Guid>();
-        foreach (var row in rows)
-            foreach (var key in docRefKeys)
-                if (CellId(row, key) is { } id) ids.Add(id);
-        if (ids.Count == 0) return;
-
-        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [.. ids.Distinct()], ct);
-        foreach (var row in rows)
-            foreach (var key in docRefKeys)
-                if (CellId(row, key) is { } id)
-                    row[key] = labels.TryGetValue(id, out var label)
-                        ? $"🔗 {label}"
-                        : MaterializeByIdMode.NotFoundLabel;
-
-        static Guid? CellId(Dictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v is string s && Guid.TryParse(s.Trim(), out var id)
-                ? id
-                : null;
-    }
+    /// <summary>Комплект, в котором будут разворачиваться ссылки строк этого набора; null — набор
+    /// живёт выше комплекта и используется в разных, и проверять принадлежность нечему.</summary>
+    private static Guid? SetOf(DataSetFile file) => file.Scope == CatalogScope.Set ? file.ScopeId : null;
 
     public async Task<DataSetSourceDto> CreateSourceAsync(Guid fileId, CreateSourceInput input, CancellationToken ct)
     {

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetSourceService.cs
@@ -278,7 +278,7 @@ public class DataSetSourceService(
     /// </summary>
     public async Task<DataSetSourceDto?> SetMaterializationAsync(
         Guid sourceId, Guid? typeId, Dictionary<string, string>? mapping,
-        MaterializeDiscriminatorConfig? discriminator, CancellationToken ct)
+        MaterializeDiscriminatorConfig? discriminator, string? byIdColumn, CancellationToken ct)
     {
         var source = await db.DataSetSources.FirstOrDefaultAsync(s => s.Id == sourceId, ct);
         if (source == null) return null;
@@ -289,14 +289,14 @@ public class DataSetSourceService(
             var typesById = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
             if (!typesById.TryGetValue(id, out var type))
                 throw new NotFoundException($"Тип {id} не найден.");
-            MaterializeConfigValidator.Validate(type, effectiveMapping, discriminator, typesById);
+            MaterializeConfigValidator.Validate(type, effectiveMapping, discriminator, typesById, byIdColumn);
         }
 
         var mappingJson = typeId is null ? null : JsonSerializer.Serialize(effectiveMapping);
         var discriminatorJson = typeId is null || discriminator is null
             ? null
             : JsonSerializer.Serialize(discriminator);
-        source.SetMaterialization(typeId, mappingJson, discriminatorJson);
+        source.SetMaterialization(typeId, mappingJson, discriminatorJson, byIdColumn);
         await db.SaveChangesAsync(ct);
         return DataSetDtoMapper.MapSource(source);
     }
@@ -308,7 +308,7 @@ public class DataSetSourceService(
     /// </summary>
     public async Task<MaterializePreviewDto?> MaterializePreviewAsync(
         Guid sourceId, int maxRows, Guid? typeId, Dictionary<string, string>? mapping,
-        MaterializeDiscriminatorConfig? discriminator, CancellationToken ct)
+        MaterializeDiscriminatorConfig? discriminator, string? byIdColumn, CancellationToken ct)
     {
         var source = await db.DataSetSources.Include(s => s.File).AsNoTracking().FirstOrDefaultAsync(s => s.Id == sourceId, ct);
         if (source == null) return null;
@@ -328,12 +328,18 @@ public class DataSetSourceService(
         var effDiscriminator = mapping is not null
             ? discriminator
             : MaterializeVariantSelector.ParseConfig(source.MaterializeDiscriminator);
+        // Колонка режима «по Ид» (issue #725) — живая по тому же признаку: диалог, ведущий настройку,
+        // присылает маппинг, и переключение режима обязано быть видно в предпросмотре сразу.
+        var effByIdColumn = mapping is not null ? byIdColumn : source.MaterializeByIdColumn;
 
         try
         {
             var rows = await rowLoader.LoadRowsAsync(source, ct);
             var take = maxRows <= 0 ? 50 : maxRows;
             var page = rows.Take(take).ToList();
+
+            if (MaterializeByIdMode.IsOn(effByIdColumn))
+                return await ByIdPreviewAsync(effTypeId, effByIdColumn!, page, rows.Count, ct);
 
             MaterializeVariantSelector? selector = null;
             if (effDiscriminator is not null && !string.IsNullOrWhiteSpace(effDiscriminator.Column))
@@ -388,12 +394,93 @@ public class DataSetSourceService(
                 variants.Add(variantKey);
             }
 
+            // Ссылки на документы — наименованиями, а не идентификаторами (issue #715, пункт проверки,
+            // и issue #725). Пока превью отдавало сырой GUID, «ссылка на удалённый документ» выглядела
+            // здесь ровно так же, как рабочая, — и расходились они только при генерации.
+            if (effTypeId is { } previewTypeId)
+                await LabelDocRefCellsAsync(mapped, previewTypeId, ct);
+
             return new MaterializePreviewDto(effTypeId, rows.Count, mapped, null, variants, skipped);
         }
         catch (Exception ex)
         {
             return new MaterializePreviewDto(effTypeId, 0, [], ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Предпросмотр режима «существующий документ по Ид» (issue #725): строка = один документ,
+    /// показанный наименованием; отсутствующий по идентификатору назван отсутствующим. Строки без
+    /// идентификатора перечисляются поимённо — как и пропуски дискриминатора, и ровно затем же.
+    /// </summary>
+    private async Task<MaterializePreviewDto> ByIdPreviewAsync(
+        Guid? typeId, string column,
+        IReadOnlyList<IReadOnlyDictionary<string, string?>> page, int totalRows, CancellationToken ct)
+    {
+        var ids = new List<Guid>();
+        var skipped = new List<MaterializeSkippedRowDto>();
+        var rowIndex = 0;
+
+        foreach (var row in page)
+        {
+            rowIndex++;
+            var (id, reason, cell) = MaterializeByIdMode.ReadId(row, column);
+            if (id is null)
+                skipped.Add(new MaterializeSkippedRowDto(
+                    rowIndex, cell, reason!, MaterializeSkipReason.Describe(reason!)));
+            else ids.Add(id.Value);
+        }
+
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [.. ids.Distinct()], ct);
+        var rows = ids
+            .Select(id => new Dictionary<string, object?>
+            {
+                ["Документ"] = labels.TryGetValue(id, out var label) ? label : MaterializeByIdMode.NotFoundLabel,
+            })
+            .ToList();
+
+        return new MaterializePreviewDto(typeId, totalRows, rows, null, null, skipped);
+    }
+
+    /// <summary>
+    /// Ячейки <c>doc-ref</c>-полей — наименованием документа вместо идентификатора. Значения, не
+    /// разобравшиеся в идентификатор, остаются как есть: «в колонке не то» видно только так
+    /// (философия issue #466), и подменять это на «не найден» значило бы назвать другую беду.
+    /// </summary>
+    private async Task LabelDocRefCellsAsync(
+        List<Dictionary<string, object?>> rows, Guid typeId, CancellationToken ct)
+    {
+        if (rows.Count == 0) return;
+
+        var typesById = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
+        if (!typesById.ContainsKey(typeId)) return;
+
+        var docRefKeys = DocumentTypeSchemaReader.EffectiveFields(typeId, typesById)
+            .Where(f => f.Type == "doc-ref")
+            .Select(f => f.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        if (docRefKeys.Count == 0) return;
+
+        // Идентификаторы всей страницы разрешаются ОДНИМ запросом — построчный дал бы по запросу на
+        // каждый документ реестра.
+        var ids = new List<Guid>();
+        foreach (var row in rows)
+            foreach (var key in docRefKeys)
+                if (CellId(row, key) is { } id) ids.Add(id);
+        if (ids.Count == 0) return;
+
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [.. ids.Distinct()], ct);
+        foreach (var row in rows)
+            foreach (var key in docRefKeys)
+                if (CellId(row, key) is { } id)
+                    row[key] = labels.TryGetValue(id, out var label)
+                        ? $"🔗 {label}"
+                        : MaterializeByIdMode.NotFoundLabel;
+
+        static Guid? CellId(Dictionary<string, object?> row, string key)
+            => row.TryGetValue(key, out var v) && v is string s && Guid.TryParse(s.Trim(), out var id)
+                ? id
+                : null;
     }
 
     public async Task<DataSetSourceDto> CreateSourceAsync(Guid fileId, CreateSourceInput input, CancellationToken ct)
@@ -630,7 +717,8 @@ public class DataSetSourceService(
             source.ColumnExpressions, source.CachedData);
         copy.SetProcessing(source.RowFilter, source.ComputedColumns, source.SortSpec);
         copy.SetTags(source.Tags);
-        copy.SetMaterialization(source.MaterializeTypeId, source.MaterializeMapping, source.MaterializeDiscriminator);
+        copy.SetMaterialization(source.MaterializeTypeId, source.MaterializeMapping, source.MaterializeDiscriminator,
+            source.MaterializeByIdColumn);
         // file уже отслеживается — см. пояснение в CreateSourceAsync (иначе Modified вместо Added).
         db.DataSetSources.Add(copy);
         await db.SaveChangesAsync(ct);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DocRefPreviewLabeler.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DocRefPreviewLabeler.cs
@@ -1,0 +1,63 @@
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.DataSets;
+
+/// <summary>
+/// Ячейки <c>doc-ref</c>-полей в предпросмотрах — наименованием документа, а не идентификатором
+/// (issue #715, пункт проверки; #725).
+///
+/// <para>Сырой GUID человеку не говорит ничего, а главное — по нему НЕ ВИДНО, разрешится ли ссылка:
+/// удалённый документ выглядит точно так же, как рабочий, и расходятся они только при генерации.
+/// Условия разрешимости здесь те же, что у резолвера (см. <see cref="MaterializeByIdMode.ResolveLabelsAsync"/>).</para>
+///
+/// <para>Одно место на оба предпросмотра — материализации (диалог) и привязки (вкладка данных):
+/// это два экрана про одни и те же данные, и разойдись они, второй показывал бы исправной ссылку,
+/// которую первый уже назвал битой.</para>
+/// </summary>
+public static class DocRefPreviewLabeler
+{
+    /// <summary>
+    /// Заменяет в строках предпросмотра значения <c>doc-ref</c>-полей типа <paramref name="rowTypeId"/>
+    /// на «🔗 наименование» либо на объяснение, почему ссылка не развернётся. Значения, не
+    /// разобравшиеся в идентификатор, остаются как есть: «в колонке не то» видно только так
+    /// (философия issue #466), и подменять это на «не найден» значило бы назвать другую беду.
+    /// </summary>
+    public static async Task LabelAsync(
+        AppDbContext db, IReadOnlyList<Dictionary<string, object?>> rows,
+        Guid? rowTypeId, Guid? setId, CancellationToken ct)
+    {
+        if (rows.Count == 0 || rowTypeId is not { } typeId) return;
+
+        var typesById = await db.DocumentTypes.AsNoTracking().ToDictionaryAsync(t => t.Id, ct);
+        if (!typesById.ContainsKey(typeId)) return;
+
+        var docRefKeys = DocumentTypeSchemaReader.EffectiveFields(typeId, typesById)
+            .Where(f => f.Type == "doc-ref")
+            .Select(f => f.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        if (docRefKeys.Count == 0) return;
+
+        // Идентификаторы всей страницы разрешаются ОДНИМ запросом — построчный дал бы по запросу на
+        // каждый документ реестра.
+        var ids = new List<Guid>();
+        foreach (var row in rows)
+            foreach (var key in docRefKeys)
+                if (CellId(row, key) is { } id) ids.Add(id);
+        if (ids.Count == 0) return;
+
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [.. ids.Distinct()], setId, ct);
+        foreach (var row in rows)
+            foreach (var key in docRefKeys)
+                if (CellId(row, key) is { } id)
+                    row[key] = labels.TryGetValue(id, out var label)
+                        ? MaterializeByIdMode.IsProblem(label) ? label : $"🔗 {label}"
+                        : MaterializeByIdMode.NotFoundLabel;
+    }
+
+    private static Guid? CellId(Dictionary<string, object?> row, string key)
+        => row.TryGetValue(key, out var v) && v is string s && Guid.TryParse(s.Trim(), out var id)
+            ? id
+            : null;
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeByIdMode.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeByIdMode.cs
@@ -1,0 +1,76 @@
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.DataSets;
+
+/// <summary>
+/// Материализация «существующий документ по Ид» (issue #725): строка источника целиком становится
+/// ссылкой <c>{"$ref":"instance","instanceId":…}</c> на уже существующий документ, а не объектом,
+/// собранным из колонок. Живые данные подставляет второй проход <c>EntityResolver</c>.
+///
+/// <para>Режим нужен там, где ссылаться надо НЕ полем: у типа-документа (напр. «Протокол измерения
+/// сопротивления изоляции») полей <c>doc-ref</c> нет, а реестр обязан ссылаться на сам документ.
+/// Маппинг <c>doc-ref</c>-полей (issue #715) этот случай не покрывает.</para>
+///
+/// <para>Одно место на трёх потребителей — генерацию, предпросмотр привязки и предпросмотр
+/// материализации: разойдись чтение колонки хоть в одном, и экран показывал бы не то, что уедет в
+/// документ. Ровно это уже случалось с <c>@@ref</c> до issue #374.</para>
+/// </summary>
+public static class MaterializeByIdMode
+{
+    /// <summary>Режим включён — колонка задана. Пустая строка = режима нет (флаг и есть колонка).</summary>
+    public static bool IsOn(string? column) => !string.IsNullOrWhiteSpace(column);
+
+    /// <summary>Идентификатор документа из строки; при неудаче — код причины (см. <see cref="MaterializeSkipReason"/>)
+    /// и само значение ячейки, чтобы предпросмотр мог показать, что именно там лежит.</summary>
+    public static (Guid? Id, string? SkipReason, string? Cell) ReadId(
+        IReadOnlyDictionary<string, string?> row, string column)
+    {
+        row.TryGetValue(column, out var cell);
+
+        // Пустая ячейка — «строки в реестре нет», а не битая ссылка: молча положить {$ref} без Ид
+        // значило бы выдать несуществующую проблему за существующую (та же идиома, что в #544).
+        if (string.IsNullOrWhiteSpace(cell)) return (null, MaterializeSkipReason.RefIdEmpty, cell);
+
+        return Guid.TryParse(cell.Trim(), out var id)
+            ? (id, null, cell)
+            : (null, MaterializeSkipReason.RefIdNotGuid, cell);
+    }
+
+    /// <summary>Ссылка на экземпляр документа — та же форма, что строит <c>DataSetValueCoercion</c>
+    /// для <c>doc-ref</c>-поля: обе разворачивает один и тот же проход резолвера.</summary>
+    public static Dictionary<string, object?> RefValue(Guid instanceId) => new()
+    {
+        ["$ref"] = "instance",
+        ["instanceId"] = instanceId.ToString(),
+    };
+
+    /// <summary>Показывается в предпросмотре вместо наименования, когда документа по Ид нет.</summary>
+    public const string NotFoundLabel = "документ не найден";
+
+    /// <summary>
+    /// Наименования документов по идентификаторам — ОДНИМ запросом на страницу строк (реестр на сотню
+    /// документов иначе дал бы сотню). Отсутствующие в словаре — удалённые или чужие: предпросмотр
+    /// обязан отличать их от рабочих, иначе битая ссылка выглядит как исправная ровно до генерации.
+    /// </summary>
+    public static async Task<Dictionary<Guid, string>> ResolveLabelsAsync(
+        AppDbContext db, IReadOnlyCollection<Guid> ids, CancellationToken ct)
+    {
+        if (ids.Count == 0) return [];
+
+        var docs = await db.DomainObjects.AsNoTracking()
+            .Where(o => ids.Contains(o.Id))
+            .Select(o => new { o.Id, o.DisplayName, o.CompositeTypeId })
+            .ToListAsync(ct);
+        if (docs.Count == 0) return [];
+
+        var typeIds = docs.Select(d => d.CompositeTypeId).Distinct().ToList();
+        var typeNames = await db.DocumentTypes.AsNoTracking()
+            .Where(t => typeIds.Contains(t.Id))
+            .ToDictionaryAsync(t => t.Id, t => t.Name, ct);
+
+        return docs.ToDictionary(
+            d => d.Id,
+            d => d.DisplayName ?? typeNames.GetValueOrDefault(d.CompositeTypeId) ?? "Документ");
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeByIdMode.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeByIdMode.cs
@@ -1,3 +1,4 @@
+﻿using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,7 +27,11 @@ public static class MaterializeByIdMode
     public static (Guid? Id, string? SkipReason, string? Cell) ReadId(
         IReadOnlyDictionary<string, string?> row, string column)
     {
-        row.TryGetValue(column, out var cell);
+        // Колонки нет вовсе — это ДРУГАЯ беда, чем пустая ячейка, и чинится она иначе: файл
+        // перезалили с переименованным заголовком, и искать надо колонку, а не пустоты в данных.
+        // Свалив их в одну причину, мы отправили бы человека проверять ячейки, которых нет.
+        if (!row.TryGetValue(column, out var cell))
+            return (null, MaterializeSkipReason.RefIdColumnMissing, null);
 
         // Пустая ячейка — «строки в реестре нет», а не битая ссылка: молча положить {$ref} без Ид
         // значило бы выдать несуществующую проблему за существующую (та же идиома, что в #544).
@@ -48,19 +53,39 @@ public static class MaterializeByIdMode
     /// <summary>Показывается в предпросмотре вместо наименования, когда документа по Ид нет.</summary>
     public const string NotFoundLabel = "документ не найден";
 
+    /// <summary>Объект по Ид существует, но ссылка на него НЕ развернётся: это запись общих данных,
+    /// а не документ комплекта.</summary>
+    public const string NotADocumentLabel = "не документ комплекта — ссылка не развернётся";
+
+    /// <summary>Документ есть, но живёт в другом комплекте — резолвер его не возьмёт.</summary>
+    public const string ForeignSetLabel = "документ другого комплекта — ссылка не развернётся";
+
+    /// <summary>Метка объясняет отказ, а не называет документ (значку «🔗» рядом с ней не место).</summary>
+    public static bool IsProblem(string label)
+        => label == NotFoundLabel || label == NotADocumentLabel || label == ForeignSetLabel;
+
     /// <summary>
-    /// Наименования документов по идентификаторам — ОДНИМ запросом на страницу строк (реестр на сотню
-    /// документов иначе дал бы сотню). Отсутствующие в словаре — удалённые или чужие: предпросмотр
-    /// обязан отличать их от рабочих, иначе битая ссылка выглядит как исправная ровно до генерации.
+    /// Как предпросмотру назвать каждый идентификатор — ОДНИМ запросом на страницу строк (реестр на
+    /// сотню документов иначе дал бы сотню).
+    ///
+    /// <para><b>Условия те же, что у резолвера</b> (<c>EntityResolver.ResolveDocumentInstanceAsync</c>):
+    /// разворачивается только документ (есть фасета), лежащий в ТОМ ЖЕ комплекте. Показывать
+    /// наименование по более широкому запросу — значит рисовать исправной ссылку, которая при
+    /// генерации останется висячей, а сканер объявит её удалённой записью. Ровно эту ложь
+    /// предпросмотра режим и должен снимать, поэтому «чужой» назван чужим, а не найденным.</para>
+    ///
+    /// <paramref name="setId"/> — комплект, в котором ссылка будет разворачиваться; null означает
+    /// «неизвестен» (источник живёт выше комплекта и используется в разных): тогда проверяем только
+    /// то, что проверить можно, — что объект вообще документ.
     /// </summary>
     public static async Task<Dictionary<Guid, string>> ResolveLabelsAsync(
-        AppDbContext db, IReadOnlyCollection<Guid> ids, CancellationToken ct)
+        AppDbContext db, IReadOnlyCollection<Guid> ids, Guid? setId, CancellationToken ct)
     {
         if (ids.Count == 0) return [];
 
         var docs = await db.DomainObjects.AsNoTracking()
             .Where(o => ids.Contains(o.Id))
-            .Select(o => new { o.Id, o.DisplayName, o.CompositeTypeId })
+            .Select(o => new { o.Id, o.DisplayName, o.CompositeTypeId, o.ScopeLevel, o.ScopeId, IsDocument = o.Facet != null })
             .ToListAsync(ct);
         if (docs.Count == 0) return [];
 
@@ -69,8 +94,9 @@ public static class MaterializeByIdMode
             .Where(t => typeIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id, t => t.Name, ct);
 
-        return docs.ToDictionary(
-            d => d.Id,
-            d => d.DisplayName ?? typeNames.GetValueOrDefault(d.CompositeTypeId) ?? "Документ");
+        return docs.ToDictionary(d => d.Id, d =>
+            !d.IsDocument ? NotADocumentLabel
+            : setId is { } sid && (d.ScopeLevel != CatalogScope.Set || d.ScopeId != sid) ? ForeignSetLabel
+            : d.DisplayName ?? typeNames.GetValueOrDefault(d.CompositeTypeId) ?? "Документ");
     }
 }

--- a/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeConfigValidator.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeConfigValidator.cs
@@ -24,9 +24,34 @@ public static class MaterializeConfigValidator
         DocumentType type,
         IReadOnlyDictionary<string, string> mapping,
         MaterializeDiscriminatorConfig? discriminator,
-        IReadOnlyDictionary<Guid, DocumentType> typesById)
+        IReadOnlyDictionary<Guid, DocumentType> typesById,
+        string? byIdColumn = null)
     {
         var isUnion = SchemaTags.TypeHasTag(type, [.. typesById.Values], FunctionalTag.TypeUnion);
+
+        // Режим «существующий документ по Ид» (issue #725): вся строка — ссылка на документ.
+        if (!string.IsNullOrWhiteSpace(byIdColumn))
+        {
+            // Ссылаться можно только на экземпляр документа: у составного типа их не бывает, и
+            // ссылка на «строку реестра» не значила бы ничего.
+            if (type.Kind != DocumentTypeKind.Document)
+                throw new InvalidRequestException(
+                    $"Тип «{type.Name}» не является типом документа — ссылаться на существующий документ по Ид для него нельзя.");
+
+            // Маппинг и режим «по Ид» — два разных ответа на вопрос «что такое строка». Сохранить оба
+            // значит оставить настройку, в которой видимое в диалоге не совпадает с результатом.
+            if (mapping.Any(p => !string.IsNullOrEmpty(p.Value)))
+                throw new InvalidRequestException(
+                    "В режиме «существующий документ по Ид» строка целиком становится ссылкой — маппинг колонок в нём не задаётся.");
+
+            // Дискриминатор — про выбор варианта union'а, то есть про составной тип; сюда он попасть
+            // не может, но отказ дешевле молчаливого игнорирования настройки.
+            if (discriminator is not null)
+                throw new InvalidRequestException(
+                    "Вариант по типу документа строки задаётся только при сборке объекта из колонок.");
+
+            return;
+        }
 
         // Дискриминатор осмыслен только для union'а: у обычного типа строка заполняет все свои поля
         // сразу, выбирать не из чего.

--- a/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeDiscriminator.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeDiscriminator.cs
@@ -14,6 +14,9 @@ public static class MaterializeSkipReason
     public const string NoVariant = "no-variant";
     public const string Ambiguous = "ambiguous-variant";
     public const string VariantNotMapped = "variant-not-mapped";
+    /// <summary>Режим «существующий документ по Ид» (issue #725): колонка с Ид пуста / в ней не Ид.</summary>
+    public const string RefIdEmpty = "ref-id-empty";
+    public const string RefIdNotGuid = "ref-id-not-guid";
 
     public static string Describe(string code) => code switch
     {
@@ -23,6 +26,8 @@ public static class MaterializeSkipReason
         NoVariant => "для типа документа не назначен вариант",
         Ambiguous => "тип документа назначен двум вариантам одинаково точно",
         VariantNotMapped => "у выбранного варианта не задан маппинг колонок",
+        RefIdEmpty => "колонка с идентификатором документа пуста",
+        RefIdNotGuid => "в колонке не идентификатор документа",
         _ => code,
     };
 }

--- a/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeDiscriminator.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeDiscriminator.cs
@@ -17,6 +17,7 @@ public static class MaterializeSkipReason
     /// <summary>Режим «существующий документ по Ид» (issue #725): колонка с Ид пуста / в ней не Ид.</summary>
     public const string RefIdEmpty = "ref-id-empty";
     public const string RefIdNotGuid = "ref-id-not-guid";
+    public const string RefIdColumnMissing = "ref-id-column-missing";
 
     public static string Describe(string code) => code switch
     {
@@ -28,6 +29,7 @@ public static class MaterializeSkipReason
         VariantNotMapped => "у выбранного варианта не задан маппинг колонок",
         RefIdEmpty => "колонка с идентификатором документа пуста",
         RefIdNotGuid => "в колонке не идентификатор документа",
+        RefIdColumnMissing => "в источнике нет колонки, выбранной для идентификатора документа",
         _ => code,
     };
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -1,9 +1,10 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Generation;
 using BHS.CRG.Application.Resolution;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.DataSets;
 using BHS.CRG.Domain.Documents;
 using BHS.CRG.Infrastructure.DataSets;
 using BHS.CRG.Infrastructure.Persistence;
@@ -94,6 +95,20 @@ public class DataSetResolver(
             {
                 // Download → parse → transformation → filter → sort (shared with preview via DataSetRowLoader).
                 var rows = await rowLoader.LoadRowsAsync(binding.Source, ct);
+
+                // Материализация ссылкой на существующий документ (issue #725). Проверяем ДО маппинга:
+                // в этом режиме маппинга нет вовсе, и общая ветка отказала бы «маппинг колонок пуст» —
+                // то есть пожаловалась бы на настройку, которой в этом режиме и не должно быть.
+                //
+                // Действует только когда материализация вообще применяется (собственный маппинг
+                // привязки замещает её целиком — то же правило, что у дискриминатора #716).
+                if (binding.Source.MaterializeTypeId is not null
+                    && DataSetMappingValue.IsEmptyMapping(binding.Mapping)
+                    && MaterializeByIdMode.IsOn(binding.Source.MaterializeByIdColumn))
+                {
+                    InjectDocumentRefs(ctx, binding, typeId, rows, await TypesAsync(), diagnostics);
+                    continue;
+                }
 
                 // Материализация на источнике (issue #19): если источник настроен на материализацию, а
                 // привязка не несёт собственного маппинга — маппинг берётся с источника (тип↔тип), а
@@ -257,6 +272,62 @@ public class DataSetResolver(
                     $"Источник данных недоступен — поле не заполнено. {ex.Message}"));
             }
         }
+    }
+
+    /// <summary>
+    /// Материализация «существующий документ по Ид» (issue #725): каждая строка источника кладётся в
+    /// целевое поле ссылкой на документ, живые данные подставит второй проход <c>EntityResolver</c>.
+    ///
+    /// Строки без идентификатора (пустая ячейка, не-Ид) в результат НЕ попадают: ссылка без Ид — это
+    /// битая ссылка, которую сканер потом объявит удалённой записью, то есть выдуманной бедой.
+    /// Молчания при этом нет — причины уходят в ту же сводку, что и пропуски дискриминатора.
+    ///
+    /// Скалярная привязка (без целевого поля) в этом режиме бессмысленна: раскладывать ссылку по
+    /// отдельным полям контекста нечем — у неё нет полей. Отказываемся словами, а не тишиной.
+    /// </summary>
+    private static void InjectDocumentRefs(
+        GenerationContext ctx, DataSetBinding binding, Guid ownerTypeId,
+        IReadOnlyList<IReadOnlyDictionary<string, string?>> rows,
+        Dictionary<Guid, DocumentType> typesById,
+        List<ResolutionDiagnostic>? diagnostics)
+    {
+        if (binding.TargetFieldKey is null)
+        {
+            diagnostics?.Add(new ResolutionDiagnostic(
+                DiagnosticSeverity.Error, "(скалярная привязка)",
+                $"Источник «{binding.Source.Name}» материализован ссылкой на существующий документ — " +
+                "такую строку можно положить только в поле-документ или в список документов, " +
+                "а не в отдельные поля."));
+            return;
+        }
+
+        var column = binding.Source.MaterializeByIdColumn!;
+        var skipped = new Dictionary<string, int>(StringComparer.Ordinal);
+        var refs = new List<Dictionary<string, object?>>();
+
+        foreach (var row in rows)
+        {
+            var (id, reason, _) = MaterializeByIdMode.ReadId(row, column);
+            if (id is null)
+            {
+                skipped[reason!] = skipped.GetValueOrDefault(reason!) + 1;
+                continue;
+            }
+            refs.Add(MaterializeByIdMode.RefValue(id.Value));
+        }
+
+        var field = DocumentTypeSchemaReader.Field(ownerTypeId, binding.TargetFieldKey, typesById);
+        if (field is not null && DocumentTypeSchemaReader.IsSingleComposite(field.Type))
+        {
+            if (refs.Count > 0)
+                ctx.Set(binding.TargetFieldKey, JsonSerializer.SerializeToElement(refs[0]));
+        }
+        else
+        {
+            ctx.Set(binding.TargetFieldKey, JsonSerializer.SerializeToElement(refs));
+        }
+
+        ReportSkipped(binding.TargetFieldKey, skipped, diagnostics);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260811025626_MaterializeByIdColumn.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260811025626_MaterializeByIdColumn.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811025626_MaterializeByIdColumn")]
+    partial class MaterializeByIdColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260811025626_MaterializeByIdColumn.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260811025626_MaterializeByIdColumn.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MaterializeByIdColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MaterializeByIdColumn",
+                table: "dataset_sources",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaterializeByIdColumn",
+                table: "dataset_sources");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DataSetConfiguration.cs
@@ -47,6 +47,7 @@ public class DataSetSourceConfiguration : IEntityTypeConfiguration<DataSetSource
         b.Property(e => e.MaterializeTypeId);
         b.Property(e => e.MaterializeMapping).HasColumnType("jsonb");
         b.Property(e => e.MaterializeDiscriminator).HasColumnType("jsonb");
+        b.Property(e => e.MaterializeByIdColumn).HasMaxLength(256);
         b.HasMany(e => e.Bindings)
          .WithOne(b => b.Source)
          .HasForeignKey(b => b.SourceId)

--- a/src/server/BHS.CRG.Tests/DataSets/DataSetDomainTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/DataSetDomainTests.cs
@@ -1,3 +1,4 @@
+using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.DataSets;
 
 namespace BHS.CRG.Tests.DataSets;
@@ -15,6 +16,30 @@ public class DataSetDomainTests
         Assert.Equal("Материалы", t.TargetFieldKey);
         Assert.Equal("{}", t.ColumnMappings);
         Assert.Equal(3, t.SortOrder);
+    }
+
+    /// <summary>
+    /// Имя колонки режима «по Ид» (issue #725) хранится КАК ЕСТЬ — заголовки файлов не подрезаются
+    /// (парсеры подрезают значения), а вычисляемая колонка вообще названа человеком. Подрезанное
+    /// «Ид » не совпало бы ни с одной строкой: реестр опустел бы целиком, причём с сообщением про
+    /// пустую колонку — то есть ложным. Дискриминатор (#716) хранит имя колонки так же.
+    /// </summary>
+    [Fact]
+    public void Materialization_ByIdColumn_IsStoredVerbatim()
+    {
+        var source = DataSetFile.Create("f.csv", DataSetFormat.Csv, "b/p", CatalogScope.System, null)
+            .AddSource("Источник", "default", "[]", 0);
+
+        source.SetMaterialization(Guid.NewGuid(), "{}", null, "Ид ");
+        Assert.Equal("Ид ", source.MaterializeByIdColumn);
+
+        // Пробелы вместо имени — это «режим не выбран», а не колонка с именем из пробелов.
+        source.SetMaterialization(Guid.NewGuid(), "{}", null, "   ");
+        Assert.Null(source.MaterializeByIdColumn);
+
+        // Снятие материализации снимает и режим.
+        source.SetMaterialization(null, null, null, "Ид");
+        Assert.Null(source.MaterializeByIdColumn);
     }
 
     [Fact]

--- a/src/server/BHS.CRG.Tests/DataSets/MaterializeConfigValidatorTests.cs
+++ b/src/server/BHS.CRG.Tests/DataSets/MaterializeConfigValidatorTests.cs
@@ -34,8 +34,9 @@ public class MaterializeConfigValidatorTests
         [RegistryTypeId] = Type(RegistryTypeId, "Реестр работ", "{'fields':[]}", DocumentTypeKind.Document),
     };
 
-    private static void Validate(Guid typeId, Dictionary<string, string> mapping, MaterializeDiscriminatorConfig? d = null)
-        => MaterializeConfigValidator.Validate(Types[typeId], mapping, d, Types);
+    private static void Validate(Guid typeId, Dictionary<string, string> mapping,
+        MaterializeDiscriminatorConfig? d = null, string? byIdColumn = null)
+        => MaterializeConfigValidator.Validate(Types[typeId], mapping, d, Types, byIdColumn);
 
     private static MaterializeDiscriminatorConfig Discriminator(Dictionary<string, List<Guid>> rules)
         => new("ТипКод", MaterializeDiscriminatorConfig.ByTypeCode, rules);
@@ -113,6 +114,47 @@ public class MaterializeConfigValidatorTests
         => Assert.Throws<InvalidRequestException>(
             () => Validate(PlainId, new() { ["Наименование"] = "A" },
                 Discriminator(new() { ["Наименование"] = [AosrTypeId] })));
+
+    // ── Режим «существующий документ по Ид» (issue #725) ──────────────────────────
+
+    /// <summary>Тип-документ + колонка с Ид — законная настройка: строка целиком станет ссылкой.</summary>
+    [Fact]
+    public void Document_ByIdColumn_IsFine()
+        => Validate(AosrTypeId, new(), byIdColumn: "Ид");
+
+    /// <summary>
+    /// Составной тип по Ид не адресуется: экземпляров-документов у него нет, и ссылка на «строку
+    /// реестра» не значила бы ничего — резолвер оставил бы её висеть.
+    /// </summary>
+    [Fact]
+    public void CompositeType_ByIdColumn_IsRejected()
+    {
+        var ex = Assert.Throws<InvalidRequestException>(() => Validate(PlainId, new(), byIdColumn: "Ид"));
+        Assert.Contains("не является типом документа", ex.Message);
+    }
+
+    /// <summary>
+    /// Маппинг и режим «по Ид» — два разных ответа на вопрос «что такое строка». Сохранив оба, мы
+    /// оставили бы настройку, в которой видимое в диалоге не совпадает с тем, что уедет в документ.
+    /// </summary>
+    [Fact]
+    public void ByIdColumn_WithMapping_IsRejected()
+    {
+        var ex = Assert.Throws<InvalidRequestException>(
+            () => Validate(AosrTypeId, new() { ["Номер"] = "A" }, byIdColumn: "Ид"));
+        Assert.Contains("маппинг колонок в нём не задаётся", ex.Message);
+    }
+
+    /// <summary>Пустые значения маппинга — это тот же пустой маппинг, и режиму они не мешают
+    /// (то же определение «пусто», по которому маппинг вообще выбирается).</summary>
+    [Fact]
+    public void ByIdColumn_WithEmptyMappingValues_IsFine()
+        => Validate(AosrTypeId, new() { ["Номер"] = "" }, byIdColumn: "Ид");
+
+    [Fact]
+    public void ByIdColumn_WithDiscriminator_IsRejected()
+        => Assert.Throws<InvalidRequestException>(
+            () => Validate(AosrTypeId, new(), Discriminator(new() { ["АОСР"] = [AosrTypeId] }), byIdColumn: "Ид"));
 
     [Fact]
     public void Discriminator_WithoutColumn_IsRejected()

--- a/src/server/BHS.CRG.Tests/Integration/DataSetDocRefMappingTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetDocRefMappingTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
@@ -50,7 +50,7 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
             new UploadFileInput(Encoding.UTF8.GetBytes(csv), "docs.csv", "text/csv", "Тест", "System", null), default);
         var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
         var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Документы", candidate.SheetOrPath, null), default);
-        await svc.SetMaterializationAsync(source.Id, rowTypeId, mapping, discriminator: null, default);
+        await svc.SetMaterializationAsync(source.Id, rowTypeId, mapping, discriminator: null, byIdColumn: null, default);
         return source.Id;
     }
 

--- a/src/server/BHS.CRG.Tests/Integration/DataSetDocRefMappingTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetDocRefMappingTests.cs
@@ -247,6 +247,45 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
     }
 
     /// <summary>
+    /// Ячейка <c>doc-ref</c>-поля показывается НАИМЕНОВАНИЕМ документа на обоих предпросмотрах —
+    /// и материализации (диалог), и привязки (вкладка данных).
+    ///
+    /// Сырой идентификатор человеку не говорит ничего, а главное — по нему не видно, разрешится ли
+    /// ссылка: удалённый документ выглядит точно как рабочий. Проверяем оба экрана, потому что
+    /// расхождение здесь и есть беда: один назвал бы ссылку битой, второй показал бы её исправной.
+    /// </summary>
+    [Fact]
+    public async Task DocRefCell_IsShownAsDocumentName_InBothPreviews()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Номер','type':'string'}]}")));
+        var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+        var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Composite, null,
+            J($"{{'fields':[{{'key':'Документ','type':'doc-ref','typeId':'{aosrType.Id}'}}]}}")));
+
+        var (_, reestrId, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var missingId = Guid.NewGuid();
+        var sourceId = await MaterializedSourceAsync(scope, $"Ид\n{aosrId}\n{missingId}\n", rowType.Id,
+            new Dictionary<string, string> { ["Документ"] = "Ид" });
+        await Svc(scope).CreateBindingAsync(new CreateBindingInput(reestrId, sourceId, "Строки", null), default);
+
+        var materialize = await Svc(scope).MaterializePreviewAsync(sourceId, 50, null, null, null, null, default);
+        Assert.Equal("🔗 АОСР", materialize!.Rows[0]["Документ"]);
+        Assert.Equal("документ не найден", materialize.Rows[1]["Документ"]);
+
+        var binding = Assert.Single(await Svc(scope).PreviewBindingsAsync(reestrId, default));
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(binding.Data);
+        Assert.Equal("🔗 АОСР", rows[0]["Документ"]);
+        Assert.Equal("документ не найден", rows[1]["Документ"]);
+    }
+
+    /// <summary>
     /// Материализация настроена, а маппинг пуст — это ошибка, и она названа словами.
     ///
     /// Ровно так выглядел живой кейс: тип для материализации выбран, маппинг пуст (маппить было

--- a/src/server/BHS.CRG.Tests/Integration/DataSetResolverDefaultsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetResolverDefaultsTests.cs
@@ -51,7 +51,7 @@ public class DataSetResolverDefaultsTests(IntegrationTestFixture fixture) : IAsy
         var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Данные", candidate.SheetOrPath, null), default);
 
         // Материализация источника: маппинг покрывает только «Поле» — «ВидДокумента» намеренно не замаплено.
-        await svc.SetMaterializationAsync(source.Id, rowType.Id, new() { ["Поле"] = "A" }, discriminator: null, default);
+        await svc.SetMaterializationAsync(source.Id, rowType.Id, new() { ["Поле"] = "A" }, discriminator: null, byIdColumn: null, default);
 
         // Биндинг табличный (TargetFieldKey задан), СВОЙ маппинг пуст — эффективный маппинг берётся
         // с материализации источника (см. EffectiveMappingJson).
@@ -98,7 +98,7 @@ public class DataSetResolverDefaultsTests(IntegrationTestFixture fixture) : IAsy
         var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
         var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Данные", candidate.SheetOrPath, null), default);
 
-        await svc.SetMaterializationAsync(source.Id, rowType.Id, new() { ["ВидДокумента"] = "B" }, discriminator: null, default);
+        await svc.SetMaterializationAsync(source.Id, rowType.Id, new() { ["ВидДокумента"] = "B" }, discriminator: null, byIdColumn: null, default);
         await svc.CreateBindingAsync(new CreateBindingInput(instance.Id, source.Id, "Строки", null), default);
 
         var inst = await m.Send(new GetDocumentInstanceQuery(instance.Id));

--- a/src/server/BHS.CRG.Tests/Integration/DataSetServiceTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Domain.Documents;
@@ -224,7 +224,7 @@ public class DataSetServiceTests(IntegrationTestFixture fixture) : IAsyncLifetim
         using var scope = fixture.Services.CreateScope();
         var svc = Svc(scope);
         var (_, src) = await UploadCsvWithSourceAsync(scope);
-        await svc.SetMaterializationAsync(src.Id, typeId, new() { ["Поле"] = "A" }, discriminator: null, default);
+        await svc.SetMaterializationAsync(src.Id, typeId, new() { ["Поле"] = "A" }, discriminator: null, byIdColumn: null, default);
 
         var entry = await scope.ServiceProvider.GetRequiredService<MediatR.IMediator>().Send(
             new CreateCommonDataEntryCommand("Запись", typeId, JsonDocument.Parse("{}"),

--- a/src/server/BHS.CRG.Tests/Integration/DataSetUnionDiscriminatorTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetUnionDiscriminatorTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
@@ -78,7 +78,7 @@ public class DataSetUnionDiscriminatorTests(IntegrationTestFixture fixture) : IA
             new UploadFileInput(Encoding.UTF8.GetBytes(csv), "docs.csv", "text/csv", "Тест", "System", null), default);
         var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
         var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Документы комплекта", candidate.SheetOrPath, null), default);
-        await svc.SetMaterializationAsync(source.Id, typeId, mapping, discriminator, default);
+        await svc.SetMaterializationAsync(source.Id, typeId, mapping, discriminator, byIdColumn: null, default);
         return source.Id;
     }
 
@@ -229,7 +229,7 @@ public class DataSetUnionDiscriminatorTests(IntegrationTestFixture fixture) : IA
             new MaterializeDiscriminatorConfig("ТипКод", MaterializeDiscriminatorConfig.ByTypeCode,
                 new Dictionary<string, List<Guid>> { ["АОСР"] = [f.AosrTypeId] }));
 
-        var preview = await Svc(scope).MaterializePreviewAsync(sourceId, 50, null, null, null, default);
+        var preview = await Svc(scope).MaterializePreviewAsync(sourceId, 50, null, null, null, null, default);
 
         Assert.NotNull(preview);
         Assert.Null(preview!.Error);
@@ -293,7 +293,7 @@ public class DataSetUnionDiscriminatorTests(IntegrationTestFixture fixture) : IA
         var preview = await Svc(scope).MaterializePreviewAsync(
             sourceId, 50, f.UnionTypeId,
             new Dictionary<string, string> { ["АОСР"] = "Ид" },
-            discriminator: null, default);
+            discriminator: null, byIdColumn: null, default);
 
         Assert.NotNull(preview);
         // Правило не применялось: обе строки на месте, пропущенных нет, варианта у строк нет.

--- a/src/server/BHS.CRG.Tests/Integration/DocumentTypeHandlerTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentTypeHandlerTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Application.QualityDocs;
@@ -288,7 +288,7 @@ public class DocumentTypeHandlerTests(IntegrationTestFixture fixture) : IAsyncLi
         var file = await svc.UploadFileAsync(new UploadFileInput(csv, "t.csv", "text/csv", "Тест", "System", null), default);
         var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
         var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Данные", candidate.SheetOrPath, null), default);
-        await svc.SetMaterializationAsync(source.Id, dt.Id, new(), discriminator: null, default);
+        await svc.SetMaterializationAsync(source.Id, dt.Id, new(), discriminator: null, byIdColumn: null, default);
 
         using var scope2 = fixture.Services.CreateScope();
         await Assert.ThrowsAsync<ConflictException>(() =>

--- a/src/server/BHS.CRG.Tests/Integration/MaterializeByIdModeTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/MaterializeByIdModeTests.cs
@@ -1,0 +1,243 @@
+using System.Text;
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Материализация «существующий документ по Ид» (issue #725, дополнение к #715).
+///
+/// Живой кейс: источник «Протоколы ЭОМ» несёт колонку с идентификаторами уже существующих
+/// документов комплекта, а материализовать его можно было только СБОРКОЙ объекта из колонок — то
+/// есть копией данных, живущей отдельно от самого документа. Маппинг <c>doc-ref</c>-полей (#715)
+/// случая не покрывает: у типа-документа таких полей нет, ссылаться надо не полем, а всей строкой.
+/// </summary>
+[Collection("Integration")]
+public class MaterializeByIdModeTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static IDataSetService Svc(IServiceScope s) => s.ServiceProvider.GetRequiredService<IDataSetService>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+
+    /// <summary>Типы «АОСР» (цель ссылки) и «Реестр» со списком документов этого типа.</summary>
+    private static async Task<(DocumentType Aosr, DocumentType Reestr)> SeedTypesAsync(IMediator m)
+    {
+        var aosr = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Номер','type':'string'}]}")));
+        var reestr = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Документы','type':'doc-array','typeId':'{aosr.Id}'}}]}}")));
+        return (aosr, reestr);
+    }
+
+    /// <summary>Комплект с реестром и одним АОСР (Номер = 17).</summary>
+    private static async Task<(Guid ReestrId, Guid AosrId)> SeedSetAsync(IMediator m, Guid reestrTypeId, Guid aosrTypeId)
+    {
+        var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "Раздел"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "Комплект"));
+        var aosr = await m.Send(new AddDocumentToSetCommand(set.Id, aosrTypeId));
+        await m.Send(new UpdateRequisitesCommand(aosr.Id, J("{'Номер':'17'}")));
+        var reestr = await m.Send(new AddDocumentToSetCommand(set.Id, reestrTypeId));
+        return (reestr.Id, aosr.Id);
+    }
+
+    /// <summary>Источник, материализованный ссылкой на документ по колонке <paramref name="idColumn"/>.</summary>
+    private static async Task<Guid> ByIdSourceAsync(IServiceScope scope, string csv, Guid typeId, string idColumn)
+    {
+        var svc = Svc(scope);
+        var file = await svc.UploadFileAsync(
+            new UploadFileInput(Encoding.UTF8.GetBytes(csv), "docs.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Протоколы", candidate.SheetOrPath, null), default);
+        await svc.SetMaterializationAsync(source.Id, typeId, mapping: new(), discriminator: null, byIdColumn: idColumn, default);
+        return source.Id;
+    }
+
+    /// <summary>Полный проход резолва — тот же порядок, что у генерации PDF.</summary>
+    private static async Task<GenerationContext> ResolveAsync(
+        IServiceScope scope, Guid instanceId, List<ResolutionDiagnostic>? diagnostics = null)
+    {
+        var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
+        var view = DocumentView.From(inst!);
+        var entity = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var ctx = await entity.ResolveAsync(view);
+        await scope.ServiceProvider.GetRequiredService<IDataSetResolver>().InjectAsync(ctx, view, diagnostics, default);
+        // Второй проход: именно он разворачивает добавленные привязкой ссылки на документы.
+        await entity.ResolveContextRefsAsync(ctx, view.DocumentSetId);
+        return ctx;
+    }
+
+    /// <summary>
+    /// Строка источника доезжает до контекста ЖИВЫМ документом, а не его копией из колонок.
+    ///
+    /// Проверяем по результату полного резолва, а не по промежуточной форме <c>$ref</c>: обещание
+    /// пользователю в том, что в шаблон попадут реквизиты того самого документа, на который он
+    /// показал колонкой, — и что они меняются вместе с ним, а не остаются снимком.
+    /// </summary>
+    [Fact]
+    public async Task RowWithDocumentId_BecomesTheLiveDocument()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (reestrId, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var sourceId = await ByIdSourceAsync(scope, $"Ид\n{aosrId}\n", aosrType.Id, "Ид");
+        // Привязка материализованного источника — типизированный указатель: своего маппинга нет.
+        await Svc(scope).CreateBindingAsync(new CreateBindingInput(reestrId, sourceId, "Документы", null), default);
+
+        var ctx = await ResolveAsync(scope, reestrId);
+
+        var rows = (JsonElement)ctx.Data["Документы"]!;
+        var doc = Assert.Single(rows.EnumerateArray());
+        Assert.False(doc.TryGetProperty("$ref", out _), "ссылка осталась неразрешённой");
+        Assert.Equal("17", doc.GetProperty("Номер").GetString());
+    }
+
+    /// <summary>
+    /// Строка без идентификатора в реестр не попадает, и об этом сказано.
+    ///
+    /// Положить ссылку без Ид значило бы завести битую ссылку там, где её нет: сканер объявил бы
+    /// целевую запись удалённой — то есть назвал бы выдуманную беду вместо настоящей («в колонке
+    /// пусто» / «выбрана соседняя колонка»).
+    /// </summary>
+    [Fact]
+    public async Task RowsWithoutId_AreSkipped_AndCountedWithReasons()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (reestrId, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        // Вторая колонка нужна, чтобы строка с пустым Ид не оказалась пустой строкой файла — такую
+        // парсер отбрасывает, и проверять было бы нечего.
+        var sourceId = await ByIdSourceAsync(scope,
+            $"Ид,Пометка\n{aosrId},годная\n,пусто\nне-идентификатор,мусор\n", aosrType.Id, "Ид");
+        await Svc(scope).CreateBindingAsync(new CreateBindingInput(reestrId, sourceId, "Документы", null), default);
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        var ctx = await ResolveAsync(scope, reestrId, diagnostics);
+
+        var rows = ((JsonElement)ctx.Data["Документы"]!).EnumerateArray().ToList();
+        Assert.Single(rows);
+        Assert.Equal("17", rows[0].GetProperty("Номер").GetString());
+
+        var warning = Assert.Single(diagnostics, d => d.Path == "Документы");
+        Assert.Equal(DiagnosticSeverity.Warning, warning.Severity);
+        Assert.Contains("колонка с идентификатором документа пуста", warning.Message);
+        Assert.Contains("в колонке не идентификатор документа", warning.Message);
+    }
+
+    /// <summary>
+    /// Скалярная привязка в этом режиме бессмысленна: у ссылки нет полей, раскладывать по ключам
+    /// контекста нечего. Отказ словами — не формальность: молча положенное «ничего» выглядит как
+    /// «источник пуст», а это ровно та тишина, ради которой заведён #715.
+    /// </summary>
+    [Fact]
+    public async Task ScalarBinding_InByIdMode_IsRefusedInWords()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (reestrId, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var sourceId = await ByIdSourceAsync(scope, $"Ид\n{aosrId}\n", aosrType.Id, "Ид");
+        await Svc(scope).CreateBindingAsync(new CreateBindingInput(reestrId, sourceId, null, null), default);
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        var ctx = await ResolveAsync(scope, reestrId, diagnostics);
+
+        var problem = Assert.Single(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("ссылкой на существующий документ", problem.Message);
+        Assert.False(ctx.Data.ContainsKey("Документы"));
+    }
+
+    /// <summary>
+    /// Предпросмотр привязки показывает НАИМЕНОВАНИЯ документов, а отсутствующий по идентификатору
+    /// назван отсутствующим. Идентификатор в таблице человеку не говорит ничего, а битая ссылка,
+    /// показанная как рабочая, расходится с генерацией — то есть врёт ровно на том экране, куда
+    /// идут проверять.
+    /// </summary>
+    [Fact]
+    public async Task BindingPreview_ShowsNames_AndNamesTheMissingOne()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (reestrId, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var sourceId = await ByIdSourceAsync(scope, $"Ид\n{aosrId}\n{Guid.NewGuid()}\n", aosrType.Id, "Ид");
+        await Svc(scope).CreateBindingAsync(new CreateBindingInput(reestrId, sourceId, "Документы", null), default);
+
+        var preview = Assert.Single(await Svc(scope).PreviewBindingsAsync(reestrId, default));
+
+        Assert.Equal("tabular", preview.Mode);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(preview.Data);
+        Assert.Equal(2, rows.Count);
+        // Имя документу не задавали — отображается имя типа (общая конвенция показа документов).
+        Assert.Equal("АОСР", rows[0]["Документ"]);
+        Assert.Equal("документ не найден", rows[1]["Документ"]);
+    }
+
+    /// <summary>
+    /// Предпросмотр материализации ведёт НЕСОХРАНЁННУЮ настройку диалога (issue #294): переключение
+    /// режима обязано быть видно сразу, иначе экран отвечает по вчерашней настройке именно тогда,
+    /// когда её меняют.
+    /// </summary>
+    [Fact]
+    public async Task MaterializePreview_FollowsUnsavedByIdColumn()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (_, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        // Источник ещё НЕ материализован — настройку целиком ведёт диалог.
+        var svc = Svc(scope);
+        var file = await svc.UploadFileAsync(
+            new UploadFileInput(Encoding.UTF8.GetBytes($"Ид\n{aosrId}\n"), "docs.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Протоколы", candidate.SheetOrPath, null), default);
+
+        var preview = await svc.MaterializePreviewAsync(source.Id, 50, aosrType.Id,
+            new Dictionary<string, string>(), discriminator: null, byIdColumn: "Ид", default);
+
+        Assert.NotNull(preview);
+        Assert.Null(preview!.Error);
+        Assert.Equal("АОСР", Assert.Single(preview.Rows)["Документ"]);
+    }
+
+    /// <summary>
+    /// Настройка «по Ид» переживает копирование источника (issue #717): копия — «тот же источник,
+    /// другой фильтр», и настраивать режим заново значило бы терять работу, ради которой копию делают.
+    /// </summary>
+    [Fact]
+    public async Task DuplicatedSource_KeepsByIdMode()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (_, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var sourceId = await ByIdSourceAsync(scope, $"Ид\n{aosrId}\n", aosrType.Id, "Ид");
+        var copy = await Svc(scope).DuplicateSourceAsync(sourceId, null, default);
+
+        Assert.Equal("Ид", copy!.MaterializeByIdColumn);
+        Assert.Equal(aosrType.Id, copy.MaterializeTypeId);
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/MaterializeByIdModeTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/MaterializeByIdModeTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using BHS.CRG.Application.DataSets;
 using BHS.CRG.Application.Documents;
@@ -219,6 +219,68 @@ public class MaterializeByIdModeTests(IntegrationTestFixture fixture) : IAsyncLi
         Assert.NotNull(preview);
         Assert.Null(preview!.Error);
         Assert.Equal("АОСР", Assert.Single(preview.Rows)["Документ"]);
+    }
+
+    /// <summary>
+    /// Документ ЧУЖОГО комплекта предпросмотр называет чужим, а не показывает наименованием.
+    ///
+    /// Условия здесь обязаны совпадать с резолвером (<c>ResolveDocumentInstanceAsync</c> берёт документ
+    /// только из своего комплекта): показав наименование, экран назвал бы исправной ссылку, которая
+    /// при генерации останется висячей, а сканер объявит её удалённой записью — то есть ровно ту
+    /// ложь предпросмотра, ради снятия которой наименования и заведены.
+    /// </summary>
+    [Fact]
+    public async Task DocumentFromAnotherSet_IsNamedForeign_NotShownAsWorking()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (reestrId, _) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+        // Второй комплект той же стройки — его АОСР для первого реестра посторонний.
+        var (_, foreignAosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var sourceId = await ByIdSourceAsync(scope, $"Ид\n{foreignAosrId}\n", aosrType.Id, "Ид");
+        await Svc(scope).CreateBindingAsync(new CreateBindingInput(reestrId, sourceId, "Документы", null), default);
+
+        var preview = Assert.Single(await Svc(scope).PreviewBindingsAsync(reestrId, default));
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(preview.Data);
+        Assert.Equal("документ другого комплекта — ссылка не развернётся", Assert.Single(rows)["Документ"]);
+
+        // И это правда: генерация такую ссылку действительно не разворачивает.
+        var ctx = await ResolveAsync(scope, reestrId);
+        var doc = Assert.Single(((JsonElement)ctx.Data["Документы"]!).EnumerateArray());
+        Assert.True(doc.TryGetProperty("$ref", out _), "чужой документ неожиданно развернулся");
+    }
+
+    /// <summary>
+    /// Колонки нет вовсе — это другая беда, чем пустая ячейка, и названа она отдельно. Свалив их в
+    /// одну причину, мы отправили бы человека проверять ячейки, которых нет: файл перезалили с
+    /// переименованным заголовком, и искать надо колонку.
+    /// </summary>
+    [Fact]
+    public async Task MissingColumn_IsNamedSeparately_NotAsEmptyCell()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        var (aosrType, reestrType) = await SeedTypesAsync(m);
+        var (reestrId, aosrId) = await SeedSetAsync(m, reestrType.Id, aosrType.Id);
+
+        var svc = Svc(scope);
+        var file = await svc.UploadFileAsync(new UploadFileInput(
+            Encoding.UTF8.GetBytes($"ИдДокумента\n{aosrId}\n"), "docs.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Протоколы", candidate.SheetOrPath, null), default);
+        // Колонка выбрана та, которой в источнике нет (заголовок переименован после настройки).
+        await svc.SetMaterializationAsync(source.Id, aosrType.Id, new(), discriminator: null, byIdColumn: "Ид", default);
+        await svc.CreateBindingAsync(new CreateBindingInput(reestrId, source.Id, "Документы", null), default);
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        await ResolveAsync(scope, reestrId, diagnostics);
+
+        var warning = Assert.Single(diagnostics, d => d.Path == "Документы");
+        Assert.Contains("нет колонки", warning.Message);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Tests/Integration/MultipleSourcesPerConsolidationTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/MultipleSourcesPerConsolidationTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.DataSets;
@@ -138,7 +138,7 @@ public class MultipleSourcesPerConsolidationTests(IntegrationTestFixture fixture
 
         await svc.SetSourceProcessingAsync(source.Id,
             new SetSourceProcessingInput(Filter("Наименование", "starts_with", "АОСР"), null, null), default);
-        await svc.SetMaterializationAsync(source.Id, unionType.Id, new() { ["АОСР"] = "Ид" }, discriminator, default);
+        await svc.SetMaterializationAsync(source.Id, unionType.Id, new() { ["АОСР"] = "Ид" }, discriminator, byIdColumn: null, default);
         // Тэги источника ставятся не через IDataSetService (у обычных источников их проставляет
         // распознавание) — для проверки копирования пишем их прямо в хранилище.
         var db = scope.ServiceProvider.GetRequiredService<Infrastructure.Persistence.AppDbContext>();
@@ -160,7 +160,7 @@ public class MultipleSourcesPerConsolidationTests(IntegrationTestFixture fixture
         Assert.Single((await svc.PreviewSourceAsync(copy.Id, 50, default))!.Rows);
 
         // Копия — самостоятельный источник: снятие материализации у неё не задевает оригинал.
-        await svc.SetMaterializationAsync(copy.Id, null, null, null, default);
+        await svc.SetMaterializationAsync(copy.Id, null, null, null, null, default);
         var original = (await svc.ListSourcesAsync(file.Id, default)).Single(s => s.Id == source.Id);
         Assert.Equal(unionType.Id, original.MaterializeTypeId);
     }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.105.2</Version>
+    <Version>0.106.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Дополнение к #715, оставшееся комментарием: материализация тип-документа **ссылкой на существующий документ** по колонке с Ид — вместо сборки объекта из колонок.

## Что было

У типа-документа полей `doc-ref` нет, поэтому маппинг из #715 живой кейс («Протоколы ЭОМ» → «Протокол измерения сопротивления изоляции ЭОМ») не покрывал: ссылаться нужно не полем, а всей строкой. Обходной путь — union из одного doc-ref-варианта, дающий обёртку `{Вариант:{$ref}}`, которую шаблон обязан копать глубже.

## Что сделано

- **Домен**: `DataSetSource.MaterializeByIdColumn` + аддитивная миграция. Отдельной колонкой — по той же причине, что и дискриминатор #716: маппинг читают циклом четыре потребителя, и служебный ключ «не поле» пришлось бы объяснять каждому.
- **Валидатор**: режим только для `Kind = Document`; вместе с маппингом и вместе с дискриминатором — отказ словами.
- **Генерация** (`DataSetResolver`): строка → `{$ref:"instance"}`, живые данные подставляет второй проход. Строки без идентификатора в результат не попадают — ссылка без Ид читается сканером как удалённая запись, то есть выдуманная беда вместо настоящей; причины уходят сводкой. Скалярная привязка в этом режиме отказывается словами.
- **Предпросмотры** (привязки и материализации): строка = документ, показанный наименованием; отсутствующий по Ид назван отсутствующим.
- **Заодно** закрыт пункт проверки из основной части #715: `doc-ref`-ячейки в предпросмотре материализации показываются наименованием, а не GUID — до этого битая ссылка выглядела рабочей ровно до генерации.
- **Клиент**: переключатель режима в диалоге материализации (только для типа-документа) + селектор колонки; чип источника и подсказка в привязке поля больше не обещают маппинг там, где его нет.

## Проверка

- Юниты валидатора (5 новых) + интеграционные (6 новых): живой документ в контексте, пропуск строк без Ид со сводкой причин, отказ скалярной привязки, оба предпросмотра, перенос режима в копию источника.
- Тесты проверены на срабатывание: с отключённой веткой падают три резолверных и два предпросмотровых.
- Весь набор: backend 1368 зелёных, frontend 470, `tsc -b` чист.
- Живьём на 250701.ЭОМ-1: «Протоколы ЭОМ» → «Протокол измерения сопротивления изоляции ЭОМ» → колонка «Ид»; предпросмотр показал наименование документа вместо GUID, сохранение легло как `mapping={}, byIdColumn="Ид"`, оба отказа валидатора сработали. Источник возвращён в исходное состояние.

Версия 0.106.0.

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJcvLMyXhnYahVv3J6yrQj
