### PR TITLE
Строка union с двумя вариантами: увидеть и сказать (#756)

### DIFF
--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
-  Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Info, Link2, Pencil, Plus, RefreshCw, Share2, Trash2, Unlink, X,
+  AlertTriangle, Clipboard, ChevronDown, ChevronUp, Database, FileSpreadsheet, GripVertical, Info, Link2, Pencil, Plus, RefreshCw, Share2, Trash2, Unlink, X,
 } from 'lucide-react';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Modal } from '@/shared/ui/Modal';
@@ -809,6 +809,12 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
               );
             }
 
+            // Строка union'а, где заполнен не один вариант (issue #756). До этой ветки она доходит
+            // именно потому, что ключей больше одного: unionRef выше требует ровно одного и
+            // возвращает null, так что строка рисовалась обычной сводкой — без единого признака,
+            // что открыть её значит потерять часть данных.
+            const extraVariants = isUnionComposite ? filledVariants(row, subFields) : [];
+
             // issue #102: строка — компактная сводка + ✎ (модалка), без инлайн-раскрытия (источник «портянки»).
             return (
               <div key={i} {...dropTarget(i)}
@@ -818,6 +824,12 @@ export function ArrayFieldEditor({ field, allDocTypes, value, onChange, showVali
                   className="flex-1 text-left text-sm text-fg2 hover:text-fg1 truncate">
                   {rowSummary(row)}
                 </button>
+                {extraVariants.length > 1 && (
+                  <span className="flex items-center gap-1 text-[11px] text-warning shrink-0"
+                    title={overfilledNote(extraVariants)} role="img" aria-label={overfilledNote(extraVariants)}>
+                    <AlertTriangle size={12} /> вариантов: {extraVariants.length}
+                  </span>
+                )}
                 <button type="button" onClick={() => setRowModal(i)} title="Редактировать"
                   className="p-1 text-fg4 hover:text-fg2 shrink-0">
                   <Pencil size={13} />
@@ -1270,6 +1282,25 @@ function SubfieldEditor({ sf, value, onChange, allDocTypes, showValidation, setI
 
 // ─── Union-поле (issue #320): заполняется РОВНО ОДИН вариант (подполе union-типа) ──
 /** Вариант считается заполненным: непустой массив / FieldRef / непустой объект / непустая строка. */
+/**
+ * Подписи заполненных вариантов union-значения (issue #756).
+ *
+ * <p>Инвариант — «заполнен ровно один» (#320), и записать иное приложение не даёт. Но
+ * <code>PUT …/requisites</code> кладёт тело как есть (путь записи схема-агностичен сознательно), так
+ * что значение с двумя ключами приезжает из восстановленной копии, правки JSONB руками или импорта.
+ * Единственный путь через такие данные в редакторе — потеря части: он показывает ПЕРВЫЙ заполненный
+ * вариант, а первая же правка выбрасывает остальные. Поэтому — сказать заранее.</p>
+ */
+function filledVariants(row: Record<string, unknown>, subFields: SchemaField[]): string[] {
+  return subFields.filter(sf => isVariantFilled(row[sf.key])).map(sf => sf.title);
+}
+
+/** Текст предупреждения о нескольких заполненных вариантах — одинаковый в списке и в редакторе. */
+function overfilledNote(titles: string[]): string {
+  return `Заполнено вариантов: ${titles.length} (${titles.join(', ')}), а должен быть один. `
+    + 'В документ попадёт первый; при правке этого значения остальные будут потеряны.';
+}
+
 function isVariantFilled(v: unknown): boolean {
   if (v == null) return false;
   if (isFieldRef(v)) return true;
@@ -1325,7 +1356,15 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
     key: sf.key, label: sf.title,
     filled: isVariantFilled(subValues[sf.key]) || isVariantFilled(stash[sf.key]),
   }));
-  const chip = (
+  // Значение пришло с несколькими заполненными вариантами (issue #756) — считаем по СОХРАНЁННОМУ
+  // значению, не по options: там к заполненным приплюсован стэш, а он наш собственный и законен.
+  const overfilled = filledVariants(subValues, subFields);
+  const chip = overfilled.length > 1 ? (
+    <span className="text-[11px] text-warning flex items-start gap-1" role="alert">
+      <AlertTriangle size={11} className="shrink-0 mt-0.5" />
+      <span>{overfilledNote(overfilled)}</span>
+    </span>
+  ) : (
     <span className="text-[11px] text-fg4 flex items-center gap-1 shrink-0" title="Заполняется ровно один из вариантов">
       <Info size={11} /> заполните одно из
     </span>

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1281,7 +1281,7 @@ function SubfieldEditor({ sf, value, onChange, allDocTypes, showValidation, setI
 }
 
 // ─── Union-поле (issue #320): заполняется РОВНО ОДИН вариант (подполе union-типа) ──
-/** Вариант считается заполненным: непустой массив / FieldRef / непустой объект / непустая строка. */
+
 /**
  * Подписи заполненных вариантов union-значения (issue #756).
  *
@@ -1290,17 +1290,27 @@ function SubfieldEditor({ sf, value, onChange, allDocTypes, showValidation, setI
  * что значение с двумя ключами приезжает из восстановленной копии, правки JSONB руками или импорта.
  * Единственный путь через такие данные в редакторе — потеря части: он показывает ПЕРВЫЙ заполненный
  * вариант, а первая же правка выбрасывает остальные. Поэтому — сказать заранее.</p>
+ *
+ * <p><code>subFields</code> приходит уже без расчётных подполей (#368) — их значение считает
+ * генерация, вариантами они не являются, и серверная проверка арности их так же исключает.</p>
  */
 function filledVariants(row: Record<string, unknown>, subFields: SchemaField[]): string[] {
   return subFields.filter(sf => isVariantFilled(row[sf.key])).map(sf => sf.title);
 }
 
-/** Текст предупреждения о нескольких заполненных вариантах — одинаковый в списке и в редакторе. */
+/**
+ * Текст предупреждения о нескольких заполненных вариантах — одинаковый в списке и в редакторе.
+ *
+ * <p>Про «попадёт в документ» не говорим: в data.json уходят оба ключа, а что напечатается, решает
+ * блок типа в шаблоне — утверждать за него нечего. Обещаем только то, что гарантирует код.</p>
+ */
 function overfilledNote(titles: string[]): string {
   return `Заполнено вариантов: ${titles.length} (${titles.join(', ')}), а должен быть один. `
-    + 'В документ попадёт первый; при правке этого значения остальные будут потеряны.';
+    + 'В данные уйдут все; что попадёт в документ, решит блок типа в шаблоне. '
+    + 'Редактор откроет первый и при правке потеряет остальные.';
 }
 
+/** Вариант считается заполненным: непустой массив / FieldRef / непустой объект / непустая строка. */
 function isVariantFilled(v: unknown): boolean {
   if (v == null) return false;
   if (isFieldRef(v)) return true;
@@ -1391,6 +1401,15 @@ function UnionFieldGroup({ field, allDocTypes, value, onChange, showValidation, 
             className="flex-1 min-w-0 text-left text-sm text-fg2 hover:text-fg1 truncate">
             {unionSummary(activeSf, subValues[activeKey], { primitiveTypes, enumTypes })}
           </button>
+          {/* Свёрнутая строка показывает ТОЛЬКО активный вариант, поэтому без метки она выглядела бы
+              обычными данными — а ✎ и первая правка унесли бы второй вариант (issue #756). Ровно та
+              же дверь, что закрыта в списке строк массива; здесь она оставалась открытой. */}
+          {overfilled.length > 1 && (
+            <span className="flex items-center gap-1 text-[11px] text-warning shrink-0"
+              title={overfilledNote(overfilled)} role="img" aria-label={overfilledNote(overfilled)}>
+              <AlertTriangle size={12} /> вариантов: {overfilled.length}
+            </span>
+          )}
           <button type="button" onClick={() => setModalOpen(true)} title="Редактировать"
             className="p-1 text-fg4 hover:text-fg2 transition-colors shrink-0"><Pencil size={13} /></button>
         </div>

--- a/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using BHS.CRG.Application.Schema;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Schema;
 
 namespace BHS.CRG.Application.Generation;
 
@@ -88,16 +89,67 @@ public static class ValueTypeScanner
             Warn(diagnostics, path, $"Поле «{Title(field)}» — составное, а хранится простое значение.");
             return;
         }
-        if (field.TypeId is not { } typeId || !typesById.ContainsKey(typeId)) return;
+        if (field.TypeId is not { } typeId || !typesById.TryGetValue(typeId, out var composite)) return;
+
+        var inners = DocumentTypeSchemaReader.EffectiveFields(typeId, typesById);
+        CheckUnionArity(path, composite, inners, value, typesById, diagnostics);
 
         // Именно здесь и живёт находка: верхнего уровня недостаточно, «ПорядковыйНомер» лежит внутри
         // элементов массива «Работы».
-        foreach (var inner in DocumentTypeSchemaReader.EffectiveFields(typeId, typesById))
+        foreach (var inner in inners)
         {
             if (!value.TryGetProperty(inner.Key, out var innerValue)) continue;
             Check($"{path}.{inner.Key}", inner, innerValue, typesById, primitivesById, diagnostics, depth + 1);
         }
     }
+
+    /// <summary>
+    /// Инвариант union'а — «заполнен ровно один вариант» (issue #320, проверка — #756).
+    ///
+    /// <para>Записать такое значение приложение не даёт: пикер варианта хранит один ключ, а таблицу,
+    /// где колонок было по числу вариантов, закрыла #748. Но <c>PUT …/requisites</c> кладёт тело как
+    /// есть — путь записи схема-агностичен СОЗНАТЕЛЬНО, — так что строка с двумя ключами приезжает из
+    /// восстановленной копии, правки JSONB руками или импорта. Здесь мы её и ловим: диагностика
+    /// генерации — единственное место, которое видит значения целиком и не мешает их записывать.</para>
+    ///
+    /// <para>Предупреждение, не ошибка, — как и всё в этом сканере: данные уже накоплены, а решение
+    /// «какой вариант верный» человеческое. Молчать при этом нельзя: редактор, открыв такую строку,
+    /// покажет ПЕРВЫЙ заполненный вариант, и первая же правка выбросит остальные.</para>
+    /// </summary>
+    private static void CheckUnionArity(
+        string path, DocumentType composite, IReadOnlyList<SchemaFieldInfo> inners, JsonElement value,
+        IReadOnlyDictionary<Guid, DocumentType> typesById, List<ResolutionDiagnostic> diagnostics)
+    {
+        if (!SchemaTags.TypeHasTag(composite, typesById, FunctionalTag.TypeUnion)) return;
+
+        var filled = inners
+            .Where(f => value.TryGetProperty(f.Key, out var v) && IsVariantFilled(v))
+            .Select(f => f.Title ?? f.Key)
+            .ToList();
+        if (filled.Count < 2) return;
+
+        diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Warning, path,
+            $"«{composite.Name}» — выбор одного из вариантов, а заполнено {filled.Count}: "
+            + string.Join(", ", filled.Select(t => $"«{t}»"))
+            + ". В документ попадёт первый; при правке этого значения в редакторе остальные будут потеряны.",
+            "union-arity"));
+    }
+
+    /// <summary>
+    /// Заполнен ли вариант. Повторяет <c>isVariantFilled</c> редактора ключ в ключ, включая неочевидное:
+    /// пустой объект и пустой массив — «не выбрано» (иначе снятая ссылка, <c>{}</c>, считалась бы вторым
+    /// вариантом и предупреждение сыпалось бы на здоровых данных), а <c>false</c> — ВЫБРАНО, потому что
+    /// редактор судит по строковому виду значения. Разойдись мы здесь, предупреждение обещало бы потерю
+    /// там, где её не будет, — или молчало бы там, где она случится.
+    /// </summary>
+    private static bool IsVariantFilled(JsonElement v) => v.ValueKind switch
+    {
+        JsonValueKind.Null or JsonValueKind.Undefined => false,
+        JsonValueKind.String => !string.IsNullOrWhiteSpace(v.GetString()),
+        JsonValueKind.Object => v.EnumerateObject().Any(),
+        JsonValueKind.Array => v.EnumerateArray().Any(),
+        _ => true,
+    };
 
     private static string Title(SchemaFieldInfo f) => f.Title ?? f.Key;
 

--- a/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
+++ b/src/server/BHS.CRG.Application/Generation/ValueTypeScanner.cs
@@ -122,16 +122,23 @@ public static class ValueTypeScanner
     {
         if (!SchemaTags.TypeHasTag(composite, typesById, FunctionalTag.TypeUnion)) return;
 
+        // Расчётные подполя вариантами не считаются: их значение пишет ComputedFieldResolver, и к
+        // моменту этой проверки оно уже проставлено. Не отфильтруй мы их — union с одним расчётным
+        // подполем предъявлял бы претензию КАЖДОМУ здоровому значению, и снять её человеку нечем.
+        // Редактор их тоже не показывает (#368), так что счёт обязан совпадать.
         var filled = inners
-            .Where(f => value.TryGetProperty(f.Key, out var v) && IsVariantFilled(v))
+            .Where(f => !f.Computed && value.TryGetProperty(f.Key, out var v) && IsVariantFilled(v))
             .Select(f => f.Title ?? f.Key)
             .ToList();
         if (filled.Count < 2) return;
 
+        // Про «попадёт в документ» не говорим: и тот и другой ключ уходят в data.json, а что
+        // напечатается, решает блок типа в шаблоне — утверждать за него нечего.
         diagnostics.Add(new ResolutionDiagnostic(DiagnosticSeverity.Warning, path,
             $"«{composite.Name}» — выбор одного из вариантов, а заполнено {filled.Count}: "
             + string.Join(", ", filled.Select(t => $"«{t}»"))
-            + ". В документ попадёт первый; при правке этого значения в редакторе остальные будут потеряны.",
+            + ". В данные уйдут все; что попадёт в документ, решит блок типа в шаблоне. "
+            + "Редактор откроет первый и при правке потеряет остальные.",
             "union-arity"));
     }
 

--- a/src/server/BHS.CRG.Application/Schema/SchemaTags.cs
+++ b/src/server/BHS.CRG.Application/Schema/SchemaTags.cs
@@ -158,6 +158,26 @@ public static class SchemaTags
     }
 
     /// <summary>
+    /// То же по словарю типов — для обходов, которые спрашивают это на каждое значение.
+    ///
+    /// <para>Список-перегрузка ищет родителя линейным <c>FirstOrDefault</c>; на строку таблицы это
+    /// незаметно, а на таблицу в две сотни строк с составными подполями — уже нет.</para>
+    /// </summary>
+    public static bool TypeHasTag(DocumentType docType, IReadOnlyDictionary<Guid, DocumentType> typesById, string tag)
+    {
+        var visited = new HashSet<Guid>();
+        var current = docType;
+        while (current is not null && visited.Add(current.Id))
+        {
+            if (SchemaHasTypeTag(current.Schema, tag)) return true;
+            current = current.ParentId.HasValue && typesById.TryGetValue(current.ParentId.Value, out var parent)
+                ? parent
+                : null;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Накладывает метаданные на реквизиты: для каждого (key, tag) берёт meta[tag], если есть.
     /// </summary>
     public static JsonDocument PatchMetadata(

--- a/src/server/BHS.CRG.Tests/Generation/ValueTypeScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ValueTypeScannerTests.cs
@@ -129,4 +129,103 @@ public class ValueTypeScannerTests
 
         Assert.Empty(diagnostics);
     }
+
+    // ── Арность union'а (issue #756) ──────────────────────────────────────────
+    //
+    // Записать такое приложение не даёт, но PUT …/requisites кладёт тело как есть, и строка с двумя
+    // ключами приезжает из восстановленной копии или правки JSONB руками. Проверка нужна потому, что
+    // ЕДИНСТВЕННЫЙ путь через такие данные в редакторе — потеря части из них: открыв строку, он
+    // покажет первый заполненный вариант, а первая же правка выбросит остальные.
+
+    private static readonly Guid UnionTypeId = Guid.NewGuid();
+    private static readonly Guid UnionChildId = Guid.NewGuid();
+
+    private static DocumentType Union(Guid id, string name, string schema, Guid? parentId = null) =>
+        Make<DocumentType>(("Id", id), ("Name", name), ("ParentId", parentId),
+            ("Schema", JsonDocument.Parse(schema.Replace('\'', '"'))));
+
+    private static List<ResolutionDiagnostic> ScanUnion(string json, params DocumentType[] types)
+    {
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ValueTypeScanner.Scan(Context(json),
+            [new SchemaFieldInfo("Документ", "complex", UnionTypeId, "Документ")],
+            types.ToDictionary(t => t.Id),
+            new Dictionary<Guid, PrimitiveType>(),
+            diagnostics);
+        return diagnostics;
+    }
+
+    private const string UnionSchema =
+        "{'tags':['type.union'],'fields':["
+        + "{'key':'Проект','type':'doc-ref','title':'Проект'},"
+        + "{'key':'Реестр','type':'doc-ref','title':'Реестр'}]}";
+
+    [Fact]
+    public void UnionWithTwoFilledVariants_IsReported()
+    {
+        var d = Assert.Single(ScanUnion(
+            """{"Документ":{"Проект":{"$ref":"catalog","entryId":"a"},"Реестр":{"$ref":"catalog","entryId":"b"}}}""",
+            Union(UnionTypeId, "Документ произвольный", UnionSchema)));
+
+        Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+        Assert.Equal("union-arity", d.Code);
+        Assert.Equal("Документ", d.Path);
+        Assert.Contains("заполнено 2", d.Message);
+        Assert.Contains("«Проект»", d.Message);
+        Assert.Contains("«Реестр»", d.Message);
+    }
+
+    [Fact]
+    public void UnionWithOneFilledVariant_IsSilent()
+        => Assert.Empty(ScanUnion("""{"Документ":{"Проект":{"$ref":"catalog","entryId":"a"}}}""",
+            Union(UnionTypeId, "Документ произвольный", UnionSchema)));
+
+    /// <summary>Снятая ссылка — это <c>{}</c>. Считай мы её вторым вариантом, предупреждение сыпалось
+    /// бы на здоровых данных: пустой объект остаётся в реквизитах после «Снять ссылку».</summary>
+    [Fact]
+    public void EmptyObjectVariant_DoesNotCount()
+        => Assert.Empty(ScanUnion("""{"Документ":{"Проект":{"$ref":"catalog","entryId":"a"},"Реестр":{}}}""",
+            Union(UnionTypeId, "Документ произвольный", UnionSchema)));
+
+    /// <summary>Тэг union'а наследуется: подтип объявляет только свои варианты (#747).</summary>
+    [Fact]
+    public void InheritedUnionTag_IsHonoured()
+    {
+        // Тэг — на предке, варианты — у потомка; поле объявлено ПОТОМКОМ.
+        var types = new Dictionary<Guid, DocumentType>
+        {
+            [UnionTypeId] = Union(UnionTypeId, "База", "{'tags':['type.union'],'fields':[]}"),
+            [UnionChildId] = Union(UnionChildId, "Потомок", UnionSchema, UnionTypeId),
+        };
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ValueTypeScanner.Scan(Context("""{"Документ":{"Проект":{"x":1},"Реестр":{"y":2}}}"""),
+            [new SchemaFieldInfo("Документ", "complex", UnionChildId, "Документ")],
+            types, new Dictionary<Guid, PrimitiveType>(), diagnostics);
+
+        var d = Assert.Single(diagnostics);
+        Assert.Equal("union-arity", d.Code);
+        Assert.Contains("заполнено 2", d.Message);
+    }
+
+    /// <summary>Обычному составному типу арность не предъявляем — там «и», а не «одно из».</summary>
+    [Fact]
+    public void NonUnionComposite_IsSilent()
+        => Assert.Empty(ScanUnion("""{"Документ":{"Проект":{"x":1},"Реестр":{"y":2}}}""",
+            Union(UnionTypeId, "Обычный", UnionSchema.Replace("'tags':['type.union'],", ""))));
+
+    /// <summary>Строки таблицы проверяются каждая: union чаще всего стоит элементом массива.</summary>
+    [Fact]
+    public void UnionInsideArrayRow_IsReportedWithRowPath()
+    {
+        var diagnostics = new List<ResolutionDiagnostic>();
+        ValueTypeScanner.Scan(
+            Context("""{"Документы":[{"Проект":{"a":1}},{"Проект":{"a":1},"Реестр":{"b":2}}]}"""),
+            [new SchemaFieldInfo("Документы", "array", UnionTypeId, "Документы")],
+            new Dictionary<Guid, DocumentType> { [UnionTypeId] = Union(UnionTypeId, "Документ", UnionSchema) },
+            new Dictionary<Guid, PrimitiveType>(),
+            diagnostics);
+
+        var d = Assert.Single(diagnostics);
+        Assert.Equal("Документы[1]", d.Path);
+    }
 }

--- a/src/server/BHS.CRG.Tests/Generation/ValueTypeScannerTests.cs
+++ b/src/server/BHS.CRG.Tests/Generation/ValueTypeScannerTests.cs
@@ -191,11 +191,14 @@ public class ValueTypeScannerTests
     [Fact]
     public void InheritedUnionTag_IsHonoured()
     {
-        // Тэг — на предке, варианты — у потомка; поле объявлено ПОТОМКОМ.
+        // Тэг — на предке, варианты — у потомка; поле объявлено ПОТОМКОМ. Схема потомка БЕЗ тэга:
+        // с тэгом обход предков не понадобился бы вовсе, и тест прошёл бы, даже если этот обход
+        // удалить, — то есть охранял бы не то, что обещает в заголовке.
         var types = new Dictionary<Guid, DocumentType>
         {
             [UnionTypeId] = Union(UnionTypeId, "База", "{'tags':['type.union'],'fields':[]}"),
-            [UnionChildId] = Union(UnionChildId, "Потомок", UnionSchema, UnionTypeId),
+            [UnionChildId] = Union(UnionChildId, "Потомок",
+                UnionSchema.Replace("'tags':['type.union'],", ""), UnionTypeId),
         };
         var diagnostics = new List<ResolutionDiagnostic>();
         ValueTypeScanner.Scan(Context("""{"Документ":{"Проект":{"x":1},"Реестр":{"y":2}}}"""),
@@ -206,6 +209,20 @@ public class ValueTypeScannerTests
         Assert.Equal("union-arity", d.Code);
         Assert.Contains("заполнено 2", d.Message);
     }
+
+    /// <summary>
+    /// Расчётное подполе вариантом не считается. Иначе union с одним таким подполем предъявлял бы
+    /// претензию КАЖДОМУ здоровому значению: <c>ComputedFieldResolver</c> проставляет его во всех
+    /// вложенных объектах ДО этой проверки, и снять предупреждение человеку было бы нечем.
+    /// </summary>
+    [Fact]
+    public void ComputedSubfield_IsNotAVariant()
+        => Assert.Empty(ScanUnion(
+            """{"Документ":{"Проект":{"$ref":"catalog","entryId":"a"},"Подпись":"Проект ЭОМ (РД)"}}""",
+            Union(UnionTypeId, "Документ произвольный",
+                "{'tags':['type.union'],'fields':["
+                + "{'key':'Проект','type':'doc-ref','title':'Проект'},"
+                + "{'key':'Подпись','type':'string','title':'Подпись','computed':true,'expression':'1'}]}")));
 
     /// <summary>Обычному составному типу арность не предъявляем — там «и», а не «одно из».</summary>
     [Fact]

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.116.0</Version>
+    <Version>0.117.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #756

Записать такое приложение не даёт: пикер варианта хранит один ключ, а таблицу с колонкой на каждый вариант закрыла #748. Но `PUT …/requisites` кладёт тело как есть — путь записи схема-агностичен **сознательно**, — так что значение с двумя ключами приезжает из восстановленной копии, правки JSONB руками или импорта.

До сих пор единственный путь через такие данные был деструктивным и молчаливым: в списке строка не опознавалась ссылкой и не помечалась никак (`unionRef` требует ровно одного ключа), а редактор показывал **первый** заполненный вариант и первой же правкой выбрасывал остальные.

## Сервер — проверка арности в `ValueTypeScanner`

Там, где живут прочие претензии к значениям, а не на записи: диагностика видит значения целиком и не мешает их класть. **Предупреждение, не ошибка** — как и всё в этом сканере: данные накоплены, а «какой вариант верный» решает человек.

Проверяются и одиночные `complex`-поля, и каждая строка массива — union чаще стоит именно элементом массива. Тэг берётся с учётом наследования: добавлена перегрузка `SchemaTags.TypeHasTag` по словарю типов, чтобы не искать родителя линейным `FirstOrDefault` на каждое значение таблицы.

Заполненность варианта повторяет `isVariantFilled` редактора **ключ в ключ**, включая неочевидное: пустой объект — «не выбрано» (иначе снятая ссылка `{}` считалась бы вторым вариантом), `false` — «выбрано» (редактор судит по строковому виду). Разойдись они, предупреждение обещало бы потерю там, где её нет, — или молчало бы там, где она случится.

## Клиент — сказать до нажатия

- строка в списке помечена значком с числом вариантов; подсказка перечисляет их и называет цену правки;
- редактор строки вместо нейтрального «заполните одно из» показывает то же предупреждение.

Считаем по **сохранённому** значению, не по `options`: там к заполненным приплюсован стэш неактивных вариантов, а он наш собственный и законен.

## Проверено

- 6 новых юнит-тестов сканера (две заполненных, одна, снятая ссылка `{}`, наследованный тэг, обычный составной тип — молчит, строка массива с путём `Документы[1]`).
- **1445** backend-тестов, **499** frontend, `tsc -b` чисто, lint 143 — как на `master`.
- Живьём: случай недостижим из интерфейса, поэтому данные подложены прямо в дев-базу (второй ключ в `ДокументыСоответствия[0]` АОСР) и сняты обратно тем же путём.
  - **6 утверждений в UI**: строка помечена, соседняя здоровая — нет, подсказка называет оба варианта и цену, редактор предупреждает.
  - `GET /api/generate/validate/{id}` вернул **ровно одну** претензию по пути `ДокументыСоответствия[0]`.
  - После восстановления — **0 диагностик** и нейтральная подпись. Проверка ведётся данными, а не константой.

Версия 0.116.0 → **0.117.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3BQxpbn49pef7734yp62