### PR TITLE
Каскадное удаление уровня: чистка объектов и guard по ссылкам извне (#739)

### DIFF
--- a/src/client/src/features/document-sets/ConstructionDetail.tsx
+++ b/src/client/src/features/document-sets/ConstructionDetail.tsx
@@ -174,8 +174,12 @@ export function ConstructionDetail() {
         }
         confirmLabel={`Удалить стройку «${construction.name}»`}
         requireCheckbox={sectionsN > 0 ? 'Понимаю, что это необратимо' : undefined}
-        onConfirm={() => {
-          deleteConstruction.mutate(construction.id);
+        onConfirm={async () => {
+          // mutateAsync, а не mutate: удаление уровня может отказать 409 («на содержимое ссылаются
+          // извне», issue #739). Fire-and-forget закрывал бы диалог и уводил со страницы так, будто
+          // всё удалилось, — отказ не увидел бы никто. ConfirmDialog на reject остаётся открытым и
+          // показывает причину, поэтому и навигация только после успеха.
+          await deleteConstruction.mutateAsync(construction.id);
           navigate('/document-sets');
         }}
       />

--- a/src/client/src/features/document-sets/ConstructionsList.tsx
+++ b/src/client/src/features/document-sets/ConstructionsList.tsx
@@ -219,7 +219,10 @@ export function ConstructionsList() {
         })()}
         confirmLabel={`Удалить стройку «${deleteTarget?.name ?? ''}»`}
         requireCheckbox={deleteTarget && deleteTarget.sections.length > 0 ? 'Понимаю, что это необратимо' : undefined}
-        onConfirm={() => { if (deleteTarget) deleteMutation.mutate(deleteTarget.id); }}
+        onConfirm={async () => {
+          // mutateAsync ради видимости отказа 409 (issue #739) — см. ConstructionDetail.
+          if (deleteTarget) await deleteMutation.mutateAsync(deleteTarget.id);
+        }}
       />
     </div>
   );

--- a/src/client/src/features/document-sets/SectionDetail.tsx
+++ b/src/client/src/features/document-sets/SectionDetail.tsx
@@ -183,8 +183,9 @@ export function SectionDetail() {
         }
         confirmLabel={`Удалить раздел «${section.name}»`}
         requireCheckbox={setsInSection > 0 ? 'Понимаю, что это необратимо' : undefined}
-        onConfirm={() => {
-          deleteSection.mutate({ id: section.id, constructionId: constructionId! });
+        onConfirm={async () => {
+          // mutateAsync ради видимости отказа 409 (issue #739) — см. ConstructionDetail.
+          await deleteSection.mutateAsync({ id: section.id, constructionId: constructionId! });
           navigate(`/document-sets/${constructionId}`);
         }}
       />

--- a/src/client/src/features/document-sets/SetDetail.tsx
+++ b/src/client/src/features/document-sets/SetDetail.tsx
@@ -467,8 +467,9 @@ export function SetDetail() {
             : undefined
         }
         confirmLabel="Удалить комплект"
-        onConfirm={() => {
-          deleteSet.mutate({ id: set.id, constructionId: constructionId! });
+        onConfirm={async () => {
+          // mutateAsync ради видимости отказа 409 (issue #739) — см. ConstructionDetail.
+          await deleteSet.mutateAsync({ id: set.id, constructionId: constructionId! });
           navigate(`/document-sets/${constructionId}/sections/${set.sectionId}`);
         }}
       />

--- a/src/client/src/features/settings/OrphanObjectsSection.tsx
+++ b/src/client/src/features/settings/OrphanObjectsSection.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { Unlink, Loader2 } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { apiClient } from '@/shared/api/client';
+import { apiError } from '@/shared/utils/apiError';
+import { CollapsibleSection } from './CollapsibleSection';
+
+interface Report {
+  sets: number;
+  sections: number;
+  constructions: number;
+  withData: number;
+  total: number;
+  dryRun: boolean;
+}
+
+async function run(dryRun: boolean): Promise<Report> {
+  const { data } = await apiClient.post<Report>('/maintenance/orphan-objects/cleanup', null, { params: { dryRun } });
+  return data;
+}
+
+/**
+ * Уборка объектов, чьё место расположения больше не существует (issue #739).
+ *
+ * Появлялись они так: у объектов нет внешнего ключа на комплект (ось расположения полиморфна), база
+ * уносила разделы за стройкой и комплекты за разделом, а объекты оставляла — прикладной каскад был
+ * только у комплекта. Причина закрыта, но след в старых базах остаётся, и восстановление прежней
+ * резервной копии способно привезти его снова.
+ *
+ * Отдельно показываем объекты С ДАННЫМИ: пустые — это лениво созданные профили уровней, терять там
+ * нечего, а вот запись с содержимым стоит посмотреть глазами прежде, чем нажимать «удалить».
+ */
+export function OrphanObjectsSection() {
+  const [report, setReport] = useState<Report | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [done, setDone] = useState<number | null>(null);
+
+  async function check() {
+    setBusy(true); setError(''); setDone(null);
+    try { setReport(await run(true)); }
+    catch (e) { setError(apiError(e, 'Не удалось посчитать')); }
+    finally { setBusy(false); }
+  }
+
+  async function apply() {
+    setConfirmOpen(false);
+    setBusy(true); setError('');
+    try {
+      const result = await run(false);
+      setDone(result.total);
+      setReport(await run(true)); // пересчёт дёшев — один запрос к базе, без разбора файлов
+    } catch (e) {
+      setError(apiError(e, 'Не удалось выполнить'));
+    } finally { setBusy(false); }
+  }
+
+  const nothingToDo = report !== null && report.total === 0;
+
+  return (
+    <CollapsibleSection title="Потерянные объекты" storageKey="orphan-objects" defaultOpen={false}>
+      <div className="space-y-3">
+        <p className="text-xs text-fg3">
+          Документы и записи общих данных, чей комплект, раздел или стройка удалены. В интерфейсе они
+          не видны, но остаются в базе — попадают в поиск, в резервную копию и в проверки ссылок.
+        </p>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outlined" size="sm" onClick={() => void check()} loading={busy}
+            icon={<Unlink size={14} />}>
+            Посчитать
+          </Button>
+          {report && !nothingToDo && (
+            <Button variant="filled" size="sm" danger onClick={() => setConfirmOpen(true)} disabled={busy}>
+              Удалить
+            </Button>
+          )}
+          {busy && <Loader2 size={14} className="animate-spin text-brand" />}
+        </div>
+
+        {error && <p className="text-xs text-danger">{error}</p>}
+
+        {done !== null && <p className="text-xs text-success">Готово: удалено объектов {done}.</p>}
+
+        {report && (
+          nothingToDo
+            ? <p className="text-xs text-fg3">Потерянных объектов нет.</p>
+            : (
+              <ul className="text-xs text-fg2 space-y-1">
+                <li>Всего: <b>{report.total}</b></li>
+                {report.sets > 0 && <li>На несуществующих комплектах: {report.sets}</li>}
+                {report.sections > 0 && <li>На несуществующих разделах: {report.sections}</li>}
+                {report.constructions > 0 && <li>На несуществующих стройках: {report.constructions}</li>}
+                {report.withData > 0 && (
+                  <li className="text-warning">
+                    С непустыми данными: {report.withData} — удаление необратимо, содержимое
+                    восстановить будет неоткуда.
+                  </li>
+                )}
+              </ul>
+            )
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen} onOpenChange={setConfirmOpen}
+        title="Удалить потерянные объекты?"
+        description={
+          report
+            ? `Будет удалено объектов: ${report.total}`
+              + (report.withData > 0 ? `, из них с данными: ${report.withData}.` : ' (все пустые).')
+              + ' Восстановить их будет неоткуда — места, к которому они относились, уже нет.'
+            : ''
+        }
+        requireCheckbox={report && report.withData > 0 ? 'Понимаю, что данные будут потеряны' : undefined}
+        confirmLabel="Удалить"
+        onConfirm={() => apply()}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/src/client/src/features/settings/OrphanObjectsSection.tsx
+++ b/src/client/src/features/settings/OrphanObjectsSection.tsx
@@ -7,10 +7,12 @@ import { apiError } from '@/shared/utils/apiError';
 import { CollapsibleSection } from './CollapsibleSection';
 
 interface Report {
-  sets: number;
-  sections: number;
-  constructions: number;
+  objects: number;
+  qualityDocuments: number;
+  materialLinks: number;
   withData: number;
+  /** Сирот, на которые ещё ссылаются живые записи — их уборка не трогает. */
+  referenced: number;
   total: number;
   dryRun: boolean;
 }
@@ -45,15 +47,17 @@ export function OrphanObjectsSection() {
     finally { setBusy(false); }
   }
 
+  /**
+   * Ошибку НЕ глотаем: диалог подтверждения — единый канал для отказов (см. ConfirmDialog), и при
+   * reject он остаётся открытым с причиной. Проглоти мы её здесь — диалог закрылся бы так, будто
+   * удаление прошло, а провал остался бы мелкой строкой в свёрнутой секции.
+   */
   async function apply() {
-    setConfirmOpen(false);
     setBusy(true); setError('');
     try {
       const result = await run(false);
       setDone(result.total);
       setReport(await run(true)); // пересчёт дёшев — один запрос к базе, без разбора файлов
-    } catch (e) {
-      setError(apiError(e, 'Не удалось выполнить'));
     } finally { setBusy(false); }
   }
 
@@ -89,14 +93,20 @@ export function OrphanObjectsSection() {
             ? <p className="text-xs text-fg3">Потерянных объектов нет.</p>
             : (
               <ul className="text-xs text-fg2 space-y-1">
-                <li>Всего: <b>{report.total}</b></li>
-                {report.sets > 0 && <li>На несуществующих комплектах: {report.sets}</li>}
-                {report.sections > 0 && <li>На несуществующих разделах: {report.sections}</li>}
-                {report.constructions > 0 && <li>На несуществующих стройках: {report.constructions}</li>}
+                <li>Будет удалено: <b>{report.total}</b></li>
+                {report.objects > 0 && <li>Документов и записей общих данных: {report.objects}</li>}
+                {report.qualityDocuments > 0 && <li>Документов качества: {report.qualityDocuments}</li>}
+                {report.materialLinks > 0 && <li>Связок материалов: {report.materialLinks}</li>}
                 {report.withData > 0 && (
                   <li className="text-warning">
                     С непустыми данными: {report.withData} — удаление необратимо, содержимое
                     восстановить будет неоткуда.
+                  </li>
+                )}
+                {report.referenced > 0 && (
+                  <li className="text-fg3">
+                    Останутся: {report.referenced} — на них ещё ссылаются живые записи, и ссылки эти
+                    работают. Удалить их значило бы своими руками сделать ссылку висячей.
                   </li>
                 )}
               </ul>

--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -14,6 +14,7 @@ import { IntegrationSettingsSection } from './IntegrationSettingsSection';
 import { EmailSettingsSection } from './EmailSettingsSection';
 import { CollapsibleSection } from './CollapsibleSection';
 import { ImageMaintenanceSection } from './ImageMaintenanceSection';
+import { OrphanObjectsSection } from './OrphanObjectsSection';
 import { MaterialLabelSection } from './MaterialLabelSection';
 
 // ─── Settings hook (re-exported for use by other pages) ───────────────────────
@@ -484,6 +485,8 @@ export function SettingsPage() {
       <ImageMaintenanceSection />
 
       <MaterialLabelSection />
+
+      <OrphanObjectsSection />
 
       <CollapsibleSection title="Резервное копирование" storageKey="backup" defaultOpen={false}>
         <p className="text-xs text-fg3">

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -29,6 +29,21 @@ public static class MaintenanceEndpoints
             });
         });
 
+        // Объекты, чьё место расположения больше не существует (issue #739). Причина закрыта
+        // прикладным каскадом удаления уровня, но след в старых базах остаётся, и восстановление
+        // прежней резервной копии способно привезти его снова.
+        g.MapPost("/orphan-objects/cleanup", async (
+            OrphanObjectCleanup cleanup, bool? dryRun, CancellationToken ct) =>
+        {
+            var isDryRun = dryRun ?? true;
+            var report = await cleanup.RunAsync(isDryRun, ct);
+            return Results.Ok(new
+            {
+                report.Sets, report.Sections, report.Constructions,
+                report.WithData, report.Total, dryRun = isDryRun,
+            });
+        });
+
         // Дозаполнение человеческих имён материалов у связок, заведённых до появления метки (#561).
         // Читает и разбирает файлы наборов, поэтому тоже действие администратора, а не миграция.
         g.MapPost("/material-links/backfill-labels", async (

--- a/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Maintenance/MaintenanceEndpoints.cs
@@ -39,8 +39,8 @@ public static class MaintenanceEndpoints
             var report = await cleanup.RunAsync(isDryRun, ct);
             return Results.Ok(new
             {
-                report.Sets, report.Sections, report.Constructions,
-                report.WithData, report.Total, dryRun = isDryRun,
+                report.Objects, report.QualityDocuments, report.MaterialLinks,
+                report.WithData, report.Referenced, report.Total, dryRun = isDryRun,
             });
         });
 

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -323,6 +323,7 @@ builder.Services.AddScoped<IRepository<QualityAuditRun>, Repository<QualityAudit
 builder.Services.AddScoped<BackupService>();
 builder.Services.AddScoped<BHS.CRG.Infrastructure.Maintenance.ImageBlobMigration>();
 builder.Services.AddScoped<BHS.CRG.Infrastructure.Maintenance.MaterialLabelBackfill>();
+builder.Services.AddScoped<BHS.CRG.Infrastructure.Maintenance.OrphanObjectCleanup>();
 
 // ── Снимок данных для внешних потребителей + MCP (issue #415) ─────────────────
 builder.Services.AddScoped<BHS.CRG.Application.DataSnapshots.IDataSnapshotService,

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -380,6 +380,7 @@ builder.Services.AddScoped<BHS.CRG.Application.Documents.ILevelProfileService, B
 // Спуск «уровень → комплекты поддерева» (issue #625): слою приложения нужен через контракт —
 // AppDbContext ему недоступен, а копия обхода была у него своя.
 builder.Services.AddScoped<BHS.CRG.Application.Common.IScopeSubtree, BHS.CRG.Infrastructure.Common.ScopeSubtreeService>();
+builder.Services.AddScoped<BHS.CRG.Application.Objects.IScopeCascade, BHS.CRG.Application.Objects.ScopeCascade>();
 builder.Services.AddScoped<IMetadataExtractor, MetadataExtractor>();
 builder.Services.AddScoped<IDataSetResolver, DataSetResolver>();
 builder.Services.AddScoped<IObjectResolver, ObjectResolver>();

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -371,9 +371,7 @@ public class DocumentTypeHandlers(
 public class ConstructionHandlers(
     IRepository<Construction> constructionRepo,
     IRepository<Section> sectionRepo,
-    IRepository<DomainObject> objRepo,
-    IRepository<QualityDocument> qualityDocRepo,
-    IScopeSubtree scopeSubtree) :
+    IScopeCascade cascade) :
     IRequestHandler<CreateConstructionCommand, Construction>,
     IRequestHandler<RenameConstructionCommand, Construction>,
     IRequestHandler<DeleteConstructionCommand>,
@@ -409,11 +407,9 @@ public class ConstructionHandlers(
     public async Task Handle(DeleteConstructionCommand cmd, CancellationToken ct)
     {
         var c = await constructionRepo.GetByIdAsync(cmd.Id, ct) ?? throw new NotFoundException();
-        var plan = await ScopeCascade.PlanAsync(objRepo, qualityDocRepo, sectionRepo, scopeSubtree,
-            CatalogScope.Construction, cmd.Id, ct);
-        if (plan.ExternalReferrers.Count > 0)
-            throw new ConflictException(ScopeCascade.RefusalMessage("стройку", plan.ExternalReferrers));
-        foreach (var o in plan.Objects) objRepo.Remove(o);
+        var plan = await cascade.PlanAsync(CatalogScope.Construction, cmd.Id, ct);
+        cascade.EnsureDeletable(plan, "стройку");
+        cascade.Remove(plan);
         constructionRepo.Remove(c);
         await constructionRepo.SaveChangesAsync(ct);
     }
@@ -450,11 +446,9 @@ public class ConstructionHandlers(
     public async Task Handle(DeleteSectionCommand cmd, CancellationToken ct)
     {
         var s = await sectionRepo.GetByIdAsync(cmd.Id, ct) ?? throw new NotFoundException();
-        var plan = await ScopeCascade.PlanAsync(objRepo, qualityDocRepo, sectionRepo, scopeSubtree,
-            CatalogScope.Section, cmd.Id, ct);
-        if (plan.ExternalReferrers.Count > 0)
-            throw new ConflictException(ScopeCascade.RefusalMessage("раздел", plan.ExternalReferrers));
-        foreach (var o in plan.Objects) objRepo.Remove(o);
+        var plan = await cascade.PlanAsync(CatalogScope.Section, cmd.Id, ct);
+        cascade.EnsureDeletable(plan, "раздел");
+        cascade.Remove(plan);
         sectionRepo.Remove(s);
         await sectionRepo.SaveChangesAsync(ct);
     }
@@ -467,7 +461,8 @@ public class DocumentSetHandlers(
     IRepository<DocumentType> docTypeRepo,
     IRepository<QualityDocument> qualityDocRepo,
     IBlobStorage blobStorage,
-    IScopeSubtree scopeSubtree) :
+    IScopeSubtree scopeSubtree,
+    IScopeCascade cascade) :
     IRequestHandler<CreateDocumentSetCommand, DocumentSet>,
     IRequestHandler<RenameDocumentSetCommand, DocumentSet>,
     IRequestHandler<DeleteDocumentSetCommand>,
@@ -509,14 +504,13 @@ public class DocumentSetHandlers(
     public async Task Handle(DeleteDocumentSetCommand cmd, CancellationToken ct)
     {
         var set = await setRepo.GetByIdAsync(cmd.Id, ct) ?? throw new NotFoundException();
-        // Объекты на оси (Set, этот Id) — документы и Set-скоуп общих данных — принадлежат комплекту:
-        // FK-каскада на комплект нет (единая ось, полиморфный ScopeId), удаляем прикладно.
+        // Всё, что висит на оси (Set, этот Id) — документы, Set-скоуп общих данных, документы
+        // качества уровня комплекта и связки материалов, — принадлежит комплекту: FK-каскада на
+        // комплект нет (единая ось, полиморфный ScopeId), удаляем прикладно.
         // issue #739: и тот же guard, что у поштучного удаления, — иначе каскад обходит его с фланга.
-        var plan = await ScopeCascade.PlanAsync(objRepo, qualityDocRepo, sectionRepo, scopeSubtree,
-            CatalogScope.Set, cmd.Id, ct);
-        if (plan.ExternalReferrers.Count > 0)
-            throw new ConflictException(ScopeCascade.RefusalMessage("комплект", plan.ExternalReferrers));
-        foreach (var o in plan.Objects) objRepo.Remove(o); // фасета + generated_files каскадируются в БД
+        var plan = await cascade.PlanAsync(CatalogScope.Set, cmd.Id, ct);
+        cascade.EnsureDeletable(plan, "комплект");
+        cascade.Remove(plan);
         setRepo.Remove(set);
         await setRepo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -370,7 +370,10 @@ public class DocumentTypeHandlers(
 
 public class ConstructionHandlers(
     IRepository<Construction> constructionRepo,
-    IRepository<Section> sectionRepo) :
+    IRepository<Section> sectionRepo,
+    IRepository<DomainObject> objRepo,
+    IRepository<QualityDocument> qualityDocRepo,
+    IScopeSubtree scopeSubtree) :
     IRequestHandler<CreateConstructionCommand, Construction>,
     IRequestHandler<RenameConstructionCommand, Construction>,
     IRequestHandler<DeleteConstructionCommand>,
@@ -398,9 +401,19 @@ public class ConstructionHandlers(
         return c;
     }
 
+    /// <summary>
+    /// Удаление стройки. Разделы и комплекты уносит каскад базы, объекты на полиморфной оси — нет:
+    /// их удаляем прикладно, иначе документы и общие данные всего поддерева остаются сиротами
+    /// (issue #739). Guard тот же, что у поштучного удаления: держатели ссылок ИЗВНЕ поддерева.
+    /// </summary>
     public async Task Handle(DeleteConstructionCommand cmd, CancellationToken ct)
     {
         var c = await constructionRepo.GetByIdAsync(cmd.Id, ct) ?? throw new NotFoundException();
+        var plan = await ScopeCascade.PlanAsync(objRepo, qualityDocRepo, sectionRepo, scopeSubtree,
+            CatalogScope.Construction, cmd.Id, ct);
+        if (plan.ExternalReferrers.Count > 0)
+            throw new ConflictException(ScopeCascade.RefusalMessage("стройку", plan.ExternalReferrers));
+        foreach (var o in plan.Objects) objRepo.Remove(o);
         constructionRepo.Remove(c);
         await constructionRepo.SaveChangesAsync(ct);
     }
@@ -433,9 +446,15 @@ public class ConstructionHandlers(
         return s;
     }
 
+    /// <inheritdoc cref="Handle(DeleteConstructionCommand, CancellationToken)" />
     public async Task Handle(DeleteSectionCommand cmd, CancellationToken ct)
     {
         var s = await sectionRepo.GetByIdAsync(cmd.Id, ct) ?? throw new NotFoundException();
+        var plan = await ScopeCascade.PlanAsync(objRepo, qualityDocRepo, sectionRepo, scopeSubtree,
+            CatalogScope.Section, cmd.Id, ct);
+        if (plan.ExternalReferrers.Count > 0)
+            throw new ConflictException(ScopeCascade.RefusalMessage("раздел", plan.ExternalReferrers));
+        foreach (var o in plan.Objects) objRepo.Remove(o);
         sectionRepo.Remove(s);
         await sectionRepo.SaveChangesAsync(ct);
     }
@@ -492,8 +511,12 @@ public class DocumentSetHandlers(
         var set = await setRepo.GetByIdAsync(cmd.Id, ct) ?? throw new NotFoundException();
         // Объекты на оси (Set, этот Id) — документы и Set-скоуп общих данных — принадлежат комплекту:
         // FK-каскада на комплект нет (единая ось, полиморфный ScopeId), удаляем прикладно.
-        var owned = await objRepo.FindAsync(o => o.ScopeLevel == CatalogScope.Set && o.ScopeId == cmd.Id, ct);
-        foreach (var o in owned) objRepo.Remove(o); // фасета + generated_files каскадируются в БД
+        // issue #739: и тот же guard, что у поштучного удаления, — иначе каскад обходит его с фланга.
+        var plan = await ScopeCascade.PlanAsync(objRepo, qualityDocRepo, sectionRepo, scopeSubtree,
+            CatalogScope.Set, cmd.Id, ct);
+        if (plan.ExternalReferrers.Count > 0)
+            throw new ConflictException(ScopeCascade.RefusalMessage("комплект", plan.ExternalReferrers));
+        foreach (var o in plan.Objects) objRepo.Remove(o); // фасета + generated_files каскадируются в БД
         setRepo.Remove(set);
         await setRepo.SaveChangesAsync(ct);
     }

--- a/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
+++ b/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
@@ -170,6 +170,42 @@ public static class DomainObjectReferences
     private static string Name(string? displayName)
         => string.IsNullOrWhiteSpace(displayName) ? "без имени" : displayName;
 
+    /// <summary>
+    /// Какие из <paramref name="candidateIds"/> ещё держат ссылками записи ВНЕ этого множества.
+    ///
+    /// <para>Обратная задача к <see cref="FindReferrersAsync(IRepository{DomainObject},
+    /// IRepository{QualityDocument}, IReadOnlySet{Guid}, CancellationToken)"/>: там спрашивают «кто
+    /// держит», здесь — «что держат». Нужна уборке осиротевших записей (issue #739): сирота не
+    /// обязательно мусор — её мог оставить прежний каскад, а ссылка на неё резолвится по
+    /// идентификатору и работает по сей день. Удали такую — рабочая ссылка стала бы висячей, то
+    /// есть уборка своими руками сделала бы то, ради предотвращения чего вся эта работа.</para>
+    ///
+    /// <para>Держатель, сам входящий в множество, не в счёт: «сирота ссылается на сироту» —
+    /// замкнутый остаток, держать его вечно незачем.</para>
+    /// </summary>
+    public static async Task<IReadOnlySet<Guid>> FindHeldTargetsAsync(
+        IRepository<DomainObject> objRepo, IRepository<QualityDocument> qualityRepo,
+        IReadOnlySet<Guid> candidateIds, CancellationToken ct)
+    {
+        if (candidateIds.Count == 0) return new HashSet<Guid>();
+
+        var held = new HashSet<Guid>();
+        foreach (var o in await objRepo.FindAsync(_ => true, ct))
+        {
+            if (candidateIds.Contains(o.Id)) continue;
+            if (BaseRefReader.GetBaseRefId(o.Data.RootElement) is { } b && candidateIds.Contains(b)) held.Add(b);
+            foreach (var id in RefReader.CollectRefIds(o.Data.RootElement))
+                if (candidateIds.Contains(id)) held.Add(id);
+        }
+        foreach (var d in await qualityRepo.FindAsync(_ => true, ct))
+        {
+            if (candidateIds.Contains(d.Id)) continue;
+            foreach (var id in RefReader.CollectRefIds(d.Requisites.RootElement, includeInstanceRefs: false))
+                if (candidateIds.Contains(id)) held.Add(id);
+        }
+        return held;
+    }
+
     private static bool ReferencesAny(JsonElement data, IReadOnlySet<Guid> targetIds)
         => (BaseRefReader.GetBaseRefId(data) is { } baseId && targetIds.Contains(baseId))
            || RefReader.CollectRefIds(data).Any(targetIds.Contains);

--- a/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
+++ b/src/server/BHS.CRG.Application/Objects/BaseRefReader.cs
@@ -125,22 +125,40 @@ public static class DomainObjectReferences
     /// в трекере ради проверки, которая ничего не меняет, — превью переноса зовёт этот же скан и не
     /// сохраняет вовсе.</para>
     /// </summary>
-    public static async Task<IReadOnlyList<Referrer>> FindReferrersAsync(
+    public static Task<IReadOnlyList<Referrer>> FindReferrersAsync(
         IRepository<DomainObject> objRepo, IRepository<QualityDocument> qualityRepo,
         Guid targetId, CancellationToken ct)
+        => FindReferrersAsync(objRepo, qualityRepo, new HashSet<Guid> { targetId }, ct);
+
+    /// <summary>
+    /// То же для ГРУППЫ целей — каскадное удаление уровня (issue #739): удаляя комплект, раздел или
+    /// стройку, мы уносим все объекты поддерева разом, и спрашивать про каждый отдельно значило бы
+    /// сканировать обе таблицы по разу на объект.
+    ///
+    /// <para><b>Держатель из самой группы не считается</b> — и это не оптимизация, а суть проверки.
+    /// Документ комплекта, ссылающийся на соседний документ того же комплекта, уходит вместе с ним:
+    /// ссылка исчезает целиком, а не повисает. Блокируй мы и такие, комплект с двумя связанными
+    /// документами стал бы неудаляемым навсегда — распутать это можно было бы только правкой
+    /// реквизитов вручную. Одиночный случай — частный: цель не блокирует сама себя.</para>
+    /// </summary>
+    public static async Task<IReadOnlyList<Referrer>> FindReferrersAsync(
+        IRepository<DomainObject> objRepo, IRepository<QualityDocument> qualityRepo,
+        IReadOnlySet<Guid> targetIds, CancellationToken ct)
     {
+        if (targetIds.Count == 0) return [];
+
         var objects = await objRepo.FindAsync(_ => true, ct);
         var quality = await qualityRepo.FindAsync(_ => true, ct);
 
         var found = objects
-            .Where(o => o.Id != targetId && ReferencesObject(o.Data.RootElement, targetId))
+            .Where(o => !targetIds.Contains(o.Id) && ReferencesAny(o.Data.RootElement, targetIds))
             .Select(o => new Referrer(o.Id, Name(o.DisplayName)));
 
         // Документ качества базового экземпляра не имеет — только «$ref» в реквизитах.
         var fromQuality = quality
-            .Where(d => d.Id != targetId
+            .Where(d => !targetIds.Contains(d.Id)
                         && RefReader.CollectRefIds(d.Requisites.RootElement, includeInstanceRefs: false)
-                            .Contains(targetId))
+                            .Any(targetIds.Contains))
             .Select(d => new Referrer(d.Id, $"документ качества «{Name(d.DisplayName)}»"));
 
         return found.Concat(fromQuality).ToList();
@@ -152,9 +170,9 @@ public static class DomainObjectReferences
     private static string Name(string? displayName)
         => string.IsNullOrWhiteSpace(displayName) ? "без имени" : displayName;
 
-    private static bool ReferencesObject(JsonElement data, Guid targetId)
-        => BaseRefReader.GetBaseRefId(data) == targetId
-           || RefReader.CollectRefIds(data).Contains(targetId);
+    private static bool ReferencesAny(JsonElement data, IReadOnlySet<Guid> targetIds)
+        => (BaseRefReader.GetBaseRefId(data) is { } baseId && targetIds.Contains(baseId))
+           || RefReader.CollectRefIds(data).Any(targetIds.Contains);
 }
 
 /// <summary>

--- a/src/server/BHS.CRG.Application/Objects/ScopeCascade.cs
+++ b/src/server/BHS.CRG.Application/Objects/ScopeCascade.cs
@@ -8,49 +8,72 @@ namespace BHS.CRG.Application.Objects;
 /// <summary>
 /// Каскад удаления уровня расположения — комплекта, раздела, стройки (issue #739).
 ///
-/// <para><b>Зачем прикладной каскад вообще.</b> У <c>DomainObject</c> нет внешнего ключа на
-/// комплект: ось расположения полиморфна (<c>ScopeLevel</c> + <c>ScopeId</c> указывают то на
-/// комплект, то на раздел, то на стройку), и одним FK её не выразить. Поэтому база уносит
-/// разделы за стройкой и комплекты за разделом, а объекты — нет: их надо удалять руками. Пока
-/// это делал только обработчик комплекта, удаление раздела или стройки оставляло документы и
-/// записи общих данных сиротами — невидимыми в интерфейсе, но живыми для сканов, поиска и
-/// резервной копии. На рабочей базе такие уже были.</para>
+/// <para><b>Зачем прикладной каскад вообще.</b> Ось расположения полиморфна: <c>ScopeLevel</c> +
+/// <c>ScopeId</c> указывают то на комплект, то на раздел, то на стройку, и одним внешним ключом её
+/// не выразить. Поэтому база уносит разделы за стройкой и комплекты за разделом, а всё, что висит
+/// на этой оси, — нет: это надо удалять руками. Пока так делал только обработчик комплекта,
+/// удаление раздела или стройки оставляло сирот — невидимых в интерфейсе, но живых для сканов,
+/// поиска и резервной копии.</para>
+///
+/// <para><b>На оси три таблицы, не одна.</b> Кроме <c>domain_objects</c> там живут документы
+/// качества (у библиотеки есть уровень: рядом с System встречаются Set и Construction) и связки
+/// материалов. На рабочей базе это 14 документов и 54 связки не-System уровня — то есть речь не о
+/// теоретической полноте, а о том, что удаление комплекта оставляет за собой хвост.</para>
 ///
 /// <para><b>Зачем guard.</b> Поштучные guard'ы (#71/#269/#735) не пускают удалить объект, на
 /// который ссылаются. Каскад обходил их с фланга: те же объекты уходили пачкой, и ссылка на них
 /// молча повисала. Правило здесь то же — «на что ссылаются, не удаляем», — но множеством:
 /// держатели ВНУТРИ удаляемого поддерева не в счёт, они уходят вместе со ссылкой.</para>
 /// </summary>
-public static class ScopeCascade
+public interface IScopeCascade
 {
     /// <summary>Что уйдёт при удалении уровня и кто держит ссылки на это извне.</summary>
-    /// <param name="Objects">Объекты поддерева — их удаляет вызывающий.</param>
-    /// <param name="ExternalReferrers">Держатели ссылок вне поддерева. Не пусто → удалять нельзя.</param>
-    public sealed record Plan(
-        IReadOnlyList<DomainObject> Objects,
-        IReadOnlyList<DomainObjectReferences.Referrer> ExternalReferrers);
+    Task<ScopeCascadePlan> PlanAsync(CatalogScope scope, Guid scopeId, CancellationToken ct = default);
 
     /// <summary>
-    /// План удаления уровня <paramref name="scope"/>/<paramref name="scopeId"/>.
+    /// Помечает содержимое плана на удаление. Не сохраняет: вызывающий удаляет ещё и сам уровень, и
+    /// уйти оба должны одной транзакцией — иначе отказ на второй половине оставил бы стройку без
+    /// документов или документы без стройки.
+    /// </summary>
+    void Remove(ScopeCascadePlan plan);
+
+    /// <summary>Отказ, если на содержимое ссылаются извне. <paramref name="levelAccusative"/> —
+    /// «комплект», «раздел», «стройку».</summary>
+    void EnsureDeletable(ScopeCascadePlan plan, string levelAccusative);
+}
+
+/// <param name="Objects">Объекты поддерева.</param>
+/// <param name="QualityDocuments">Документы качества, чья область — внутри поддерева.</param>
+/// <param name="MaterialLinks">Связки материалов той же области.</param>
+/// <param name="ExternalReferrers">Держатели ссылок вне поддерева. Не пусто → удалять нельзя.</param>
+public sealed record ScopeCascadePlan(
+    IReadOnlyList<DomainObject> Objects,
+    IReadOnlyList<QualityDocument> QualityDocuments,
+    IReadOnlyList<MaterialQualityLink> MaterialLinks,
+    IReadOnlyList<DomainObjectReferences.Referrer> ExternalReferrers);
+
+/// <inheritdoc cref="IScopeCascade" />
+public class ScopeCascade(
+    IRepository<DomainObject> objRepo,
+    IRepository<QualityDocument> qualityRepo,
+    IRepository<MaterialQualityLink> linkRepo,
+    IRepository<Section> sectionRepo,
+    IScopeSubtree subtree) : IScopeCascade
+{
+    /// <summary>
+    /// План удаления уровня.
     ///
     /// <para>Поддерево берётся у общего спуска (<see cref="IScopeSubtree"/>), а не своим запросом:
     /// он же отвечает счётчику замечаний и провайдерам системных наборов, и «что лежит под
     /// стройкой» должно значить везде одно и то же.</para>
     ///
-    /// <para>Объекты собираются по ВСЕМ уровням поддерева, а не только по комплектам: у стройки
-    /// это ещё общие данные её разделов и её собственные. Пропусти их — и сироты остались бы
-    /// ровно там, где их труднее всего заметить, на верхних уровнях, где записей мало и никто не
-    /// пересчитывает.</para>
+    /// <para>Собираются ВСЕ уровни поддерева, а не только комплекты: у стройки это ещё общие данные
+    /// её разделов и её собственные. Пропусти их — и сироты остались бы ровно там, где их труднее
+    /// всего заметить, на верхних уровнях, где записей мало и никто не пересчитывает.</para>
     /// </summary>
-    public static async Task<Plan> PlanAsync(
-        IRepository<DomainObject> objRepo,
-        IRepository<QualityDocument> qualityRepo,
-        IRepository<Section> sectionRepo,
-        IScopeSubtree subtree,
-        CatalogScope scope, Guid scopeId, CancellationToken ct)
+    public async Task<ScopeCascadePlan> PlanAsync(CatalogScope scope, Guid scopeId, CancellationToken ct = default)
     {
         var setIds = (await subtree.SetIdsUnderAsync(scope, scopeId, ct)).ToList();
-
         var sectionIds = scope switch
         {
             CatalogScope.Section => [scopeId],
@@ -60,24 +83,54 @@ public static class ScopeCascade
         };
         var constructionIds = scope == CatalogScope.Construction ? new List<Guid> { scopeId } : [];
 
-        var objects = await objRepo.FindAsync(o =>
-            o.ScopeId != null
+        // Предикат один и тот же по смыслу, но выписан трижды: общий хелпер в Expression не
+        // транслируется в SQL — EF увидел бы вызов метода и отказался (или, хуже, увёл бы отбор
+        // в память, вытащив три таблицы целиком).
+        var objects = await objRepo.FindAsync(o => o.ScopeId != null
             && ((o.ScopeLevel == CatalogScope.Set && setIds.Contains(o.ScopeId.Value))
                 || (o.ScopeLevel == CatalogScope.Section && sectionIds.Contains(o.ScopeId.Value))
                 || (o.ScopeLevel == CatalogScope.Construction && constructionIds.Contains(o.ScopeId.Value))), ct);
 
-        var ids = objects.Select(o => o.Id).ToHashSet();
-        var referrers = await DomainObjectReferences.FindReferrersAsync(objRepo, qualityRepo, ids, ct);
-        return new Plan(objects, referrers);
+        var quality = await qualityRepo.FindAsync(d => d.ScopeId != null
+            && ((d.Scope == CatalogScope.Set && setIds.Contains(d.ScopeId.Value))
+                || (d.Scope == CatalogScope.Section && sectionIds.Contains(d.ScopeId.Value))
+                || (d.Scope == CatalogScope.Construction && constructionIds.Contains(d.ScopeId.Value))), ct);
+
+        var links = await linkRepo.FindAsync(l => l.ScopeId != null
+            && ((l.Scope == CatalogScope.Set && setIds.Contains(l.ScopeId.Value))
+                || (l.Scope == CatalogScope.Section && sectionIds.Contains(l.ScopeId.Value))
+                || (l.Scope == CatalogScope.Construction && constructionIds.Contains(l.ScopeId.Value))), ct);
+
+        // Цели — И объекты, И документы качества поддерева. Одним множеством, потому что оно
+        // работает в обе стороны: ссылка на любую из этих записей извне удаление запрещает, а
+        // держатель, сам входящий в множество, не считается. Не включи мы сюда документы качества
+        // уровня комплекта — сертификат, заведённый в этом же комплекте и ссылающийся на его
+        // запись общих данных, объявил бы комплект неудаляемым, «сославшись извне» на самого себя.
+        var targetIds = objects.Select(o => o.Id).Concat(quality.Select(d => d.Id)).ToHashSet();
+        var referrers = await DomainObjectReferences.FindReferrersAsync(objRepo, qualityRepo, targetIds, ct);
+        return new ScopeCascadePlan(objects, quality, links, referrers);
     }
 
-    /// <summary>
-    /// Текст отказа. Уровень назван словом в винительном падеже («комплект», «раздел», «стройку»),
-    /// а держатели — списком: ссылка может держаться и вне удаляемого места (документ качества
-    /// общей библиотеки), и без имени человеку негде её искать.
-    /// </summary>
-    public static string RefusalMessage(string levelAccusative, IReadOnlyList<DomainObjectReferences.Referrer> referrers)
-        => $"Нельзя удалить {levelAccusative} — на содержимое ссылаются извне: "
-           + string.Join(", ", referrers.Select(r => r.Label))
-           + ". Сначала снимите эти ссылки.";
+    /// <inheritdoc />
+    public void Remove(ScopeCascadePlan plan)
+    {
+        // Порядок: связки, потом документы качества, потом объекты. Связки у документа качества
+        // ушли бы и каскадом базы, но только у СВОЕГО: связка уровня комплекта, указывающая на
+        // документ общей библиотеки, каскадом не покрыта — её уносим сами.
+        foreach (var l in plan.MaterialLinks) linkRepo.Remove(l);
+        foreach (var d in plan.QualityDocuments) qualityRepo.Remove(d);
+        foreach (var o in plan.Objects) objRepo.Remove(o); // фасета + generated_files каскадируются в БД
+    }
+
+    /// <inheritdoc />
+    public void EnsureDeletable(ScopeCascadePlan plan, string levelAccusative)
+    {
+        if (plan.ExternalReferrers.Count == 0) return;
+        // Уровень назван словом в винительном падеже, держатели — списком: ссылка может держаться и
+        // вне удаляемого места (документ качества общей библиотеки), и без имени её негде искать.
+        throw new ConflictException(
+            $"Нельзя удалить {levelAccusative} — на содержимое ссылаются извне: "
+            + string.Join(", ", plan.ExternalReferrers.Select(r => r.Label))
+            + ". Сначала снимите эти ссылки.");
+    }
 }

--- a/src/server/BHS.CRG.Application/Objects/ScopeCascade.cs
+++ b/src/server/BHS.CRG.Application/Objects/ScopeCascade.cs
@@ -1,0 +1,83 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
+
+namespace BHS.CRG.Application.Objects;
+
+/// <summary>
+/// Каскад удаления уровня расположения — комплекта, раздела, стройки (issue #739).
+///
+/// <para><b>Зачем прикладной каскад вообще.</b> У <c>DomainObject</c> нет внешнего ключа на
+/// комплект: ось расположения полиморфна (<c>ScopeLevel</c> + <c>ScopeId</c> указывают то на
+/// комплект, то на раздел, то на стройку), и одним FK её не выразить. Поэтому база уносит
+/// разделы за стройкой и комплекты за разделом, а объекты — нет: их надо удалять руками. Пока
+/// это делал только обработчик комплекта, удаление раздела или стройки оставляло документы и
+/// записи общих данных сиротами — невидимыми в интерфейсе, но живыми для сканов, поиска и
+/// резервной копии. На рабочей базе такие уже были.</para>
+///
+/// <para><b>Зачем guard.</b> Поштучные guard'ы (#71/#269/#735) не пускают удалить объект, на
+/// который ссылаются. Каскад обходил их с фланга: те же объекты уходили пачкой, и ссылка на них
+/// молча повисала. Правило здесь то же — «на что ссылаются, не удаляем», — но множеством:
+/// держатели ВНУТРИ удаляемого поддерева не в счёт, они уходят вместе со ссылкой.</para>
+/// </summary>
+public static class ScopeCascade
+{
+    /// <summary>Что уйдёт при удалении уровня и кто держит ссылки на это извне.</summary>
+    /// <param name="Objects">Объекты поддерева — их удаляет вызывающий.</param>
+    /// <param name="ExternalReferrers">Держатели ссылок вне поддерева. Не пусто → удалять нельзя.</param>
+    public sealed record Plan(
+        IReadOnlyList<DomainObject> Objects,
+        IReadOnlyList<DomainObjectReferences.Referrer> ExternalReferrers);
+
+    /// <summary>
+    /// План удаления уровня <paramref name="scope"/>/<paramref name="scopeId"/>.
+    ///
+    /// <para>Поддерево берётся у общего спуска (<see cref="IScopeSubtree"/>), а не своим запросом:
+    /// он же отвечает счётчику замечаний и провайдерам системных наборов, и «что лежит под
+    /// стройкой» должно значить везде одно и то же.</para>
+    ///
+    /// <para>Объекты собираются по ВСЕМ уровням поддерева, а не только по комплектам: у стройки
+    /// это ещё общие данные её разделов и её собственные. Пропусти их — и сироты остались бы
+    /// ровно там, где их труднее всего заметить, на верхних уровнях, где записей мало и никто не
+    /// пересчитывает.</para>
+    /// </summary>
+    public static async Task<Plan> PlanAsync(
+        IRepository<DomainObject> objRepo,
+        IRepository<QualityDocument> qualityRepo,
+        IRepository<Section> sectionRepo,
+        IScopeSubtree subtree,
+        CatalogScope scope, Guid scopeId, CancellationToken ct)
+    {
+        var setIds = (await subtree.SetIdsUnderAsync(scope, scopeId, ct)).ToList();
+
+        var sectionIds = scope switch
+        {
+            CatalogScope.Section => [scopeId],
+            CatalogScope.Construction => (await sectionRepo.FindAsync(s => s.ConstructionId == scopeId, ct))
+                .Select(s => s.Id).ToList(),
+            _ => new List<Guid>(),
+        };
+        var constructionIds = scope == CatalogScope.Construction ? new List<Guid> { scopeId } : [];
+
+        var objects = await objRepo.FindAsync(o =>
+            o.ScopeId != null
+            && ((o.ScopeLevel == CatalogScope.Set && setIds.Contains(o.ScopeId.Value))
+                || (o.ScopeLevel == CatalogScope.Section && sectionIds.Contains(o.ScopeId.Value))
+                || (o.ScopeLevel == CatalogScope.Construction && constructionIds.Contains(o.ScopeId.Value))), ct);
+
+        var ids = objects.Select(o => o.Id).ToHashSet();
+        var referrers = await DomainObjectReferences.FindReferrersAsync(objRepo, qualityRepo, ids, ct);
+        return new Plan(objects, referrers);
+    }
+
+    /// <summary>
+    /// Текст отказа. Уровень назван словом в винительном падеже («комплект», «раздел», «стройку»),
+    /// а держатели — списком: ссылка может держаться и вне удаляемого места (документ качества
+    /// общей библиотеки), и без имени человеку негде её искать.
+    /// </summary>
+    public static string RefusalMessage(string levelAccusative, IReadOnlyList<DomainObjectReferences.Referrer> referrers)
+        => $"Нельзя удалить {levelAccusative} — на содержимое ссылаются извне: "
+           + string.Join(", ", referrers.Select(r => r.Label))
+           + ". Сначала снимите эти ссылки.";
+}

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/OrphanObjectCleanup.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/OrphanObjectCleanup.cs
@@ -1,63 +1,114 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Objects;
 using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace BHS.CRG.Infrastructure.Maintenance;
 
-/// <summary>Осиротевший объект — сколько и где.</summary>
-/// <param name="Sets">На несуществующих комплектах.</param>
-/// <param name="Sections">На несуществующих разделах.</param>
-/// <param name="Constructions">На несуществующих стройках.</param>
-/// <param name="WithData">Из них с непустыми данными — их потеря заметна, в отличие от пустых профилей.</param>
-public record OrphanCleanupReport(int Sets, int Sections, int Constructions, int WithData)
+/// <summary>Осиротевшие записи — сколько, где и сколько из них ещё держат ссылками.</summary>
+/// <param name="Objects">Документы и записи общих данных.</param>
+/// <param name="QualityDocuments">Документы качества уровня комплекта/раздела/стройки.</param>
+/// <param name="MaterialLinks">Связки материалов той же оси.</param>
+/// <param name="WithData">Объектов с непустыми данными — их потеря заметна, в отличие от пустых профилей.</param>
+/// <param name="Referenced">На стольких сирот ссылаются живые записи; такие не удаляются.</param>
+public record OrphanCleanupReport(
+    int Objects, int QualityDocuments, int MaterialLinks, int WithData, int Referenced)
 {
-    public int Total => Sets + Sections + Constructions;
+    /// <summary>Сколько будет удалено: найденное за вычетом того, на что ещё ссылаются.</summary>
+    public int Total => Objects + QualityDocuments + MaterialLinks - Referenced;
 }
 
 /// <summary>
-/// Уборка объектов, чьё место расположения больше не существует (issue #739).
+/// Уборка записей, чьё место расположения больше не существует (issue #739).
 ///
-/// <para>Как они появлялись: у <c>domain_objects</c> нет внешнего ключа на комплект — ось
-/// расположения полиморфна, — и база уносила разделы за стройкой и комплекты за разделом, а объекты
-/// оставляла. Прикладной каскад был только у комплекта. Причина закрыта там же, где заведена эта
-/// уборка, но след остаётся: на рабочей базе такие записи уже были, а восстановление старой
-/// резервной копии способно привезти их снова — поэтому инструмент, а не разовый SQL.</para>
+/// <para>Как они появлялись: у оси расположения нет внешнего ключа — она полиморфна, — и база
+/// уносила разделы за стройкой и комплекты за разделом, а всё, что на этой оси висит, оставляла.
+/// Прикладной каскад был только у комплекта, да и тот знал лишь про <c>domain_objects</c>. Причина
+/// закрыта там же, где заведена эта уборка, но след остаётся: на рабочей базе такие записи уже
+/// были, а восстановление старой резервной копии способно привезти их снова — поэтому инструмент,
+/// а не разовый SQL.</para>
 ///
-/// <para>Действие администратора с предварительным подсчётом (<c>dryRun</c>), как и прочее
-/// обслуживание: удаление тут окончательное, и увидеть числа до него важнее, чем сэкономить шаг.
-/// <c>WithData</c> в отчёте отделяет пустые объекты-профили уровня (их создают лениво при открытии
-/// экрана, и терять там нечего) от записей с содержимым — если такие есть, это повод посмотреть
-/// глазами, а не жать «удалить».</para>
+/// <para><b>Сирота ≠ мусор.</b> На неё может ссылаться живая запись: ссылки резолвятся по
+/// идентификатору, а не по месту, и такая ссылка работает по сей день. Удали мы её цель — рабочая
+/// ссылка стала бы висячей, то есть уборка сделала бы ровно то, что вся эта работа предотвращает.
+/// Поэтому держимые сироты остаются, а отчёт их считает отдельно.</para>
+///
+/// <para>Действие администратора с предварительным подсчётом (<c>dryRun</c>): удаление
+/// окончательное, и увидеть числа до него важнее, чем сэкономить шаг.</para>
 ///
 /// <para>Идемпотентна: повторный прогон на убранной базе находит ноль.</para>
 /// </summary>
-public class OrphanObjectCleanup(AppDbContext db)
+public class OrphanObjectCleanup(
+    AppDbContext db,
+    IRepository<DomainObject> objRepo,
+    IRepository<QualityDocument> qualityRepo)
 {
     /// <param name="dryRun">Только посчитать, ничего не удаляя.</param>
     public async Task<OrphanCleanupReport> RunAsync(bool dryRun, CancellationToken ct = default)
     {
-        // Отбор в базе: сравнение с тремя таблицами дешевле любого обхода в памяти, а в этой же
-        // таблице лежат многомегабайтные JSONB документов — тянуть их сюда незачем.
-        var orphans = await db.DomainObjects
+        // Отбор и подсчёт — проекциями, без сущностей: в domain_objects лежат многомегабайтные
+        // JSONB (одни картинки в общих данных дают мегабайты), и сухой прогон на базе с сотней
+        // сирот вытянул бы их все, да ещё и в трекер изменений. «Есть ли данные» считает база.
+        var objectIds = await db.DomainObjects
             .Where(o => o.ScopeId != null
-                && ((o.ScopeLevel == CatalogScope.Set
-                     && !db.DocumentSets.Any(s => s.Id == o.ScopeId!.Value))
-                 || (o.ScopeLevel == CatalogScope.Section
-                     && !db.Sections.Any(s => s.Id == o.ScopeId!.Value))
-                 || (o.ScopeLevel == CatalogScope.Construction
-                     && !db.Constructions.Any(c => c.Id == o.ScopeId!.Value))))
+                && ((o.ScopeLevel == CatalogScope.Set && !db.DocumentSets.Any(s => s.Id == o.ScopeId!.Value))
+                 || (o.ScopeLevel == CatalogScope.Section && !db.Sections.Any(s => s.Id == o.ScopeId!.Value))
+                 || (o.ScopeLevel == CatalogScope.Construction && !db.Constructions.Any(c => c.Id == o.ScopeId!.Value))))
+            .Select(o => o.Id)
             .ToListAsync(ct);
 
-        var report = new OrphanCleanupReport(
-            Sets: orphans.Count(o => o.ScopeLevel == CatalogScope.Set),
-            Sections: orphans.Count(o => o.ScopeLevel == CatalogScope.Section),
-            Constructions: orphans.Count(o => o.ScopeLevel == CatalogScope.Construction),
-            WithData: orphans.Count(o => o.Data.RootElement.EnumerateObject().Any()));
+        // «Данные непусты» считает база отдельным запросом: в LINQ-проекцию это не выражается
+        // (JsonDocument там не сравнить), а тянуть сам JSONB ради одного флага — то самое, чего
+        // проекции и избегают. jsonb '{}' сравниваем как текст: у пустого объекта запись одна.
+        // $$ вместо $: в запросе есть литерал '{}', и при одинарном $ он был бы принят за дыру
+        // интерполяции. С двойным дырой считается только {{...}}.
+        var withData = objectIds.Count == 0 ? 0 : await db.Database
+            .SqlQuery<int>($$"""
+                SELECT count(*)::int AS "Value" FROM domain_objects
+                WHERE "Id" = ANY({{objectIds}}) AND "Data"::text <> '{}'
+                """)
+            .SingleAsync(ct);
 
-        if (!dryRun && orphans.Count > 0)
+        var qualityIds = await db.QualityDocuments
+            .Where(d => d.ScopeId != null
+                && ((d.Scope == CatalogScope.Set && !db.DocumentSets.Any(s => s.Id == d.ScopeId!.Value))
+                 || (d.Scope == CatalogScope.Section && !db.Sections.Any(s => s.Id == d.ScopeId!.Value))
+                 || (d.Scope == CatalogScope.Construction && !db.Constructions.Any(c => c.Id == d.ScopeId!.Value))))
+            .Select(d => d.Id)
+            .ToListAsync(ct);
+
+        var linkIds = await db.MaterialQualityLinks
+            .Where(l => l.ScopeId != null
+                && ((l.Scope == CatalogScope.Set && !db.DocumentSets.Any(s => s.Id == l.ScopeId!.Value))
+                 || (l.Scope == CatalogScope.Section && !db.Sections.Any(s => s.Id == l.ScopeId!.Value))
+                 || (l.Scope == CatalogScope.Construction && !db.Constructions.Any(c => c.Id == l.ScopeId!.Value))))
+            .Select(l => l.Id)
+            .ToListAsync(ct);
+
+        var candidates = objectIds.Concat(qualityIds).ToHashSet();
+        var held = await DomainObjectReferences.FindHeldTargetsAsync(objRepo, qualityRepo, candidates, ct);
+
+        var report = new OrphanCleanupReport(
+            Objects: objectIds.Count,
+            QualityDocuments: qualityIds.Count,
+            MaterialLinks: linkIds.Count,
+            WithData: withData,
+            Referenced: held.Count);
+
+        if (!dryRun && report.Total > 0)
         {
-            db.DomainObjects.RemoveRange(orphans); // фасета + generated_files каскадируются в БД
-            await db.SaveChangesAsync(ct);
+            // ExecuteDelete — по той же причине, что и проекции выше: удалять, не загружая JSONB.
+            // Порядок: связки, потом документы качества (их собственные связки уносит FK-каскад),
+            // потом объекты (за ними каскадом идут фасета и generated_files).
+            var objIds = objectIds.Where(id => !held.Contains(id)).ToList();
+            var qIds = qualityIds.Where(id => !held.Contains(id)).ToList();
+
+            await db.MaterialQualityLinks.Where(l => linkIds.Contains(l.Id)).ExecuteDeleteAsync(ct);
+            await db.QualityDocuments.Where(d => qIds.Contains(d.Id)).ExecuteDeleteAsync(ct);
+            await db.DomainObjects.Where(o => objIds.Contains(o.Id)).ExecuteDeleteAsync(ct);
         }
 
         return report;

--- a/src/server/BHS.CRG.Infrastructure/Maintenance/OrphanObjectCleanup.cs
+++ b/src/server/BHS.CRG.Infrastructure/Maintenance/OrphanObjectCleanup.cs
@@ -1,0 +1,65 @@
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHS.CRG.Infrastructure.Maintenance;
+
+/// <summary>Осиротевший объект — сколько и где.</summary>
+/// <param name="Sets">На несуществующих комплектах.</param>
+/// <param name="Sections">На несуществующих разделах.</param>
+/// <param name="Constructions">На несуществующих стройках.</param>
+/// <param name="WithData">Из них с непустыми данными — их потеря заметна, в отличие от пустых профилей.</param>
+public record OrphanCleanupReport(int Sets, int Sections, int Constructions, int WithData)
+{
+    public int Total => Sets + Sections + Constructions;
+}
+
+/// <summary>
+/// Уборка объектов, чьё место расположения больше не существует (issue #739).
+///
+/// <para>Как они появлялись: у <c>domain_objects</c> нет внешнего ключа на комплект — ось
+/// расположения полиморфна, — и база уносила разделы за стройкой и комплекты за разделом, а объекты
+/// оставляла. Прикладной каскад был только у комплекта. Причина закрыта там же, где заведена эта
+/// уборка, но след остаётся: на рабочей базе такие записи уже были, а восстановление старой
+/// резервной копии способно привезти их снова — поэтому инструмент, а не разовый SQL.</para>
+///
+/// <para>Действие администратора с предварительным подсчётом (<c>dryRun</c>), как и прочее
+/// обслуживание: удаление тут окончательное, и увидеть числа до него важнее, чем сэкономить шаг.
+/// <c>WithData</c> в отчёте отделяет пустые объекты-профили уровня (их создают лениво при открытии
+/// экрана, и терять там нечего) от записей с содержимым — если такие есть, это повод посмотреть
+/// глазами, а не жать «удалить».</para>
+///
+/// <para>Идемпотентна: повторный прогон на убранной базе находит ноль.</para>
+/// </summary>
+public class OrphanObjectCleanup(AppDbContext db)
+{
+    /// <param name="dryRun">Только посчитать, ничего не удаляя.</param>
+    public async Task<OrphanCleanupReport> RunAsync(bool dryRun, CancellationToken ct = default)
+    {
+        // Отбор в базе: сравнение с тремя таблицами дешевле любого обхода в памяти, а в этой же
+        // таблице лежат многомегабайтные JSONB документов — тянуть их сюда незачем.
+        var orphans = await db.DomainObjects
+            .Where(o => o.ScopeId != null
+                && ((o.ScopeLevel == CatalogScope.Set
+                     && !db.DocumentSets.Any(s => s.Id == o.ScopeId!.Value))
+                 || (o.ScopeLevel == CatalogScope.Section
+                     && !db.Sections.Any(s => s.Id == o.ScopeId!.Value))
+                 || (o.ScopeLevel == CatalogScope.Construction
+                     && !db.Constructions.Any(c => c.Id == o.ScopeId!.Value))))
+            .ToListAsync(ct);
+
+        var report = new OrphanCleanupReport(
+            Sets: orphans.Count(o => o.ScopeLevel == CatalogScope.Set),
+            Sections: orphans.Count(o => o.ScopeLevel == CatalogScope.Section),
+            Constructions: orphans.Count(o => o.ScopeLevel == CatalogScope.Construction),
+            WithData: orphans.Count(o => o.Data.RootElement.EnumerateObject().Any()));
+
+        if (!dryRun && orphans.Count > 0)
+        {
+            db.DomainObjects.RemoveRange(orphans); // фасета + generated_files каскадируются в БД
+            await db.SaveChangesAsync(ct);
+        }
+
+        return report;
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/ScopeCascadeDeleteTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ScopeCascadeDeleteTests.cs
@@ -225,7 +225,7 @@ public class ScopeCascadeDeleteTests(IntegrationTestFixture fixture) : IAsyncLif
 
             var dry = await cleanup.RunAsync(dryRun: true);
             Assert.Equal(1, dry.Total);
-            Assert.Equal(1, dry.Sets);
+            Assert.Equal(1, dry.Objects);
             Assert.Equal(1, dry.WithData); // непустой — повод посмотреть глазами, а не жать «удалить»
             Assert.Equal(2, await CountObjectsAsync()); // сухой прогон ничего не тронул
 
@@ -235,5 +235,109 @@ public class ScopeCascadeDeleteTests(IntegrationTestFixture fixture) : IAsyncLif
 
             Assert.Equal(0, (await cleanup.RunAsync(dryRun: true)).Total);
         }
+    }
+
+    /// <summary>
+    /// Сирота, на которую ещё ссылается ЖИВАЯ запись, уборкой не трогается. Ссылки резолвятся по
+    /// идентификатору, а не по месту: такая ссылка работает по сей день, и снеси мы её цель —
+    /// уборка своими руками сделала бы висячей ровно ту ссылку, ради которой всё затевалось.
+    /// </summary>
+    [Fact]
+    public async Task OrphanCleanup_KeepsOrphansStillReferencedByLiveRecords()
+    {
+        var seed = await SeedAsync();
+        Guid orphanId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IRepository<DomainObject>>();
+            var orphan = DomainObject.Create(seed.DocTypeId, "Потерянная запись", J("{'Поле':'значение'}"),
+                CatalogScope.Set, Guid.NewGuid());
+            await repo.AddAsync(orphan);
+            await repo.SaveChangesAsync();
+            orphanId = orphan.Id;
+        }
+        // Живой документ ссылается на сироту — ссылка по идентификатору, и она резолвится.
+        await AddDocumentAsync(seed, "Живой акт", $"{{'Ссылка':{{'$ref':'catalog','entryId':'{orphanId}'}}}}");
+
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var cleanup = scope.ServiceProvider.GetRequiredService<OrphanObjectCleanup>();
+            var dry = await cleanup.RunAsync(dryRun: true);
+            Assert.Equal(1, dry.Objects);
+            Assert.Equal(1, dry.Referenced);
+            Assert.Equal(0, dry.Total); // удалять нечего: единственная сирота держится ссылкой
+
+            await cleanup.RunAsync(dryRun: false);
+            Assert.Equal(2, await CountObjectsAsync()); // сирота на месте
+        }
+    }
+
+    // ── Документы качества и связки на той же оси ────────────────────────────────
+
+    /// <summary>
+    /// Документ качества уровня комплекта и связки материалов висят на той же полиморфной оси, что и
+    /// объекты, и внешнего ключа у них тоже нет. Не унеси их каскад — они остались бы сиротами: на
+    /// рабочей базе таких документов 14, а связок 54, так что это не теоретическая полнота.
+    /// </summary>
+    [Fact]
+    public async Task DeletingSet_RemovesQualityDocsAndLinksOfThatScope()
+    {
+        var seed = await SeedAsync();
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var cert = await M(scope).Send(new CreateQualityDocumentCommand(
+                seed.DocTypeId, "Сертификат комплекта", J("{}"),
+                CatalogScope.Set, seed.SetId, QualityDocSource.Manual, null, null, null));
+            await M(scope).Send(new SetMaterialLinksCommand(
+                CatalogScope.Set, seed.SetId, [new MaterialLinkInput("ВВГнг|3х2,5", "Кабель")], cert.Id));
+        }
+
+        await SendAsync(new DeleteDocumentSetCommand(seed.SetId));
+
+        using var check = fixture.Services.CreateScope();
+        var quality = await check.ServiceProvider.GetRequiredService<IRepository<QualityDocument>>()
+            .FindAsync(_ => true);
+        var links = await check.ServiceProvider.GetRequiredService<IRepository<MaterialQualityLink>>()
+            .FindAsync(_ => true);
+        Assert.Empty(quality);
+        Assert.Empty(links);
+    }
+
+    /// <summary>
+    /// Документ качества, лежащий В УДАЛЯЕМОМ комплекте, не должен считаться внешним держателем.
+    /// Он уходит вместе с комплектом, ссылка исчезает целиком — а объяви мы его «ссылающимся
+    /// извне», комплект стал бы неудаляемым из-за собственного содержимого, и сообщение об отказе
+    /// называло бы документ, который лежит внутри.
+    /// </summary>
+    [Fact]
+    public async Task DeletingSet_WithQualityDocOfSameScopeReferencingInside_Succeeds()
+    {
+        var seed = await SeedAsync();
+        var docId = await AddDocumentAsync(seed, "Акт", "{'Номер':'7'}");
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new CreateQualityDocumentCommand(
+                seed.DocTypeId, "Сертификат комплекта",
+                J($"{{'Основание':{{'$ref':'document','instanceId':'{docId}','fieldKey':'Номер'}}}}"),
+                CatalogScope.Set, seed.SetId, QualityDocSource.Manual, null, null, null));
+
+        await SendAsync(new DeleteDocumentSetCommand(seed.SetId));
+
+        Assert.Equal(0, await CountObjectsAsync());
+    }
+
+    /// <summary>А документ качества ОБЩЕЙ библиотеки — по-прежнему внешний держатель.</summary>
+    [Fact]
+    public async Task DeletingSet_WithSystemQualityDocReferencingInside_IsRejected()
+    {
+        var seed = await SeedAsync();
+        var docId = await AddDocumentAsync(seed, "Акт", "{'Номер':'7'}");
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new CreateQualityDocumentCommand(
+                seed.DocTypeId, "Сертификат библиотеки",
+                J($"{{'Основание':{{'$ref':'document','instanceId':'{docId}','fieldKey':'Номер'}}}}"),
+                CatalogScope.System, null, QualityDocSource.Manual, null, null, null));
+
+        await Assert.ThrowsAsync<ConflictException>(
+            () => SendAsync(new DeleteDocumentSetCommand(seed.SetId)));
     }
 }

--- a/src/server/BHS.CRG.Tests/Integration/ScopeCascadeDeleteTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/ScopeCascadeDeleteTests.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.QualityDocs;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
+using BHS.CRG.Infrastructure.Maintenance;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Каскадное удаление уровня расположения (issue #739).
+///
+/// <para>Две беды, обе от одного: у объекта нет внешнего ключа на комплект — ось расположения
+/// полиморфна. База уносит разделы за стройкой и комплекты за разделом, а объекты оставляет, и
+/// прикладной каскад был только у комплекта: удаление раздела или стройки плодило сирот. Оно же
+/// обходило с фланга поштучные guard'ы (#71/#269/#735) — объекты уходили пачкой, и ссылки на них
+/// молча повисали.</para>
+///
+/// <para>Ключевая граница проверяется отдельно: держатель ВНУТРИ удаляемого поддерева блокировать
+/// не должен. Иначе комплект с двумя связанными документами стал бы неудаляемым навсегда.</para>
+/// </summary>
+[Collection("Integration")]
+public class ScopeCascadeDeleteTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+    private readonly Guid _userId = Guid.NewGuid();
+
+    private sealed record Seed(Guid ConstructionId, Guid SectionId, Guid SetId, Guid DocTypeId);
+
+    private async Task<Seed> SeedAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var construction = await m.Send(new CreateConstructionCommand("Объект", _userId));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "ЭОМ-1"));
+        var docType = await m.Send(new CreateDocumentTypeCommand(
+            "Акт", "AOSR", DocumentTypeKind.Document, null, J("{'fields':[]}")));
+        return new Seed(construction.Id, section.Id, set.Id, docType.Id);
+    }
+
+    private async Task<Guid> AddDocumentAsync(Seed seed, string name, string requisites = "{}")
+    {
+        using var scope = fixture.Services.CreateScope();
+        var inst = await M(scope).Send(new AddDocumentToSetCommand(seed.SetId, seed.DocTypeId));
+        await M(scope).Send(new RenameDocumentInstanceCommand(inst.Id, name));
+        await M(scope).Send(new UpdateRequisitesCommand(inst.Id, J(requisites)));
+        return inst.Id;
+    }
+
+    private async Task<int> CountObjectsAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IRepository<DomainObject>>();
+        return (await repo.FindAsync(_ => true)).Count;
+    }
+
+    private async Task SendAsync(IRequest request)
+    {
+        using var scope = fixture.Services.CreateScope();
+        await M(scope).Send(request);
+    }
+
+    // ── Сироты: каскад обязан уносить объекты поддерева ──────────────────────────
+
+    [Fact]
+    public async Task DeletingSection_RemovesObjectsOfItsSets()
+    {
+        var seed = await SeedAsync();
+        await AddDocumentAsync(seed, "Акт 1");
+        await AddDocumentAsync(seed, "Акт 2");
+        Assert.Equal(2, await CountObjectsAsync());
+
+        await SendAsync(new DeleteSectionCommand(seed.SectionId));
+
+        // Комплект уносит база (FK раздела), объекты — прикладной каскад. Не унеси он их —
+        // остались бы сироты: в интерфейсе невидимы, в базе живы.
+        Assert.Equal(0, await CountObjectsAsync());
+    }
+
+    [Fact]
+    public async Task DeletingConstruction_RemovesObjectsOfAllLevels()
+    {
+        var seed = await SeedAsync();
+        await AddDocumentAsync(seed, "Акт");
+        using (var scope = fixture.Services.CreateScope())
+        {
+            // Общие данные на каждом уровне поддерева — их тоже уносит только прикладной каскад.
+            await M(scope).Send(new CreateCommonDataEntryCommand(
+                "Данные раздела", seed.DocTypeId, J("{}"), CatalogScope.Section, seed.SectionId));
+            await M(scope).Send(new CreateCommonDataEntryCommand(
+                "Данные стройки", seed.DocTypeId, J("{}"), CatalogScope.Construction, seed.ConstructionId));
+        }
+        Assert.Equal(3, await CountObjectsAsync());
+
+        await SendAsync(new DeleteConstructionCommand(seed.ConstructionId));
+
+        Assert.Equal(0, await CountObjectsAsync());
+    }
+
+    /// <summary>Объекты чужой стройки каскад не трогает — поддерево, а не «всё подряд».</summary>
+    [Fact]
+    public async Task DeletingConstruction_LeavesOtherConstructionsAlone()
+    {
+        var seed = await SeedAsync();
+        await AddDocumentAsync(seed, "Акт своей стройки");
+        Guid otherSetId;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var other = await M(scope).Send(new CreateConstructionCommand("Чужой объект", _userId));
+            var section = await M(scope).Send(new CreateSectionCommand(other.Id, "СС"));
+            var set = await M(scope).Send(new CreateDocumentSetCommand(section.Id, "СС-1"));
+            otherSetId = set.Id;
+            await M(scope).Send(new AddDocumentToSetCommand(otherSetId, seed.DocTypeId));
+        }
+
+        await SendAsync(new DeleteConstructionCommand(seed.ConstructionId));
+
+        Assert.Equal(1, await CountObjectsAsync());
+    }
+
+    // ── Guard: ссылки извне ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeletingSet_ReferencedFromQualityLibrary_IsRejected()
+    {
+        var seed = await SeedAsync();
+        var docId = await AddDocumentAsync(seed, "Акт", "{'Номер':'7'}");
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new CreateQualityDocumentCommand(
+                seed.DocTypeId, "Протокол испытаний",
+                J($"{{'Основание':{{'$ref':'document','instanceId':'{docId}','fieldKey':'Номер'}}}}"),
+                CatalogScope.System, null, QualityDocSource.Manual, null, null, null));
+
+        var ex = await Assert.ThrowsAsync<ConflictException>(
+            () => SendAsync(new DeleteDocumentSetCommand(seed.SetId)));
+
+        Assert.Contains("документ качества «Протокол испытаний»", ex.Message);
+        Assert.Equal(1, await CountObjectsAsync()); // ничего не снесено
+    }
+
+    /// <summary>Тот же отказ на верхних уровнях: правило одно на комплект, раздел и стройку.</summary>
+    [Fact]
+    public async Task DeletingConstruction_ReferencedFromOutside_IsRejected()
+    {
+        var seed = await SeedAsync();
+        var docId = await AddDocumentAsync(seed, "Акт", "{'Номер':'7'}");
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new CreateQualityDocumentCommand(
+                seed.DocTypeId, "Сертификат",
+                J($"{{'Основание':{{'$ref':'document','instanceId':'{docId}','fieldKey':'Номер'}}}}"),
+                CatalogScope.System, null, QualityDocSource.Manual, null, null, null));
+
+        await Assert.ThrowsAsync<ConflictException>(
+            () => SendAsync(new DeleteConstructionCommand(seed.ConstructionId)));
+        await Assert.ThrowsAsync<ConflictException>(
+            () => SendAsync(new DeleteSectionCommand(seed.SectionId)));
+    }
+
+    /// <summary>
+    /// Граница guard'а и главное, что он НЕ должен ломать. Документ, ссылающийся на соседний
+    /// документ того же комплекта, уходит вместе с ним: ссылка исчезает целиком, а не повисает.
+    /// Считай мы и такого держателя — комплект с двумя связанными документами стал бы неудаляемым
+    /// навсегда, распутать это можно было бы только правкой реквизитов вручную.
+    /// </summary>
+    [Fact]
+    public async Task DeletingSet_WithReferencesInsideItself_Succeeds()
+    {
+        var seed = await SeedAsync();
+        var targetId = await AddDocumentAsync(seed, "Акт-основание");
+        await AddDocumentAsync(seed, "Акт со ссылкой",
+            $"{{'Основание':{{'$ref':'instance','instanceId':'{targetId}'}}}}");
+
+        await SendAsync(new DeleteDocumentSetCommand(seed.SetId));
+
+        Assert.Equal(0, await CountObjectsAsync());
+    }
+
+    /// <summary>То же для базового экземпляра: наследование внутри поддерева удалению не помеха.</summary>
+    [Fact]
+    public async Task DeletingSection_WithBaseRefInsideSubtree_Succeeds()
+    {
+        var seed = await SeedAsync();
+        var baseId = await AddDocumentAsync(seed, "Базовый акт");
+        await AddDocumentAsync(seed, "Наследник", $"{{'_baseRef':{{'kind':'document','id':'{baseId}'}}}}");
+
+        await SendAsync(new DeleteSectionCommand(seed.SectionId));
+
+        Assert.Equal(0, await CountObjectsAsync());
+    }
+
+    // ── Уборка ранее накопившихся сирот ──────────────────────────────────────────
+
+    /// <summary>
+    /// Инструмент обслуживания на сиротах, заведённых как их плодила прежняя ошибка: объект есть,
+    /// комплекта нет. Сухой прогон обязан их видеть, боевой — убрать, повторный — найти ноль.
+    /// </summary>
+    [Fact]
+    public async Task OrphanCleanup_FindsAndRemovesObjectsOfMissingScopes()
+    {
+        var seed = await SeedAsync();
+        await AddDocumentAsync(seed, "Акт");
+
+        // Сирота ровно того вида, что оставляло удаление раздела до этой правки.
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IRepository<DomainObject>>();
+            var orphan = DomainObject.Create(seed.DocTypeId, "Потерянный", J("{'Поле':'значение'}"),
+                CatalogScope.Set, Guid.NewGuid());
+            await repo.AddAsync(orphan);
+            await repo.SaveChangesAsync();
+        }
+
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var cleanup = scope.ServiceProvider.GetRequiredService<OrphanObjectCleanup>();
+
+            var dry = await cleanup.RunAsync(dryRun: true);
+            Assert.Equal(1, dry.Total);
+            Assert.Equal(1, dry.Sets);
+            Assert.Equal(1, dry.WithData); // непустой — повод посмотреть глазами, а не жать «удалить»
+            Assert.Equal(2, await CountObjectsAsync()); // сухой прогон ничего не тронул
+
+            var real = await cleanup.RunAsync(dryRun: false);
+            Assert.Equal(1, real.Total);
+            Assert.Equal(1, await CountObjectsAsync()); // живой документ на месте
+
+            Assert.Equal(0, (await cleanup.RunAsync(dryRun: true)).Total);
+        }
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.109.0</Version>
+    <Version>0.110.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #739.

## Две беды от одной причины

У `DomainObject` нет внешнего ключа на комплект — ось расположения полиморфна (`ScopeLevel` + `ScopeId` указывают то на комплект, то на раздел, то на стройку), одним FK её не выразить.

**Сироты (в issue этого не было — нашлось при разборе).** База уносит разделы за стройкой и комплекты за разделом, а объекты оставляет; прикладной каскад был только у `DeleteDocumentSetCommand`. `DeleteSectionCommand` и `DeleteConstructionCommand` — это `Remove(s)` и всё. Документы и записи общих данных оставались в таблице навсегда: в интерфейсе невидимы, но живы для сканов ссылок, поиска и резервной копии. **На рабочей базе такие уже есть** — 2 объекта от 24 июля (оба пустые, похоже профили уровня; проверено SQL-ом).

**Висячие ссылки — исходный предмет issue.** Тот же каскад обходил с фланга поштучные guard'ы (#71/#269/#735): объекты уходили пачкой, и ссылка на них молча повисала.

## Решение

Общий план удаления — `ScopeCascade.PlanAsync`. Поддерево берётся у `IScopeSubtree` (тот же спуск, что у счётчика замечаний и системных наборов — «что лежит под стройкой» должно значить везде одно), объекты собираются по **всем** его уровням: у стройки это ещё общие данные её разделов и её собственные. Пропусти их — и сироты остались бы там, где их труднее всего заметить.

Держатели ссылок ищутся **множеством**, и держатель ВНУТРИ поддерева не в счёт: он уходит вместе со ссылкой, она исчезает целиком, а не повисает. Считай мы и таких — комплект с двумя связанными документами стал бы неудаляемым навсегда, распутать это можно было бы только правкой реквизитов вручную. Одиночный guard стал частным случаем множественного: цель не блокирует сама себя.

**Выбрана блокировка, а не предупреждение** — то же правило, что у поштучного удаления, чтобы одно действие не вело себя по-разному в зависимости от экрана, с которого начали. Правило одно на комплект, раздел и стройку.

## Уборка накопившегося

Операция в «Обслуживании» рядом с существующими: `dryRun` по умолчанию, отчёт по уровням, отдельной строкой — объекты **с непустыми данными** (пустой профиль уровня терять не жалко, запись с содержимым стоит посмотреть глазами прежде, чем жать «удалить»; при таких включается чекбокс-барьер). Не разовый SQL: восстановление старой резервной копии способно привезти сирот снова.

## Проверка

8 новых тестов (`ScopeCascadeDeleteTests`), полный набор 1404/1404, `npx tsc -b` чист.

Живой прогон на реальных эндпоинтах (0.110.0, своя временная стройка, за собой убрано):

```
1. удаление «комплект» при ссылке извне -> HTTP 409
   Нельзя удалить комплект — на содержимое ссылаются извне: документ качества «…». Сначала снимите эти ссылки.
   то же для «раздел» и «стройка»
2. ссылку сняли -> удаление стройки HTTP 204; сирот было 2, стало 2   ← каскад унёс объекты
3. связанные документы внутри поддерева -> HTTP 204; сирот не прибавилось
```

Инструмент уборки на живой базе показывает `{sets: 1, constructions: 1, withData: 0, total: 2}` — ровно то, что нашёл SQL. Боевую уборку не запускал: это данные пользователя, решение за ним.

Версия 0.110.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3BQxpbn49pef7734yp62