### PR TITLE
Осиротевшие привязки наборов данных: отказ, аудит, перенос при rename (#737)

### DIFF
--- a/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
+++ b/src/client/src/features/document-sets/editor/InstanceAuditModal.tsx
@@ -17,7 +17,16 @@ const CATEGORY_LABEL: Record<string, string> = {
   'orphan-key': 'Поля, которых нет в текущей схеме',
   'type-mismatch': 'Несовпадение вида значения с типом поля',
   'value-type': 'Значение не соответствует объявленному типу', // issue #642
+  'orphan-binding': 'Привязки наборов данных на несуществующие поля', // issue #737
 };
+
+/**
+ * Находки, которые правятся НЕ здесь (issue #737). Осиротела не запись, а настройка: привязка живёт
+ * в «Наборах данных», и здешние исправления к ней неприменимы — «удалить» стёрло бы значение из
+ * реквизитов, оставив саму привязку на месте, то есть находка вернулась бы следующим же прогоном, а
+ * данные пропали. Показываем находку без кнопок и говорим, куда идти.
+ */
+const FIXED_ELSEWHERE = new Set(['orphan-binding', 'orphan-binding-template']);
 
 export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys, open, onClose }: {
   setId: string; instanceId: string; docName: string; schemaFieldKeys: string[]; open: boolean; onClose: () => void;
@@ -87,6 +96,12 @@ export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys
                             <span className="block text-xs text-fg4">{f.message}</span>
                           </span>
                         </div>
+                        {FIXED_ELSEWHERE.has(f.code) ? (
+                          <p className="pt-1.5 text-xs text-fg4">
+                            Правится на вкладке «Данные»: переключите привязку на поле текущей схемы
+                            или удалите её.
+                          </p>
+                        ) : (
                         <div className="flex flex-wrap items-center gap-2 pt-1.5">
                           {/* Для расхождения с типом приведение — исправление, а удаление — потеря
                               значения; поэтому оно первое и без подтверждения (issue #643). */}
@@ -116,6 +131,7 @@ export function InstanceAuditModal({ setId, instanceId, docName, schemaFieldKeys
                             </>
                           )}
                         </div>
+                        )}
                       </div>
                     );
                   })}

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -831,6 +831,12 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
             <ul className="text-xs font-mono text-fg3">
               {pendingMigration.map(r => <li key={r.from}>{r.from} → {r.to}</li>)}
             </ul>
+            {/* issue #737: ключ держат не только реквизиты — привязки наборов ссылаются на него
+                своим целевым полем и ключами маппинга. Переносим вместе, иначе привязка осиротеет
+                и перестанет заполнять поле молча. */}
+            <p className="text-xs text-fg4">
+              Вместе с данными переедут привязки наборов данных и шаблоны привязок, нацеленные на этот ключ.
+            </p>
             <p className="text-xs text-fg4">Без переноса старые значения останутся под прежним ключом (осиротеют) — их потом покажет «Аудит».</p>
           </div>
         )}
@@ -838,12 +844,21 @@ function SchemaEditor({ docType, allDocTypes, onSelectType }: {
         onConfirm={async () => {
           const renames = pendingMigration ?? [];
           setPendingMigration(null);
-          let total = 0;
+          let docs = 0, bindings = 0, templates = 0;
           for (const r of renames) {
-            try { total += (await migrateKey.mutateAsync({ oldKey: r.from, newKey: r.to })).migrated; }
+            try {
+              const res = await migrateKey.mutateAsync({ oldKey: r.from, newKey: r.to });
+              docs += res.migrated; bindings += res.bindings; templates += res.templates;
+            }
             catch { schemaToast.error(`Не удалось перенести «${r.from}»`); }
           }
-          schemaToast.success(`Перенесено документов: ${total}`);
+          // Привязки называем только когда они были: в обычном переименовании их нет, и нулевой
+          // счётчик в тосте — шум.
+          const extra = [
+            bindings > 0 ? `привязок: ${bindings}` : null,
+            templates > 0 ? `шаблонов: ${templates}` : null,
+          ].filter(Boolean).join(', ');
+          schemaToast.success(`Перенесено документов: ${docs}${extra ? `; ${extra}` : ''}`);
         }}
       />
     </div>

--- a/src/client/src/features/settings/TypeAuditModal.tsx
+++ b/src/client/src/features/settings/TypeAuditModal.tsx
@@ -18,7 +18,18 @@ const CATEGORY_LABEL: Record<string, string> = {
   // issue #642: тонкий слой — базовый тип, шаблон и границы примитива, разбор даты. Те же правила,
   // что и при выпуске документа, но здесь их видят и записи общих данных.
   'value-type': 'Значение не соответствует объявленному типу',
+  // issue #737: держатели ключа поля вне реквизитов — привязки наборов и шаблоны привязок.
+  'orphan-binding': 'Привязки наборов данных на несуществующие поля',
+  'orphan-binding-template': 'Шаблоны привязок на несуществующие поля',
 };
+
+/**
+ * Находки, которые правятся НЕ здесь (issue #737). Осиротела настройка, а не запись: исправления
+ * этого окна мутируют реквизиты инстанса и к привязке неприменимы. Для шаблона они и технически
+ * невозможны — у его находки на месте документа стоит сам тип, и «удалить» ушло бы в
+ * несуществующий объект.
+ */
+const FIXED_ELSEWHERE = new Set(['orphan-binding', 'orphan-binding-template']);
 
 interface Row { code: string; path: string; message: string; instances: { id: string; name: string }[] }
 
@@ -121,6 +132,12 @@ export function TypeAuditModal({ typeId, typeName, schemaFieldKeys, open, onClos
                               <ul className="space-y-0.5">
                                 {row.instances.map(i => <li key={i.id} className="text-xs text-fg3 truncate">{i.name}</li>)}
                               </ul>
+                              {FIXED_ELSEWHERE.has(row.code) ? (
+                                <p className="pt-1 text-xs text-fg4">
+                                  Правится в настройке привязок: переключите на поле текущей схемы
+                                  или удалите привязку.
+                                </p>
+                              ) : (
                               <div className="flex flex-wrap items-center gap-2 pt-1">
                                 {/* Приведение (issue #643) идёт ПЕРВЫМ и без подтверждения: для
                                     расхождения с типом это исправление, а удаление — потеря. */}
@@ -152,6 +169,7 @@ export function TypeAuditModal({ typeId, typeName, schemaFieldKeys, open, onClos
                                   </>
                                 )}
                               </div>
+                              )}
                             </div>
                           )}
                         </div>

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -141,7 +141,12 @@ export function useMigrateFieldKey(typeId: string | undefined) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['document-type-audit', typeId] });
       qc.invalidateQueries({ queryKey: ['document-sets'] });
-      qc.invalidateQueries({ queryKey: ['dataset-bindings'] });
+      // Ключи именно такие, как их заводят сами списки (datasets.ts / bindingTemplates.ts).
+      // Промахнись мы мимо — панель привязок осталась бы с дореформенным ключом, и сохранение
+      // из этой устаревшей формы вернуло бы старый ключ обратно, осиротив только что
+      // починенную привязку.
+      qc.invalidateQueries({ queryKey: ['datasets', 'bindings'] });
+      qc.invalidateQueries({ queryKey: ['binding-templates'] });
     },
   });
 }

--- a/src/client/src/shared/api/documentTypes.ts
+++ b/src/client/src/shared/api/documentTypes.ts
@@ -128,15 +128,20 @@ export function useApplyAuditFixes(typeId: string | undefined) {
   });
 }
 
-/** Миграция ключа поля в данных инстансов при переименовании ключа в схеме (issue #357). */
+/**
+ * Перенос ключа поля при переименовании его в схеме: данные инстансов (issue #357) и держатели
+ * ключа вне данных — привязки наборов и шаблоны привязок (issue #737).
+ */
 export function useMigrateFieldKey(typeId: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ oldKey, newKey }: { oldKey: string; newKey: string }) =>
-      apiClient.post<{ migrated: number }>(`/document-types/${typeId}/migrate-field-key`, { oldKey, newKey }).then(r => r.data),
+      apiClient.post<{ migrated: number; bindings: number; templates: number }>(
+        `/document-types/${typeId}/migrate-field-key`, { oldKey, newKey }).then(r => r.data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['document-type-audit', typeId] });
       qc.invalidateQueries({ queryKey: ['document-sets'] });
+      qc.invalidateQueries({ queryKey: ['dataset-bindings'] });
     },
   });
 }

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/DocumentTypeEndpoints.cs
@@ -91,8 +91,13 @@ public static class DocumentTypeEndpoints
             => Results.Ok(await m.Send(new ApplyAuditFixesCommand(req.Fixes))));
 
         // Миграция ключа поля в данных инстансов при переименовании ключа в схеме (issue #357).
-        admin.MapPost("/{id:guid}/migrate-field-key", async (Guid id, MigrateFieldKeyRequest req, IMediator m)
-            => Results.Ok(new { migrated = await m.Send(new MigrateFieldKeyCommand(id, req.OldKey, req.NewKey)) }));
+        admin.MapPost("/{id:guid}/migrate-field-key", async (Guid id, MigrateFieldKeyRequest req, IMediator m) =>
+        {
+            var r = await m.Send(new MigrateFieldKeyCommand(id, req.OldKey, req.NewKey));
+            // «migrated» — прежнее имя поля (число инстансов): клиент читает его с issue #357, и
+            // ломать ответ ради стройности незачем. Привязки и шаблоны добавлены рядом (issue #737).
+            return Results.Ok(new { migrated = r.Instances, bindings = r.Bindings, templates = r.Templates });
+        });
 
         // Использование типа (issue #275) — проактивный показ «чем занят тип» до попытки удаления.
         admin.MapGet("/{id:guid}/usage", async (Guid id, IMediator m) =>

--- a/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
+++ b/src/server/BHS.CRG.Application/DataSets/DataSetDtos.cs
@@ -58,6 +58,11 @@ public record DataSetBindingDto(
     Guid Id, Guid OwnerId, Guid SourceId, string? TargetFieldKey,
     Dictionary<string, string> Mapping, BindingSourceDto? Source);
 
+/// <summary>Сколько держателей ключа поля перенесено при переименовании (issue #737).</summary>
+/// <param name="Bindings">Привязок (целевое поле или ключ маппинга).</param>
+/// <param name="Templates">Шаблонов привязок типа.</param>
+public record BindingKeyMigrationResult(int Bindings, int Templates);
+
 /// <summary>Шаблон маппинга (для типа документа). Filter/Transformation/Sort — см. DataSetProcessingTemplateDto.</summary>
 public record DataSetBindingTemplateDto(
     Guid Id, Guid DocumentTypeId, string Name, string? TargetFieldKey,

--- a/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
+++ b/src/server/BHS.CRG.Application/DataSets/IDataSetService.cs
@@ -146,6 +146,29 @@ public interface IDataSetService
 
     // ── Bindings (владелец — единый DomainObject.OwnerId, issue #84) ─────────────────
     Task<IReadOnlyList<DataSetBindingDto>> ListBindingsAsync(Guid ownerId, CancellationToken ct);
+
+    /// <summary>
+    /// Привязки СРАЗУ МНОГИХ владельцев — для аудита типа (issue #737), который обходит все его
+    /// инстансы. Поштучный вызов дал бы запрос на объект: у типа с сотней документов это сотня
+    /// обращений ради проверки, которую база делает одним IN.
+    /// </summary>
+    Task<IReadOnlyList<DataSetBindingDto>> ListBindingsForOwnersAsync(
+        IReadOnlyCollection<Guid> ownerIds, CancellationToken ct);
+
+    /// <summary>
+    /// Переносит ключ поля <paramref name="oldKey"/> → <paramref name="newKey"/> у привязок
+    /// перечисленных владельцев и у шаблонов привязок перечисленных типов (issue #737).
+    ///
+    /// <para>Спутник миграции данных при переименовании поля (issue #357): та переносит значения в
+    /// реквизитах, а ключ живёт и здесь. Не перенеси — привязка осиротеет и перестанет заполнять
+    /// поле, причём молча: пользователь переименовал поле и увидел пустоту там, где были данные.</para>
+    ///
+    /// <para>Затрагивает и <c>TargetFieldKey</c>, и ключи маппинга (у скалярной привязки целевые
+    /// поля перечислены только в нём).</para>
+    /// </summary>
+    Task<BindingKeyMigrationResult> MigrateFieldKeyAsync(
+        IReadOnlyCollection<Guid> ownerIds, IReadOnlyCollection<Guid> documentTypeIds,
+        string oldKey, string newKey, CancellationToken ct);
     Task<DataSetBindingDto?> CreateBindingAsync(CreateBindingInput input, CancellationToken ct);
     Task<DataSetBindingDto?> UpdateBindingAsync(Guid id, UpdateBindingInput input, CancellationToken ct);
     Task<bool> DeleteBindingAsync(Guid id, CancellationToken ct);

--- a/src/server/BHS.CRG.Application/Documents/Commands.cs
+++ b/src/server/BHS.CRG.Application/Documents/Commands.cs
@@ -47,7 +47,16 @@ public record AuditInstanceQuery(Guid InstanceId) : IRequest<IReadOnlyList<Audit
 /// Миграция ключа поля в данных всех инстансов типа (и подтипов) при переименовании ключа в схеме
 /// (issue #357): переносит значение старый→новый ключ (только в пустую цель), атомарно. Возвращает
 /// число перенесённых инстансов. Композиция «rename в схеме × rename в данных» (переиспользует JsonPathEditor).
-public record MigrateFieldKeyCommand(Guid TypeId, string OldKey, string NewKey) : IRequest<int>;
+public record MigrateFieldKeyCommand(Guid TypeId, string OldKey, string NewKey) : IRequest<MigrateFieldKeyResult>;
+
+/// <summary>
+/// Что перенесено (issue #737). Держателей ключа поля три, и раньше отвечали числом только про
+/// первого — привязки молча оставались на старом ключе.
+/// </summary>
+/// <param name="Instances">Документов и записей, где значение переехало на новый ключ.</param>
+/// <param name="Bindings">Привязок наборов данных (целевое поле или ключ маппинга).</param>
+/// <param name="Templates">Шаблонов привязок типа.</param>
+public record MigrateFieldKeyResult(int Instances, int Bindings, int Templates);
 
 /// Применение исправлений аудита (issue #350). Мутирует реквизиты инстансов по JSON-пути, атомарно
 /// (одна SaveChanges). Батч = список фиксов; фронт разворачивает «применить ко всем» в per-instance.

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -67,10 +67,17 @@ public class DocumentTypeHandlers(
                 migrated++;
             }
         }
-        if (migrated > 0) await objectRepo.SaveChangesAsync(ct); // атомарно
+        // Реквизиты — одним сохранением: либо все инстансы переехали, либо ни один.
+        if (migrated > 0) await objectRepo.SaveChangesAsync(ct);
 
         // Держатели ключа вне реквизитов. Владельцы привязок — те же инстансы; шаблоны принадлежат
         // самому типу и его подтипам (ключ мог быть объявлен выше по цепочке).
+        //
+        // Второе сохранение, а не общая транзакция: обе половины идут через один контекст, но
+        // делить транзакцию между слоями значило бы протащить её в контракт службы наборов.
+        // Расхождение между половинами не тупик — операция ИДЕМПОТЕНТНА: повторный вызов не тронет
+        // уже переехавшие реквизиты (старого ключа в них больше нет) и доделает привязки. А самое
+        // вероятное исключение здесь — неразбираемый маппинг — обезврежено в RenameMappingKey.
         var holders = await dataSetService.MigrateFieldKeyAsync(
             instances.Select(i => i.Id).ToList(), typeIds, cmd.OldKey, cmd.NewKey, ct);
 
@@ -211,10 +218,15 @@ public class DocumentTypeHandlers(
 
         // Шаблоны привязок принадлежат ТИПУ, а не документу: их находки не привязаны к инстансу, и
         // место документа в строке занимает сам тип — иначе непонятно, где искать настройку.
-        foreach (var iss in Schema.BindingKeyAuditor.AuditTemplates(
-                     await dataSetService.ListTemplatesAsync(q.TypeId, ct), q.TypeId, byId))
-            findings.Add(new(q.TypeId, $"Шаблоны привязок типа «{type.Name}»",
-                iss.Code, iss.Severity.ToString(), iss.Path, iss.Message));
+        //
+        // Обходим ВЕСЬ поддерево (typeIds), как и инстансы: шаблон на подтипе проверяется против
+        // схемы своего типа. Спроси мы только корень — аудит родителя показывал бы «чисто» на
+        // поддереве, где чисто не было.
+        foreach (var tid in typeIds)
+            foreach (var iss in Schema.BindingKeyAuditor.AuditTemplates(
+                         await dataSetService.ListTemplatesAsync(tid, ct), tid, byId))
+                findings.Add(new(tid, $"Шаблоны привязок типа «{byId[tid].Name}»",
+                    iss.Code, iss.Severity.ToString(), iss.Path, iss.Message));
 
         return new(q.TypeId, type.Name, instances.Count, findings);
     }

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -32,13 +32,23 @@ public class DocumentTypeHandlers(
     IRequestHandler<GetDocumentTypeUsageQuery, DocumentTypeUsage>,
     IRequestHandler<AuditDocumentTypeQuery, DocumentTypeAuditReport>,
     IRequestHandler<AuditInstanceQuery, IReadOnlyList<AuditFinding>>,
-    IRequestHandler<MigrateFieldKeyCommand, int>,
+    IRequestHandler<MigrateFieldKeyCommand, MigrateFieldKeyResult>,
     IRequestHandler<ApplyAuditFixesCommand, ApplyAuditFixesResult>
 {
-    public async Task<int> Handle(MigrateFieldKeyCommand cmd, CancellationToken ct)
+    /// <summary>
+    /// Перенос ключа поля при переименовании его в схеме (issue #357) — и в данных, и у держателей
+    /// ключа вне данных (issue #737).
+    ///
+    /// <para>Держателей три: реквизиты инстансов, привязки наборов данных (целевое поле и ключи
+    /// маппинга) и шаблоны привязок типа. Перенеси мы только данные — привязка осталась бы на
+    /// старом ключе и перестала заполнять поле, причём молча: человек переименовал поле и увидел
+    /// пустоту там, где были данные. Ровно так и разъехался живой реестр исполнительной
+    /// документации, с которого началась issue.</para>
+    /// </summary>
+    public async Task<MigrateFieldKeyResult> Handle(MigrateFieldKeyCommand cmd, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(cmd.OldKey) || string.IsNullOrWhiteSpace(cmd.NewKey) || cmd.OldKey == cmd.NewKey)
-            return 0;
+            return new MigrateFieldKeyResult(0, 0, 0);
         var all = await repo.GetAllAsync(ct);
         var byId = all.ToDictionary(t => t.Id);
         var typeIds = all.Where(t => Schema.DocumentTypeSchemaReader.IsSameOrDescendant(t.Id, cmd.TypeId, byId))
@@ -58,7 +68,13 @@ public class DocumentTypeHandlers(
             }
         }
         if (migrated > 0) await objectRepo.SaveChangesAsync(ct); // атомарно
-        return migrated;
+
+        // Держатели ключа вне реквизитов. Владельцы привязок — те же инстансы; шаблоны принадлежат
+        // самому типу и его подтипам (ключ мог быть объявлен выше по цепочке).
+        var holders = await dataSetService.MigrateFieldKeyAsync(
+            instances.Select(i => i.Id).ToList(), typeIds, cmd.OldKey, cmd.NewKey, ct);
+
+        return new MigrateFieldKeyResult(migrated, holders.Bindings, holders.Templates);
     }
 
     public async Task<IReadOnlyList<AuditFinding>> Handle(AuditInstanceQuery q, CancellationToken ct)
@@ -67,7 +83,15 @@ public class DocumentTypeHandlers(
             ?? throw new NotFoundException($"Instance {q.InstanceId} not found");
         var byId = (await repo.GetAllAsync(ct)).ToDictionary(t => t.Id);
         var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
-        return Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId, primitives)
+
+        // Ключ поля держат не только реквизиты (issue #737): привязки наборов данных ссылаются на
+        // него своим TargetFieldKey и ключами маппинга. Осиротевший ключ ТАМ аудит данных не видит —
+        // он сверяет Data, а разошлась настройка, и живой случай выглядел как «данные из ниоткуда».
+        var bindings = await dataSetService.ListBindingsAsync(inst.Id, ct);
+        var issues = Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId, primitives)
+            .Concat(Schema.BindingKeyAuditor.AuditBindings(bindings, inst.CompositeTypeId, byId));
+
+        return issues
             .Select(iss => new AuditFinding(inst.Id, inst.DisplayName, iss.Code, iss.Severity.ToString(), iss.Path, iss.Message))
             .ToList();
     }
@@ -168,10 +192,29 @@ public class DocumentTypeHandlers(
         // проверки выпуска (см. SchemaCatalog, issue #628).
         var primitives = (await primitiveRepo.GetAllAsync(ct)).ToDictionary(t => t.Id);
 
+        // Привязки всех инстансов — ОДНИМ запросом (issue #737): поштучно это было бы обращение на
+        // документ, а у типа их бывает сотня.
+        var bindingsByOwner = (await dataSetService.ListBindingsForOwnersAsync(
+                instances.Select(i => i.Id).ToList(), ct))
+            .GroupBy(b => b.OwnerId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<DataSets.DataSetBindingDto>)g.ToList());
+
         var findings = new List<AuditFinding>();
         foreach (var inst in instances)
-            foreach (var iss in Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId, primitives))
+        {
+            var issues = Schema.SchemaDataAuditor.Audit(inst.Data.RootElement, inst.CompositeTypeId, byId, primitives)
+                .Concat(Schema.BindingKeyAuditor.AuditBindings(
+                    bindingsByOwner.GetValueOrDefault(inst.Id, []), inst.CompositeTypeId, byId));
+            foreach (var iss in issues)
                 findings.Add(new(inst.Id, inst.DisplayName, iss.Code, iss.Severity.ToString(), iss.Path, iss.Message));
+        }
+
+        // Шаблоны привязок принадлежат ТИПУ, а не документу: их находки не привязаны к инстансу, и
+        // место документа в строке занимает сам тип — иначе непонятно, где искать настройку.
+        foreach (var iss in Schema.BindingKeyAuditor.AuditTemplates(
+                     await dataSetService.ListTemplatesAsync(q.TypeId, ct), q.TypeId, byId))
+            findings.Add(new(q.TypeId, $"Шаблоны привязок типа «{type.Name}»",
+                iss.Code, iss.Severity.ToString(), iss.Path, iss.Message));
 
         return new(q.TypeId, type.Name, instances.Count, findings);
     }

--- a/src/server/BHS.CRG.Application/Schema/BindingKeyAuditor.cs
+++ b/src/server/BHS.CRG.Application/Schema/BindingKeyAuditor.cs
@@ -1,0 +1,97 @@
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Schema;
+
+/// <summary>
+/// Аудит ДЕРЖАТЕЛЕЙ КЛЮЧЕЙ ПОЛЕЙ, живущих вне реквизитов (issue #737).
+///
+/// <para><see cref="SchemaDataAuditor"/> сверяет со схемой сами данные объекта. Но ключ поля
+/// хранится не только там: на него ссылаются привязки наборов данных (<c>TargetFieldKey</c> и ключи
+/// маппинга) и шаблоны привязок типа. Переименуй поле — и эти ссылки осиротеют, оставаясь
+/// невидимыми: аудит смотрел в данные, а разошлась настройка.</para>
+///
+/// <para>Живой случай, ради которого это заведено: в реестре исполнительной документации поле
+/// переименовали «ОсновнойДокументы» → «ОсновныеДокументы», человек завёл привязку заново, старая
+/// осталась — и продолжала наливать устаревшие данные в мёртвый ключ. В <c>data.json</c> они
+/// попадали, аудит инстанса молчал.</para>
+///
+/// <para>Чистая функция: на вход — уже прочитанные привязки и справочник типов, на выход — находки
+/// того же вида, что у аудитора данных. Отдельным классом, а не веткой внутри
+/// <see cref="SchemaDataAuditor"/>, потому что тот сознательно ничего не знает о наборах данных —
+/// он работает над одним JSON-документом.</para>
+/// </summary>
+public static class BindingKeyAuditor
+{
+    /// <summary>Привязка указывает на поле, которого нет в эффективной схеме владельца.</summary>
+    public const string OrphanBinding = "orphan-binding";
+
+    /// <summary>То же для шаблона привязок типа документа.</summary>
+    public const string OrphanBindingTemplate = "orphan-binding-template";
+
+    /// <summary>
+    /// Находки по привязкам одного владельца против эффективной схемы его типа.
+    ///
+    /// <para>Скалярная привязка (<c>TargetFieldKey == null</c>) — легальный режим: целевых полей у
+    /// неё несколько, и перечисляет их маппинг. Поэтому проверяются либо один целевой ключ, либо
+    /// ключи маппинга, но не «пустой ключ» как таковой — пустой ключ здесь не поломка.</para>
+    /// </summary>
+    public static IReadOnlyList<AuditIssue> AuditBindings(
+        IEnumerable<DataSetBindingDto> bindings, Guid typeId,
+        IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        var known = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).Select(f => f.Key).ToHashSet();
+        var issues = new List<AuditIssue>();
+
+        foreach (var b in bindings)
+        {
+            var source = b.Source?.Name ?? "без имени";
+            if (b.TargetFieldKey is { } key)
+            {
+                if (!known.Contains(key))
+                    issues.Add(new(OrphanBinding, AuditSeverity.Warning, key,
+                        $"Привязка источника «{source}» указывает на поле «{key}», которого нет в схеме типа — "
+                        + "данные в документ не попадают."));
+                continue;
+            }
+
+            // Скалярная: целевые поля перечислены в маппинге.
+            foreach (var mapKey in b.Mapping.Keys.Where(k => !known.Contains(k)))
+                issues.Add(new(OrphanBinding, AuditSeverity.Warning, mapKey,
+                    $"Маппинг привязки источника «{source}» указывает на поле «{mapKey}», которого нет в схеме типа — "
+                    + "значение не записывается."));
+        }
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Находки по шаблонам привязок типа. Шаблон не заполняет документ сам — он заготовка, по
+    /// которой привязку создают. Поэтому осиротевший ключ здесь не портит данные сегодня, но
+    /// гарантирует, что следующая созданная по нему привязка окажется мёртвой с рождения.
+    /// </summary>
+    public static IReadOnlyList<AuditIssue> AuditTemplates(
+        IEnumerable<DataSetBindingTemplateDto> templates, Guid typeId,
+        IReadOnlyDictionary<Guid, DocumentType> byId)
+    {
+        var known = DocumentTypeSchemaReader.EffectiveFields(typeId, byId).Select(f => f.Key).ToHashSet();
+        var issues = new List<AuditIssue>();
+
+        foreach (var t in templates)
+        {
+            if (t.TargetFieldKey is { } key)
+            {
+                if (!known.Contains(key))
+                    issues.Add(new(OrphanBindingTemplate, AuditSeverity.Warning, key,
+                        $"Шаблон привязки «{t.Name}» нацелен на поле «{key}», которого нет в схеме типа."));
+                continue;
+            }
+
+            foreach (var mapKey in t.ColumnMappings.Keys.Where(k => !known.Contains(k)))
+                issues.Add(new(OrphanBindingTemplate, AuditSeverity.Warning, mapKey,
+                    $"Шаблон привязки «{t.Name}» ссылается на поле «{mapKey}», которого нет в схеме типа."));
+        }
+
+        return issues;
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -28,6 +28,76 @@ public class DataSetBindingService(
         return bindings.Select(DataSetDtoMapper.MapBinding).ToList();
     }
 
+    /// <inheritdoc cref="Application.DataSets.IDataSetService.ListBindingsForOwnersAsync" />
+    public async Task<IReadOnlyList<DataSetBindingDto>> ListBindingsForOwnersAsync(
+        IReadOnlyCollection<Guid> ownerIds, CancellationToken ct)
+    {
+        if (ownerIds.Count == 0) return [];
+        var bindings = await db.DataSetBindings
+            .Include(b => b.Source).ThenInclude(s => s.File)
+            .Where(b => ownerIds.Contains(b.OwnerId))
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return bindings.Select(DataSetDtoMapper.MapBinding).ToList();
+    }
+
+    /// <inheritdoc cref="Application.DataSets.IDataSetService.MigrateFieldKeyAsync" />
+    public async Task<BindingKeyMigrationResult> MigrateFieldKeyAsync(
+        IReadOnlyCollection<Guid> ownerIds, IReadOnlyCollection<Guid> documentTypeIds,
+        string oldKey, string newKey, CancellationToken ct)
+    {
+        var bindings = ownerIds.Count == 0
+            ? []
+            : await db.DataSetBindings.Where(b => ownerIds.Contains(b.OwnerId)).ToListAsync(ct);
+
+        var touchedBindings = 0;
+        foreach (var b in bindings)
+        {
+            var key = b.TargetFieldKey == oldKey ? newKey : b.TargetFieldKey;
+            var mapping = RenameMappingKey(b.Mapping, oldKey, newKey, out var mappingChanged);
+            if (key == b.TargetFieldKey && !mappingChanged) continue;
+            b.Update(key, mapping);
+            touchedBindings++;
+        }
+
+        var templates = documentTypeIds.Count == 0
+            ? []
+            : await db.DataSetBindingTemplates.Where(t => documentTypeIds.Contains(t.DocumentTypeId)).ToListAsync(ct);
+
+        var touchedTemplates = 0;
+        foreach (var t in templates)
+        {
+            var key = t.TargetFieldKey == oldKey ? newKey : t.TargetFieldKey;
+            var mappings = RenameMappingKey(t.ColumnMappings, oldKey, newKey, out var mappingChanged);
+            if (key == t.TargetFieldKey && !mappingChanged) continue;
+            t.Update(t.Name, key, mappings, t.SortOrder);
+            touchedTemplates++;
+        }
+
+        if (touchedBindings + touchedTemplates > 0) await db.SaveChangesAsync(ct);
+        return new BindingKeyMigrationResult(touchedBindings, touchedTemplates);
+    }
+
+    /// <summary>
+    /// Переименование КЛЮЧА в JSON-маппинге «поле → колонка». Значение (имя колонки в файле) не
+    /// трогаем: переименовали поле схемы, а не заголовок в источнике.
+    ///
+    /// <para>В занятую цель не пишем — то же правило, что у миграции данных
+    /// (<c>JsonPathEditor.Rename</c>): если новый ключ в маппинге уже есть, значит привязку успели
+    /// перенастроить вручную, и её настройка авторитетнее нашей догадки.</para>
+    /// </summary>
+    private static string RenameMappingKey(string mappingJson, string oldKey, string newKey, out bool changed)
+    {
+        changed = false;
+        var map = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson) ?? [];
+        if (!map.TryGetValue(oldKey, out var value) || map.ContainsKey(newKey)) return mappingJson;
+
+        map.Remove(oldKey);
+        map[newKey] = value;
+        changed = true;
+        return JsonSerializer.Serialize(map);
+    }
+
     public async Task<DataSetBindingDto?> CreateBindingAsync(CreateBindingInput input, CancellationToken ct)
     {
         var source = await db.DataSetSources.Include(s => s.File)

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetBindingService.cs
@@ -54,7 +54,19 @@ public class DataSetBindingService(
         foreach (var b in bindings)
         {
             var key = b.TargetFieldKey == oldKey ? newKey : b.TargetFieldKey;
-            var mapping = RenameMappingKey(b.Mapping, oldKey, newKey, out var mappingChanged);
+
+            // Ключи маппинга трогаем ТОЛЬКО у скалярной привязки. У табличной они принадлежат типу
+            // СТРОКИ, а не владельцу (резолвер ищет их в rowFields, редактор предлагает поля типа
+            // элемента), и переименование поля документа к ним отношения не имеет. Одноимённое поле
+            // в типе строки — не редкость («Номер» и там, и там), и слепой перенос сломал бы
+            // работающий маппинг, оставив в строке ключ, которого в её типе нет. Ту же границу
+            // соблюдает BindingKeyAuditor — иначе аудит и перенос разошлись бы в понимании того,
+            // чьё это поле.
+            var mapping = b.Mapping;
+            var mappingChanged = false;
+            if (b.TargetFieldKey is null)
+                mapping = RenameMappingKey(b.Mapping, oldKey, newKey, out mappingChanged);
+
             if (key == b.TargetFieldKey && !mappingChanged) continue;
             b.Update(key, mapping);
             touchedBindings++;
@@ -68,7 +80,13 @@ public class DataSetBindingService(
         foreach (var t in templates)
         {
             var key = t.TargetFieldKey == oldKey ? newKey : t.TargetFieldKey;
-            var mappings = RenameMappingKey(t.ColumnMappings, oldKey, newKey, out var mappingChanged);
+            // Та же граница, что и у привязки: у табличного шаблона ключи ColumnMappings — поля
+            // типа строки.
+            var mappings = t.ColumnMappings;
+            var mappingChanged = false;
+            if (t.TargetFieldKey is null)
+                mappings = RenameMappingKey(t.ColumnMappings, oldKey, newKey, out mappingChanged);
+
             if (key == t.TargetFieldKey && !mappingChanged) continue;
             t.Update(t.Name, key, mappings, t.SortOrder);
             touchedTemplates++;
@@ -89,7 +107,19 @@ public class DataSetBindingService(
     private static string RenameMappingKey(string mappingJson, string oldKey, string newKey, out bool changed)
     {
         changed = false;
-        var map = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson) ?? [];
+        Dictionary<string, string>? map;
+        try
+        {
+            map = JsonSerializer.Deserialize<Dictionary<string, string>>(mappingJson);
+        }
+        catch (JsonException)
+        {
+            // Неразбираемый маппинг оставляем как есть. Уронить здесь значило бы оборвать перенос
+            // на полпути: реквизиты уже переехали на новый ключ, а привязки остались на старом —
+            // ровно то расхождение, ради устранения которого перенос и написан.
+            return mappingJson;
+        }
+        if (map is null) return mappingJson;
         if (!map.TryGetValue(oldKey, out var value) || map.ContainsKey(newKey)) return mappingJson;
 
         map.Remove(oldKey);

--- a/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
+++ b/src/server/BHS.CRG.Infrastructure/DataSets/DataSetService.cs
@@ -122,6 +122,15 @@ public class DataSetService(
     // ── Bindings ──────────────────────────────────────────────────────────────
     public Task<IReadOnlyList<DataSetBindingDto>> ListBindingsAsync(Guid ownerId, CancellationToken ct) =>
         bindings.ListBindingsAsync(ownerId, ct);
+
+    public Task<IReadOnlyList<DataSetBindingDto>> ListBindingsForOwnersAsync(
+        IReadOnlyCollection<Guid> ownerIds, CancellationToken ct) =>
+        bindings.ListBindingsForOwnersAsync(ownerIds, ct);
+
+    public Task<BindingKeyMigrationResult> MigrateFieldKeyAsync(
+        IReadOnlyCollection<Guid> ownerIds, IReadOnlyCollection<Guid> documentTypeIds,
+        string oldKey, string newKey, CancellationToken ct) =>
+        bindings.MigrateFieldKeyAsync(ownerIds, documentTypeIds, oldKey, newKey, ct);
     public Task<DataSetBindingDto?> CreateBindingAsync(CreateBindingInput input, CancellationToken ct) =>
         bindings.CreateBindingAsync(input, ct);
     public Task<DataSetBindingDto?> UpdateBindingAsync(Guid id, UpdateBindingInput input, CancellationToken ct) =>

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -93,6 +93,29 @@ public class DataSetResolver(
         {
             try
             {
+                // Целевое поле привязки исчезло из схемы (issue #737). Отказываем ДО загрузки набора:
+                // качать файл ради записи в мёртвый ключ незачем.
+                //
+                // Молча писать «не туда» хуже честного отказа. Живой случай: поле переименовали
+                // «ОсновнойДокументы» → «ОсновныеДокументы», человек завёл привязку заново, а старая
+                // осталась — и продолжала наливать устаревшие данные в ключ, которого в схеме нет.
+                // В data.json они попадали, шаблон их не ждал, аудит инстанса о них не знал (он
+                // сверяет реквизиты, а тут разошлась привязка), и найти это можно было только
+                // глазами в отладочном ZIP.
+                //
+                // Ключи вне схемы в контексте легальны у вычисляемых полей и служебных «_», но у
+                // привязки легального случая нет: интерфейс заводит её только по полю схемы.
+                if (binding.TargetFieldKey is { } targetKey
+                    && DocumentTypeSchemaReader.Field(typeId, targetKey, await TypesAsync()) is null)
+                {
+                    diagnostics?.Add(new ResolutionDiagnostic(
+                        DiagnosticSeverity.Error, targetKey,
+                        $"Привязка источника «{binding.Source.Name}» указывает на несуществующее поле " +
+                        $"«{targetKey}» — поле не заполнено, данные в документ не попадают. " +
+                        "Удалите привязку или переключите её на поле текущей схемы."));
+                    continue;
+                }
+
                 // Download → parse → transformation → filter → sort (shared with preview via DataSetRowLoader).
                 var rows = await rowLoader.LoadRowsAsync(binding.Source, ct);
 
@@ -170,6 +193,18 @@ public class DataSetResolver(
                         foreach (var (fieldKey, mapVal) in scalarPairs)
                         {
                             var field = ownFields.GetValueOrDefault(fieldKey);
+                            // Та же проверка, что у табличной привязки (issue #737), только ключей здесь
+                            // несколько: в скалярном режиме целевые поля перечисляет маппинг. Переживи
+                            // маппинг переименование поля — часть ключей осиротеет поодиночке, и без
+                            // отказа документ получил бы половину значений молча, а не «пусто целиком».
+                            if (field is null)
+                            {
+                                diagnostics?.Add(new ResolutionDiagnostic(
+                                    DiagnosticSeverity.Error, fieldKey,
+                                    $"Маппинг привязки источника «{binding.Source.Name}» указывает на " +
+                                    $"несуществующее поле «{fieldKey}» — значение не записано."));
+                                continue;
+                            }
                             var value = await ApplyMappedAsync(mapVal, row, ownerId, scopeLevel, scopeId, diagnostics, fieldKey, ct);
                             value = DataSetValueCoercion.Coerce(value, field, primitives, await TypesAsync());
                             WarnUnbuiltDocRef(field, value, mapVal, fieldKey);

--- a/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
+++ b/src/server/BHS.CRG.Infrastructure/Generation/DataSetResolver.cs
@@ -105,11 +105,18 @@ public class DataSetResolver(
                 //
                 // Ключи вне схемы в контексте легальны у вычисляемых полей и служебных «_», но у
                 // привязки легального случая нет: интерфейс заводит её только по полю схемы.
+                //
+                // Предупреждение, а не ошибка, и это осознанно: Error обрывает выпуск документа
+                // целиком (GenerateDocumentHandler бросает ResolutionValidationException на любой),
+                // и живой комплект с одной устаревшей привязкой перестал бы и генерироваться, и
+                // показываться в предпросмотре. Данные при этом всё равно не пишутся — цель
+                // достигнута, — а несобираемый документ был бы лечением тяжелее болезни. Тот же
+                // довод, что у соседнего WarnUnbuiltDocRef.
                 if (binding.TargetFieldKey is { } targetKey
                     && DocumentTypeSchemaReader.Field(typeId, targetKey, await TypesAsync()) is null)
                 {
                     diagnostics?.Add(new ResolutionDiagnostic(
-                        DiagnosticSeverity.Error, targetKey,
+                        DiagnosticSeverity.Warning, targetKey,
                         $"Привязка источника «{binding.Source.Name}» указывает на несуществующее поле " +
                         $"«{targetKey}» — поле не заполнено, данные в документ не попадают. " +
                         "Удалите привязку или переключите её на поле текущей схемы."));
@@ -199,8 +206,11 @@ public class DataSetResolver(
                             // отказа документ получил бы половину значений молча, а не «пусто целиком».
                             if (field is null)
                             {
+                                // Предупреждение по той же причине, что и у табличной привязки выше:
+                                // Error здесь снял бы с выпуска весь документ, причём из-за одного
+                                // ключа маппинга — остальные поля этой же привязки заполняются.
                                 diagnostics?.Add(new ResolutionDiagnostic(
-                                    DiagnosticSeverity.Error, fieldKey,
+                                    DiagnosticSeverity.Warning, fieldKey,
                                     $"Маппинг привязки источника «{binding.Source.Name}» указывает на " +
                                     $"несуществующее поле «{fieldKey}» — значение не записано."));
                                 continue;

--- a/src/server/BHS.CRG.Tests/Integration/DataSetDocRefMappingTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetDocRefMappingTests.cs
@@ -82,8 +82,9 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
 
         var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Document, null, J("{'fields':[{'key':'Номер','type':'string'}]}")));
+        // «Строки» объявлены в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Строки','type':'array'}]}")));
         var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Composite, null,
             J($"{{'fields':[{{'key':'Документ','type':'doc-ref','typeId':'{aosrType.Id}'}}]}}")));
@@ -119,8 +120,9 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
 
         var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Document, null, J("{'fields':[{'key':'Номер','type':'string'}]}")));
+        // «Строки» объявлены в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Строки','type':'array'}]}")));
         var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Composite, null,
             J($"{{'fields':[{{'key':'Документ','type':'doc-ref','typeId':'{aosrType.Id}'}}]}}")));
@@ -163,8 +165,9 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
         using var scope = fixture.Services.CreateScope();
         var m = M(scope);
 
+        // «Строки» объявлены в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Строки','type':'array'}]}")));
         var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Composite, null, J("{'fields':[{'key':'Поле','type':'string'}]}")));
         var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
@@ -228,8 +231,9 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
         using var scope = fixture.Services.CreateScope();
         var m = M(scope);
 
+        // «Строки» объявлены в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Строки','type':'array'}]}")));
         var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Composite, null, J("{'fields':[{'key':'Поле','type':'string'}]}")));
         var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
@@ -262,8 +266,9 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
 
         var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Document, null, J("{'fields':[{'key':'Номер','type':'string'}]}")));
+        // «Строки» объявлены в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Строки','type':'array'}]}")));
         var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Composite, null,
             J($"{{'fields':[{{'key':'Документ','type':'doc-ref','typeId':'{aosrType.Id}'}}]}}")));
@@ -298,8 +303,9 @@ public class DataSetDocRefMappingTests(IntegrationTestFixture fixture) : IAsyncL
         using var scope = fixture.Services.CreateScope();
         var m = M(scope);
 
+        // «Строки» объявлены в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null, J("{'fields':[{'key':'Строки','type':'array'}]}")));
         var rowType = await m.Send(new CreateDocumentTypeCommand("СтрокаРеестра", $"ROW{Guid.NewGuid():N}"[..12],
             DocumentTypeKind.Composite, null, J("{'fields':[{'key':'Поле','type':'string'}]}")));
         var aosrType = await m.Send(new CreateDocumentTypeCommand("АОСР", $"AOSR{Guid.NewGuid():N}"[..12],

--- a/src/server/BHS.CRG.Tests/Integration/DataSetResolverDefaultsTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetResolverDefaultsTests.cs
@@ -39,7 +39,10 @@ public class DataSetResolverDefaultsTests(IntegrationTestFixture fixture) : IAsy
         var rowType = await m.Send(new CreateDocumentTypeCommand("ROW", "ROW", DocumentTypeKind.Composite, null,
             J("{'fields':[{'key':'Поле','type':'string','required':false},{'key':'ВидДокумента','type':'string','required':false,'defaultValue':'исполнительная схема'}]}")));
 
-        var docType = await m.Send(new CreateDocumentTypeCommand("REESTR", "REESTR", DocumentTypeKind.Document, null, J("{'fields':[]}")));
+        // Целевое поле привязки ОБЪЯВЛЕНО в схеме владельца (issue #737): резолвер больше не пишет в
+        // ключ, которого в схеме нет, а интерфейс и не даёт завести такую привязку.
+        var docType = await m.Send(new CreateDocumentTypeCommand("REESTR", "REESTR", DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Строки','type':'array','typeId':'{rowType.Id}'}}]}}")));
 
         var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
         var section = await m.Send(new CreateSectionCommand(construction.Id, "Раздел"));
@@ -87,7 +90,8 @@ public class DataSetResolverDefaultsTests(IntegrationTestFixture fixture) : IAsy
         // «ВидДокумента» ИМЕЕТ и defaultValue, И явный маппинг (на колонку B) — маппинг должен победить.
         var rowType = await m.Send(new CreateDocumentTypeCommand("ROW2", "ROW2", DocumentTypeKind.Composite, null,
             J("{'fields':[{'key':'ВидДокумента','type':'string','required':false,'defaultValue':'дефолт'}]}")));
-        var docType = await m.Send(new CreateDocumentTypeCommand("REESTR2", "REESTR2", DocumentTypeKind.Document, null, J("{'fields':[]}")));
+        var docType = await m.Send(new CreateDocumentTypeCommand("REESTR2", "REESTR2", DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Строки','type':'array','typeId':'{rowType.Id}'}}]}}")));
 
         var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
         var section = await m.Send(new CreateSectionCommand(construction.Id, "Раздел"));

--- a/src/server/BHS.CRG.Tests/Integration/DataSetUnionDiscriminatorTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DataSetUnionDiscriminatorTests.cs
@@ -52,8 +52,10 @@ public class DataSetUnionDiscriminatorTests(IntegrationTestFixture fixture) : IA
             J($"{{'tags':['type.union'],'fields':[" +
               $"{{'key':'АОСР','type':'doc-ref','typeId':'{aosrType.Id}'}}," +
               $"{{'key':'РеестрРабот','type':'doc-ref','typeId':'{workRegistryType.Id}'}}]}}")));
+        // «Состав» объявлен в схеме владельца: резолвер не пишет в ключ вне схемы (issue #737).
         var reestrType = await m.Send(new CreateDocumentTypeCommand("Сводный реестр", $"SUM{Guid.NewGuid():N}"[..12],
-            DocumentTypeKind.Document, null, J("{'fields':[]}")));
+            DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Состав','type':'array','typeId':'{unionType.Id}'}}]}}")));
 
         var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
         var section = await m.Send(new CreateSectionCommand(construction.Id, "Раздел"));

--- a/src/server/BHS.CRG.Tests/Integration/EntityResolverQualityCascadeTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/EntityResolverQualityCascadeTests.cs
@@ -470,7 +470,12 @@ public class EntityResolverQualityCascadeTests(IntegrationTestFixture fixture) :
             DocumentTypeKind.Composite, null,
             J($"{{'fields':[{{'key':'Документ','type':'doc-ref','typeId':'{seed.CertTypeId}'}}]}}")));
 
-        var owner = await m.Send(new AddDocumentToSetCommand(seed.SetId, seed.DocTypeId));
+        // Свой тип владельца с объявленным полем «Качество»: резолвер не пишет в ключ вне схемы
+        // (issue #737), а общий тип «Акт» из Seed полей не имеет — он нужен другим тестам пустым.
+        var ownerType = await m.Send(new CreateDocumentTypeCommand("АктСКачеством", $"AQ{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Качество','type':'array','typeId':'{rowType.Id}'}}]}}")));
+        var owner = await m.Send(new AddDocumentToSetCommand(seed.SetId, ownerType.Id));
 
         var file = await svc.UploadFileAsync(new UploadFileInput(
             Encoding.UTF8.GetBytes($"Ид\n{quality.Id}\n"), "quality.csv", "text/csv", "Тест", "System", null), default);

--- a/src/server/BHS.CRG.Tests/Integration/OrphanBindingKeyTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/OrphanBindingKeyTests.cs
@@ -77,8 +77,14 @@ public class OrphanBindingKeyTests(IntegrationTestFixture fixture) : IAsyncLifet
 
     // ── 1. Резолвер: честный отказ вместо молчаливой записи ──────────────────────
 
+    /// <summary>
+    /// Отказ — ПРЕДУПРЕЖДЕНИЕ, а не ошибка: Error обрывает выпуск документа целиком
+    /// (<c>GenerateDocumentHandler</c> бросает <c>ResolutionValidationException</c> на любой), и
+    /// живой комплект с одной устаревшей привязкой перестал бы и генерироваться, и показываться в
+    /// предпросмотре. Данные при этом всё равно не пишутся — цель достигнута.
+    /// </summary>
     [Fact]
-    public async Task Resolver_OrphanTargetKey_ReportsError_AndWritesNothing()
+    public async Task Resolver_OrphanTargetKey_Warns_AndWritesNothing()
     {
         using var scope = fixture.Services.CreateScope();
         var seed = await SeedAsync(scope);
@@ -92,8 +98,11 @@ public class OrphanBindingKeyTests(IntegrationTestFixture fixture) : IAsyncLifet
         // Ключа в контексте нет: молча-не-туда хуже честного отказа — иначе данные уезжают в
         // data.json под мёртвым ключом и выглядят как «взялись из ниоткуда».
         Assert.False(ctx.Data.ContainsKey("ОсновнойДокументы"));
-        var issue = Assert.Single(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        var issue = Assert.Single(diagnostics, d => d.Path == "ОсновнойДокументы");
+        Assert.Equal(DiagnosticSeverity.Warning, issue.Severity);
         Assert.Contains("ОсновнойДокументы", issue.Message);
+        // Ни одной ошибки: документ обязан остаться выпускаемым.
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
     }
 
     [Fact]
@@ -206,6 +215,48 @@ public class OrphanBindingKeyTests(IntegrationTestFixture fixture) : IAsyncLifet
         var template = Assert.Single(await Svc(scope).ListTemplatesAsync(seed.TypeId, default));
         Assert.True(template.ColumnMappings.ContainsKey("ОсновныеДокументы"));
         Assert.False(template.ColumnMappings.ContainsKey("ОсновнойДокументы"));
+    }
+
+    /// <summary>
+    /// Ключи маппинга ТАБЛИЧНОЙ привязки принадлежат типу СТРОКИ, а не владельцу, и переименование
+    /// поля документа их касаться не должно. Случай не выдуманный: одноимённое поле в обоих типах
+    /// («Номер» и у реестра, и у его строки) — обычное дело, и слепой перенос оставил бы в строке
+    /// ключ, которого в её типе нет, тихо перестав заполнять колонку.
+    /// </summary>
+    [Fact]
+    public async Task MigrateFieldKey_DoesNotTouchMappingKeysOfTableBinding()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var svc = Svc(scope);
+
+        // «Наименование» есть И у строки, И у документа — переименовываем документное.
+        var rowType = await m.Send(new CreateDocumentTypeCommand("Строка", $"ROW{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Composite, null, J("{'fields':[{'key':'Наименование','type':'string'}]}")));
+        var docType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'Наименование','type':'string'}},"
+              + $"{{'key':'Строки','type':'array','typeId':'{rowType.Id}'}}]}}")));
+
+        var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "Комплект"));
+        var instance = await m.Send(new AddDocumentToSetCommand(set.Id, docType.Id));
+
+        var file = await svc.UploadFileAsync(new UploadFileInput(
+            Encoding.UTF8.GetBytes("A\nАкт №1\n"), "docs.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Документы", candidate.SheetOrPath, null), default);
+        // Табличная привязка: свой маппинг по полю ТИПА СТРОКИ.
+        await svc.CreateBindingAsync(new CreateBindingInput(instance.Id, source.Id, "Строки",
+            new Dictionary<string, string> { ["Наименование"] = "A" }), default);
+
+        await m.Send(new MigrateFieldKeyCommand(docType.Id, "Наименование", "НаименованиеДокумента"));
+
+        var binding = Assert.Single(await svc.ListBindingsAsync(instance.Id, default));
+        Assert.Equal("Строки", binding.TargetFieldKey);
+        Assert.True(binding.Mapping.ContainsKey("Наименование"), "ключ строки не должен переименовываться");
+        Assert.False(binding.Mapping.ContainsKey("НаименованиеДокумента"));
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Tests/Integration/OrphanBindingKeyTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/OrphanBindingKeyTests.cs
@@ -1,0 +1,230 @@
+using System.Text;
+using System.Text.Json;
+using BHS.CRG.Application.DataSets;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Application.Generation;
+using BHS.CRG.Application.Schema;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// Осиротевшие привязки наборов данных (issue #737).
+///
+/// <para>Живой кейс, с которого началось: в комплекте 250701.ЭОМ-1 у документа «Реестр
+/// исполнительной документации» поле переименовали «ОсновнойДокументы» → «ОсновныеДокументы».
+/// Человек завёл привязку заново, а старая осталась — и продолжала наливать устаревшие данные в
+/// ключ, которого в схеме нет. В <c>data.json</c> они попадали, шаблон их не ждал, аудит молчал:
+/// он сверяет реквизиты, а разошлась ПРИВЯЗКА. Найти это можно было только глазами в отладочном
+/// ZIP.</para>
+///
+/// <para>Три причины, три проверки: резолвер писал мимо схемы молча, аудит держателей ключа вне
+/// реквизитов не видел, переименование ключа привязки не переносило.</para>
+/// </summary>
+[Collection("Integration")]
+public class OrphanBindingKeyTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+    private static IDataSetService Svc(IServiceScope s) => s.ServiceProvider.GetRequiredService<IDataSetService>();
+    private static JsonDocument J(string singleQuoted) => JsonDocument.Parse(singleQuoted.Replace('\'', '"'));
+
+    private sealed record Seed(Guid TypeId, Guid RowTypeId, Guid InstanceId, Guid SourceId);
+
+    /// <summary>
+    /// Тип с полем «ОсновныеДокументы» (как в живом кейсе ПОСЛЕ переименования), документ этого
+    /// типа и материализованный источник — привязку каждый тест заводит свою.
+    /// </summary>
+    private async Task<Seed> SeedAsync(IServiceScope scope)
+    {
+        var m = M(scope);
+        var rowType = await m.Send(new CreateDocumentTypeCommand("Строка", $"ROW{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Composite, null, J("{'fields':[{'key':'Наименование','type':'string'}]}")));
+        var docType = await m.Send(new CreateDocumentTypeCommand("Реестр", $"REG{Guid.NewGuid():N}"[..12],
+            DocumentTypeKind.Document, null,
+            J($"{{'fields':[{{'key':'ОсновныеДокументы','type':'array','typeId':'{rowType.Id}'}}]}}")));
+
+        var construction = await m.Send(new CreateConstructionCommand("Объект", Guid.NewGuid()));
+        var section = await m.Send(new CreateSectionCommand(construction.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(section.Id, "250701.ЭОМ-1"));
+        var instance = await m.Send(new AddDocumentToSetCommand(set.Id, docType.Id));
+
+        var svc = Svc(scope);
+        var file = await svc.UploadFileAsync(new UploadFileInput(
+            Encoding.UTF8.GetBytes("A\nАкт №1\n"), "docs.csv", "text/csv", "Тест", "System", null), default);
+        var candidate = (await svc.DetectSourceCandidatesAsync(file.Id, default)).Single();
+        var source = await svc.CreateSourceAsync(file.Id, new CreateSourceInput("Документы", candidate.SheetOrPath, null), default);
+        await svc.SetMaterializationAsync(source.Id, rowType.Id,
+            new Dictionary<string, string> { ["Наименование"] = "A" }, discriminator: null, byIdColumn: null, default);
+
+        return new Seed(docType.Id, rowType.Id, instance.Id, source.Id);
+    }
+
+    private static async Task<GenerationContext> ResolveAsync(
+        IServiceScope scope, Guid instanceId, List<ResolutionDiagnostic> diagnostics)
+    {
+        var inst = await M(scope).Send(new GetDocumentInstanceQuery(instanceId));
+        var view = DocumentView.From(inst!);
+        var entity = scope.ServiceProvider.GetRequiredService<IEntityResolver>();
+        var ctx = await entity.ResolveAsync(view);
+        await scope.ServiceProvider.GetRequiredService<IDataSetResolver>().InjectAsync(ctx, view, diagnostics, default);
+        return ctx;
+    }
+
+    // ── 1. Резолвер: честный отказ вместо молчаливой записи ──────────────────────
+
+    [Fact]
+    public async Task Resolver_OrphanTargetKey_ReportsError_AndWritesNothing()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        // Привязка на ключ ДО переименования — ровно та, что осталась в живой базе.
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновнойДокументы", null), default);
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        var ctx = await ResolveAsync(scope, seed.InstanceId, diagnostics);
+
+        // Ключа в контексте нет: молча-не-туда хуже честного отказа — иначе данные уезжают в
+        // data.json под мёртвым ключом и выглядят как «взялись из ниоткуда».
+        Assert.False(ctx.Data.ContainsKey("ОсновнойДокументы"));
+        var issue = Assert.Single(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("ОсновнойДокументы", issue.Message);
+    }
+
+    [Fact]
+    public async Task Resolver_ValidTargetKey_StillFills()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновныеДокументы", null), default);
+
+        var diagnostics = new List<ResolutionDiagnostic>();
+        var ctx = await ResolveAsync(scope, seed.InstanceId, diagnostics);
+
+        Assert.True(ctx.Data.ContainsKey("ОсновныеДокументы"));
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    // ── 2. Аудит: держатели ключа вне реквизитов ─────────────────────────────────
+
+    [Fact]
+    public async Task Audit_Instance_FindsOrphanBinding()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновнойДокументы", null), default);
+
+        var findings = await M(scope).Send(new AuditInstanceQuery(seed.InstanceId));
+
+        var f = Assert.Single(findings, x => x.Code == BindingKeyAuditor.OrphanBinding);
+        Assert.Equal("ОсновнойДокументы", f.Path);
+        Assert.Contains("Документы", f.Message); // имя источника названо — иначе непонятно, какую привязку править
+    }
+
+    /// <summary>
+    /// Аудит ТИПА проходит по всем инстансам и добавляет шаблоны привязок самого типа. Шаблон
+    /// данных не портит, но следующая созданная по нему привязка родилась бы мёртвой.
+    /// </summary>
+    [Fact]
+    public async Task Audit_Type_FindsOrphanBindingAndTemplate()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновнойДокументы", null), default);
+        await Svc(scope).CreateTemplateAsync(seed.TypeId,
+            new CreateTemplateInput("Старый шаблон", "ОсновнойДокументы", []), default);
+
+        var report = await M(scope).Send(new AuditDocumentTypeQuery(seed.TypeId));
+
+        Assert.Contains(report.Findings, f => f.Code == BindingKeyAuditor.OrphanBinding);
+        Assert.Contains(report.Findings, f => f.Code == BindingKeyAuditor.OrphanBindingTemplate);
+    }
+
+    [Fact]
+    public async Task Audit_ValidBinding_IsNotFlagged()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновныеДокументы", null), default);
+
+        var findings = await M(scope).Send(new AuditInstanceQuery(seed.InstanceId));
+
+        Assert.DoesNotContain(findings, x => x.Code == BindingKeyAuditor.OrphanBinding);
+    }
+
+    // ── 3. Переименование ключа переносит и привязки ─────────────────────────────
+
+    /// <summary>
+    /// Перенос при rename — спутник миграции данных (#357). Не перенеси привязку, и человек,
+    /// переименовавший поле, увидел бы пустоту там, где были данные: привязка осталась бы на старом
+    /// ключе, а резолвер (после п.1) честно отказался бы её применять.
+    /// </summary>
+    [Fact]
+    public async Task MigrateFieldKey_MovesBindingTargetKey()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновнойДокументы", null), default);
+
+        var result = await M(scope).Send(new MigrateFieldKeyCommand(
+            seed.TypeId, "ОсновнойДокументы", "ОсновныеДокументы"));
+
+        Assert.Equal(1, result.Bindings);
+        var bindings = await Svc(scope).ListBindingsAsync(seed.InstanceId, default);
+        Assert.Equal("ОсновныеДокументы", Assert.Single(bindings).TargetFieldKey);
+
+        // И теперь привязка снова заполняет поле — то есть перенос вернул её в строй.
+        var diagnostics = new List<ResolutionDiagnostic>();
+        var ctx = await ResolveAsync(scope, seed.InstanceId, diagnostics);
+        Assert.True(ctx.Data.ContainsKey("ОсновныеДокументы"));
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public async Task MigrateFieldKey_MovesTemplateKeyAndMappingKeys()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateTemplateAsync(seed.TypeId,
+            new CreateTemplateInput("Шаблон", null,
+                new Dictionary<string, string> { ["ОсновнойДокументы"] = "A" }), default);
+
+        var result = await M(scope).Send(new MigrateFieldKeyCommand(
+            seed.TypeId, "ОсновнойДокументы", "ОсновныеДокументы"));
+
+        Assert.Equal(1, result.Templates);
+        var template = Assert.Single(await Svc(scope).ListTemplatesAsync(seed.TypeId, default));
+        Assert.True(template.ColumnMappings.ContainsKey("ОсновныеДокументы"));
+        Assert.False(template.ColumnMappings.ContainsKey("ОсновнойДокументы"));
+    }
+
+    /// <summary>
+    /// В занятую цель не пишем — то же правило, что у миграции данных: если привязку уже
+    /// перенастроили руками на новый ключ, её настройка авторитетнее нашей догадки.
+    /// </summary>
+    [Fact]
+    public async Task MigrateFieldKey_DoesNotOverwriteAlreadyCorrectBinding()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var seed = await SeedAsync(scope);
+        await Svc(scope).CreateBindingAsync(
+            new CreateBindingInput(seed.InstanceId, seed.SourceId, "ОсновныеДокументы", null), default);
+
+        var result = await M(scope).Send(new MigrateFieldKeyCommand(
+            seed.TypeId, "ОсновнойДокументы", "ОсновныеДокументы"));
+
+        Assert.Equal(0, result.Bindings);
+        Assert.Equal("ОсновныеДокументы", Assert.Single(
+            await Svc(scope).ListBindingsAsync(seed.InstanceId, default)).TargetFieldKey);
+    }
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.110.0</Version>
+    <Version>0.111.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #737.

## Живой случай

В «Реестре исполнительной документации» комплекта 250701.ЭОМ-1 поле переименовали «ОсновнойДокументы» → «ОсновныеДокументы». Человек завёл привязку заново, старая осталась — и продолжала наливать устаревшие данные в ключ, которого в схеме нет. В `data.json` они попадали, шаблон их не ждал, аудит молчал: он сверяет реквизиты, а разошлась **привязка**. Найти это можно было только глазами в отладочном ZIP.

Подтверждено запросом к рабочей базе до правки: из четырёх привязок документа две бьют мимо схемы (`ОсновнойДокументы`, `ДокументыКачество` — в схеме `ДокументыКачества`), две корректны.

## Три причины — три правки

**Резолвер писал мимо схемы молча.** Теперь сверяет целевой ключ с эффективной схемой владельца (`DocumentTypeSchemaReader.Field`, наследование учитывается) и при промахе отказывает `ResolutionDiagnostic` уровня Error, не записывая ничего. Проверка стоит **до** загрузки набора: качать файл ради записи в мёртвый ключ незачем.

**Скалярная привязка — не поломка, а режим.** `TargetFieldKey = null` означает «первая строка раскладывается по отдельным полям», и целевые поля перечисляет маппинг (на живой базе таких две). Проверяются его ключи, а не сам пустой ключ. В issue этот случай выглядел как ещё один вид порчи — это не так.

**Аудит не видел держателей ключа вне реквизитов.** Добавлен `BindingKeyAuditor` — чистая функция: привязки объекта и шаблоны привязок типа против той же эффективной схемы. Подключён и к аудиту документа, и к аудиту типа; привязки всех инстансов читаются одним запросом (`ListBindingsForOwnersAsync`), а не по одному на документ.

**Rename не переносил привязки.** Механизм переноса уже был — `MigrateFieldKeyCommand` (#357) для данных. Он расширен, а не продублирован: одно действие чинит реквизиты, привязки (целевое поле и ключи маппинга) и шаблоны, диалог называет это заранее, тост показывает числа. В занятую цель не пишем — то же правило, что у миграции данных.

## Правка чужих тестов

Одиннадцать тестов упали, и правились они по делу: их фикстуры заводили тип со схемой `{'fields':[]}` и привязку на ключ вне неё — то есть срезали угол ровно там, где теперь проходит проверка. Целевые поля объявлены, как их заводит UI. Это не ослабление проверок, а приведение фикстур к реальной конфигурации.

## Проверка

8 новых тестов (`OrphanBindingKeyTests`), полный набор 1416/1416, `npx tsc -b` чист.

Живой документ (0.111.0), только чтение:

```
НАХОДКИ АУДИТА ИНСТАНСА:
  [orphan-binding] ОсновнойДокументы: Привязка источника «Основные документы комплекта» указывает
                   на поле «ОсновнойДокументы», которого нет в схеме типа — данные не попадают.
  [orphan-binding] ДокументыКачество: Привязка источника «Документы качества» указывает
                   на поле «ДокументыКачество», которого нет в схеме типа — данные не попадают.

data.json: ОсновнойДокументы — нет (был со старыми данными), ДокументыКачество — нет,
           ОсновныеДокументы — есть (7557 символов)
```

Последнее стоит отметить отдельно: поле `ДокументыКачества` осталось пустым, потому что привязка на него не переключена. Это тот самый побочный эффект из issue — **вторая, независимая от #733 причина «документы качества не связываются»**. Теперь она названа вслух в аудите, а не молчит; переключение привязки — действие пользователя.

Версия 0.111.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3BQxpbn49pef7734yp62