### PR TITLE
Разбор находок и замечаний на вкладке «Проблемы» комплекта (#731)

### DIFF
--- a/src/client/src/features/document-sets/SetProblemsPanel.tsx
+++ b/src/client/src/features/document-sets/SetProblemsPanel.tsx
@@ -5,8 +5,9 @@ import { Button } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { useToast } from '@/shared/ui/Toast';
 import {
-  useRelatedProblems, useRunReconciliation, useFindings, useSetDecision, useRemoveDecision,
-  downloadDiscrepancyReport, STATUS_LABELS, DECISION_LABELS, provenanceSummary, needsAttention,
+  useRelatedProblems, useRunReconciliation, useReconciliationRuns, useFindings,
+  useSetDecision, useRemoveDecision, downloadDiscrepancyReport,
+  STATUS_LABELS, DECISION_LABELS, provenanceSummary, needsAttention, runSummary,
   type Finding,
 } from '@/shared/api/reconciliations';
 import {
@@ -33,14 +34,20 @@ function num(v: number | null): string {
   return v == null ? '—' : String(Math.round(v * 1000) / 1000);
 }
 
+/*
+ * Вход в разбор — отдельная кнопка в строке, а не строка целиком.
+ *
+ * Строкой-кнопкой было бы меньше кода, но с этого экрана значения и метки позиций сверяют с
+ * документами: внутри `button` браузер не даёт выделить текст (а блочная разметка в ней ещё и
+ * невалидна). Клик по всей строке как дополнение к кнопке тоже не годится — двойной клик по
+ * слову успевает открыть диалог раньше, чем появляется выделение (проверено живьём), то есть
+ * ломает ровно то, ради чего строка осталась текстом.
+ */
+
 function FindingLine({ f, onDecide }: { f: Finding; onDecide: (f: Finding) => void }) {
   const open = needsAttention(f);
   return (
-    // Вся строка — вход в разбор, и подпись действия видна всегда, а не на hover (#680): скрытое
-    // действие на непривычном экране просто не находят.
-    <button type="button" onClick={() => onDecide(f)}
-      className={`w-full text-left px-3 py-2 border-b border-stroke text-sm transition-colors
-        hover:bg-muted/40 focus-visible:outline-none focus-visible:bg-muted/40 ${open ? '' : 'opacity-60'}`}>
+    <div className={`px-3 py-2 border-b border-stroke text-sm ${open ? '' : 'opacity-60'}`}>
       <div className="flex items-center gap-2">
         <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${
           f.status === 'Match' ? 'text-fg4' : open ? 'bg-danger-subtle text-danger' : 'bg-muted text-fg3'}`}>
@@ -50,7 +57,11 @@ function FindingLine({ f, onDecide }: { f: Finding; onDecide: (f: Finding) => vo
         <span className="tabular-nums text-fg2 shrink-0">
           {num(f.leftValue)} <span className="text-fg4">/</span> {num(f.rightValue)}
         </span>
-        <span className="text-xs text-brand shrink-0">{f.decision ? 'Изменить' : 'Разобрать'}</span>
+        {/* Кнопка видна всегда, а не на hover (#680): скрытое действие на непривычном экране
+            просто не находят. */}
+        <Button variant="text" size="sm" className="shrink-0" onClick={() => onDecide(f)}>
+          {f.decision ? 'Изменить' : 'Разобрать'}
+        </Button>
       </div>
       <div className="flex items-center gap-3 mt-0.5 text-[11px] text-fg4">
         {provenanceSummary(f.provenance.left) && <span>слева: {provenanceSummary(f.provenance.left)}</span>}
@@ -62,7 +73,7 @@ function FindingLine({ f, onDecide }: { f: Finding; onDecide: (f: Finding) => vo
           </span>
         )}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -70,6 +81,7 @@ function ReconciliationBlock({ id, name, unresolved }: {
   id: string; name: string; unresolved: number;
 }) {
   const { data: findings = [] } = useFindings(id);
+  const { data: runs = [] } = useReconciliationRuns(id);
   const run = useRunReconciliation();
   const setDecision = useSetDecision();
   const removeDecision = useRemoveDecision();
@@ -78,12 +90,24 @@ function ReconciliationBlock({ id, name, unresolved }: {
   const [deciding, setDeciding] = useState<Finding | null>(null);
 
   const shown = onlyOpen ? findings.filter(needsAttention) : findings;
+  const lastRun = runs[0] ?? null;
 
   return (
     <div className="border border-stroke rounded-lg overflow-hidden">
       <div className="flex items-center gap-2 px-3 py-2 bg-muted/40">
         <Scale size={14} className="text-fg4 shrink-0" />
-        <span className="flex-1 truncate text-sm font-medium text-fg1">{name}</span>
+        <div className="flex-1 min-w-0">
+          <div className="truncate text-sm font-medium text-fg1">{name}</div>
+          {/* Когда прогон был и чем кончился — обязательная часть блока, а не украшение: список
+              находок строится по последнему УДАЧНОМУ прогону, поэтому без этой строки «Всё
+              разобрано» читалось бы одинаково и когда расхождений нет, и когда сверку ни разу не
+              считали, и когда последний прогон упал. Это самое опасное недоразумение подсистемы. */}
+          <div className="text-[11px] text-fg4">
+            {lastRun
+              ? `${runSummary(lastRun)} · ${new Date(lastRun.startedAt).toLocaleString('ru-RU')}`
+              : 'Прогонов ещё не было'}
+          </div>
+        </div>
         {/* История прогонов, алиасы и правка определения живут только в разделе «Сверка»: здесь
             разбирают находки, а не настраивают сверку. */}
         <Link to={`/reconciliations?id=${id}`}
@@ -104,7 +128,17 @@ function ReconciliationBlock({ id, name, unresolved }: {
           <Play size={13} /> Прогнать
         </Button>
       </div>
-      {shown.length === 0
+      {/* Неудачный прогон обязан быть виден: ниже показаны находки предыдущего удачного, и без
+          этой плашки они выдавали бы себя за сегодняшний результат. */}
+      {lastRun?.status === 'Failed' && (
+        <div className="px-3 py-2 bg-danger-subtle text-danger text-xs">
+          <strong>Последний прогон не выполнен.</strong> {lastRun.error}
+        </div>
+      )}
+
+      {runs.length === 0
+        ? <p className="px-3 py-2 text-xs text-fg4">Сверка ещё не считалась — нажмите «Прогнать».</p>
+        : shown.length === 0
         ? <p className="px-3 py-2 text-xs text-fg4">{onlyOpen ? 'Всё разобрано.' : 'Находок нет.'}</p>
         : shown.map(f => <FindingLine key={f.id} f={f} onDecide={setDeciding} />)}
 
@@ -136,10 +170,7 @@ function ObservationCard({ o, documentNames, onReview }: {
   onReview: (o: Observation) => void;
 }) {
   return (
-    <button type="button" onClick={() => onReview(o)}
-      className={`w-full text-left px-3 py-2 border border-stroke rounded-lg transition-colors
-        hover:bg-muted/40 focus-visible:outline-none focus-visible:bg-muted/40 ${
-        isUnreviewed(o) ? '' : 'opacity-60'}`}>
+    <div className={`px-3 py-2 border border-stroke rounded-lg ${isUnreviewed(o) ? '' : 'opacity-60'}`}>
       <div className="flex items-start gap-2">
         <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 mt-0.5 ${
           o.severity === 'Error' ? 'bg-warning-subtle text-warning' : 'bg-muted text-fg3'}`}>
@@ -165,11 +196,11 @@ function ObservationCard({ o, documentNames, onReview }: {
           )}
         </div>
         <span className="text-[11px] text-fg4 shrink-0">{OBSERVATION_STATUS_LABELS[o.status]}</span>
-        <span className="text-xs text-brand shrink-0">
+        <Button variant="text" size="sm" className="shrink-0 -mt-1" onClick={() => onReview(o)}>
           {isUnreviewed(o) ? 'Разобрать' : 'Изменить'}
-        </span>
+        </Button>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/src/client/src/features/document-sets/SetProblemsPanel.tsx
+++ b/src/client/src/features/document-sets/SetProblemsPanel.tsx
@@ -1,30 +1,46 @@
 import { useState } from 'react';
-import { Play, FileSpreadsheet, AlertTriangle, Bot, Scale } from 'lucide-react';
+import { Link, useParams } from 'react-router';
+import { Play, FileSpreadsheet, AlertTriangle, Bot, Scale, ExternalLink } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { EmptyState } from '@/shared/ui/EmptyState';
 import { useToast } from '@/shared/ui/Toast';
 import {
-  useRelatedProblems, useRunReconciliation, useFindings,
+  useRelatedProblems, useRunReconciliation, useFindings, useSetDecision, useRemoveDecision,
   downloadDiscrepancyReport, STATUS_LABELS, DECISION_LABELS, provenanceSummary, needsAttention,
   type Finding,
 } from '@/shared/api/reconciliations';
-import { useObservations, SEVERITY_LABELS, OBSERVATION_STATUS_LABELS, isUnreviewed } from '@/shared/api/observations';
+import {
+  useObservations, SEVERITY_LABELS, OBSERVATION_STATUS_LABELS, isUnreviewed,
+  type Observation,
+} from '@/shared/api/observations';
+import { DecisionDialog } from '@/features/reconciliations/DecisionDialog';
+import { ObservationReviewDialog } from '@/features/reconciliations/ObservationReviewDialog';
 
 /**
  * Проблемы комплекта (issue #452) — дом подсистемы сверки в иерархии.
  *
  * Две подписанные секции, а НЕ общий список и не табы: находка сверки — результат арифметики
  * системы, замечание — утверждение внешнего агента. Смешать их значило бы выдать одно за другое.
+ *
+ * Разбирают их здесь же (#731): вкладка была читальным залом и отсылала в раздел «Сверка», хотя
+ * комплект — именно тот уровень, на котором с проблемами и работают. Диалоги разбора те же самые,
+ * что и на главной странице, — общие компоненты, а не копии разметки. В разделе «Сверка» остаётся
+ * то, что к разбору не относится: история прогонов, алиасы, правка определения, чистка журнала
+ * агента; ссылки «Открыть в „Сверке“» ведут туда.
  */
 
 function num(v: number | null): string {
   return v == null ? '—' : String(Math.round(v * 1000) / 1000);
 }
 
-function FindingLine({ f }: { f: Finding }) {
+function FindingLine({ f, onDecide }: { f: Finding; onDecide: (f: Finding) => void }) {
   const open = needsAttention(f);
   return (
-    <div className={`px-3 py-2 border-b border-stroke text-sm ${open ? '' : 'opacity-60'}`}>
+    // Вся строка — вход в разбор, и подпись действия видна всегда, а не на hover (#680): скрытое
+    // действие на непривычном экране просто не находят.
+    <button type="button" onClick={() => onDecide(f)}
+      className={`w-full text-left px-3 py-2 border-b border-stroke text-sm transition-colors
+        hover:bg-muted/40 focus-visible:outline-none focus-visible:bg-muted/40 ${open ? '' : 'opacity-60'}`}>
       <div className="flex items-center gap-2">
         <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${
           f.status === 'Match' ? 'text-fg4' : open ? 'bg-danger-subtle text-danger' : 'bg-muted text-fg3'}`}>
@@ -34,13 +50,19 @@ function FindingLine({ f }: { f: Finding }) {
         <span className="tabular-nums text-fg2 shrink-0">
           {num(f.leftValue)} <span className="text-fg4">/</span> {num(f.rightValue)}
         </span>
+        <span className="text-xs text-brand shrink-0">{f.decision ? 'Изменить' : 'Разобрать'}</span>
       </div>
       <div className="flex items-center gap-3 mt-0.5 text-[11px] text-fg4">
         {provenanceSummary(f.provenance.left) && <span>слева: {provenanceSummary(f.provenance.left)}</span>}
         {provenanceSummary(f.provenance.right) && <span>справа: {provenanceSummary(f.provenance.right)}</span>}
-        {f.decision && <span className="text-fg3">{DECISION_LABELS[f.decision.kind]}</span>}
+        {f.decision && (
+          <span className="text-fg3">
+            {DECISION_LABELS[f.decision.kind]}
+            {f.decision.note ? ` — ${f.decision.note}` : ''}
+          </span>
+        )}
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -49,8 +71,11 @@ function ReconciliationBlock({ id, name, unresolved }: {
 }) {
   const { data: findings = [] } = useFindings(id);
   const run = useRunReconciliation();
+  const setDecision = useSetDecision();
+  const removeDecision = useRemoveDecision();
   const toast = useToast();
   const [onlyOpen, setOnlyOpen] = useState(true);
+  const [deciding, setDeciding] = useState<Finding | null>(null);
 
   const shown = onlyOpen ? findings.filter(needsAttention) : findings;
 
@@ -59,6 +84,12 @@ function ReconciliationBlock({ id, name, unresolved }: {
       <div className="flex items-center gap-2 px-3 py-2 bg-muted/40">
         <Scale size={14} className="text-fg4 shrink-0" />
         <span className="flex-1 truncate text-sm font-medium text-fg1">{name}</span>
+        {/* История прогонов, алиасы и правка определения живут только в разделе «Сверка»: здесь
+            разбирают находки, а не настраивают сверку. */}
+        <Link to={`/reconciliations?id=${id}`}
+          className="inline-flex items-center gap-1 text-[11px] text-brand hover:underline shrink-0">
+          <ExternalLink size={11} /> Открыть в «Сверке»
+        </Link>
         <button type="button" onClick={() => setOnlyOpen(v => !v)}
           className={`text-[11px] px-2 py-0.5 rounded-full transition-colors ${
             onlyOpen ? 'bg-brand-subtle text-brand font-medium' : 'text-fg3 hover:bg-base'}`}>
@@ -75,8 +106,70 @@ function ReconciliationBlock({ id, name, unresolved }: {
       </div>
       {shown.length === 0
         ? <p className="px-3 py-2 text-xs text-fg4">{onlyOpen ? 'Всё разобрано.' : 'Находок нет.'}</p>
-        : shown.map(f => <FindingLine key={f.id} f={f} />)}
+        : shown.map(f => <FindingLine key={f.id} f={f} onDecide={setDeciding} />)}
+
+      {deciding && (
+        <DecisionDialog
+          finding={deciding}
+          onClose={() => setDeciding(null)}
+          onSave={async (kind, note) => {
+            await setDecision.mutateAsync({ id, key: deciding.key, kind, note });
+            setDeciding(null);
+            // Решение адресовано ключом позиции, поэтому переживёт следующий прогон — говорим это
+            // прямо, иначе непонятно, почему отметка не исчезает после пересчёта.
+            toast.success('Решение сохранено и переживёт следующий прогон');
+          }}
+          onRemove={deciding.decision ? async () => {
+            await removeDecision.mutateAsync({ id, key: deciding.key });
+            setDeciding(null);
+            toast.info('Решение снято');
+          } : undefined}
+        />
+      )}
     </div>
+  );
+}
+
+function ObservationCard({ o, documentNames, onReview }: {
+  o: Observation;
+  documentNames: Map<string, string>;
+  onReview: (o: Observation) => void;
+}) {
+  return (
+    <button type="button" onClick={() => onReview(o)}
+      className={`w-full text-left px-3 py-2 border border-stroke rounded-lg transition-colors
+        hover:bg-muted/40 focus-visible:outline-none focus-visible:bg-muted/40 ${
+        isUnreviewed(o) ? '' : 'opacity-60'}`}>
+      <div className="flex items-start gap-2">
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 mt-0.5 ${
+          o.severity === 'Error' ? 'bg-warning-subtle text-warning' : 'bg-muted text-fg3'}`}>
+          {SEVERITY_LABELS[o.severity]}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm text-fg1">{o.title}</div>
+          {o.detail && <p className="text-xs text-fg3 mt-0.5 line-clamp-2">{o.detail}</p>}
+          {/* Имена документов, а не идентификаторы: «документ 77de9193» человеку ничего не говорит. */}
+          {(o.references.documentIds ?? []).length > 0 && (
+            <p className="text-[11px] text-fg4 mt-1">
+              {(o.references.documentIds ?? [])
+                .map(id => documentNames.get(id) ?? `документ ${id.slice(0, 8)}`)
+                .join(' · ')}
+            </p>
+          )}
+          {/* Чем кончился разбор — на карточке: иначе видно только «Отклонено» без причины. */}
+          {o.reviewNote && (
+            <p className="text-[11px] text-fg3 mt-1">
+              {OBSERVATION_STATUS_LABELS[o.status]}: {o.reviewNote}
+              {o.reviewedBy ? ` (${o.reviewedBy})` : ''}
+            </p>
+          )}
+        </div>
+        <span className="text-[11px] text-fg4 shrink-0">{OBSERVATION_STATUS_LABELS[o.status]}</span>
+        <span className="text-xs text-brand shrink-0">
+          {isUnreviewed(o) ? 'Разобрать' : 'Изменить'}
+        </span>
+      </div>
+    </button>
   );
 }
 
@@ -86,12 +179,16 @@ export function SetProblemsPanel({ setId, setName, documentNames }: {
   /** Имена документов комплекта: в ссылках замечаний иначе стоят нечитаемые идентификаторы. */
   documentNames: Map<string, string>;
 }) {
+  const { constructionId } = useParams<{ constructionId: string }>();
   const { data: problems } = useRelatedProblems('Set', setId);
   const { data: observations = [] } = useObservations(setId);
   const toast = useToast();
   const [busy, setBusy] = useState(false);
+  const [reviewing, setReviewing] = useState<Observation | null>(null);
 
-  const open = observations.filter(isUnreviewed);
+  // Deep-link документа из диалога разбора: замечание знает комплект, а путь собирается из стройки
+  // и комплекта. Стройки в адресе нет — ссылки в диалоге не рисуем, битая ссылка хуже её отсутствия.
+  const setPath = constructionId ? `/document-sets/${constructionId}/sets/${setId}` : null;
 
   return (
     <div className="flex-1 min-w-0 overflow-y-auto p-4 space-y-5">
@@ -137,10 +234,17 @@ export function SetProblemsPanel({ setId, setName, documentNames }: {
       <section className="space-y-2">
         <h3 className="text-xs font-semibold uppercase tracking-wide text-fg4 flex items-center gap-1.5">
           <Bot size={13} /> Замечания анализа
+          <span className="flex-1" />
+          {/* Журнал агента целиком (и его чистка) — в разделе «Сверка»: удалять записи с вкладки
+              комплекта незачем, здесь их разбирают. */}
+          <Link to="/reconciliations?view=observations"
+            className="inline-flex items-center gap-1 text-[11px] font-normal normal-case tracking-normal text-brand hover:underline">
+            <ExternalLink size={11} /> Весь журнал
+          </Link>
         </h3>
         {/* Происхождение обязано быть видно рядом с данными: это утверждения, а не результат системы. */}
         <p className="text-[11px] text-fg4 -mt-1">
-          Утверждения внешнего ИИ-агента. Система их не проверяла.
+          Утверждения внешнего ИИ-агента. Система их не проверяла — подтвердите или отклоните.
         </p>
 
         {observations.length === 0 && (
@@ -149,34 +253,15 @@ export function SetProblemsPanel({ setId, setName, documentNames }: {
         )}
 
         {observations.map(o => (
-          <div key={o.id} className={`px-3 py-2 border border-stroke rounded-lg ${
-            isUnreviewed(o) ? '' : 'opacity-60'}`}>
-            <div className="flex items-start gap-2">
-              <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 mt-0.5 ${
-                o.severity === 'Error' ? 'bg-warning-subtle text-warning' : 'bg-muted text-fg3'}`}>
-                {SEVERITY_LABELS[o.severity]}
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className="text-sm text-fg1">{o.title}</div>
-                {o.detail && <p className="text-xs text-fg3 mt-0.5 line-clamp-2">{o.detail}</p>}
-                {/* Имена документов, а не идентификаторы: «документ 77de9193» человеку ничего не говорит. */}
-                {(o.references.documentIds ?? []).length > 0 && (
-                  <p className="text-[11px] text-fg4 mt-1">
-                    {(o.references.documentIds ?? [])
-                      .map(id => documentNames.get(id) ?? `документ ${id.slice(0, 8)}`)
-                      .join(' · ')}
-                  </p>
-                )}
-              </div>
-              <span className="text-[11px] text-fg4 shrink-0">{OBSERVATION_STATUS_LABELS[o.status]}</span>
-            </div>
-          </div>
+          <ObservationCard key={o.id} o={o} documentNames={documentNames} onReview={setReviewing} />
         ))}
-
-        {observations.length > 0 && open.length === 0 && (
-          <p className="text-xs text-fg4">Всё разобрано. Разбирать замечания — в разделе «Сверка».</p>
-        )}
       </section>
+
+      {reviewing && (
+        <ObservationReviewDialog observation={reviewing} setPath={setPath}
+          nameOf={id => documentNames.get(id)}
+          onClose={() => setReviewing(null)} />
+      )}
     </div>
   );
 }

--- a/src/client/src/features/reconciliations/DecisionDialog.tsx
+++ b/src/client/src/features/reconciliations/DecisionDialog.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { TextField } from '@/shared/ui/TextField';
 import { Select, SelectItem } from '@/shared/ui/Select';
+import { useToast } from '@/shared/ui/Toast';
 import { DECISION_LABELS, STATUS_LABELS, type DecisionKind, type Finding } from '@/shared/api/reconciliations';
 
 /**
@@ -19,10 +20,20 @@ export function DecisionDialog({ finding, onClose, onSave, onRemove }: {
   const [kind, setKind] = useState<DecisionKind>(finding.decision?.kind ?? 'Accepted');
   const [note, setNote] = useState(finding.decision?.note ?? '');
   const [busy, setBusy] = useState(false);
+  const toast = useToast();
 
   async function run(action: () => Promise<void>) {
     setBusy(true);
-    try { await action(); } finally { setBusy(false); }
+    try {
+      await action();
+    } catch {
+      // Сверку могли удалить или переопределить, пока диалог открыт. Молча оживившая кнопка
+      // «Сохранить» неотличима от «клик не сработал», а находка остаётся в списке — выглядит так,
+      // будто ничего и не просили. Ошибку ловим здесь: диалог общий для обеих поверхностей.
+      toast.error('Не удалось сохранить решение. Возможно, сверка изменилась — обновите страницу');
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (

--- a/src/client/src/features/reconciliations/ObservationReviewDialog.tsx
+++ b/src/client/src/features/reconciliations/ObservationReviewDialog.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Check, X, RotateCcw, FileText, Layers } from 'lucide-react';
+import { Link } from 'react-router';
+import { Button } from '@/shared/ui/Button';
+import { Modal } from '@/shared/ui/Modal';
+import { TextField } from '@/shared/ui/TextField';
+import { useToast } from '@/shared/ui/Toast';
+import {
+  useReviewObservation, type Observation, type ObservationStatus,
+} from '@/shared/api/observations';
+
+/**
+ * Разбор замечания внешнего анализа — ОДИН на все поверхности (issue #731).
+ *
+ * Замечание разбирают из двух мест: журнал агента в разделе «Сверка» и вкладка «Проблемы»
+ * комплекта. Набор решений и формулировки обязаны совпадать до буквы — «Отклонено» здесь значит
+ * то же самое, что и там, и причину в обоих случаях читает агент. Держать это двумя копиями
+ * разметки значило бы обречь их разъехаться на первой же правке.
+ *
+ * Диалог, а не три кнопки на карточке: к решению полагается примечание (при отклонении оно и
+ * есть суть — агент прочтёт его при следующем анализе), а поле ввода в каждой строке списка
+ * превратило бы список в форму.
+ */
+
+/**
+ * Ссылки на первоисточник: без перехода проверять утверждение неудобно, а непроверенное — мнение.
+ *
+ * Документ открывается deep-link'ом внутрь комплекта, поэтому нужен путь комплекта: он вычисляется
+ * по области замечания. Не нашёлся — показываем идентификатор текстом, но НЕ рисуем ссылку: битая
+ * ссылка хуже её отсутствия.
+ *
+ * `nameOf` задаёт вызывающая сторона, если знает имена документов: «документ 77de9193» человеку
+ * ничего не говорит, а на вкладке комплекта состав под рукой.
+ */
+export function ObservationReferences({ o, setPath, nameOf }: {
+  o: Observation;
+  setPath: string | null;
+  nameOf?: (documentId: string) => string | undefined;
+}) {
+  const docs = o.references.documentIds ?? [];
+  const sourceId = o.references.sourceId;
+  const rows = o.references.rows ?? [];
+  if (docs.length === 0 && !sourceId && !o.references.note) return null;
+
+  const label = (id: string) => nameOf?.(id) ?? `документ ${id.slice(0, 8)}`;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-[11px]">
+      {docs.map(id => setPath ? (
+        <Link key={id} to={`${setPath}?doc=${id}`}
+          className="inline-flex items-center gap-1 text-brand hover:underline">
+          <FileText size={11} /> {label(id)}
+        </Link>
+      ) : (
+        <span key={id} className="inline-flex items-center gap-1 text-fg4">
+          <FileText size={11} /> {label(id)}
+        </span>
+      ))}
+      {sourceId && (
+        <Link to="/datasets" className="inline-flex items-center gap-1 text-brand hover:underline">
+          <Layers size={11} /> источник {sourceId.slice(0, 8)}
+          {rows.length > 0 && <span className="text-fg4">· строк {rows.length}</span>}
+        </Link>
+      )}
+      {o.references.note && <span className="text-fg4">{o.references.note}</span>}
+    </div>
+  );
+}
+
+export function ObservationReviewDialog({ observation, setPath, nameOf, onClose }: {
+  observation: Observation;
+  setPath: string | null;
+  nameOf?: (documentId: string) => string | undefined;
+  onClose: () => void;
+}) {
+  const [note, setNote] = useState(observation.reviewNote ?? '');
+  const review = useReviewObservation();
+  const toast = useToast();
+
+  async function decide(status: ObservationStatus) {
+    await review.mutateAsync({ id: observation.id, status, note: note.trim() || null });
+    onClose();
+    toast.success(status === 'Rejected'
+      // Примечание к отклонению читает агент — иначе он сообщит то же самое в следующий раз.
+      ? 'Отклонено. Причину увидит агент при следующем анализе'
+      : status === 'Confirmed' ? 'Подтверждено' : 'Возвращено в работу');
+  }
+
+  return (
+    <Modal open onOpenChange={o => { if (!o) onClose(); }} title="Разбор замечания" wide
+      footer={
+        <div className="flex items-center gap-2">
+          {observation.status !== 'New' && (
+            <Button disabled={review.isPending} onClick={() => decide('New')}>
+              <RotateCcw size={14} /> Вернуть в работу
+            </Button>
+          )}
+          <span className="flex-1" />
+          <Button disabled={review.isPending} onClick={onClose}>Отмена</Button>
+          <Button danger disabled={review.isPending} onClick={() => decide('Rejected')}>
+            <X size={14} /> Отклонить
+          </Button>
+          <Button variant="filled" loading={review.isPending} onClick={() => decide('Confirmed')}>
+            <Check size={14} /> Подтвердить
+          </Button>
+        </div>
+      }>
+      <div className="space-y-4">
+        <div>
+          <div className="text-sm font-medium text-fg1">{observation.title}</div>
+          {observation.detail && (
+            <p className="text-sm text-fg2 mt-1 whitespace-pre-wrap">{observation.detail}</p>
+          )}
+          <ObservationReferences o={observation} setPath={setPath} nameOf={nameOf} />
+        </div>
+
+        <TextField label="Примечание" value={note} onChange={e => setNote(e.target.value)}
+          hint="При отклонении объясните, почему это не ошибка — это прочитает агент и не повторит замечание" />
+      </div>
+    </Modal>
+  );
+}

--- a/src/client/src/features/reconciliations/ObservationReviewDialog.tsx
+++ b/src/client/src/features/reconciliations/ObservationReviewDialog.tsx
@@ -78,7 +78,14 @@ export function ObservationReviewDialog({ observation, setPath, nameOf, onClose 
   const toast = useToast();
 
   async function decide(status: ObservationStatus) {
-    await review.mutateAsync({ id: observation.id, status, note: note.trim() || null });
+    try {
+      await review.mutateAsync({ id: observation.id, status, note: note.trim() || null });
+    } catch {
+      // Замечание мог отозвать или удалить агент, пока диалог открыт. Без этой ветки диалог
+      // просто оставался бы на месте с ожившими кнопками — неотличимо от «клик не сработал».
+      toast.error('Не удалось сохранить разбор. Возможно, замечание изменилось — обновите страницу');
+      return;
+    }
     onClose();
     toast.success(status === 'Rejected'
       // Примечание к отклонению читает агент — иначе он сообщит то же самое в следующий раз.

--- a/src/client/src/features/reconciliations/ObservationsPanel.tsx
+++ b/src/client/src/features/reconciliations/ObservationsPanel.tsx
@@ -1,17 +1,14 @@
 import { useMemo, useState } from 'react';
-import { Bot, Check, X, RotateCcw, FileText, Layers } from 'lucide-react';
-import { Link } from 'react-router';
+import { Bot } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
-import { Modal } from '@/shared/ui/Modal';
-import { TextField } from '@/shared/ui/TextField';
 import { EmptyState } from '@/shared/ui/EmptyState';
-import { useToast } from '@/shared/ui/Toast';
 import { useListConstructions } from '@/shared/api/constructions';
 import {
-  useObservations, useReviewObservation,
+  useObservations,
   SEVERITY_LABELS, OBSERVATION_STATUS_LABELS, isUnreviewed,
   type Observation, type ObservationStatus,
 } from '@/shared/api/observations';
+import { ObservationReviewDialog, ObservationReferences } from './ObservationReviewDialog';
 
 /**
  * Журнал замечаний внешнего анализа (issue #442).
@@ -34,93 +31,6 @@ const STATUS_STYLE: Record<ObservationStatus, string> = {
   Retracted: 'bg-warning-subtle text-warning',
 };
 
-/**
- * Ссылки на первоисточник: без перехода проверять утверждение неудобно, а непроверенное — мнение.
- *
- * Документ открывается deep-link'ом внутрь комплекта, поэтому нужна ещё и стройка: она вычисляется по
- * области замечания. Не нашлась — показываем идентификатор текстом, но НЕ рисуем ссылку: битая ссылка
- * хуже её отсутствия.
- */
-function References({ o, setPath }: { o: Observation; setPath: string | null }) {
-  const docs = o.references.documentIds ?? [];
-  const sourceId = o.references.sourceId;
-  const rows = o.references.rows ?? [];
-  if (docs.length === 0 && !sourceId && !o.references.note) return null;
-
-  return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-[11px]">
-      {docs.map(id => setPath ? (
-        <Link key={id} to={`${setPath}?doc=${id}`}
-          className="inline-flex items-center gap-1 text-brand hover:underline">
-          <FileText size={11} /> документ {id.slice(0, 8)}
-        </Link>
-      ) : (
-        <span key={id} className="inline-flex items-center gap-1 text-fg4">
-          <FileText size={11} /> документ {id.slice(0, 8)}
-        </span>
-      ))}
-      {sourceId && (
-        <Link to="/datasets" className="inline-flex items-center gap-1 text-brand hover:underline">
-          <Layers size={11} /> источник {sourceId.slice(0, 8)}
-          {rows.length > 0 && <span className="text-fg4">· строк {rows.length}</span>}
-        </Link>
-      )}
-      {o.references.note && <span className="text-fg4">{o.references.note}</span>}
-    </div>
-  );
-}
-
-function ReviewDialog({ observation, setPath, onClose }: {
-  observation: Observation; setPath: string | null; onClose: () => void;
-}) {
-  const [note, setNote] = useState(observation.reviewNote ?? '');
-  const review = useReviewObservation();
-  const toast = useToast();
-
-  async function decide(status: ObservationStatus) {
-    await review.mutateAsync({ id: observation.id, status, note: note.trim() || null });
-    onClose();
-    toast.success(status === 'Rejected'
-      // Примечание к отклонению читает агент — иначе он сообщит то же самое в следующий раз.
-      ? 'Отклонено. Причину увидит агент при следующем анализе'
-      : status === 'Confirmed' ? 'Подтверждено' : 'Возвращено в работу');
-  }
-
-  return (
-    <Modal open onOpenChange={o => { if (!o) onClose(); }} title="Разбор замечания" wide
-      footer={
-        <div className="flex items-center gap-2">
-          {observation.status !== 'New' && (
-            <Button disabled={review.isPending} onClick={() => decide('New')}>
-              <RotateCcw size={14} /> Вернуть в работу
-            </Button>
-          )}
-          <span className="flex-1" />
-          <Button disabled={review.isPending} onClick={onClose}>Отмена</Button>
-          <Button danger disabled={review.isPending} onClick={() => decide('Rejected')}>
-            <X size={14} /> Отклонить
-          </Button>
-          <Button variant="filled" loading={review.isPending} onClick={() => decide('Confirmed')}>
-            <Check size={14} /> Подтвердить
-          </Button>
-        </div>
-      }>
-      <div className="space-y-4">
-        <div>
-          <div className="text-sm font-medium text-fg1">{observation.title}</div>
-          {observation.detail && (
-            <p className="text-sm text-fg2 mt-1 whitespace-pre-wrap">{observation.detail}</p>
-          )}
-          <References o={observation} setPath={setPath} />
-        </div>
-
-        <TextField label="Примечание" value={note} onChange={e => setNote(e.target.value)}
-          hint="При отклонении объясните, почему это не ошибка — это прочитает агент и не повторит замечание" />
-      </div>
-    </Modal>
-  );
-}
-
 function ObservationRow({ o, setPath, onReview }: {
   o: Observation; setPath: string | null; onReview: (o: Observation) => void;
 }) {
@@ -134,7 +44,7 @@ function ObservationRow({ o, setPath, onReview }: {
         <div className="min-w-0 flex-1">
           <div className="text-sm text-fg1">{o.title}</div>
           {o.detail && <p className="text-xs text-fg3 mt-0.5 line-clamp-3">{o.detail}</p>}
-          <References o={o} setPath={setPath} />
+          <ObservationReferences o={o} setPath={setPath} />
           {o.reviewNote && (
             <p className="text-[11px] text-fg3 mt-1">
               {OBSERVATION_STATUS_LABELS[o.status]}: {o.reviewNote}
@@ -213,7 +123,7 @@ export function ObservationsPanel() {
       </div>
 
       {reviewing && (
-        <ReviewDialog observation={reviewing} setPath={pathOf(reviewing)}
+        <ObservationReviewDialog observation={reviewing} setPath={pathOf(reviewing)}
           onClose={() => setReviewing(null)} />
       )}
     </div>

--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
 import {
   Plus, Play, AlertTriangle, CheckCircle2, CircleSlash, History, Scale, Bot, FileSpreadsheet, Link2,
 } from 'lucide-react';
@@ -129,6 +130,23 @@ export function ReconciliationsPage() {
   const [view, setView] = useState<'reconciliation' | 'observations' | 'aliases'>('reconciliation');
   // Связывание позиций: выбираем ровно две несопоставленные находки.
   const [linking, setLinking] = useState<string[]>([]);
+
+  /**
+   * Вход снаружи: `?id=<сверка>` и `?view=observations|aliases` (#731). Вкладка «Проблемы»
+   * комплекта отсылает сюда за тем, чего там нет — историей прогонов, алиасами, чисткой журнала, —
+   * и приводить на пустой экран «Выберите сверку» после явного «Открыть в „Сверке“» нельзя.
+   *
+   * Эффектом, а не только начальным значением состояния: смена одной строки запроса компонент не
+   * размонтирует, и вторая такая ссылка подряд иначе ничего бы не сделала. Дальше выбор ведёт
+   * обычное состояние — держать его в адресе целиком эта страница не умеет.
+   */
+  const [searchParams] = useSearchParams();
+  useEffect(() => {
+    const id = searchParams.get('id');
+    const requested = searchParams.get('view');
+    if (requested === 'observations' || requested === 'aliases') setView(requested);
+    else if (id) { setView('reconciliation'); setSelectedId(id); setRunId(null); }
+  }, [searchParams]);
 
   const { data: items = [], isLoading } = useReconciliations();
   const { data: observations = [] } = useObservations();

--- a/src/client/src/shared/api/observations.ts
+++ b/src/client/src/shared/api/observations.ts
@@ -43,6 +43,15 @@ export interface Observation {
 
 const KEY = ['observations'] as const;
 
+/**
+ * Счётчики проблем («Требует разбора», бейдж вкладки комплекта, маркеры в дереве) считает
+ * `/reconciliations/related` и `/reconciliations/summary` — они кэшируются под ЧУЖИМ ключом.
+ * Разбор замечания меняет эти числа, поэтому каждая мутация журнала гасит и его: иначе шапка
+ * остаётся протухшей до перезагрузки. На главной странице «Сверка» это долго не проявлялось —
+ * там счётчик замечаний считается по самому списку, — а на вкладке комплекта видно сразу (#731).
+ */
+const PROBLEM_COUNTERS_KEY = ['reconciliations'] as const;
+
 export function useObservations(scopeId?: string | null, status?: ObservationStatus) {
   return useQuery({
     queryKey: [...KEY, scopeId ?? null, status ?? null],
@@ -58,7 +67,10 @@ export function useReviewObservation() {
     mutationFn: async ({ id, status, note }: {
       id: string; status: ObservationStatus; note?: string | null;
     }) => (await apiClient.put<Observation>(`/observations/${id}/review`, { status, note })).data,
-    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: KEY });
+      void qc.invalidateQueries({ queryKey: PROBLEM_COUNTERS_KEY });
+    },
   });
 }
 
@@ -66,7 +78,11 @@ export function useDeleteObservation() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: string) => { await apiClient.delete(`/observations/${id}`); },
-    onSuccess: () => { void qc.invalidateQueries({ queryKey: KEY }); },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: KEY });
+      // Удаление неразобранного замечания уменьшает «Требует разбора» ровно так же, как разбор.
+      void qc.invalidateQueries({ queryKey: PROBLEM_COUNTERS_KEY });
+    },
   });
 }
 

--- a/src/client/src/shared/api/observations.ts
+++ b/src/client/src/shared/api/observations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from './client';
+import { RECONCILIATION_KEY } from './reconciliations';
 
 /**
  * Замечания внешнего анализа (issue #440). Пишет их агент через MCP; здесь их только читают и
@@ -49,8 +50,10 @@ const KEY = ['observations'] as const;
  * Разбор замечания меняет эти числа, поэтому каждая мутация журнала гасит и его: иначе шапка
  * остаётся протухшей до перезагрузки. На главной странице «Сверка» это долго не проявлялось —
  * там счётчик замечаний считается по самому списку, — а на вкладке комплекта видно сразу (#731).
+ *
+ * Импортом, а не своей копией строки: иначе переименование ключа там компилируется здесь молча.
  */
-const PROBLEM_COUNTERS_KEY = ['reconciliations'] as const;
+const PROBLEM_COUNTERS_KEY = RECONCILIATION_KEY;
 
 export function useObservations(scopeId?: string | null, status?: ObservationStatus) {
   return useQuery({

--- a/src/client/src/shared/api/reconciliations.ts
+++ b/src/client/src/shared/api/reconciliations.ts
@@ -124,7 +124,14 @@ export interface Finding {
   decision: FindingDecision | null;
 }
 
-const KEY = ['reconciliations'] as const;
+/**
+ * Префикс кэша подсистемы. Экспортируется потому, что под ним лежат не только сверки: счётчики
+ * проблем (`related`, `summary`) считает сервер здесь же, а меняет их и разбор ЗАМЕЧАНИЯ —
+ * мутациям журнала (`shared/api/observations.ts`) нужно гасить этот ключ. Со своей копией строки
+ * там переименование ключа здесь компилировалось бы молча, а бейджи снова протухали бы (#731).
+ */
+export const RECONCILIATION_KEY = ['reconciliations'] as const;
+const KEY = RECONCILIATION_KEY;
 
 export function useReconciliations(scope?: string, scopeId?: string) {
   return useQuery({

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.106.2</Version>
+    <Version>0.107.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #731

## Что сделано

**Находки сверки.** Строка стала входом в разбор — клик открывает существующий `DecisionDialog`, решение сохраняется/снимается теми же хуками. Подпись действия («Разобрать» / «Изменить») видна всегда, а не на hover (#680).

**Замечания анализа.** Карточка открывает разбор: подтвердить / отклонить / вернуть в работу + примечание. Диалог вынесен из `ObservationsPanel` в общий `ObservationReviewDialog` — обе поверхности используют один, иначе набор решений и формулировки разъехались бы на первой же правке. Ссылки на документы в диалоге показываются именами: на вкладке комплекта состав под рукой (`nameOf`), на главной остаются короткие идентификаторы. На карточке теперь виден и результат разбора (`reviewNote`) — иначе после отклонения видно «Отклонено» без причины.

Диалог, а не три кнопки прямо в строке: к решению полагается примечание (при отклонении оно и есть суть — его читает агент), а поле ввода в каждой строке превратило бы список в форму.

**Удаление замечания на вкладку не перенесено** — как и просил issue: чистка журнала агента остаётся на главной, где под ней `ConfirmDialog`.

**Счётчики.** `useReviewObservation` гасил только ключ `observations`, а «Требует разбора», бейдж вкладки и маркеры в дереве считает `/reconciliations/related` (+ `/summary`) под ключом `reconciliations` — после разбора шапка оставалась протухшей до перезагрузки. Добавлена кросс-инвалидация; то же самое сделано для `useDeleteObservation` — удаление неразобранного замечания меняет те же числа.

**Переход в полный контекст.** «Открыть в „Сверке“» у блока сверки и «Весь журнал» у секции замечаний. Чтобы они приводили не на пустой экран «Выберите сверку», страница «Сверка» научилась входу `?id=` и `?view=observations|aliases` — эффектом, а не только начальным состоянием: смена строки запроса компонент не размонтирует.

Третья поверхность — чип «Замечания» в редакторе документа — намеренно осталась читающей; её подпись «разбирать — на странице комплекта» с этим PR стала правдой.

Backend не менялся.

## Проверка

`npx tsc -b` — чисто, `npm test` — 470/470.

Живьём на комплекте 250701.ЭОМ-1 (14 неразобранных замечаний), 8/8 проверок:

- строка находки открывает «Разбор находки», подпись входа видна без hover;
- карточка замечания открывает «Разбор замечания», ссылка на документ — именем («250701.ЭОМ-1.2.Реестр материалов»);
- подтверждение замечания: «Требует разбора» 14 → 13 и бейдж вкладки 14 → 13 **без перезагрузки**;
- «Вернуть в работу» возвращает 13 → 14 (состояние базы после прогона восстановлено — проверено через API);
- «Открыть в „Сверке“» открывает раздел с выбранной сверкой, «Весь журнал» — журнал замечаний;
- главная «Сверка» без параметров ведёт себя как раньше (пустое состояние «Выберите сверку»).

Версия — 0.107.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)