### PR TITLE
Пикер «Из каталога» понимает варианты union-поля (#747)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
   Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Info, Link2, Pencil, Plus, RefreshCw, Share2, Trash2, Unlink, X,
 } from 'lucide-react';
-import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
@@ -13,11 +12,12 @@ import type {
 import { isFieldRef, SCOPE_LABELS } from '@/shared/api/types';
 import { useListPrimitiveTypes } from '@/shared/api/primitiveTypes';
 import {
-  resolveEffectiveFields, getDefaultValues, type SchemaField,
+  resolveEffectiveFields, getDefaultValues, isUnionType, type SchemaField,
 } from '@/shared/api/schema';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
 import { formatFieldValue, type FieldTypeDefs } from '@/shared/utils/fieldDisplay';
 import { objectSummary } from './objectSummary';
+import { VariantPicker } from './VariantPicker';
 import { ExtractToCommonDataModal } from './ExtractToCommonDataModal';
 import {
   CELL_INPUT, SCOPE_COLORS, TABLE_SHOWN_TYPES, defaultColWidth,
@@ -449,8 +449,9 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   const subFields = compositeType ? resolveEffectiveFields(compositeType, allDocTypes).filter(f => !f.computed) : [];
   // Строка массива union-типа (issue #320): редактируется переключателем варианта, а не стопкой всех
   // полей — иначе диалог строки показывал оба поля union (баг). Тип union = тэг type.union на схеме.
-  const isUnionComposite = !!compositeType
-    && ((compositeType.schema as { tags?: string[] }).tags ?? []).includes(FUNCTIONAL_TAG.typeUnion);
+  // typeHasTag, а не `.tags.includes`: инлайновая проверка не видит ни УНАСЛЕДОВАННЫЙ тэг, ни
+  // параметризованную запись `type.union:2` (issue #747).
+  const isUnionComposite = !!compositeType && isUnionType(compositeType, allDocTypes);
   const [rowModal, setRowModal] = useState<number | null>(null); // issue #102: строка массива правится в модалке, не инлайн
   const [extractRow, setExtractRow] = useState<number | null>(null); // issue #663
   const [tableOpen, setTableOpen] = useState(false);
@@ -473,8 +474,27 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
     setRowModal(allItems.length); // сразу открыть модалку новой строки
   }
 
-  function addFromCatalog(ref: FieldRef) {
-    onChange([...allItems, ref]);
+  /**
+   * Запись каталога становится строкой массива. Для union'а (issue #747) она заворачивается в ключ
+   * варианта — ровно один ключ, инвариант #320 держится конструкцией; какой это вариант, решил
+   * пикер по типу записи (и спросил человека, если тип не назвал единственного).
+   */
+  function addFromCatalog(ref: FieldRef, variantKey?: string) {
+    onChange([...allItems, variantKey ? { [variantKey]: ref } : ref]);
+  }
+
+  /**
+   * Единственный заполненный вариант union-строки, если это ссылка: {ключ, ссылка, подпись}.
+   * Не union или не ссылка — null.
+   */
+  function unionRef(row: Record<string, unknown>): { key: string; ref: FieldRef; label: string } | null {
+    if (!isUnionComposite) return null;
+    const keys = Object.keys(row);
+    if (keys.length !== 1) return null;
+    const value = row[keys[0]];
+    if (!isFieldRef(value)) return null;
+    const sub = subFields.find(f => f.key === keys[0]);
+    return { key: keys[0], ref: value, label: sub?.title ?? keys[0] };
   }
 
   function removeItem(i: number) {
@@ -558,6 +578,32 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
               );
             }
             const row = item as Record<string, unknown>;
+
+            // Строка union'а, чей единственный вариант — ссылка (issue #747). Без этой ветки она
+            // ушла бы в rowSummary как обычный объект: сводка вернула бы голое displayName, и
+            // строка потеряла бы и признак ссылки, и вариант — на вид обычные данные, которых на
+            // самом деле нет. Рисуем тем же языком, что соседние ref-строки, плюс метка варианта.
+            const wrapped = unionRef(row);
+            if (wrapped) {
+              return (
+                <div key={i} className="flex items-center gap-2 px-3 py-2 hover:bg-base">
+                  <span className="text-xs text-fg4 font-mono w-5 text-right shrink-0">{i + 1}</span>
+                  <Link2 size={12} className="text-warning shrink-0" />
+                  <span className="flex-1 text-sm text-warning truncate">{wrapped.ref.displayName}</span>
+                  <span className="text-[11px] text-fg4 shrink-0 truncate max-w-[40%]">{wrapped.label}</span>
+                  {/* ✎ оставлен: это единственный вход сменить вариант и снять ссылку. */}
+                  <button type="button" onClick={() => setRowModal(i)} title="Редактировать"
+                    className="p-1 text-fg4 hover:text-fg2 shrink-0">
+                    <Pencil size={13} />
+                  </button>
+                  <button type="button" onClick={() => removeItem(i)}
+                    className="p-1 text-fg4 hover:text-danger shrink-0">
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+              );
+            }
+
             // issue #102: строка — компактная сводка + ✎ (модалка), без инлайн-раскрытия (источник «портянки»).
             return (
               <div key={i} className="flex items-center gap-2 px-3 py-2 hover:bg-base">
@@ -661,6 +707,7 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
           setId={setId} scope={scope} scopeId={scopeId}
           otherInstances={[]}
           allDocTypes={allDocTypes}
+          unionAware
           onSelect={addFromCatalog}
         />
       )}
@@ -734,8 +781,7 @@ export function ComplexFieldGroup({ field, allDocTypes, value, onChange, showVal
 
   // Union-тип (issue #320): составной тип с тэгом type.union — «заполняется ровно одно из полей».
   // Рендерим переключатель варианта + редактор активного подполя вместо стопки всех подполей.
-  const isUnion = !!compositeType
-    && ((compositeType.schema as { tags?: string[] }).tags ?? []).includes(FUNCTIONAL_TAG.typeUnion);
+  const isUnion = !!compositeType && isUnionType(compositeType, allDocTypes);
   if (isUnion) {
     return (
       <UnionFieldGroup field={field} allDocTypes={allDocTypes} value={value} onChange={onChange}
@@ -995,61 +1041,9 @@ function isVariantFilled(v: unknown): boolean {
   return String(v).trim() !== '';
 }
 
-/**
- * Выбор ОДНОГО варианта union (issue #320/#391). Представление зависит от контента (совет Дизайнера):
- * сегмент — для ≤3 коротких подписей; вертикальный список radio-строк — для многих/длинных
- * (не обрезаются, масштабируется 2-8). `auto` выбирает сам. В списке разведены два смысла:
- * ЛЕВО = radio-выбор, ПРАВО = бейдж «задан» (есть ли значение/маппинг) — в сегменте они слипались в точку.
- */
-export function VariantPicker({ options, active, onSelect, layout = 'auto' }: {
-  options: { key: string; label: string; filled: boolean }[];
-  active: string; onSelect: (key: string) => void;
-  layout?: 'segmented' | 'list' | 'auto';
-}) {
-  const useList = layout === 'list'
-    || (layout === 'auto' && (options.length > 3 || options.some(o => o.label.length > 18)));
-
-  if (useList) {
-    return (
-      <div role="radiogroup" className="flex flex-col gap-1 text-sm">
-        {options.map(o => {
-          const on = o.key === active;
-          return (
-            <button key={o.key} type="button" role="radio" aria-checked={on} onClick={() => onSelect(o.key)}
-              className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors ${
-                on ? 'border-brand bg-brand/10 text-fg1 font-medium' : 'border-stroke bg-surface text-fg2 hover:bg-base'}`}>
-              <span className={`grid place-items-center w-4 h-4 rounded-full border shrink-0 ${on ? 'border-brand' : 'border-stroke'}`}>
-                {on && <span className="w-2 h-2 rounded-full bg-brand" />}
-              </span>
-              <span className="flex-1 min-w-0 truncate">{o.label}</span>
-              {o.filled && (
-                <span className="text-[11px] text-brand flex items-center gap-1 shrink-0" title="Значение задано">
-                  <span className="w-1.5 h-1.5 rounded-full bg-brand" /> задан
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-    );
-  }
-
-  return (
-    <div role="radiogroup" className="inline-flex rounded-lg border border-stroke overflow-hidden text-sm">
-      {options.map((o, i) => {
-        const on = o.key === active;
-        return (
-          <button key={o.key} type="button" role="radio" aria-checked={on} onClick={() => onSelect(o.key)}
-            className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${i > 0 ? 'border-l border-stroke' : ''} ${
-              on ? 'bg-brand text-white font-medium' : 'bg-surface text-fg2 hover:bg-base'}`}>
-            {o.filled && <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${on ? 'bg-white' : 'bg-brand'}`} />}
-            <span className="truncate">{o.label}</span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
+// VariantPicker живёт своим файлом (issue #747): его зовёт ещё и пикер ссылок, а импорт
+// оттуда в ComplexFields замкнул бы цикл. Реэкспорт — чтобы не трогать существующих потребителей.
+export { VariantPicker };
 
 function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, setId,
   otherInstances = [], scope, scopeId, docRefMode = 'catalog', nested = false }: {

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -585,11 +585,17 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
             // самом деле нет. Рисуем тем же языком, что соседние ref-строки, плюс метка варианта.
             const wrapped = unionRef(row);
             if (wrapped) {
+              // Путь битой ссылки сервер строит ВНУТРЬ объекта («Поле[0].Вариант», ResolutionDiagnostics),
+              // а не по индексу строки: проверь мы только «Поле[0]», удалённая цель показалась бы
+              // здоровой ссылкой — ровно та потеря признака, ради которой заведена эта ветка.
+              const wrappedBroken = !!basePath
+                && !!brokenPaths?.has(`${basePath}[${i}].${wrapped.key}`);
               return (
-                <div key={i} className="flex items-center gap-2 px-3 py-2 hover:bg-base">
-                  <span className="text-xs text-fg4 font-mono w-5 text-right shrink-0">{i + 1}</span>
-                  <Link2 size={12} className="text-warning shrink-0" />
-                  <span className="flex-1 text-sm text-warning truncate">{wrapped.ref.displayName}</span>
+                <div key={i}>
+                <div className={`flex items-center gap-2 px-3 py-2 ${wrappedBroken ? BROKEN_PLATE : 'hover:bg-base'}`}>
+                  <span className={`text-xs font-mono w-5 text-right shrink-0 ${wrappedBroken ? 'text-danger' : 'text-fg4'}`}>{i + 1}</span>
+                  <Link2 size={12} className={`shrink-0 ${wrappedBroken ? 'text-danger' : 'text-warning'}`} />
+                  <span className={`flex-1 text-sm truncate ${wrappedBroken ? BROKEN_LABEL : 'text-warning'}`}>{wrapped.ref.displayName}</span>
                   <span className="text-[11px] text-fg4 shrink-0 truncate max-w-[40%]">{wrapped.label}</span>
                   {/* ✎ оставлен: это единственный вход сменить вариант и снять ссылку. */}
                   <button type="button" onClick={() => setRowModal(i)} title="Редактировать"
@@ -600,6 +606,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                     className="p-1 text-fg4 hover:text-danger shrink-0">
                     <Trash2 size={13} />
                   </button>
+                </div>
+                {wrappedBroken && <BrokenRefNote compact />}
                 </div>
               );
             }
@@ -634,7 +642,11 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                   отдельной задачей, у него свой selection-state. */}
               {canExtract ? (
                 <Button variant="text" size="sm" icon={<Share2 size={13} />}
-                  disabled={isRowEmpty(allItems[rowModal] as Record<string, unknown>, subFields)}
+                  // Строка-ссылка выносу не подлежит: получилась бы запись, всё содержимое которой —
+                  // ссылка на другую запись, то есть лишнее звено в цепочке (у неё есть предел, #723).
+                  // ComplexFieldGroup такую ветку до выноса не доводит вовсе; у массива защиты не было.
+                  disabled={isRowEmpty(allItems[rowModal] as Record<string, unknown>, subFields)
+                    || !!unionRef(allItems[rowModal] as Record<string, unknown>)}
                   title="Создать запись общих данных из этой строки"
                   onClick={() => { const i = rowModal; setRowModal(null); setExtractRow(i); }}>
                   Вынести в общие данные…

--- a/src/client/src/features/document-sets/fields/RefPickerModal.tsx
+++ b/src/client/src/features/document-sets/fields/RefPickerModal.tsx
@@ -6,13 +6,17 @@ import type {
   CommonDataEntry, DocumentInstance, DocumentType, FieldRef, CatalogScope,
 } from '@/shared/api/types';
 import { SCOPE_LABELS } from '@/shared/api/types';
-import { resolveEffectiveFields, isSubtypeOf, type SchemaField } from '@/shared/api/schema';
+import {
+  resolveEffectiveFields, isSubtypeOf, isUnionType, placeInUnion,
+  type SchemaField, type UnionPlacement,
+} from '@/shared/api/schema';
 import { SCOPE_COLORS } from './constants';
+import { VariantPicker } from './VariantPicker';
 
 export function RefPickerModal({
   open, onOpenChange, compositeType,
   setId, scope, scopeId,
-  otherInstances = [], allDocTypes, onSelect,
+  otherInstances = [], allDocTypes, unionAware = false, onSelect,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -22,7 +26,19 @@ export function RefPickerModal({
   scopeId?: string | null;
   otherInstances?: DocumentInstance[];
   allDocTypes: DocumentType[];
-  onSelect: (ref: FieldRef) => void;
+  /**
+   * Вызывающий умеет класть значение в ключ варианта union'а (issue #747) — и только тогда пикер
+   * предлагает записи типов-ВАРИАНТОВ, а не только самого составного типа.
+   *
+   * Согласие обязано быть явным, потому что тот же пикер зовёт <code>ComplexCellPicker</code>,
+   * который пишет голую ссылку и заворачивать не умеет: расширь мы фильтр молча, union получил бы
+   * значение без ключа варианта — инвариант «ровно один ключ» (#320) сломался бы там, где никто не
+   * смотрит. Сегодня дыра латентна (union-типы стоят элементами массивов, а не complex-колонками),
+   * и открылась бы она тихо.
+   */
+  unionAware?: boolean;
+  /** Второй аргумент — ключ варианта union'а; отсутствует, когда значение кладётся как есть. */
+  onSelect: (ref: FieldRef, variantKey?: string) => void;
 }) {
   const [search, setSearch] = useState('');
 
@@ -35,10 +51,46 @@ export function RefPickerModal({
     scope: effScope, scopeId: effScopeId, enabled: open && !!effScope,
   });
 
+  // Union-режим (issue #747): кандидат подходит, если его тип годится САМОМУ union'у или любому его
+  // одиночному варианту. Куда ляжет запись, считаем здесь же и несём до onSelect — второй раз тот же
+  // вопрос задавать негде: в обработчике выбора уже нет ни типов, ни цепочки наследования под рукой.
+  const unionMode = unionAware && !!compositeType && isUnionType(compositeType, allDocTypes);
+  const placementOf = (e: CommonDataEntry): UnionPlacement =>
+    placeInUnion(e.compositeTypeId, compositeType!, allDocTypes);
+
   const filtered = catalogEntries.filter(e => {
-    if (compositeType && !isSubtypeOf(e.compositeTypeId, compositeType.id, allDocTypes)) return false;
+    if (compositeType) {
+      const fits = unionMode
+        ? placementOf(e).kind !== 'none'
+        : isSubtypeOf(e.compositeTypeId, compositeType.id, allDocTypes);
+      if (!fits) return false;
+    }
     return e.displayName.toLowerCase().includes(search.toLowerCase());
   });
+
+  // Запись, для которой тип не назвал единственного варианта: показываем её вторым шагом со
+  // списком вариантов вместо того, чтобы прятать. Прятать нельзя — ничья означает, что два
+  // варианта объявлены на один тип (иначе при одиночном наследовании дистанции не совпали бы),
+  // то есть это осмысленная схема, а не порча данных, и исправить её из пикера человек не может.
+  const [askVariantFor, setAskVariantFor] = useState<CommonDataEntry | null>(null);
+  useEffect(() => { if (!open) setAskVariantFor(null); }, [open]);
+
+  /** Подписи вариантов union'а — для метки на кандидате и для второго шага. */
+  const variantFields = unionMode
+    ? resolveEffectiveFields(compositeType!, allDocTypes).filter(f => f.type === 'complex' || f.type === 'doc-ref')
+    : [];
+  const variantTitle = (key: string) => variantFields.find(f => f.key === key)?.title ?? key;
+
+  // Метка «куда ляжет» — только когда принимающих слотов больше одного: при единственном варианте
+  // она повторяла бы заголовок поля и была бы шумом.
+  function variantHint(entry: CommonDataEntry): string | null {
+    if (!unionMode || variantFields.length < 2) return null;
+    const placement = placementOf(entry);
+    if (placement.kind === 'variant') return variantTitle(placement.variantKey);
+    if (placement.kind === 'ambiguous') return `${placement.variantKeys.length} варианта`;
+    return null;
+  }
+
 
   // Группировка по scope: ближайший уровень (Комплект) вверху, дальние — ниже. Пустые группы скрыты.
   const SCOPE_ORDER: CatalogScope[] = ['Set', 'Section', 'Construction', 'System'];
@@ -47,6 +99,27 @@ export function RefPickerModal({
     .filter(g => g.entries.length > 0);
 
   const searching = search.trim().length > 0;
+
+  /**
+   * Пустое состояние объясняет ПРИЧИНУ. Раньше текст был один на три случая и в самом частом врал:
+   * записи в каталоге есть, просто других типов, — а совет «Добавьте записи в каталог общих данных»
+   * отправлял человека заводить дубль того, что уже заведено.
+   */
+  const acceptedTitles = unionMode
+    ? variantFields.map(f => allDocTypes.find(t => t.id === f.typeId)?.name).filter(Boolean) as string[]
+    : (compositeType ? [compositeType.name] : []);
+  const emptyState = searching
+    ? { title: `По запросу «${search.trim()}» ничего не найдено.`, hint: 'Измените запрос или очистите поиск.' }
+    : catalogEntries.length > 0
+      ? {
+          title: 'Подходящих записей нет.',
+          hint: acceptedTitles.length > 0
+            ? `Сюда годятся записи типов: ${acceptedTitles.slice(0, 3).join(', ')}`
+              + (acceptedTitles.length > 3 ? ` и ещё ${acceptedTitles.length - 3}` : '')
+              + `. На доступных уровнях записей: ${catalogEntries.length}, но другого типа.`
+            : `На доступных уровнях записей: ${catalogEntries.length}, но ни одна не подходит по типу.`,
+        }
+      : { title: 'Нет объектов доступных для ссылки.', hint: 'Добавьте записи в каталог общих данных.' };
   const firstScope = groups[0]?.scope; // ближайшая НЕпустая группа — раскрыта по умолчанию
   // Ручные переопределения сворачивания (действуют, когда поиск пуст). При поиске все группы с
   // совпадениями раскрыты (иначе матч спрятался бы за свёрнутой группой).
@@ -90,13 +163,29 @@ export function RefPickerModal({
     else if (e.key === 'Enter') { e.preventDefault(); const o = options[active]; if (o) activate(o); }
   }
 
+  const refOf = (entry: CommonDataEntry): FieldRef => ({
+    $ref: 'catalog',
+    entryId: entry.id,
+    displayName: entry.displayName,
+    scope: entry.scope,
+  });
+
   function selectCatalog(entry: CommonDataEntry) {
-    onSelect({
-      $ref: 'catalog',
-      entryId: entry.id,
-      displayName: entry.displayName,
-      scope: entry.scope,
-    });
+    if (!unionMode) {
+      onSelect(refOf(entry));
+      onOpenChange(false);
+      return;
+    }
+    const placement = placementOf(entry);
+    // Ничья — единственный случай, когда диалог не закрывается: спрашиваем вариант вторым шагом.
+    if (placement.kind === 'ambiguous') { setAskVariantFor(entry); return; }
+    onSelect(refOf(entry), placement.kind === 'variant' ? placement.variantKey : undefined);
+    onOpenChange(false);
+  }
+
+  function selectVariant(entry: CommonDataEntry, variantKey: string) {
+    onSelect(refOf(entry), variantKey);
+    setAskVariantFor(null);
     onOpenChange(false);
   }
 
@@ -108,6 +197,27 @@ export function RefPickerModal({
       displayName: `${dt.name} → ${field.title}`,
     });
     onOpenChange(false);
+  }
+
+  // Второй шаг: тип не назвал единственного варианта — спрашиваем. Отдельным экраном той же
+  // модалки, а не отдельным диалогом: выбор ещё не сделан, и «назад» обязано возвращать к списку.
+  if (askVariantFor) {
+    const placement = placementOf(askVariantFor);
+    const keys = placement.kind === 'ambiguous' ? placement.variantKeys : [];
+    return (
+      <Modal open={open} onOpenChange={onOpenChange} title="В какой вариант поместить?">
+        <div className="space-y-4">
+          <p className="text-sm text-fg2">
+            <span className="font-medium">{askVariantFor.displayName}</span> подходит нескольким
+            вариантам одинаково: они объявлены на один и тот же тип, и по типу выбрать нельзя.
+          </p>
+          <VariantPicker layout="list" options={keys.map(k => ({ key: k, label: variantTitle(k), filled: false }))}
+            active="" onSelect={k => selectVariant(askVariantFor, k)} />
+          <button type="button" onClick={() => setAskVariantFor(null)}
+            className="text-xs text-fg3 hover:text-fg1 transition-colors">← Назад к списку</button>
+        </div>
+      </Modal>
+    );
   }
 
   return (
@@ -150,6 +260,11 @@ export function RefPickerModal({
                               className={`w-full flex items-center px-3 py-2 text-sm text-left rounded-md transition-colors ${
                                 on ? 'bg-tonal text-on-tonal' : 'hover:bg-brand-subtle'}`}>
                               <span className={`flex-1 font-medium truncate ${on ? 'text-on-tonal' : 'text-fg1'}`}>{entry.displayName}</span>
+                              {variantHint(entry) && (
+                                <span className={`text-[11px] shrink-0 ml-2 truncate max-w-[45%] ${on ? 'text-on-tonal' : 'text-fg4'}`}>
+                                  {variantHint(entry)}
+                                </span>
+                              )}
                             </button>
                           );
                         })}
@@ -189,9 +304,21 @@ export function RefPickerModal({
 
         {filtered.length === 0 && docSources.length === 0 && (
           <p className="text-sm text-fg4 text-center py-4">
-            Нет объектов доступных для ссылки.
+            {emptyState.title}
             <br />
-            <span className="text-xs">Добавьте записи в каталог общих данных.</span>
+            <span className="text-xs">{emptyState.hint}</span>
+            {/* Шов между двумя входами (issue #751): этот диалог отвечает на вопрос «дай строку
+                целиком из справочника», а документы комплекта выбирают внутри строки. Пока диалоги
+                не сведены, единственное место, где об этом можно сказать, — здесь. */}
+            {unionMode && (
+              <>
+                <br />
+                <span className="text-xs">
+                  Документы комплекта здесь не показываются — их выбирают внутри строки:
+                  «Добавить строку» → вариант → «Выбрать документ…».
+                </span>
+              </>
+            )}
           </p>
         )}
       </div>

--- a/src/client/src/features/document-sets/fields/RefPickerModal.tsx
+++ b/src/client/src/features/document-sets/fields/RefPickerModal.tsx
@@ -55,8 +55,17 @@ export function RefPickerModal({
   // одиночному варианту. Куда ляжет запись, считаем здесь же и несём до onSelect — второй раз тот же
   // вопрос задавать негде: в обработчике выбора уже нет ни типов, ни цепочки наследования под рукой.
   const unionMode = unionAware && !!compositeType && isUnionType(compositeType, allDocTypes);
-  const placementOf = (e: CommonDataEntry): UnionPlacement =>
-    placeInUnion(e.compositeTypeId, compositeType!, allDocTypes);
+  // Мемо по типу записи, а не по записи: решение зависит ТОЛЬКО от типа, а типов на порядки меньше,
+  // чем записей. Без него placeInUnion звался бы трижды на каждого кандидата при каждом нажатии
+  // клавиши в поиске, и каждый вызов заново разрешает схему union'а и идёт вверх по цепочке.
+  const placements = new Map<string, UnionPlacement>();
+  const placementOf = (e: CommonDataEntry): UnionPlacement => {
+    const cached = placements.get(e.compositeTypeId);
+    if (cached) return cached;
+    const computed = placeInUnion(e.compositeTypeId, compositeType!, allDocTypes);
+    placements.set(e.compositeTypeId, computed);
+    return computed;
+  };
 
   const filtered = catalogEntries.filter(e => {
     if (compositeType) {
@@ -100,13 +109,19 @@ export function RefPickerModal({
 
   const searching = search.trim().length > 0;
 
+  const hints = new Map(filtered.map(e => [e.id, variantHint(e)] as const));
+
   /**
    * Пустое состояние объясняет ПРИЧИНУ. Раньше текст был один на три случая и в самом частом врал:
    * записи в каталоге есть, просто других типов, — а совет «Добавьте записи в каталог общих данных»
    * отправлял человека заводить дубль того, что уже заведено.
    */
+  // Тип самого union'а в список входит: запись такого типа заводит «Вынести в общие данные» (#663),
+  // и фильтр её пропускает. Не назови мы его — подсказка перечисляла бы всё, кроме единственного
+  // типа, который человек уже, возможно, и создал.
   const acceptedTitles = unionMode
-    ? variantFields.map(f => allDocTypes.find(t => t.id === f.typeId)?.name).filter(Boolean) as string[]
+    ? [compositeType!.name,
+       ...variantFields.map(f => allDocTypes.find(t => t.id === f.typeId)?.name).filter(Boolean) as string[]]
     : (compositeType ? [compositeType.name] : []);
   const emptyState = searching
     ? { title: `По запросу «${search.trim()}» ничего не найдено.`, hint: 'Измените запрос или очистите поиск.' }
@@ -260,9 +275,9 @@ export function RefPickerModal({
                               className={`w-full flex items-center px-3 py-2 text-sm text-left rounded-md transition-colors ${
                                 on ? 'bg-tonal text-on-tonal' : 'hover:bg-brand-subtle'}`}>
                               <span className={`flex-1 font-medium truncate ${on ? 'text-on-tonal' : 'text-fg1'}`}>{entry.displayName}</span>
-                              {variantHint(entry) && (
+                              {hints.get(entry.id) && (
                                 <span className={`text-[11px] shrink-0 ml-2 truncate max-w-[45%] ${on ? 'text-on-tonal' : 'text-fg4'}`}>
-                                  {variantHint(entry)}
+                                  {hints.get(entry.id)}
                                 </span>
                               )}
                             </button>

--- a/src/client/src/features/document-sets/fields/VariantPicker.tsx
+++ b/src/client/src/features/document-sets/fields/VariantPicker.tsx
@@ -1,0 +1,63 @@
+/**
+ * Выбор одного варианта union-поля — вынесен из ComplexFields (issue #747).
+ *
+ * Своим файлом, потому что тот же переключатель понадобился ПИКЕРУ: когда запись каталога
+ * одинаково подходит двум вариантам, он спрашивает вариант вторым шагом. Оставь компонент в
+ * ComplexFields — вышел бы цикл импорта (ComplexFields зовёт RefPickerModal, RefPickerModal
+ * звал бы ComplexFields).
+ */
+/**
+ * Выбор ОДНОГО варианта union (issue #320/#391). Представление зависит от контента (совет Дизайнера):
+ * сегмент — для ≤3 коротких подписей; вертикальный список radio-строк — для многих/длинных
+ * (не обрезаются, масштабируется 2-8). `auto` выбирает сам. В списке разведены два смысла:
+ * ЛЕВО = radio-выбор, ПРАВО = бейдж «задан» (есть ли значение/маппинг) — в сегменте они слипались в точку.
+ */
+export function VariantPicker({ options, active, onSelect, layout = 'auto' }: {
+  options: { key: string; label: string; filled: boolean }[];
+  active: string; onSelect: (key: string) => void;
+  layout?: 'segmented' | 'list' | 'auto';
+}) {
+  const useList = layout === 'list'
+    || (layout === 'auto' && (options.length > 3 || options.some(o => o.label.length > 18)));
+
+  if (useList) {
+    return (
+      <div role="radiogroup" className="flex flex-col gap-1 text-sm">
+        {options.map(o => {
+          const on = o.key === active;
+          return (
+            <button key={o.key} type="button" role="radio" aria-checked={on} onClick={() => onSelect(o.key)}
+              className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors ${
+                on ? 'border-brand bg-brand/10 text-fg1 font-medium' : 'border-stroke bg-surface text-fg2 hover:bg-base'}`}>
+              <span className={`grid place-items-center w-4 h-4 rounded-full border shrink-0 ${on ? 'border-brand' : 'border-stroke'}`}>
+                {on && <span className="w-2 h-2 rounded-full bg-brand" />}
+              </span>
+              <span className="flex-1 min-w-0 truncate">{o.label}</span>
+              {o.filled && (
+                <span className="text-[11px] text-brand flex items-center gap-1 shrink-0" title="Значение задано">
+                  <span className="w-1.5 h-1.5 rounded-full bg-brand" /> задан
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div role="radiogroup" className="inline-flex rounded-lg border border-stroke overflow-hidden text-sm">
+      {options.map((o, i) => {
+        const on = o.key === active;
+        return (
+          <button key={o.key} type="button" role="radio" aria-checked={on} onClick={() => onSelect(o.key)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${i > 0 ? 'border-l border-stroke' : ''} ${
+              on ? 'bg-brand text-white font-medium' : 'bg-surface text-fg2 hover:bg-base'}`}>
+            {o.filled && <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${on ? 'bg-white' : 'bg-brand'}`} />}
+            <span className="truncate">{o.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/client/src/shared/api/schema.test.ts
+++ b/src/client/src/shared/api/schema.test.ts
@@ -5,6 +5,9 @@ import {
   chainFieldKeys,
   groupEffectiveFields,
   isSubtypeOf,
+  inheritanceDistance,
+  isUnionType,
+  placeInUnion,
   getDefaultValues,
   isFieldMissing,
   isScalarField,
@@ -447,5 +450,103 @@ describe('материалы за составной обёрткой', () => {
   it('пустая обёртка и отсутствующие ключи материалов не дают', () => {
     expect(collectMaterialRows(aosr, all, {})).toEqual([]);
     expect(collectMaterialRows(aosr, all, { Материалы: {} })).toEqual([]);
+  });
+});
+
+// ── Куда ляжет запись каталога в union-строке (issue #747) ───────────────────
+
+/**
+ * Правило матчинга варианта. Проверяем не «работает ли фильтр», а те четыре исхода, спутав любые
+ * два из которых, приложение ломается по-разному: голая ссылка вместо обёртки нарушит инвариант
+ * «ровно один ключ» (#320), обёртка вместо голой — сломает round-trip с «Вынести в общие данные»,
+ * тихий выбор при ничьей поставит запись не в тот вариант, а «none» вместо ничьей уберёт из пикера
+ * запись, которую человек видит в каталоге.
+ */
+describe('placeInUnion', () => {
+  const base = dt({ fields: [] }, null, 'base');
+  const child = dt({ fields: [] }, 'base', 'child');
+  const other = dt({ fields: [] }, null, 'other');
+  const listItem = dt({ fields: [] }, null, 'listItem');
+  const union = dt({
+    tags: ['type.union'],
+    fields: [
+      { key: 'Осн', title: 'Основной', type: 'doc-ref', typeId: 'base', required: false },
+      { key: 'Список', title: 'Список', type: 'array', typeId: 'listItem', required: false },
+    ],
+  }, null, 'union');
+  const all = [base, child, other, listItem, union];
+
+  it('запись типа самого union-а кладётся голой ссылкой', () => {
+    expect(placeInUnion('union', union, all)).toEqual({ kind: 'self' });
+  });
+
+  it('запись типа варианта заворачивается в его ключ', () => {
+    expect(placeInUnion('base', union, all)).toEqual({ kind: 'variant', variantKey: 'Осн' });
+  });
+
+  it('подтип цели варианта тоже подходит', () => {
+    expect(placeInUnion('child', union, all)).toEqual({ kind: 'variant', variantKey: 'Осн' });
+  });
+
+  it('чужой тип не подходит ничему', () => {
+    expect(placeInUnion('other', union, all)).toEqual({ kind: 'none' });
+  });
+
+  it('варианты-списки не участвуют: одиночная ссылка в массиве пропала бы молча', () => {
+    expect(placeInUnion('listItem', union, all)).toEqual({ kind: 'none' });
+  });
+
+  it('из нескольких подходящих вариантов побеждает ближайший по цепочке', () => {
+    const u = dt({
+      tags: ['type.union'],
+      fields: [
+        { key: 'Дальний', title: 'Дальний', type: 'doc-ref', typeId: 'base', required: false },
+        { key: 'Ближний', title: 'Ближний', type: 'doc-ref', typeId: 'child', required: false },
+      ],
+    }, null, 'u2');
+    expect(placeInUnion('child', u, [...all, u])).toEqual({ kind: 'variant', variantKey: 'Ближний' });
+  });
+
+  it('два варианта на один тип дают ничью — выбрать за пользователя нечем', () => {
+    // Живой случай: у «Кабельной линии» варианты освещения внутреннего и наружного смотрят на один
+    // тип «Основная кабельная линия» — форма данных одна, различие живёт только в ключе варианта.
+    const u = dt({
+      tags: ['type.union'],
+      fields: [
+        { key: 'ЭО', title: 'Внутреннее', type: 'complex', typeId: 'base', required: false },
+        { key: 'ЭОН', title: 'Наружное', type: 'complex', typeId: 'base', required: false },
+      ],
+    }, null, 'u3');
+    expect(placeInUnion('base', u, [...all, u])).toEqual({ kind: 'ambiguous', variantKeys: ['ЭО', 'ЭОН'] });
+  });
+
+  it('union опознаётся по УНАСЛЕДОВАННОМУ и по параметризованному тэгу', () => {
+    const parametrized = dt({ tags: ['type.union:2'], fields: [] }, null, 'p');
+    const heir = dt({ fields: [] }, 'p', 'heir');
+    expect(isUnionType(parametrized, [parametrized, heir])).toBe(true);
+    expect(isUnionType(heir, [parametrized, heir])).toBe(true);
+  });
+});
+
+describe('inheritanceDistance', () => {
+  const a = dt({ fields: [] }, null, 'a');
+  const b = dt({ fields: [] }, 'a', 'b');
+  const c = dt({ fields: [] }, 'b', 'c');
+  const all = [a, b, c];
+
+  it('считает шаги вверх по цепочке', () => {
+    expect(inheritanceDistance('c', 'c', all)).toBe(0);
+    expect(inheritanceDistance('c', 'b', all)).toBe(1);
+    expect(inheritanceDistance('c', 'a', all)).toBe(2);
+    expect(inheritanceDistance('a', 'c', all)).toBeNull();
+  });
+
+  it('цикл в цепочке не вешает обход', () => {
+    // Цепочку типов строит пользователь, и испорченный parentId раньше валил вкладку
+    // переполнением стека: у прежней isSubtypeOf не было ни предела шагов, ни visited-set.
+    const x = dt({ fields: [] }, 'y', 'x');
+    const y = dt({ fields: [] }, 'x', 'y');
+    expect(inheritanceDistance('x', 'somewhere', [x, y])).toBeNull();
+    expect(isSubtypeOf('x', 'somewhere', [x, y])).toBe(false);
   });
 });

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -223,12 +223,38 @@ export function resolveEffectiveFields(
   ];
 }
 
+/**
+ * Сколько шагов вверх по цепочке наследования от `childId` до `parentId`; `null` — не потомок.
+ * 0 — это тот же тип.
+ *
+ * Дистанция, а не просто «да/нет», нужна выбору варианта union'а (issue #747): когда запись
+ * подходит нескольким вариантам, побеждает БЛИЖАЙШИЙ. Ту же специфичность считает сервер при
+ * материализации наборов (`MaterializeDiscriminator.InheritanceDistance`, issue #716) — правила там
+ * задаёт админ явно, а здесь они выводятся из `typeId` варианта, но мера близости обязана совпадать.
+ *
+ * <p>Обход итеративный и с visited-set. Прежняя <code>isSubtypeOf</code> была рекурсивна без предела
+ * и без защиты от цикла: испорченный <code>parentId</code> (цепочку типов строит пользователь) вешал
+ * вкладку переполнением стека. У серверного аналога предел 32 шага, у <code>typeHasTag</code> —
+ * visited-set; здесь не было ничего.</p>
+ */
+export function inheritanceDistance(
+  childId: string, parentId: string, allDocTypes: DocumentType[],
+): number | null {
+  const visited = new Set<string>();
+  let current: string | undefined = childId;
+  let steps = 0;
+  while (current && !visited.has(current)) {
+    if (current === parentId) return steps;
+    visited.add(current);
+    current = allDocTypes.find(t => t.id === current)?.parentId ?? undefined;
+    steps++;
+  }
+  return null;
+}
+
 /** Returns true if childId equals parentId or has parentId anywhere in its ancestor chain. */
 export function isSubtypeOf(childId: string, parentId: string, allDocTypes: DocumentType[]): boolean {
-  if (childId === parentId) return true;
-  const child = allDocTypes.find(t => t.id === childId);
-  if (!child?.parentId) return false;
-  return isSubtypeOf(child.parentId, parentId, allDocTypes);
+  return inheritanceDistance(childId, parentId, allDocTypes) !== null;
 }
 
 /**
@@ -298,6 +324,67 @@ export function typeHasTag(docType: DocumentType, tag: string, allDocTypes: Docu
     current = current.parentId ? allDocTypes.find(t => t.id === current!.parentId) : undefined;
   }
   return false;
+}
+
+/** Является ли составной тип union'ом — «заполняется ровно один из вариантов» (issue #320). */
+export function isUnionType(docType: DocumentType, allDocTypes: DocumentType[]): boolean {
+  return typeHasTag(docType, FUNCTIONAL_TAG.typeUnion, allDocTypes);
+}
+
+/**
+ * Куда ляжет запись каталога, выбранная для строки union-типа (issue #747).
+ *
+ * <ul>
+ *   <li><b>self</b> — запись типизирована самим union'ом (или потомком): кладётся голая ссылка, как
+ *       у обычного составного поля. Путь не гипотетический: «Вынести в общие данные» из
+ *       union-массива создаёт запись именно union-типа (issue #663);</li>
+ *   <li><b>variant</b> — запись подходит одному варианту (или нескольким, и тогда берётся
+ *       БЛИЖАЙШИЙ по цепочке наследования): кладётся <code>{ключВарианта: ссылка}</code>;</li>
+ *   <li><b>ambiguous</b> — вариант по типу не определить, спрашиваем человека;</li>
+ *   <li><b>none</b> — запись не подходит ничему, кандидата не показываем.</li>
+ * </ul>
+ *
+ * <p><b>Почему «ambiguous» существует, а не сведён к «взять первый».</b> Наследование одиночное,
+ * поэтому все подходящие варианты лежат на ОДНОЙ цепочке предков записи и различаются глубиной;
+ * равенство дистанций возможно исключительно тогда, когда два варианта объявлены на один и тот же
+ * <code>typeId</code>. Это не порча данных, а осмысленная конфигурация: у «Кабельной линии» варианты
+ * «КабельнаяЛинияЭО» и «КабельнаяЛинияЭОН» смотрят на один тип «Основная кабельная линия» —
+ * освещение внутреннее и наружное, форма данных одна, различие живёт только в ключе варианта.
+ * Выбрать за пользователя тут нечем, а спрятать кандидата значило бы молча отнять у него запись,
+ * которую он видит в каталоге.</p>
+ *
+ * <p><b>Почему только одиночные варианты.</b> <code>array</code> и <code>doc-array</code> объявляют
+ * СПИСОК, а пикер отдаёт одну запись. Завернуть её в одноэлементный массив логично ровно до второго
+ * выбора, который сделает вторую строку вместо добавления в первую. Хуже того, отказ был бы тихим:
+ * <code>ArrayFieldEditor</code> берёт значение как <code>Array.isArray(v) ? v : []</code>, то есть
+ * одиночная ссылка исчезла бы из редактора без следа, а в шаблон уехал объект вместо перечисления.</p>
+ *
+ * <p>Ту же меру близости считает сервер при материализации наборов (issue #716); правила там задаёт
+ * админ явно, здесь они выводятся из <code>typeId</code> варианта, но исходы совпадают.</p>
+ */
+export type UnionPlacement =
+  | { kind: 'self' }
+  | { kind: 'variant'; variantKey: string }
+  | { kind: 'ambiguous'; variantKeys: string[] }
+  | { kind: 'none' };
+
+export function placeInUnion(
+  entryTypeId: string, unionType: DocumentType, allDocTypes: DocumentType[],
+): UnionPlacement {
+  if (inheritanceDistance(entryTypeId, unionType.id, allDocTypes) !== null) return { kind: 'self' };
+
+  const matches = resolveEffectiveFields(unionType, allDocTypes)
+    .filter(f => (f.type === 'complex' || f.type === 'doc-ref') && !!f.typeId)
+    .map(f => ({ key: f.key, distance: inheritanceDistance(entryTypeId, f.typeId!, allDocTypes) }))
+    .filter((m): m is { key: string; distance: number } => m.distance !== null);
+
+  if (matches.length === 0) return { kind: 'none' };
+
+  const nearest = Math.min(...matches.map(m => m.distance));
+  const winners = matches.filter(m => m.distance === nearest).map(m => m.key);
+  return winners.length === 1
+    ? { kind: 'variant', variantKey: winners[0] }
+    : { kind: 'ambiguous', variantKeys: winners };
 }
 
 /**

--- a/src/client/src/shared/api/schema.ts
+++ b/src/client/src/shared/api/schema.ts
@@ -191,16 +191,19 @@ export function chainFieldKeys(docType: DocumentType, allDocTypes: DocumentType[
 export function resolveEffectiveFields(
   docType: DocumentType,
   allDocTypes: DocumentType[],
+  /** Пройденные типы — защита от цикла в цепочке наследования (issue #747); внутренний параметр. */
+  visited: Set<string> = new Set(),
 ): SchemaField[] {
   const schema = docType.schema as unknown as SchemaDefinition;
   const ownFields = parseSchemaFields(docType.schema);
 
-  if (!docType.parentId) return ownFields;
+  if (!docType.parentId || visited.has(docType.id)) return ownFields;
+  visited.add(docType.id);
 
   const parent = allDocTypes.find(dt => dt.id === docType.parentId);
   if (!parent) return ownFields;
 
-  const parentFields = resolveEffectiveFields(parent, allDocTypes);
+  const parentFields = resolveEffectiveFields(parent, allDocTypes, visited);
   const excluded = new Set(schema.excludedFields ?? []);
   const overrides = schema.fieldOverrides ?? {};
 
@@ -235,7 +238,9 @@ export function resolveEffectiveFields(
  * <p>Обход итеративный и с visited-set. Прежняя <code>isSubtypeOf</code> была рекурсивна без предела
  * и без защиты от цикла: испорченный <code>parentId</code> (цепочку типов строит пользователь) вешал
  * вкладку переполнением стека. У серверного аналога предел 32 шага, у <code>typeHasTag</code> —
- * visited-set; здесь не было ничего.</p>
+ * visited-set; здесь не было ничего. По той же цепочке ходит <code>resolveEffectiveFields</code>, и
+ * её защитили заодно: закрывать один вход из двух бессмысленно — цикл валил бы вкладку следующей же
+ * строкой.</p>
  */
 export function inheritanceDistance(
   childId: string, parentId: string, allDocTypes: DocumentType[],

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.113.1</Version>
+    <Version>0.114.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Закрывает #747. Постановка согласована с товарищами «Архитектор» и «Дизайнер».

## Что было

Кнопка «Из каталога» на строке union-массива сверяла тип записи с типом самого union'а и внутрь вариантов не заглядывала. Записей, типизированных САМИМ union-типом, в базе **ноль** — то есть фильтр не «слишком узкий», он не пропускал ничего ни на одном union-типе, и кнопка не находила ничего никогда.

## Правило

Чистый хелпер `placeInUnion`, семантика совпадает с серверным выбором варианта по типу (#716):

1. тип записи ⊑ тип самого union'а → голая ссылка (round-trip с «Вынести в общие данные»);
2. ⊑ тип варианта → `{ключВарианта: ссылка}`, ровно один ключ — инвариант #320 держится конструкцией;
3. подходит несколько → ближайший по цепочке наследования;
4. у двух вариантов один `typeId` → спросить человека вторым шагом той же модалки;
5. варианты-СПИСКИ (`array`/`doc-array`) не участвуют никогда.

**Ничью не прячем.** Наследование одиночное, поэтому подходящие варианты лежат на одной цепочке и различаются глубиной; равенство дистанций возможно только при совпадении `typeId` — это осмысленная схема (у «Кабельной линии» ЭО и ЭОН смотрят на один тип «Основная кабельная линия»), а не порча данных, и пользователь её из пикера не исправит.

**Списки исключены** не для симметрии: пикер отдаёт одну запись, а `ArrayFieldEditor` берёт значение как `Array.isArray(v) ? v : []` — одиночная ссылка исчезла бы из редактора без следа, а в шаблон уехал бы объект вместо перечисления.

## Контракт и ловушки

- `onSelect(ref, variantKey?)` + явный проп `unionAware`. Без него тот же пикер из `ComplexCellPicker` писал бы голую ссылку в union — инвариант сломался бы там, где никто не смотрит.
- **Ловушка отрисовки** (нашёл Дизайнер): завёрнутая строка — обычный объект, и без отдельной ветки ушла бы в `rowSummary` как данные, потеряв и признак ссылки, и вариант. Рисуем языком ref-строк плюс тихая метка варианта.
- `isSubtypeOf` выражена через новую `inheritanceDistance`: у неё не было ни предела шагов, ни visited-set, и цикл в цепочке типов вешал вкладку переполнением стека.
- Union опознаётся `typeHasTag`, а не инлайновым `.includes('type.union')` — тот не видел ни унаследованный тэг, ни параметризованную запись `type.union:2`.
- `VariantPicker` вынесен своим файлом: его зовёт теперь и пикер, импорт из `ComplexFields` замкнул бы цикл.
- Пустое состояние разделено на три причины. Раньше один текст на все случаи советовал «добавьте записи в каталог общих данных» там, где записи есть — просто других типов, и человек шёл заводить дубль.

## Проверено

- 480 frontend-тестов (+10 новых на хелпер: наследование, ближайший вариант, ничья, исключение списков, параметризованный тэг, цикл в цепочке), `npx tsc -b` чистый.
- **Живьём:** АОСР → «Документы соответствия» → «Из каталога» показывает «Проект ЭОМ (ИД)» и «Проект ЭОМ (РД)» с меткой варианта «Проект», группами по уровням. До правки диалог был пуст.

Версия 0.114.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3BQxpbn49pef7734yp62