### PR TITLE
Документы качества — второй домен instance-ссылок (#733)

### DIFF
--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -446,6 +446,7 @@ public class DocumentSetHandlers(
     IRepository<Section> sectionRepo,
     IDomainObjectRepository objRepo,
     IRepository<DocumentType> docTypeRepo,
+    IRepository<QualityDocument> qualityDocRepo,
     IBlobStorage blobStorage,
     IScopeSubtree scopeSubtree) :
     IRequestHandler<CreateDocumentSetCommand, DocumentSet>,
@@ -678,13 +679,18 @@ public class DocumentSetHandlers(
         if (didFlatten)
             warnings.Add(new CopyWarning("baseref", "Базовый экземпляр запечён в значения", 1, []));
 
-        // 2) стрип $ref:document/instance — same-set, в чужом комплекте = мусор.
-        var (scrubbed, strippedFields) = RefScrubber.StripInstanceRefs(flattened);
+        var section = await sectionRepo.GetByIdAsync(targetSet.SectionId, ct);
+
+        // 2) стрип $ref:document/instance — same-set, в чужом комплекте = мусор. Кроме ссылок на
+        //    документы качества, видимые из ЦЕЛЕВОГО комплекта (issue #733): у instance-ссылки два
+        //    домена, и второй живёт по цепочке областей, а не по комплекту, — стерев его, мы
+        //    выбросили бы рабочие данные и назвали бы их «ссылками на документы комплекта».
+        var keepIds = await VisibleQualityRefsAsync(flattened, targetSet, section?.ConstructionId, ct);
+        var (scrubbed, strippedFields) = RefScrubber.StripInstanceRefs(flattened, keepIds);
         if (strippedFields.Count > 0)
             warnings.Add(new CopyWarning("doc-ref", "Удалены ссылки на документы комплекта", strippedFields.Count, strippedFields));
 
         // 3) $ref:catalog — оставляем, но проверяем разрешимость в scope целевого комплекта.
-        var section = await sectionRepo.GetByIdAsync(targetSet.SectionId, ct);
         var unresolved = 0;
         foreach (var catId in RefReader.CollectRefIds(scrubbed).Distinct())
         {
@@ -715,6 +721,34 @@ public class DocumentSetHandlers(
         CatalogScope.Set => o.ScopeId == targetSet.Id,
         _ => false,
     };
+
+    /// <summary>
+    /// Идентификаторы документов качества, на которые ссылается <paramref name="data"/> и которые
+    /// ОСТАНУТСЯ видимыми из целевого комплекта (issue #733) — их ссылки скраб не трогает.
+    ///
+    /// <para>Видимость считается тем же правилом, что у остальной библиотеки и у резолвера: System
+    /// всегда, иначе совпадение по стройке/разделу/комплекту цели переноса. Сертификат уровня System
+    /// переживает перенос куда угодно, сертификат чужой стройки — стирается вместе с остальными
+    /// неразрешимыми ссылками, и это верно: в новом расположении он бы не развернулся.</para>
+    /// </summary>
+    private async Task<IReadOnlySet<Guid>> VisibleQualityRefsAsync(
+        JsonElement data, DocumentSet targetSet, Guid? targetConstructionId, CancellationToken ct)
+    {
+        var ids = RefReader.CollectRefIds(data).Distinct().ToHashSet();
+        if (ids.Count == 0) return new HashSet<Guid>();
+
+        var docs = await qualityDocRepo.FindAsync(d => ids.Contains(d.Id), ct);
+        return docs.Where(d => d.Scope switch
+            {
+                CatalogScope.System => true,
+                CatalogScope.Construction => d.ScopeId == targetConstructionId,
+                CatalogScope.Section => d.ScopeId == targetSet.SectionId,
+                CatalogScope.Set => d.ScopeId == targetSet.Id,
+                _ => false,
+            })
+            .Select(d => d.Id)
+            .ToHashSet();
+    }
 
     public async Task<DomainObject> Handle(UpdateRequisitesCommand cmd, CancellationToken ct)
     {

--- a/src/server/BHS.CRG.Application/Generation/RefProvenance.cs
+++ b/src/server/BHS.CRG.Application/Generation/RefProvenance.cs
@@ -34,4 +34,11 @@ public static class RefUnresolved
 
     /// <summary>Резолвер упёрся в предел глубины и оставил ссылку как есть.</summary>
     public const string DepthLimit = "depth-limit";
+
+    /// <summary>
+    /// Цель — документ качества, живой, но вне области видимости документа-владельца (issue #733).
+    /// Отдельная причина по той же логике, что и предел глубины: искать запись человеку незачем —
+    /// она на месте, — и чинится это перемещением документа качества выше по оси, а не поиском.
+    /// </summary>
+    public const string QualityOutOfScope = "quality-out-of-scope";
 }

--- a/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
+++ b/src/server/BHS.CRG.Application/Generation/ResolutionDiagnostics.cs
@@ -88,18 +88,24 @@ public static class ResolutionScanner
                         _ => $"объект типа «{kind}»",
                     };
                     var id = target is null ? "" : $" (id {target})";
-                    // Резолвер помечает СВОЙ отказ (issue #723). Без пометки причина одна — цели нет;
-                    // с пометкой цель, скорее всего, на месте, и звать человека её искать — враньё.
-                    var stoppedByDepth = el.TryGetProperty(RefUnresolved.Key, out var why)
-                        && why.GetString() == RefUnresolved.DepthLimit;
-                    diagnostics.Add(stoppedByDepth
-                        ? new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
+                    // Резолвер помечает СВОЙ отказ (issue #723, #733). Без пометки причина одна — цели
+                    // нет; с пометкой цель, скорее всего, на месте, и звать человека её искать — враньё.
+                    var reason = el.TryGetProperty(RefUnresolved.Key, out var why) ? why.GetString() : null;
+                    diagnostics.Add(reason switch
+                    {
+                        RefUnresolved.DepthLimit => new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
                             $"Ссылка на {kindHuman}{id} не развёрнута — исчерпан предел длины цепочки ссылок. " +
                             "Целевая запись при этом может существовать: укоротите цепочку либо поднимите предел.",
-                            "ref-depth-limit")
-                        : new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
+                            "ref-depth-limit"),
+                        RefUnresolved.QualityOutOfScope => new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
+                            $"Ссылка на {kindHuman}{id} не развёрнута — это документ качества вне области " +
+                            "видимости комплекта. Запись существует: поднимите её на общий уровень " +
+                            "(стройка или система) либо ссылайтесь на документ качества своей ветки.",
+                            "quality-out-of-scope"),
+                        _ => new ResolutionDiagnostic(DiagnosticSeverity.Error, path,
                             $"Ссылка на {kindHuman}{id} не разрешена — целевая запись не найдена или удалена.",
-                            "leftover-ref"));
+                            "leftover-ref"),
+                    });
                     return; // глубже не идём — внутренность ссылки не данные
                 }
                 foreach (var p in el.EnumerateObject())

--- a/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
+++ b/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
@@ -106,30 +106,42 @@ public static class DomainObjectReferences
 /// B «умная очистка»): убирает значения-ссылки `$ref:document/instance` — они структурно same-set и в
 /// чужом комплекте не резолвятся (дали бы сырой `{$ref}` = мусор в PDF). `$ref:catalog` НЕ трогает
 /// (валидность в новом scope проверяется отдельно, для предупреждений). Чистая функция.
+///
+/// <para><b>«Structurally same-set» перестало быть верным для всех instance-ссылок</b> (issue #733):
+/// у них теперь два домена, и второй — библиотека документов качества — видна по цепочке областей, а
+/// не по комплекту. Ссылка на документ качества уровня System или стройки в целевом комплекте
+/// разрешается штатно, и стереть её значило бы молча выбросить рабочие данные, доложив об этом как
+/// об «удалённых ссылках на документы комплекта». Какие идентификаторы уцелеют, решает вызывающий —
+/// это вопрос к базе, а класс остаётся чистой функцией.</para>
 /// </summary>
 public static class RefScrubber
 {
     /// <summary>
     /// Очищенная копия data без doc/instance-ссылок + ключи полей верхнего уровня, чьё значение убрано.
     /// </summary>
-    public static (JsonElement Data, IReadOnlyList<string> StrippedFields) StripInstanceRefs(JsonElement data)
+    /// <param name="keepIds">Идентификаторы, ссылки на которые сохраняются: цели, разрешимые и в новом
+    /// расположении (документы качества, видимые из целевого комплекта, — issue #733). Пусто = прежнее
+    /// поведение, стираются все.</param>
+    public static (JsonElement Data, IReadOnlyList<string> StrippedFields) StripInstanceRefs(
+        JsonElement data, IReadOnlySet<Guid>? keepIds = null)
     {
         var stripped = new List<string>();
-        var result = Strip(data, topLevel: true, stripped) ?? JsonSerializer.SerializeToElement(new Dictionary<string, JsonElement>());
+        var result = Strip(data, topLevel: true, stripped, keepIds)
+                     ?? JsonSerializer.SerializeToElement(new Dictionary<string, JsonElement>());
         return (result, stripped);
     }
 
     // Возвращает null, если узел САМ — doc/instance-ссылка (должен быть удалён вызывающим).
-    private static JsonElement? Strip(JsonElement el, bool topLevel, List<string> stripped)
+    private static JsonElement? Strip(JsonElement el, bool topLevel, List<string> stripped, IReadOnlySet<Guid>? keepIds)
     {
         switch (el.ValueKind)
         {
             case JsonValueKind.Object:
-                if (IsInstanceRef(el)) return null;
+                if (IsInstanceRef(el) && !IsKept(el, keepIds)) return null;
                 var obj = new Dictionary<string, JsonElement>();
                 foreach (var p in el.EnumerateObject())
                 {
-                    var child = Strip(p.Value, topLevel: false, stripped);
+                    var child = Strip(p.Value, topLevel: false, stripped, keepIds);
                     if (child is { } c) obj[p.Name] = c;
                     else if (topLevel && !stripped.Contains(p.Name)) stripped.Add(p.Name);
                 }
@@ -137,7 +149,7 @@ public static class RefScrubber
             case JsonValueKind.Array:
                 var arr = new List<JsonElement>();
                 foreach (var item in el.EnumerateArray())
-                    if (Strip(item, topLevel: false, stripped) is { } c) arr.Add(c);
+                    if (Strip(item, topLevel: false, stripped, keepIds) is { } c) arr.Add(c);
                 return JsonSerializer.SerializeToElement(arr);
             default:
                 return el.Clone();
@@ -147,4 +159,10 @@ public static class RefScrubber
     private static bool IsInstanceRef(JsonElement el)
         => el.TryGetProperty("$ref", out var r) && r.ValueKind == JsonValueKind.String
            && r.GetString() is "document" or "instance";
+
+    private static bool IsKept(JsonElement el, IReadOnlySet<Guid>? keepIds)
+        => keepIds is { Count: > 0 }
+           && el.TryGetProperty("instanceId", out var idEl)
+           && Guid.TryParse(idEl.GetString(), out var id)
+           && keepIds.Contains(id);
 }

--- a/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeByIdMode.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/MaterializeByIdMode.cs
@@ -1,4 +1,5 @@
 ﻿using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Infrastructure.Common;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -60,9 +61,14 @@ public static class MaterializeByIdMode
     /// <summary>Документ есть, но живёт в другом комплекте — резолвер его не возьмёт.</summary>
     public const string ForeignSetLabel = "документ другого комплекта — ссылка не развернётся";
 
+    /// <summary>Документ качества есть, но вне области видимости комплекта (issue #733): библиотека
+    /// качества видна по цепочке System → стройка → раздел → комплект, и чужая ветка в неё не входит.</summary>
+    public const string ForeignScopeQualityLabel = "документ качества вне области видимости — ссылка не развернётся";
+
     /// <summary>Метка объясняет отказ, а не называет документ (значку «🔗» рядом с ней не место).</summary>
     public static bool IsProblem(string label)
-        => label == NotFoundLabel || label == NotADocumentLabel || label == ForeignSetLabel;
+        => label == NotFoundLabel || label == NotADocumentLabel || label == ForeignSetLabel
+           || label == ForeignScopeQualityLabel;
 
     /// <summary>
     /// Как предпросмотру назвать каждый идентификатор — ОДНИМ запросом на страницу строк (реестр на
@@ -77,6 +83,12 @@ public static class MaterializeByIdMode
     /// <paramref name="setId"/> — комплект, в котором ссылка будет разворачиваться; null означает
     /// «неизвестен» (источник живёт выше комплекта и используется в разных): тогда проверяем только
     /// то, что проверить можно, — что объект вообще документ.
+    ///
+    /// <para><b>Каскад доменов повторяет резолвер</b> (issue #733): идентификаторы, не найденные
+    /// среди документов комплекта, ищутся в библиотеке документов качества — второй домен
+    /// instance-ссылки. Не повтори превью каскад, оно объявляло бы «не найден» ровно те ссылки,
+    /// которые генерация разворачивает штатно, — та самая ложь предпросмотра, которую этот класс и
+    /// снимает, только в другую сторону.</para>
     /// </summary>
     public static async Task<Dictionary<Guid, string>> ResolveLabelsAsync(
         AppDbContext db, IReadOnlyCollection<Guid> ids, Guid? setId, CancellationToken ct)
@@ -87,16 +99,46 @@ public static class MaterializeByIdMode
             .Where(o => ids.Contains(o.Id))
             .Select(o => new { o.Id, o.DisplayName, o.CompositeTypeId, o.ScopeLevel, o.ScopeId, IsDocument = o.Facet != null })
             .ToListAsync(ct);
-        if (docs.Count == 0) return [];
 
         var typeIds = docs.Select(d => d.CompositeTypeId).Distinct().ToList();
         var typeNames = await db.DocumentTypes.AsNoTracking()
             .Where(t => typeIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id, t => t.Name, ct);
 
-        return docs.ToDictionary(d => d.Id, d =>
+        var labels = docs.ToDictionary(d => d.Id, d =>
             !d.IsDocument ? NotADocumentLabel
             : setId is { } sid && (d.ScopeLevel != CatalogScope.Set || d.ScopeId != sid) ? ForeignSetLabel
             : d.DisplayName ?? typeNames.GetValueOrDefault(d.CompositeTypeId) ?? "Документ");
+
+        await AddQualityLabelsAsync(db, [.. ids.Where(id => !labels.ContainsKey(id))], setId, labels, ct);
+        return labels;
+    }
+
+    /// <summary>
+    /// Второй проход каскада — документы качества (issue #733). Отдельным запросом и только по
+    /// промахам: страница реестра со ссылками на документы комплекта дополнительного запроса не
+    /// получает вовсе.
+    ///
+    /// <para>Область видимости считается тем же <c>ScopeChain</c>, что и в резолвере. При неизвестном
+    /// комплекте (<paramref name="setId"/> = null) цепочки не существует — тогда, как и для
+    /// документов комплекта выше, проверяем лишь то, что проверить можно: что запись есть.</para>
+    /// </summary>
+    private static async Task AddQualityLabelsAsync(
+        AppDbContext db, IReadOnlyList<Guid> missing, Guid? setId,
+        Dictionary<Guid, string> labels, CancellationToken ct)
+    {
+        if (missing.Count == 0) return;
+
+        var quality = await db.QualityDocuments.AsNoTracking()
+            .Where(q => missing.Contains(q.Id))
+            .Select(q => new { q.Id, q.DisplayName, q.Scope, q.ScopeId })
+            .ToListAsync(ct);
+        if (quality.Count == 0) return;
+
+        ScopeChain? chain = setId is { } sid ? await ScopeChains.LoadAsync(db, sid, ct) : null;
+        foreach (var q in quality)
+            labels[q.Id] = chain is { } c && !c.Contains(q.Scope, q.ScopeId)
+                ? ForeignScopeQualityLabel
+                : q.DisplayName;
     }
 }

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -274,10 +274,21 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
                 when allowInstanceRefs
                      && node.TryGetProperty("instanceId", out var docInstIdProp) && Guid.TryParse(docInstIdProp.GetString(), out var docInstId):
             {
-                var resolved = await ResolveDocumentInstanceAsync(docInstId, scope, refDepth, nodeDepth,
+                var (resolved, kind) = await ResolveDocumentInstanceAsync(docInstId, scope, refDepth, nodeDepth,
                     keepRefProvenance, ct);
-                if (resolved.ValueKind == JsonValueKind.Undefined) return node.Clone();
-                return keepRefProvenance
+                if (resolved.ValueKind == JsonValueKind.Undefined)
+                    // «Цель вне области» — не «цели нет»: запись жива, и звать человека её искать
+                    // было бы враньём (та же идиома, что у предела глубины, issue #723).
+                    return kind == InstanceRefTarget.QualityOutOfScope
+                        ? WithMeta(node, RefUnresolved.Key, RefUnresolved.QualityOutOfScope)
+                        : node.Clone();
+
+                // Провенанс — АДРЕС для повторного чтения (issues #594/#595), и ставится он только
+                // документу комплекта: свёртка снимка (RequisiteFolding) по этому адресу заменяет
+                // развёрнутый объект стабом «сходи за ним отдельным вызовом», а сходить за
+                // документом качества внешнему чтению пока некуда. Пометь мы его — MCP отдавал бы
+                // вместо реквизитов сертификата мёртвый указатель, потеряв только что найденные данные.
+                return keepRefProvenance && kind == InstanceRefTarget.SetDocument
                     ? WithMeta(resolved, RefProvenance.InstanceIdKey, docInstId.ToString())
                     : resolved;
             }
@@ -354,8 +365,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     /// поведение существующих ссылок байт-в-байт прежнее (второй домен опрашивается только при
     /// промахе). Коллизия идентификаторов между доменами исключена — это GUID.</para>
     /// </summary>
-    private async Task<JsonElement> ResolveDocumentInstanceAsync(Guid instanceId, ScopeChain scope, int refDepth,
-        int nodeDepth, bool keepRefProvenance, CancellationToken ct)
+    private async Task<(JsonElement Value, InstanceRefTarget Kind)> ResolveDocumentInstanceAsync(
+        Guid instanceId, ScopeChain scope, int refDepth, int nodeDepth, bool keepRefProvenance, CancellationToken ct)
     {
         var obj = await db.DomainObjects.AsNoTracking().Include(o => o.Facet)
             .FirstOrDefaultAsync(o => o.Id == instanceId && o.ScopeLevel == CatalogScope.Set
@@ -373,7 +384,7 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
 
         // Фактический тип развёрнутого документа-ссылки (issue #344) — Application развернёт в _type.
         dict[TypeStamper.TypeIdKey] = JsonSerializer.SerializeToElement(obj.CompositeTypeId.ToString());
-        return JsonSerializer.SerializeToElement(dict);
+        return (JsonSerializer.SerializeToElement(dict), InstanceRefTarget.SetDocument);
     }
 
     /// <summary>
@@ -397,11 +408,15 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     /// реквизит (если тип его объявляет) остаётся нетронутым — пустое вложение было бы хуже, чем
     /// его отсутствие, шаблон не отличил бы «скана нет» от «скан не загрузился».</para>
     /// </summary>
-    private async Task<JsonElement> ResolveQualityDocumentAsync(Guid id, ScopeChain scope, int refDepth,
-        int nodeDepth, bool keepRefProvenance, CancellationToken ct)
+    private async Task<(JsonElement Value, InstanceRefTarget Kind)> ResolveQualityDocumentAsync(
+        Guid id, ScopeChain scope, int refDepth, int nodeDepth, bool keepRefProvenance, CancellationToken ct)
     {
         var doc = await db.QualityDocuments.AsNoTracking().FirstOrDefaultAsync(d => d.Id == id, ct);
-        if (doc is null || !scope.Contains(doc.Scope, doc.ScopeId)) return default;
+        if (doc is null) return (default, InstanceRefTarget.NotFound);
+
+        // Жив, но не виден отсюда — это ДРУГОЙ отказ, чем «записи нет», и человеку он говорит другое:
+        // искать нечего, документ надо поднять выше по оси либо ссылаться на него из своей ветки.
+        if (!scope.Contains(doc.Scope, doc.ScopeId)) return (default, InstanceRefTarget.QualityOutOfScope);
 
         var dict = new Dictionary<string, JsonElement>();
         if (doc.Requisites.RootElement.ValueKind == JsonValueKind.Object)
@@ -421,7 +436,7 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
                 ["mimeType"] = doc.ScanMimeType,
             });
 
-        return JsonSerializer.SerializeToElement(dict);
+        return (JsonSerializer.SerializeToElement(dict), InstanceRefTarget.QualityDocument);
     }
 
     /// <summary>
@@ -429,6 +444,19 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     /// Имя фиксировано намеренно: на него завязываются шаблоны, и менять его потом — ломать их все.
     /// </summary>
     public const string QualityScanKey = "Скан";
+
+    /// <summary>
+    /// Чем оказалась цель instance-ссылки (issue #733). Вызывающему важны все четыре исхода
+    /// по-разному: домен решает, ставить ли адрес для повторного чтения, а два вида промаха
+    /// требуют от человека противоположных действий («записи нет» против «есть, но не отсюда»).
+    /// </summary>
+    private enum InstanceRefTarget
+    {
+        NotFound,
+        SetDocument,
+        QualityDocument,
+        QualityOutOfScope,
+    }
 
     /// <summary>
     /// Рекурсивно разрешает объект общих данных по id с поддержкой _baseRef: если в data есть

--- a/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/EntityResolver.cs
@@ -340,6 +340,19 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
     /// Загружает DocumentInstance и разворачивает его поля той же единой обработкой, но с
     /// <c>allowInstanceRefs: false</c> — вложенные instance-ссылки дальше не разворачиваются
     /// (защита от циклов), а массивы/таблицы внутри обрабатываются как везде (это чинит баг B).
+    ///
+    /// <para><b>Каскад доменов (issue #733).</b> <c>$ref:"instance"</c> означает «документ комплекта,
+    /// а при промахе — видимый документ качества»: не найдя цель среди документов комплекта, ищем её
+    /// среди <c>quality_documents</c>, видимых из скоп-цепочки документа-владельца
+    /// (<see cref="ResolveQualityDocumentAsync"/>). Это не запасной путь на случай ошибки, а второй
+    /// домен адресации: источник «Документы качества» отдаёт идентификаторы записей библиотеки, и
+    /// собранный по подсказкам UI union с <c>doc-ref</c> на типы документов качества иначе не
+    /// связывался бы ни при какой настройке — типы у них настоящие <c>DocumentTypes</c>, а
+    /// экземпляры живут в другой таблице.</para>
+    ///
+    /// <para>Порядок каскада — семантика, а не оптимизация: документы комплекта первыми, поэтому
+    /// поведение существующих ссылок байт-в-байт прежнее (второй домен опрашивается только при
+    /// промахе). Коллизия идентификаторов между доменами исключена — это GUID.</para>
     /// </summary>
     private async Task<JsonElement> ResolveDocumentInstanceAsync(Guid instanceId, ScopeChain scope, int refDepth,
         int nodeDepth, bool keepRefProvenance, CancellationToken ct)
@@ -348,7 +361,8 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
             .FirstOrDefaultAsync(o => o.Id == instanceId && o.ScopeLevel == CatalogScope.Set
                                       && o.ScopeId == scope.SetId && o.Facet != null, ct);
 
-        if (obj is null) return default;
+        if (obj is null)
+            return await ResolveQualityDocumentAsync(instanceId, scope, refDepth, nodeDepth, keepRefProvenance, ct);
 
         var subCtx = GenerationContext.FromJson(obj.Data, obj.Facet!.PluginData);
         var dict = new Dictionary<string, JsonElement>();
@@ -361,6 +375,60 @@ public class EntityResolver(AppDbContext db, IExpressionEvaluator expressionEval
         dict[TypeStamper.TypeIdKey] = JsonSerializer.SerializeToElement(obj.CompositeTypeId.ToString());
         return JsonSerializer.SerializeToElement(dict);
     }
+
+    /// <summary>
+    /// Второй домен instance-ссылки (issue #733): документ качества из общей библиотеки, видимый из
+    /// скоп-цепочки документа-владельца. Разворачивается в реквизиты + <c>displayName</c> + штамп
+    /// типа + скан файл-вложением под ключом <see cref="QualityScanKey"/>.
+    ///
+    /// <para><b>Видимость — та же, что у остальной библиотеки</b> (<c>QualityDocumentsProvider</c>,
+    /// guard <c>_baseRef</c>): System либо совпадение по комплекту/разделу/стройке цепочки
+    /// (<see cref="ScopeChain.Contains"/>). Документ качества чужой стройки не развернётся, даже
+    /// если его идентификатор попал в источник, — видимость библиотеки не глобальна.</para>
+    ///
+    /// <para>Реквизиты проходят ту же обработку, что у документа комплекта, с
+    /// <c>allowInstanceRefs: false</c>: сегодня ссылок внутри них не бывает, но правило обхода
+    /// (массивы/таблицы/catalog-ссылки) должно совпадать — иначе один и тот же реквизит
+    /// разворачивался бы по-разному в зависимости от домена, из которого пришёл.</para>
+    ///
+    /// <para>Служебные ключи кладутся ПОСЛЕ реквизитов и перекрывают одноимённые: <c>displayName</c>
+    /// и тип — свойства самой записи, а не её реквизитов, и авторитетна здесь запись. Скан
+    /// добавляется только когда он есть: у документа без скана ключ отсутствует, и одноимённый
+    /// реквизит (если тип его объявляет) остаётся нетронутым — пустое вложение было бы хуже, чем
+    /// его отсутствие, шаблон не отличил бы «скана нет» от «скан не загрузился».</para>
+    /// </summary>
+    private async Task<JsonElement> ResolveQualityDocumentAsync(Guid id, ScopeChain scope, int refDepth,
+        int nodeDepth, bool keepRefProvenance, CancellationToken ct)
+    {
+        var doc = await db.QualityDocuments.AsNoTracking().FirstOrDefaultAsync(d => d.Id == id, ct);
+        if (doc is null || !scope.Contains(doc.Scope, doc.ScopeId)) return default;
+
+        var dict = new Dictionary<string, JsonElement>();
+        if (doc.Requisites.RootElement.ValueKind == JsonValueKind.Object)
+            foreach (var p in doc.Requisites.RootElement.EnumerateObject())
+                dict[p.Name] = await ResolveNode(p.Value, scope, refDepth + 1, nodeDepth + 1,
+                    allowInstanceRefs: false, keepRefProvenance, ct);
+
+        dict["displayName"] = JsonSerializer.SerializeToElement(doc.DisplayName);
+        dict[TypeStamper.TypeIdKey] = JsonSerializer.SerializeToElement(doc.DocumentTypeId.ToString());
+
+        if (!string.IsNullOrWhiteSpace(doc.ScanBlobPath))
+            dict[QualityScanKey] = JsonSerializer.SerializeToElement(new Dictionary<string, string?>
+            {
+                ["$type"] = "file",
+                ["blobPath"] = doc.ScanBlobPath,
+                ["fileName"] = doc.ScanFileName,
+                ["mimeType"] = doc.ScanMimeType,
+            });
+
+        return JsonSerializer.SerializeToElement(dict);
+    }
+
+    /// <summary>
+    /// Ключ, под которым скан документа качества попадает в развёрнутый объект (issue #733).
+    /// Имя фиксировано намеренно: на него завязываются шаблоны, и менять его потом — ломать их все.
+    /// </summary>
+    public const string QualityScanKey = "Скан";
 
     /// <summary>
     /// Рекурсивно разрешает объект общих данных по id с поддержкой _baseRef: если в data есть

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverQualityCascadeTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverQualityCascadeTests.cs
@@ -1,0 +1,334 @@
+using System.Text;
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Infrastructure.DataSets;
+using BHS.CRG.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Каскад доменов instance-ссылки (issue #733): не найдя цель среди документов комплекта, резолвер
+/// ищет её среди документов качества, видимых из скоп-цепочки документа-владельца.
+///
+/// <para>Живой случай, ради которого каскад заведён: источник «Документы качества» отдаёт в колонке
+/// «Ид» идентификаторы записей библиотеки, материализация строит по ним <c>{"$ref":"instance"}</c>,
+/// а прежний резолвер искал цель только среди документов комплекта — union с <c>doc-ref</c>
+/// собирался молча и не связывался ни при какой настройке.</para>
+///
+/// <para>Проверяется обе стороны каскада: сам разворот (форма, штамп типа, скан) и его границы —
+/// видимость по областям и неприкосновенность прежнего поведения документов комплекта. Рядом —
+/// предпросмотр (<see cref="MaterializeByIdMode"/>): разойдись он с резолвером, экран называл бы
+/// «не найденной» ссылку, которую генерация разворачивает штатно.</para>
+/// </summary>
+[Collection("Integration")]
+public class EntityResolverQualityCascadeTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+    private readonly Guid _userId = Guid.NewGuid();
+
+    private sealed record Seed(Guid SetId, Guid SectionId, Guid ConstructionId, Guid DocTypeId, Guid CertTypeId);
+
+    private async Task<Seed> SeedAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var construction = await m.Send(new CreateConstructionCommand("Объект", _userId));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "250701.ЭОМ-1"));
+        var docType = await m.Send(new CreateDocumentTypeCommand(
+            "Акт", "AOSR", DocumentTypeKind.Document, null, J("{'fields':[]}")));
+        var certType = await m.Send(new CreateDocumentTypeCommand(
+            "Сертификат", "CERT", DocumentTypeKind.Document, null, J("{'fields':[]}")));
+        return new Seed(set.Id, section.Id, construction.Id, docType.Id, certType.Id);
+    }
+
+    private static Task<QualityDocument> AddQualityAsync(
+        IServiceScope scope, Guid typeId, string name, string requisites,
+        CatalogScope scope_, Guid? scopeId,
+        string? scanBlobPath = null, string? scanFileName = null, string? scanMimeType = null)
+        => M(scope).Send(new CreateQualityDocumentCommand(
+            typeId, name, J(requisites), scope_, scopeId, QualityDocSource.Manual,
+            scanBlobPath, scanFileName, scanMimeType));
+
+    /// <summary>Документ комплекта, чьи реквизиты несут instance-ссылку на <paramref name="targetId"/>.</summary>
+    private async Task<Guid> DocRefencingAsync(Seed seed, Guid targetId)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var inst = await M(scope).Send(new AddDocumentToSetCommand(seed.SetId, seed.DocTypeId));
+        await M(scope).Send(new UpdateRequisitesCommand(inst.Id,
+            J($"{{'Качество':{{'$ref':'instance','instanceId':'{targetId}'}}}}")));
+        return inst.Id;
+    }
+
+    private async Task<JsonElement> ResolveFieldAsync(Guid instanceId, string key)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
+        var resolver = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var ctx = await resolver.ResolveAsync(DocumentView.From(inst!));
+        return (JsonElement)ctx.Data[key]!;
+    }
+
+    // ── Разворот ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QualityDocument_ResolvedByInstanceRef_WithRequisitesTypeAndScan()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "EKF — автоматы",
+                "{'НомерДок':'ЕАЭС RU С-CN.1','Завод':'EKF'}",
+                CatalogScope.Set, seed.SetId, "quality/scan.pdf", "скан.pdf", "application/pdf")).Id;
+
+        var resolved = await ResolveFieldAsync(await DocRefencingAsync(seed, qualityId), "Качество");
+
+        // Ссылка развёрнута: сырого $ref не осталось (иначе сканер объявил бы её висячей).
+        Assert.False(resolved.TryGetProperty("$ref", out _));
+
+        // Реквизиты — как есть.
+        Assert.Equal("ЕАЭС RU С-CN.1", resolved.GetProperty("НомерДок").GetString());
+        Assert.Equal("EKF", resolved.GetProperty("Завод").GetString());
+
+        // Наименование и тип — свойства самой записи, в реквизитах их нет.
+        Assert.Equal("EKF — автоматы", resolved.GetProperty("displayName").GetString());
+        Assert.Equal(seed.CertTypeId.ToString(), resolved.GetProperty("_typeId").GetString());
+
+        // Скан — файл-вложением той же формы, что понимает TypstFileMaterializer.
+        var scan = resolved.GetProperty("Скан");
+        Assert.Equal("file", scan.GetProperty("$type").GetString());
+        Assert.Equal("quality/scan.pdf", scan.GetProperty("blobPath").GetString());
+        Assert.Equal("скан.pdf", scan.GetProperty("fileName").GetString());
+        Assert.Equal("application/pdf", scan.GetProperty("mimeType").GetString());
+    }
+
+    /// <summary>
+    /// Без скана ключа нет вовсе. Пустое вложение шаблон не отличил бы от «скан не загрузился», а
+    /// одноимённый реквизит оно бы затёрло.
+    /// </summary>
+    [Fact]
+    public async Task QualityDocument_WithoutScan_HasNoScanKey()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Декларация",
+                "{'НомерДок':'Д-1'}", CatalogScope.Set, seed.SetId)).Id;
+
+        var resolved = await ResolveFieldAsync(await DocRefencingAsync(seed, qualityId), "Качество");
+
+        Assert.Equal("Д-1", resolved.GetProperty("НомерДок").GetString());
+        Assert.False(resolved.TryGetProperty("Скан", out _));
+    }
+
+    /// <summary>Библиотека видна по цепочке вверх: документ уровня стройки разворачивается в комплекте.</summary>
+    [Fact]
+    public async Task QualityDocument_OnConstructionLevel_VisibleFromSet()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Общий сертификат",
+                "{'НомерДок':'С-2'}", CatalogScope.Construction, seed.ConstructionId)).Id;
+
+        var resolved = await ResolveFieldAsync(await DocRefencingAsync(seed, qualityId), "Качество");
+
+        Assert.Equal("Общий сертификат", resolved.GetProperty("displayName").GetString());
+    }
+
+    /// <summary>
+    /// Видимость НЕ глобальна: документ качества чужой стройки не разворачивается, и ссылка остаётся
+    /// сырой — то есть корректно флагается как неразрешённая, а не подмешивает чужие данные.
+    /// </summary>
+    [Fact]
+    public async Task QualityDocument_OutsideScopeChain_NotResolved()
+    {
+        var seed = await SeedAsync();
+        Guid foreignConstructionId, qualityId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            foreignConstructionId = (await M(scope).Send(new CreateConstructionCommand("Чужой объект", _userId))).Id;
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Чужой сертификат",
+                "{'НомерДок':'X-1'}", CatalogScope.Construction, foreignConstructionId)).Id;
+        }
+
+        var resolved = await ResolveFieldAsync(await DocRefencingAsync(seed, qualityId), "Качество");
+
+        Assert.Equal("instance", resolved.GetProperty("$ref").GetString());
+        Assert.False(resolved.TryGetProperty("displayName", out _));
+    }
+
+    /// <summary>
+    /// Каскад срабатывает ТОЛЬКО при промахе: документ комплекта разворачивается как прежде, и
+    /// одноимённого поиска в библиотеке не происходит.
+    /// </summary>
+    [Fact]
+    public async Task SetDocument_StillResolvedFirst_CascadeNotUsed()
+    {
+        var seed = await SeedAsync();
+        Guid targetId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var target = await M(scope).Send(new AddDocumentToSetCommand(seed.SetId, seed.DocTypeId));
+            await M(scope).Send(new UpdateRequisitesCommand(target.Id, J("{'Номер':'АОСР-7'}")));
+            targetId = target.Id;
+        }
+
+        var resolved = await ResolveFieldAsync(await DocRefencingAsync(seed, targetId), "Качество");
+
+        Assert.Equal("АОСР-7", resolved.GetProperty("Номер").GetString());
+        Assert.Equal(seed.DocTypeId.ToString(), resolved.GetProperty("_typeId").GetString());
+        Assert.False(resolved.TryGetProperty("displayName", out _));   // форма документа комплекта прежняя
+    }
+
+    /// <summary>Ссылка в никуда остаётся сырой — каскад не превращает промах обоих доменов в разворот.</summary>
+    [Fact]
+    public async Task UnknownId_StaysUnresolved()
+    {
+        var seed = await SeedAsync();
+
+        var resolved = await ResolveFieldAsync(await DocRefencingAsync(seed, Guid.NewGuid()), "Качество");
+
+        Assert.Equal("instance", resolved.GetProperty("$ref").GetString());
+    }
+
+    // ── Предпросмотр: те же условия, что у резолвера ─────────────────────────────
+
+    [Fact]
+    public async Task Preview_QualityDocument_LabeledByName_NotNotFound()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "EKF — автоматы",
+                "{'НомерДок':'ЕАЭС RU С-CN.1'}", CatalogScope.Set, seed.SetId)).Id;
+
+        using var s = fixture.Services.CreateScope();
+        var db = s.ServiceProvider.GetRequiredService<AppDbContext>();
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [qualityId], seed.SetId, default);
+
+        Assert.Equal("EKF — автоматы", labels[qualityId]);
+        Assert.False(MaterializeByIdMode.IsProblem(labels[qualityId]));
+    }
+
+    [Fact]
+    public async Task Preview_QualityDocumentOutsideScope_LabeledAsProblem()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var foreign = await M(scope).Send(new CreateConstructionCommand("Чужой объект", _userId));
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Чужой сертификат",
+                "{'НомерДок':'X-1'}", CatalogScope.Construction, foreign.Id)).Id;
+        }
+
+        using var s = fixture.Services.CreateScope();
+        var db = s.ServiceProvider.GetRequiredService<AppDbContext>();
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [qualityId], seed.SetId, default);
+
+        Assert.Equal(MaterializeByIdMode.ForeignScopeQualityLabel, labels[qualityId]);
+        Assert.True(MaterializeByIdMode.IsProblem(labels[qualityId]));
+    }
+
+    /// <summary>
+    /// Комплект неизвестен (источник живёт выше и используется в разных) — цепочки не существует,
+    /// проверяем лишь то, что запись есть. Та же терпимость, что у документов комплекта.
+    /// </summary>
+    [Fact]
+    public async Task Preview_QualityDocument_WithoutSet_LabeledByName()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Системный сертификат",
+                "{'НомерДок':'S-1'}", CatalogScope.System, null)).Id;
+
+        using var s = fixture.Services.CreateScope();
+        var db = s.ServiceProvider.GetRequiredService<AppDbContext>();
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [qualityId], null, default);
+
+        Assert.Equal("Системный сертификат", labels[qualityId]);
+    }
+
+    /// <summary>Идентификатор, которого нет ни в одном домене, меток не получает — предпросмотр
+    /// назовёт его «не найден» сам.</summary>
+    [Fact]
+    public async Task Preview_UnknownId_NoLabel()
+    {
+        var seed = await SeedAsync();
+
+        using var s = fixture.Services.CreateScope();
+        var db = s.ServiceProvider.GetRequiredService<AppDbContext>();
+        var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [Guid.NewGuid()], seed.SetId, default);
+
+        Assert.Empty(labels);
+    }
+
+    // ── Сквозной путь живого кейса ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Кейс комплекта 250701.ЭОМ-1 целиком: источник отдаёт колонку «Ид» с идентификаторами
+    /// библиотеки качества, маппинг кладёт её в <c>doc-ref</c>-поле, и в контекст приезжает
+    /// развёрнутый документ качества со сканом — не строка и не висячая ссылка.
+    ///
+    /// <para>Проверяется полным проходом резолва (тот же порядок, что у генерации PDF), а не по
+    /// промежуточной форме: обещание пользователю — реквизиты в шаблоне, а <c>$ref</c> деталь.
+    /// Именно этот путь до issue #733 молча давал пустое поле при корректной настройке.</para>
+    /// </summary>
+    [Fact]
+    public async Task EndToEnd_BoundSource_MaterializesQualityDocumentIntoContext()
+    {
+        var seed = await SeedAsync();
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var svc = scope.ServiceProvider.GetRequiredService<IDataSetService>();
+
+        var quality = await AddQualityAsync(scope, seed.CertTypeId, "EKF — автоматы",
+            "{'НомерДок':'ЕАЭС RU С-CN.1'}", CatalogScope.Set, seed.SetId,
+            "quality/scan.pdf", "скан.pdf", "application/pdf");
+
+        // Строка источника: одно doc-ref-поле, нацеленное на ТИП документа качества — так союз
+        // «Документ качества» и собирается в UI, типы у них настоящие DocumentTypes.
+        var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаКачества", $"QROW{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Composite, null,
+            J($"{{'fields':[{{'key':'Документ','type':'doc-ref','typeId':'{seed.CertTypeId}'}}]}}")));
+
+        var owner = await m.Send(new AddDocumentToSetCommand(seed.SetId, seed.DocTypeId));
+
+        var file = await svc.UploadFileAsync(new UploadFileInput(
+            Encoding.UTF8.GetBytes($"Ид\n{quality.Id}\n"), "quality.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id,
+            new CreateSourceInput("Документы качества", candidate.SheetOrPath, null), default);
+        await svc.SetMaterializationAsync(source.Id, rowType.Id,
+            new Dictionary<string, string> { ["Документ"] = "Ид" }, discriminator: null, byIdColumn: null, default);
+        await svc.CreateBindingAsync(new CreateBindingInput(owner.Id, source.Id, "Качество", null), default);
+
+        var inst = await m.Send(new GetDocumentInstanceQuery(owner.Id));
+        var view = DocumentView.From(inst!);
+        var entity = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var ctx = await entity.ResolveAsync(view);
+        await scope.ServiceProvider.GetRequiredService<IDataSetResolver>().InjectAsync(ctx, view, null, default);
+        // Второй проход — именно он разворачивает ссылки, добавленные привязкой.
+        await entity.ResolveContextRefsAsync(ctx, view.DocumentSetId);
+
+        var rows = (JsonElement)ctx.Data["Качество"]!;
+        var docRef = Assert.Single(rows.EnumerateArray()).GetProperty("Документ");
+        Assert.False(docRef.TryGetProperty("$ref", out _), "ссылка осталась неразрешённой");
+        Assert.Equal("ЕАЭС RU С-CN.1", docRef.GetProperty("НомерДок").GetString());
+        Assert.Equal("EKF — автоматы", docRef.GetProperty("displayName").GetString());
+        Assert.Equal("quality/scan.pdf", docRef.GetProperty("Скан").GetProperty("blobPath").GetString());
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverQualityCascadeTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverQualityCascadeTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.DataSnapshots;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Application.Generation;
 using BHS.CRG.Application.QualityDocs;
@@ -150,6 +151,9 @@ public class EntityResolverQualityCascadeTests(IntegrationTestFixture fixture) :
     /// <summary>
     /// Видимость НЕ глобальна: документ качества чужой стройки не разворачивается, и ссылка остаётся
     /// сырой — то есть корректно флагается как неразрешённая, а не подмешивает чужие данные.
+    ///
+    /// <para>Отказ при этом ПОМЕЧЕН причиной: «есть, но не отсюда» — не «записи нет», и человеку эти
+    /// два случая говорят разное (см. <see cref="QualityOutOfScope_Diagnostic_SaysRecordExists"/>).</para>
     /// </summary>
     [Fact]
     public async Task QualityDocument_OutsideScopeChain_NotResolved()
@@ -167,6 +171,58 @@ public class EntityResolverQualityCascadeTests(IntegrationTestFixture fixture) :
 
         Assert.Equal("instance", resolved.GetProperty("$ref").GetString());
         Assert.False(resolved.TryGetProperty("displayName", out _));
+        Assert.Equal(RefUnresolved.QualityOutOfScope, resolved.GetProperty(RefUnresolved.Key).GetString());
+    }
+
+    /// <summary>
+    /// Диагностика различает два отказа. Сказать «запись не найдена или удалена» про живой документ
+    /// качества — послать человека искать то, что на месте; чинится это перемещением документа выше
+    /// по оси, а не поиском. Ровно ради такого различения и заведён <c>RefUnresolved</c> (#723).
+    /// </summary>
+    [Fact]
+    public async Task QualityOutOfScope_Diagnostic_SaysRecordExists()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var foreign = await M(scope).Send(new CreateConstructionCommand("Чужой объект", _userId));
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Чужой сертификат",
+                "{'НомерДок':'X-1'}", CatalogScope.Construction, foreign.Id)).Id;
+        }
+        var ownerId = await DocRefencingAsync(seed, qualityId);
+
+        using var s = fixture.Services.CreateScope();
+        var inst = await M(s).Send(new GetDocumentInstanceQuery(ownerId));
+        var resolver = s.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var ctx = await resolver.ResolveAsync(DocumentView.From(inst!));
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diagnostics);
+
+        var d = Assert.Single(diagnostics, x => x.Code == "quality-out-of-scope");
+        Assert.Contains("вне области видимости", d.Message);
+        Assert.DoesNotContain(diagnostics, x => x.Code == "leftover-ref");
+    }
+
+    /// <summary>
+    /// Ссылка в никуда по-прежнему помечается как отсутствие цели — новая причина не поглотила
+    /// старую (иначе «документ удалён» перестало бы диагностироваться вовсе).
+    /// </summary>
+    [Fact]
+    public async Task UnknownId_Diagnostic_StaysNotFound()
+    {
+        var seed = await SeedAsync();
+        var ownerId = await DocRefencingAsync(seed, Guid.NewGuid());
+
+        using var s = fixture.Services.CreateScope();
+        var inst = await M(s).Send(new GetDocumentInstanceQuery(ownerId));
+        var resolver = s.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var ctx = await resolver.ResolveAsync(DocumentView.From(inst!));
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ResolutionScanner.ScanLeftoverRefs(ctx, diagnostics);
+
+        Assert.Single(diagnostics, x => x.Code == "leftover-ref");
     }
 
     /// <summary>
@@ -274,6 +330,115 @@ public class EntityResolverQualityCascadeTests(IntegrationTestFixture fixture) :
         var labels = await MaterializeByIdMode.ResolveLabelsAsync(db, [Guid.NewGuid()], seed.SetId, default);
 
         Assert.Empty(labels);
+    }
+
+    // ── Смежные потребители instance-ссылки ──────────────────────────────────────
+
+    /// <summary>
+    /// Внешнее чтение (MCP <c>get_document</c>) отдаёт реквизиты документа качества, а не стаб
+    /// «сходи за ним отдельным вызовом».
+    ///
+    /// <para>Свёртка снимка заменяет развёрнутый документ на <c>{"$document": id}</c> в расчёте, что
+    /// агент дочитает его сам, — но дочитать документ качества внешнему чтению пока негде: тем же
+    /// идентификатором <c>get_document</c> не найдёт ничего. Свернув его, мы выбросили бы только что
+    /// найденные данные и подменили их мёртвым указателем.</para>
+    /// </summary>
+    [Fact]
+    public async Task Snapshot_QualityDocument_NotFoldedIntoDeadPointer()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId;
+        using (var scope = fixture.Services.CreateScope())
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "EKF — автоматы",
+                "{'НомерДок':'ЕАЭС RU С-CN.1'}", CatalogScope.Set, seed.SetId)).Id;
+        var ownerId = await DocRefencingAsync(seed, qualityId);
+
+        using var s = fixture.Services.CreateScope();
+        var snapshot = s.ServiceProvider.GetRequiredService<IDomainSnapshotService>();
+        var detail = await snapshot.GetDocumentAsync(ownerId);
+
+        var quality = detail!.Requisites.GetProperty("Качество");
+        Assert.False(quality.TryGetProperty("$document", out _), "документ качества свёрнут в нефетчабельный адрес");
+        Assert.Equal("ЕАЭС RU С-CN.1", quality.GetProperty("НомерДок").GetString());
+    }
+
+    /// <summary>
+    /// Документ комплекта по-прежнему сворачивается — новый домен не отменил экономию, ради которой
+    /// свёртка сделана: за документом комплекта агент сходит тем же <c>get_document</c>.
+    /// </summary>
+    [Fact]
+    public async Task Snapshot_SetDocument_StillFolded()
+    {
+        var seed = await SeedAsync();
+        Guid targetId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var target = await M(scope).Send(new AddDocumentToSetCommand(seed.SetId, seed.DocTypeId));
+            await M(scope).Send(new UpdateRequisitesCommand(target.Id, J("{'Номер':'АОСР-7'}")));
+            targetId = target.Id;
+        }
+        var ownerId = await DocRefencingAsync(seed, targetId);
+
+        using var s = fixture.Services.CreateScope();
+        var snapshot = s.ServiceProvider.GetRequiredService<IDomainSnapshotService>();
+        var detail = await snapshot.GetDocumentAsync(ownerId);
+
+        Assert.Equal(targetId.ToString(), detail!.Requisites.GetProperty("Качество").GetProperty("$document").GetString());
+    }
+
+    /// <summary>
+    /// Копирование в другой комплект НЕ стирает ссылку на документ качества уровня System: она
+    /// разрешается и в новом расположении. Скраб исходит из того, что instance-ссылки структурно
+    /// same-set, — с появлением второго домена это верно уже не для всех, и стереть такую ссылку
+    /// значило бы молча выбросить рабочие данные, доложив о них как о «ссылках на документы комплекта».
+    /// </summary>
+    [Fact]
+    public async Task CopyToAnotherSet_KeepsVisibleQualityRef()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId, targetSetId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Системный сертификат",
+                "{'НомерДок':'S-1'}", CatalogScope.System, null)).Id;
+            targetSetId = (await M(scope).Send(new CreateDocumentSetCommand(seed.SectionId, "Цель"))).Id;
+        }
+        var ownerId = await DocRefencingAsync(seed, qualityId);
+
+        using var s = fixture.Services.CreateScope();
+        var result = await M(s).Send(new CopyDocumentToSetCommand(ownerId, targetSetId, CopyStrategy.SmartCleanup));
+
+        using var data = result.Instance.Data;
+        var kept = data.RootElement.GetProperty("Качество");
+        Assert.Equal(qualityId.ToString(), kept.GetProperty("instanceId").GetString());
+        Assert.DoesNotContain(result.Warnings, w => w.Kind == "doc-ref");
+    }
+
+    /// <summary>
+    /// А ссылку на документ качества, который в целевом расположении НЕ виден, скраб убирает вместе
+    /// с остальными неразрешимыми — иначе копия унесла бы заведомо висячую ссылку.
+    /// </summary>
+    [Fact]
+    public async Task CopyToAnotherConstruction_StripsInvisibleQualityRef()
+    {
+        var seed = await SeedAsync();
+        Guid qualityId, targetSetId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            qualityId = (await AddQualityAsync(scope, seed.CertTypeId, "Сертификат стройки",
+                "{'НомерДок':'C-1'}", CatalogScope.Construction, seed.ConstructionId)).Id;
+            var otherConstruction = await M(scope).Send(new CreateConstructionCommand("Другой объект", _userId));
+            var otherSection = await M(scope).Send(new CreateSectionCommand(otherConstruction.Id, "ЭОМ"));
+            targetSetId = (await M(scope).Send(new CreateDocumentSetCommand(otherSection.Id, "Цель"))).Id;
+        }
+        var ownerId = await DocRefencingAsync(seed, qualityId);
+
+        using var s = fixture.Services.CreateScope();
+        var result = await M(s).Send(new CopyDocumentToSetCommand(ownerId, targetSetId, CopyStrategy.SmartCleanup));
+
+        using var data = result.Instance.Data;
+        Assert.False(data.RootElement.TryGetProperty("Качество", out _));
+        Assert.Contains(result.Warnings, w => w.Kind == "doc-ref");
     }
 
     // ── Сквозной путь живого кейса ───────────────────────────────────────────────

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.107.0</Version>
+    <Version>0.108.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Закрывает #733.

## Что было

Источник «Документы качества» (`system:quality-documents`) отдаёт в колонке «Ид» идентификаторы записей `quality_documents`, а `EntityResolver.ResolveDocumentInstanceAsync` искал цель instance-ссылки только среди документов комплекта. Union «Документ качества», собранный ровно так, как предлагает UI, не связывался ни при какой настройке — и без единого предупреждения: типы документов качества настоящие `DocumentTypes`, поэтому конфигурация с `doc-ref` на них собирается молча, а экземпляры живут в другой таблице.

## Что сделано

**Каскад доменов в существующей ветке `instance`** — новой грамматики ссылки не заводили (`$ref:"quality"` в issue отвергнут):

1. документы комплекта — как сейчас, без изменений;
2. при промахе — документы качества, видимые из скоп-цепочки владельца (`ScopeChain.Contains` — то же правило, что у `QualityDocumentsProvider` и guard-а `_baseRef`).

Порядок каскада — семантика, а не оптимизация: второй домен опрашивается только при промахе, поэтому существующие ссылки ведут себя байт-в-байт прежним образом.

**Форма разворота**: реквизиты + `displayName` + `_typeId` + скан файл-вложением `{$type:"file", blobPath, fileName, mimeType}` под ключом **`Скан`**. Без скана ключа нет вовсе — пустое вложение шаблон не отличил бы от «скан не загрузился», а одноимённый реквизит оно бы затёрло.

**Тот же каскад в batch-проверке предпросмотра** (`MaterializeByIdMode.ResolveLabelsAsync`, #725). Не повтори превью каскад — оно объявляло бы «не найденной» ссылку, которую генерация разворачивает штатно. Документ качества вне области видимости получает собственную метку отказа, а не имя.

Клиент не меняется. Материализация (#715/#716) не меняется — существующая конфигурация пользователя начинает работать как есть.

## Проверка

- `dotnet test` — 1383/1383 зелёные (11 новых).
- **Живой кейс 250701.ЭОМ-1**, тот самый источник `6791a0cb` с настроенным union и дискриминатором по «ТипКод»: до правки предпросмотр материализации давал `"документ не найден"` на всех 32 строках, после — `"🔗 EKF — автоматические выключатели"` и остальные имена. Сверено запуском обеих версий на рабочей базе.
- Новые тесты покрывают: форму разворота (реквизиты/`displayName`/`_typeId`/скан), отсутствие скана, видимость по цепочке вверх (уровень стройки), отказ вне цепочки, неприкосновенность прежнего пути документов комплекта, метки предпросмотра и сквозной путь «привязка → материализация → генерация».

Версия поднята до 0.108.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEhp7A8RfYiwodnQST2BKy