### PR TITLE
Перестановка и пакетное удаление строк в списке массива (#754)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -16,8 +16,9 @@ import {
 } from '@/shared/api/schema';
 import { useListEnumTypes } from '@/shared/api/enumTypes';
 import { formatFieldValue, type FieldTypeDefs } from '@/shared/utils/fieldDisplay';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { objectSummary } from './objectSummary';
-import { mergeTableRows } from './arrayRows';
+import { mergeTableRows, moveOrder, dropOrder, applyOrder, remapSelection } from './arrayRows';
 import { VariantPicker } from './VariantPicker';
 import { ExtractToCommonDataModal } from './ExtractToCommonDataModal';
 import {
@@ -468,6 +469,12 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   const [tableOpen, setTableOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(true);
   const [catalogPickerOpen, setCatalogPickerOpen] = useState(false);
+  // Перестановка и пакетное удаление прямо в списке (issue #754). Выбор — номерами строк, см.
+  // arrayRows: личностей у элементов массива нет, а номера переживают наши операции через remapSelection.
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [dropIdx, setDropIdx] = useState<number | null>(null);
+  const [confirmBulk, setConfirmBulk] = useState(false);
 
   /**
    * Таблица — для ОДНОРОДНЫХ строк, поэтому union-массиву её не предлагаем (issue #748).
@@ -534,9 +541,110 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
     return { key: keys[0], ref: value, label: sub?.title ?? keys[0] };
   }
 
+  /**
+   * Единственная дверь ко всякому изменению порядка и состава строк (issue #754).
+   *
+   * <p>Порядок применяется и к строкам, и к номерам выбранных — одним и тем же значением, поэтому
+   * выбор не может указать на чужую строку. Массив ПЕРЕСТАВЛЯЕТСЯ, а не пересобирается из частей:
+   * пересборка по частям — это #755, где ссылочные строки уезжали в начало.</p>
+   */
+  function reorder(order: number[]) {
+    onChange(applyOrder(allItems, order));
+    setSelected(prev => remapSelection(prev, order));
+  }
+
+  function moveItem(from: number, to: number) {
+    if (to < 0 || to >= allItems.length || from === to) return;
+    reorder(moveOrder(allItems.length, from, to));
+  }
+
   function removeItem(i: number) {
-    onChange(allItems.filter((_, idx) => idx !== i));
+    reorder(dropOrder(allItems.length, new Set([i])));
     setRowModal(null);
+  }
+
+  // Номера выбранных, которые ещё существуют: массив мог поредеть помимо выбора (таблица, вынос).
+  // Считаем по ним и удаляем их же — подпись обязана совпадать с тем, что произойдёт.
+  const chosen = [...selected].filter(i => i < allItems.length).sort((a, b) => a - b);
+
+  function toggleSelect(i: number) {
+    setSelected(prev => { const n = new Set(prev); n.has(i) ? n.delete(i) : n.add(i); return n; });
+  }
+
+  function deleteSelected() {
+    reorder(dropOrder(allItems.length, new Set(chosen)));
+    setRowModal(null);
+  }
+
+  /** Свёрнутый список выбор не показывает — держать невидимый выбор значит удалить вслепую. */
+  function toggleCollapsed() {
+    if (!collapsed) setSelected(new Set());
+    setCollapsed(v => !v);
+  }
+
+  /**
+   * Строка, чью ручку надо вернуть под фокус после перестановки клавиатурой.
+   *
+   * <p>Ключ строки здесь — её номер (личностей у элементов массива нет), поэтому React после
+   * перестановки переиспользует тот же узел: фокус остался бы на МЕСТЕ, а не на уехавшей строке, и
+   * второе нажатие ↑ двинуло бы уже соседа. Без этого клавиатурная перестановка работает ровно один
+   * раз — а «довести строку до края клавиатурой» и есть тот сценарий, ради которого живёт
+   * MoveButtons (#517, #542).</p>
+   */
+  const listRef = useRef<HTMLDivElement>(null);
+  const [focusRow, setFocusRow] = useState<number | null>(null);
+  useEffect(() => {
+    if (focusRow === null) return;
+    listRef.current?.querySelector<HTMLElement>(`[data-grip="${focusRow}"]`)?.focus();
+    setFocusRow(null);
+  }, [focusRow]);
+
+  /** Чекбокс + ручка перетаскивания + номер. Обычная функция, не компонент: у компонента,
+   *  объявленного внутри рендера, каждый раз новый тип — React размонтировал бы ручку с фокусом. */
+  function rowChrome(i: number, danger = false) {
+    return (
+      <>
+        <input type="checkbox" checked={selected.has(i)} onChange={() => toggleSelect(i)}
+          aria-label={`Выбрать строку ${i + 1}`}
+          className="shrink-0 w-3.5 h-3.5 accent-brand cursor-pointer" />
+        <button type="button" draggable data-grip={i}
+          onDragStart={e => { setDragIdx(i); e.dataTransfer.effectAllowed = 'move'; }}
+          onDragEnd={() => { setDragIdx(null); setDropIdx(null); }}
+          onKeyDown={e => {
+            const to = e.key === 'ArrowUp' ? i - 1 : e.key === 'ArrowDown' ? i + 1 : null;
+            if (to === null || to < 0 || to >= allItems.length) return;
+            e.preventDefault(); e.stopPropagation();
+            moveItem(i, to);
+            setFocusRow(to);
+          }}
+          title="Перетащить для изменения порядка (или стрелки ↑↓)"
+          aria-label={`Переместить строку ${i + 1}: стрелки вверх и вниз`}
+          className="shrink-0 cursor-grab active:cursor-grabbing text-fg4 hover:text-fg2 focus-visible:outline-none focus-visible:text-brand">
+          <GripVertical size={12} />
+        </button>
+        <span className={`text-xs font-mono w-5 text-right shrink-0 ${danger ? 'text-danger' : 'text-fg4'}`}>
+          {i + 1}
+        </span>
+      </>
+    );
+  }
+
+  /** Обвязка строки: приём перетаскиваемой строки на своё место + подсветка цели. */
+  function dropTarget(i: number) {
+    return {
+      onDragOver: (e: React.DragEvent) => {
+        if (dragIdx === null) return;
+        e.preventDefault();
+        if (dropIdx !== i) setDropIdx(i);
+      },
+      onDrop: (e: React.DragEvent) => {
+        e.preventDefault();
+        if (dragIdx !== null) moveItem(dragIdx, i);
+        setDragIdx(null); setDropIdx(null);
+      },
+      style: dragIdx !== null && dropIdx === i && dragIdx !== i
+        ? { outline: '2px solid var(--color-brand)', outlineOffset: '-2px' } : undefined,
+    };
   }
 
   function updateRow(i: number, row: Record<string, unknown>) {
@@ -550,7 +658,7 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   return (
     <div className="border border-stroke rounded-lg overflow-hidden">
       <div className={`flex items-center justify-between px-3 py-2 bg-base ${collapsed ? '' : 'border-b border-stroke'}`}>
-        <button type="button" onClick={() => setCollapsed(v => !v)}
+        <button type="button" onClick={toggleCollapsed}
           className="flex items-center gap-1.5 min-w-0 text-sm font-medium text-fg2 hover:text-fg1 transition-colors">
           {collapsed
             ? <ChevronDown size={12} className="shrink-0 text-fg4" />
@@ -561,6 +669,23 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
           )}
           <span className="text-xs text-fg4 font-normal ml-1 shrink-0">{allItems.length} стр.</span>
         </button>
+        {/* Есть выбор — шапка показывает действия над выбранным вместо действий над списком (тот же
+            приём, что в подвале модалки таблицы). Место выбрано за то, что оно ВИДНО: подвал списка
+            у контейнера с overflow-hidden не «липнет», и на девятнадцати строках кнопка удаления
+            оказалась бы за экраном — отметил строки вверху, а нажать нечего. */}
+        {chosen.length > 0 ? (
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-fg2 px-1">Выбрано: {chosen.length}</span>
+            <button type="button" onClick={() => setConfirmBulk(true)}
+              className="flex items-center gap-1 text-xs text-danger hover:text-danger px-2 py-0.5 rounded hover:bg-danger-subtle transition-colors">
+              <Trash2 size={11} /> Удалить выбранные
+            </button>
+            <button type="button" onClick={() => setSelected(new Set())}
+              className="text-xs text-fg4 hover:text-fg2 px-2 py-0.5 rounded hover:bg-stroke transition-colors">
+              Снять выбор
+            </button>
+          </div>
+        ) : (
         <div className="flex items-center gap-1">
           {hasTableFields && (
             <button type="button" onClick={() => setTableOpen(true)}
@@ -579,20 +704,21 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
             <Plus size={11} /> Добавить строку
           </button>
         </div>
+        )}
       </div>
       {!collapsed && allItems.length === 0 && (
         <p className="text-xs text-fg4 text-center py-3">Нет строк — нажмите «Добавить строку» или «Из каталога»</p>
       )}
       {!collapsed && allItems.length > 0 && (
-        <div className="divide-y divide-muted">
+        <div ref={listRef} className="divide-y divide-muted">
           {allItems.map((item, i) => {
             if (isFieldRef(item)) {
               const itemBroken = !!basePath && !!brokenPaths?.has(`${basePath}[${i}]`);
               if (itemBroken) {
                 return (
                   <div key={i}>
-                    <div className={`flex items-center gap-2 px-3 py-2 ${BROKEN_PLATE}`}>
-                      <span className="text-xs text-danger font-mono w-5 text-right shrink-0">{i + 1}</span>
+                    <div className={`flex items-center gap-2 px-3 py-2 ${BROKEN_PLATE}`} {...dropTarget(i)}>
+                      {rowChrome(i, true)}
                       <Link2 size={12} className="text-danger shrink-0" />
                       <span className={`flex-1 text-sm truncate ${BROKEN_LABEL}`}>{item.displayName}</span>
                       <button type="button" onClick={() => removeItem(i)}
@@ -603,8 +729,9 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                 );
               }
               return (
-                <div key={i} className="flex items-center gap-2 px-3 py-2 hover:bg-base">
-                  <span className="text-xs text-fg4 font-mono w-5 text-right shrink-0">{i + 1}</span>
+                <div key={i} {...dropTarget(i)}
+                  className={`flex items-center gap-2 px-3 py-2 ${selected.has(i) ? 'bg-brand-subtle' : 'hover:bg-base'}`}>
+                  {rowChrome(i)}
                   <Link2 size={12} className="text-warning shrink-0" />
                   <span className="flex-1 text-sm text-warning truncate">{item.displayName}</span>
                   <button type="button" onClick={() => removeItem(i)}
@@ -629,8 +756,10 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                 && !!brokenPaths?.has(`${basePath}[${i}].${wrapped.key}`);
               return (
                 <div key={i}>
-                <div className={`flex items-center gap-2 px-3 py-2 ${wrappedBroken ? BROKEN_PLATE : 'hover:bg-base'}`}>
-                  <span className={`text-xs font-mono w-5 text-right shrink-0 ${wrappedBroken ? 'text-danger' : 'text-fg4'}`}>{i + 1}</span>
+                <div {...dropTarget(i)}
+                  className={`flex items-center gap-2 px-3 py-2 ${wrappedBroken ? BROKEN_PLATE
+                    : selected.has(i) ? 'bg-brand-subtle' : 'hover:bg-base'}`}>
+                  {rowChrome(i, wrappedBroken)}
                   <Link2 size={12} className={`shrink-0 ${wrappedBroken ? 'text-danger' : 'text-warning'}`} />
                   <span className={`flex-1 text-sm truncate ${wrappedBroken ? BROKEN_LABEL : 'text-warning'}`}>{wrapped.ref.displayName}</span>
                   <span className="text-[11px] text-fg4 shrink-0 truncate max-w-[40%]">{wrapped.label}</span>
@@ -651,8 +780,9 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
 
             // issue #102: строка — компактная сводка + ✎ (модалка), без инлайн-раскрытия (источник «портянки»).
             return (
-              <div key={i} className="flex items-center gap-2 px-3 py-2 hover:bg-base">
-                <span className="text-xs text-fg4 font-mono w-5 text-right shrink-0">{i + 1}</span>
+              <div key={i} {...dropTarget(i)}
+                className={`flex items-center gap-2 px-3 py-2 ${selected.has(i) ? 'bg-brand-subtle' : 'hover:bg-base'}`}>
+                {rowChrome(i)}
                 <button type="button" onClick={() => setRowModal(i)}
                   className="flex-1 text-left text-sm text-fg2 hover:text-fg1 truncate">
                   {rowSummary(row)}
@@ -670,6 +800,13 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
           })}
         </div>
       )}
+      <ConfirmDialog
+        open={confirmBulk} onOpenChange={setConfirmBulk}
+        title={`Удалить строк: ${chosen.length}?`}
+        description={<p>Строки исчезнут из поля «{field.title}». Изменение попадёт в документ при
+          сохранении формы — до этого его можно отменить, закрыв форму без сохранения.</p>}
+        confirmLabel={`Удалить (${chosen.length})`}
+        onConfirm={deleteSelected} />
       {rowModal !== null && allItems[rowModal] != null && !isFieldRef(allItems[rowModal]) && (
         <Modal open onOpenChange={o => { if (!o) setRowModal(null); }} wide
           title={`${compositeType?.name ?? field.title} — строка ${rowModal + 1}`}
@@ -746,7 +883,9 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
         open={tableOpen} onOpenChange={setTableOpen}
         field={field} compositeType={compositeType} allDocTypes={allDocTypes}
         items={inlineItems}
-        onSave={(rows, origins) => onChange(mergeTableRows(allItems, rows, origins))}
+        // Выбор снимаем: таблица меняет и состав, и порядок строк, и номера выбранных после неё
+        // указывали бы неизвестно на что (issue #754).
+        onSave={(rows, origins) => { onChange(mergeTableRows(allItems, rows, origins)); setSelected(new Set()); }}
         setId={setId} scope={scope} scopeId={scopeId}
       />
       {compositeType && (

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -22,7 +22,7 @@ import { mergeTableRows, moveOrder, dropOrder, applyOrder, remapSelection } from
 import { VariantPicker } from './VariantPicker';
 import { ExtractToCommonDataModal } from './ExtractToCommonDataModal';
 import {
-  CELL_INPUT, SCOPE_COLORS, TABLE_SHOWN_TYPES, defaultColWidth, showsArrayTable,
+  CELL_INPUT, ROW_DRAG_MIME, SCOPE_COLORS, TABLE_SHOWN_TYPES, defaultColWidth, showsArrayTable,
 } from './constants';
 import { isMissing, PrimitiveInput } from './PrimitiveInput';
 import { ImageField } from './ImageField';
@@ -376,7 +376,12 @@ export function ArrayTableModal({
                 <td role="rowheader" style={{ border: BORDER, padding: 0 }} className={sel ? 'bg-brand-subtle' : 'bg-base'}>
                   <div className="flex items-center justify-center gap-0.5" style={{ height: 26 }}>
                     <button type="button" draggable
-                      onDragStart={e => { setDragIdx(i); e.dataTransfer.effectAllowed = 'move'; }}
+                      // setData обязателен: без груза Firefox отменяет перетаскивание (см. ROW_DRAG_MIME).
+                      onDragStart={e => {
+                        setDragIdx(i);
+                        e.dataTransfer.effectAllowed = 'move';
+                        e.dataTransfer.setData(ROW_DRAG_MIME, String(i));
+                      }}
                       onDragEnd={() => { setDragIdx(null); setDropIdx(null); }}
                       onKeyDown={e => {
                         if (e.key === 'ArrowUp') { e.preventDefault(); e.stopPropagation(); moveRow(i, i - 1); }
@@ -568,7 +573,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
   const chosen = [...selected].filter(i => i < allItems.length).sort((a, b) => a - b);
 
   function toggleSelect(i: number) {
-    setSelected(prev => { const n = new Set(prev); n.has(i) ? n.delete(i) : n.add(i); return n; });
+    // delete возвращает «было ли», так что снятие и постановка — одна ветка.
+    setSelected(prev => { const n = new Set(prev); if (!n.delete(i)) n.add(i); return n; });
   }
 
   function deleteSelected() {
@@ -592,12 +598,15 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
    * MoveButtons (#517, #542).</p>
    */
   const listRef = useRef<HTMLDivElement>(null);
-  const [focusRow, setFocusRow] = useState<number | null>(null);
+  const focusRow = useRef<number | null>(null);
+  // Без списка зависимостей: заявка живёт в ref, поэтому эффекту нечего сравнивать — он просто
+  // смотрит после каждой отрисовки, не ждёт ли кто фокуса, и почти всегда сразу выходит.
   useEffect(() => {
-    if (focusRow === null) return;
-    listRef.current?.querySelector<HTMLElement>(`[data-grip="${focusRow}"]`)?.focus();
-    setFocusRow(null);
-  }, [focusRow]);
+    const target = focusRow.current;
+    if (target === null) return;
+    focusRow.current = null;
+    listRef.current?.querySelector<HTMLElement>(`[data-grip="${target}"]`)?.focus();
+  });
 
   /** Чекбокс + ручка перетаскивания + номер. Обычная функция, не компонент: у компонента,
    *  объявленного внутри рендера, каждый раз новый тип — React размонтировал бы ручку с фокусом. */
@@ -608,14 +617,23 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
           aria-label={`Выбрать строку ${i + 1}`}
           className="shrink-0 w-3.5 h-3.5 accent-brand cursor-pointer" />
         <button type="button" draggable data-grip={i}
-          onDragStart={e => { setDragIdx(i); e.dataTransfer.effectAllowed = 'move'; }}
+          // setData обязателен: без груза Firefox отменяет перетаскивание (см. ROW_DRAG_MIME).
+          onDragStart={e => {
+            setDragIdx(i);
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData(ROW_DRAG_MIME, String(i));
+          }}
           onDragEnd={() => { setDragIdx(null); setDropIdx(null); }}
           onKeyDown={e => {
             const to = e.key === 'ArrowUp' ? i - 1 : e.key === 'ArrowDown' ? i + 1 : null;
-            if (to === null || to < 0 || to >= allItems.length) return;
+            if (to === null) return;
+            // Стрелку гасим и на краю: иначе последнее нажатие в «довести строку до низа»
+            // достаётся браузеру, и форма уезжает прокруткой ровно в тот момент, когда строка
+            // встала на место. Тот же сценарий, ради которого MoveButtons не делает disabled (#517).
             e.preventDefault(); e.stopPropagation();
+            if (to < 0 || to >= allItems.length) return;
             moveItem(i, to);
-            setFocusRow(to);
+            focusRow.current = to;
           }}
           title="Перетащить для изменения порядка (или стрелки ↑↓)"
           aria-label={`Переместить строку ${i + 1}: стрелки вверх и вниз`}
@@ -627,6 +645,17 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
         </span>
       </>
     );
+  }
+
+  /**
+   * Признак выбора для строки, у которой фон уже занят (битая ссылка — danger-плитка).
+   *
+   * <p>Иначе выбранная битая строка отличалась бы от невыбранной одним чекбоксом в 14 пикселей,
+   * при том что шапка говорит «Выбрано: 3», а удаление пачкой её и правда унесёт. Ровно то
+   * «удалить вслепую», ради которого выбор снимается при сворачивании списка.</p>
+   */
+  function selectedRing(i: number) {
+    return selected.has(i) ? 'ring-1 ring-inset ring-brand' : '';
   }
 
   /** Обвязка строки: приём перетаскиваемой строки на своё место + подсветка цели. */
@@ -717,7 +746,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
               if (itemBroken) {
                 return (
                   <div key={i}>
-                    <div className={`flex items-center gap-2 px-3 py-2 ${BROKEN_PLATE}`} {...dropTarget(i)}>
+                    <div {...dropTarget(i)}
+                      className={`flex items-center gap-2 px-3 py-2 ${BROKEN_PLATE} ${selectedRing(i)}`}>
                       {rowChrome(i, true)}
                       <Link2 size={12} className="text-danger shrink-0" />
                       <span className={`flex-1 text-sm truncate ${BROKEN_LABEL}`}>{item.displayName}</span>
@@ -757,7 +787,8 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
               return (
                 <div key={i}>
                 <div {...dropTarget(i)}
-                  className={`flex items-center gap-2 px-3 py-2 ${wrappedBroken ? BROKEN_PLATE
+                  className={`flex items-center gap-2 px-3 py-2 ${wrappedBroken
+                    ? `${BROKEN_PLATE} ${selectedRing(i)}`
                     : selected.has(i) ? 'bg-brand-subtle' : 'hover:bg-base'}`}>
                   {rowChrome(i, wrappedBroken)}
                   <Link2 size={12} className={`shrink-0 ${wrappedBroken ? 'text-danger' : 'text-warning'}`} />

--- a/src/client/src/features/document-sets/fields/arrayRows.test.ts
+++ b/src/client/src/features/document-sets/fields/arrayRows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeTableRows } from './arrayRows';
+import { mergeTableRows, moveOrder, dropOrder, applyOrder, remapSelection } from './arrayRows';
 
 const ref = (name: string) => ({ $ref: 'catalog' as const, entryId: name, displayName: name });
 const row = (n: string) => ({ Наименование: n });
@@ -61,5 +61,59 @@ describe('mergeTableRows', () => {
     // Удалили «б», оставшиеся поменяли местами.
     expect(mergeTableRows(all, [row('в'), row('а')], [2, 0]))
       .toEqual([row('в'), ref('Р1'), row('а')]);
+  });
+});
+
+/**
+ * Перестановка и пакетное удаление в аккордеонном списке (issue #754).
+ *
+ * Тесты держат главное свойство: строки и выбор переставляет ОДИН порядок, поэтому они не могут
+ * разъехаться. Расхождение массива с сопутствующим состоянием — это #755, второй раз не надо.
+ */
+describe('порядок строк массива', () => {
+  it('moveOrder двигает элемент вниз', () => {
+    expect(moveOrder(4, 0, 2)).toEqual([1, 2, 0, 3]);
+  });
+
+  it('moveOrder двигает элемент вверх', () => {
+    expect(moveOrder(4, 3, 1)).toEqual([0, 3, 1, 2]);
+  });
+
+  it('moveOrder за краем и на месте — порядок не меняется', () => {
+    expect(moveOrder(3, 0, -1)).toEqual([0, 1, 2]);
+    expect(moveOrder(3, 2, 3)).toEqual([0, 1, 2]);
+    expect(moveOrder(3, 1, 1)).toEqual([0, 1, 2]);
+  });
+
+  it('dropOrder выбрасывает указанные и только их', () => {
+    expect(dropOrder(5, new Set([1, 3]))).toEqual([0, 2, 4]);
+    expect(dropOrder(3, new Set())).toEqual([0, 1, 2]);
+    expect(dropOrder(2, new Set([0, 1]))).toEqual([]);
+  });
+
+  it('applyOrder переставляет строки, включая ссылочные', () => {
+    const all = [row('а'), ref('Р1'), row('б')];
+    expect(applyOrder(all, moveOrder(3, 2, 0))).toEqual([row('б'), row('а'), ref('Р1')]);
+  });
+
+  it('выбор едет вместе со строками', () => {
+    // Выбраны «а» (0) и «б» (2). Тащим «б» в начало — выбранными обязаны остаться те же строки.
+    const order = moveOrder(3, 2, 0);
+    expect(applyOrder([row('а'), ref('Р1'), row('б')], order))
+      .toEqual([row('б'), row('а'), ref('Р1')]);
+    expect(remapSelection(new Set([0, 2]), order)).toEqual(new Set([1, 0]));
+  });
+
+  it('после удаления выбранных выбор пуст, соседи не выбираются', () => {
+    const order = dropOrder(4, new Set([1, 2]));
+    expect(applyOrder([row('а'), row('б'), row('в'), row('г')], order))
+      .toEqual([row('а'), row('г')]);
+    expect(remapSelection(new Set([1, 2]), order)).toEqual(new Set());
+  });
+
+  it('удаление одной строки не сдвигает выбор на чужую', () => {
+    // Выбрана «г» (3). Удаляем «б» (1) корзиной — выбранной обязана остаться «г», теперь под № 2.
+    const order = dropOrder(4, new Set([1]));
+    expect(remapSelection(new Set([3]), order)).toEqual(new Set([2]));
   });
 });

--- a/src/client/src/features/document-sets/fields/arrayRows.ts
+++ b/src/client/src/features/document-sets/fields/arrayRows.ts
@@ -1,6 +1,47 @@
 import { isFieldRef } from '@/shared/api/types';
 
 /**
+ * Перестановка и удаление строк массива одним общим языком — «порядком» (issue #754).
+ *
+ * <p>Порядок здесь — массив СТАРЫХ индексов в новом порядке: <code>[2, 0, 1]</code> значит «третья
+ * строка стала первой». Операция описывается порядком, а применяется двумя способами — к самим
+ * строкам и к номерам выбранных строк. Оба берут ОДИН И ТОТ ЖЕ порядок, поэтому разъехаться не
+ * могут: нельзя переставить строки и забыть переставить выбор. Ровно этот класс расхождения —
+ * массив пересобрали, а сопутствующее состояние нет — и был дефектом #755.</p>
+ *
+ * <p>Выбор хранится номерами, а не личностями строк, потому что личностей у элементов массива нет:
+ * значение приходит пропом из формы, две одинаковые строки неразличимы, а собственные id пришлось бы
+ * синхронизировать с правками извне (таблица, вынос в общие данные) — лишний источник расхождения.
+ * Номера же переживают любую нашу операцию, если пропущены через <code>remapSelection</code>.</p>
+ */
+export function moveOrder(length: number, from: number, to: number): number[] {
+  const order = Array.from({ length }, (_, i) => i);
+  if (from < 0 || from >= length || to < 0 || to >= length || from === to) return order;
+  const [moved] = order.splice(from, 1);
+  order.splice(to, 0, moved);
+  return order;
+}
+
+/** Порядок после удаления строк: те же индексы без выброшенных. */
+export function dropOrder(length: number, dropped: Set<number>): number[] {
+  const order: number[] = [];
+  for (let i = 0; i < length; i++) if (!dropped.has(i)) order.push(i);
+  return order;
+}
+
+/** Строки в новом порядке. */
+export function applyOrder<T>(items: T[], order: number[]): T[] {
+  return order.map(i => items[i]);
+}
+
+/** Номера выбранных строк в новом порядке; выбывшие строки из выбора исчезают. */
+export function remapSelection(selected: Set<number>, order: number[]): Set<number> {
+  const next = new Set<number>();
+  order.forEach((old, i) => { if (selected.has(old)) next.add(i); });
+  return next;
+}
+
+/**
  * Возврат отредактированных в таблице строк на их места в массиве (issue #755).
  *
  * <p>Модалка «Таблица» правит только НЕссылочные строки — ссылочные из неё исключены, потому что

--- a/src/client/src/features/document-sets/fields/constants.ts
+++ b/src/client/src/features/document-sets/fields/constants.ts
@@ -49,6 +49,17 @@ export function defaultColWidth(f: SchemaField) {
   return DEFAULT_COL_WIDTHS[f.type] ?? 140;
 }
 
+/**
+ * Тип полезной нагрузки при перетаскивании строки массива.
+ *
+ * <p>Класть в <code>dataTransfer</code> хоть что-то ОБЯЗАТЕЛЬНО: ручка — это <code>button</code>,
+ * не изначально перетаскиваемый элемент, а Firefox отменяет перетаскивание, если
+ * <code>dragstart</code> не положил ничего (issue #517). Тип свой, не <code>text/plain</code>:
+ * с текстовым типом ручка становится источником перетаскивания для всей страницы, и отпущенная
+ * над чужим полем ввода вставила бы туда номер строки (issue #518).</p>
+ */
+export const ROW_DRAG_MIME = 'application/x-crg-array-row';
+
 export const CELL_INPUT =
   'w-full h-full px-1.5 bg-transparent border-none outline-none text-xs text-fg1 tabular-nums focus:bg-brand-subtle';
 

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.114.2</Version>
+    <Version>0.115.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #754

Закрыв таблицу для union-массивов (#748), мы отняли у них единственный способ переупорядочить строки и удалить их пачкой. Возвращаем оба — в аккордеонный список, где они полезны **всем** массивам: порядок строк значим (#663), а таблица для массива со сложными подполями бывает неинформативна.

## Что появилось

У каждой строки — чекбокс, ручка перетаскивания и номер:

- **перетаскивание** мышью, цель подсвечивается контуром;
- **↑↓ с клавиатуры** на ручке — и фокус едет вместе со строкой, иначе второе нажатие двигало бы уже соседа;
- **выбор строк** → шапка группы показывает «Выбрано: N · Удалить выбранные · Снять выбор» вместо действий над списком;
- **удаление пачкой** — через `ConfirmDialog` с числом строк.

Вставку из Excel для union-массивов сознательно не возвращаем: её маппинг кладёт колонку в ключ варианта, то есть две колонки на два варианта дают два ключа — ровно та дыра, которую закрыла #748.

## Как это не повторяет #755

Порядок строк и номера выбранных переставляет **один и тот же «порядок»** — массив старых индексов (`arrayRows.ts`): нельзя переставить строки и забыть переставить выбор. Массив при этом **переставляется**, а не пересобирается из частей; пересборка по частям и была дефектом #755, где ссылочные строки уезжали в начало.

Выбор хранится номерами, а не личностями строк: личностей у элементов массива нет — значение приходит пропом, две одинаковые строки неразличимы, а свои id пришлось бы синхронизировать с правками извне. Поэтому выбор снимается при сворачивании группы и после сохранения таблицы (она меняет и состав, и порядок).

## Панель выбора — в шапке, не в подвале

Сначала подвал списка, `sticky bottom-0`, как в «Документах качества». Не работает: у контейнера поля `overflow-hidden`, sticky внутри него не липнет, и на девятнадцати строках «Реестра работ» кнопка удаления оказывалась за экраном — отметил строки вверху, а нажать нечего. Шапка видна всегда; тот же приём, что в подвале модалки таблицы.

## Проверено

- `npx tsc -b` чисто; **499 тестов** (+8 на порядок: перемещение, край, удаление, «выбор едет со строкой»).
- Живая проверка на АОСР «250701.ЭОМ-1» → «Иные члены комиссии» (3 строки-ссылки): **17 утверждений**, среди них «фокус уехал вместе со строкой», «на краю ↓ фокус не теряется», «отмеченной осталась ТА ЖЕ строка, а не её место», «осталась одна строка — та, что не была выбрана». Ничего не сохранялось.
- **Достижимость проверки**: нарочная поломка `remapSelection` (вернуть выбор как есть) роняет 3 юнит-теста и 2 живых утверждения — отмеченной становится чужая строка. После восстановления снова 17/17.
- Плотность посмотрена на «Реестре работ» (19 обычных строк) — ряд не разъехался.

Версия 0.114.2 → **0.115.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3BQxpbn49pef7734yp62