### PR TITLE
Типы: открывать последний открытый тип, выбор — в URL (#778)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   Plus, ChevronRight, Trash2, Copy, Folder, FileText, Boxes, EyeOff, Check,
@@ -1037,10 +1038,37 @@ interface TypesPageProps {
   kind: DocumentTypeKind;
 }
 
+/**
+ * Конвенция (issue #778): выбор list-detail живёт в URL (`?type=<id>`, replace — стрелки браузера
+ * не ходят по каждому клику в списке), последний открытый — в localStorage. Вход без параметра
+ * открывает тот же тип, на котором работу оставили, а конкретный тип можно дать ссылкой.
+ * Обе страницы («Типы документов» и «Составные типы») — один компонент, поэтому память раздельная
+ * по kind. Кандидат на тиражирование на другие list-detail-страницы.
+ */
+const lastTypeKey = (kind: DocumentTypeKind) => `types-last:${kind}`;
+
 export function DocumentTypesPage({ kind }: TypesPageProps) {
   const [createOpen, setCreateOpen] = useState(false);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+
+  // Порядок разрешения при входе: `?type=` → localStorage → первый в списке (страхует `?? filtered[0]`
+  // ниже, поэтому удалённый или не проходящий kind-фильтр id просто игнорируется).
+  // Память читаем один раз до первого выбора; kind в ключе — на случай, если роутер переиспользует
+  // экземпляр компонента между двумя маршрутами.
+  const restored = useRef<{ kind: DocumentTypeKind; id: string | null } | null>(null);
+  if (restored.current?.kind !== kind) restored.current = { kind, id: localStorage.getItem(lastTypeKey(kind)) };
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedId = searchParams.get('type') ?? restored.current.id;
+  const setSelectedId = (id: string | null) => {
+    restored.current = { kind, id: null };  // дальше выбор ведёт URL, восстановленный id не участвует
+    if (id) localStorage.setItem(lastTypeKey(kind), id);
+    else localStorage.removeItem(lastTypeKey(kind));
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      if (id) next.set('type', id); else next.delete('type');
+      return next;
+    }, { replace: true });
+  };
   const { data: allDocTypes = [], isLoading } = useListDocumentTypes();
 
   // Реестр незасохранённых форм текущего типа (явное сохранение, issue #197 / #210 — общий).
@@ -1164,6 +1192,18 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
   // группы раскрыты, чтобы результаты были видны.
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const searching = query.trim().length > 0;
+
+  // Группа выбранного типа раскрывается сама: иначе восстановленный при входе выбор (#778)
+  // виден только в детали, а рейл стоит свёрнутым и без единой подсветки. Раскрываем один раз
+  // на смену выбора — свернув группу руками, пользователь оставляет её свёрнутой.
+  const autoExpanded = useRef<string | null>(null);
+  if (selectedId && autoExpanded.current !== selectedId) {
+    const g = [...byGroup].find(([, items]) => items.some(t => t.id === selectedId))?.[0];
+    if (g !== undefined) {
+      autoExpanded.current = selectedId;
+      if (!expandedGroups.has(g)) setExpandedGroups(prev => new Set(prev).add(g));
+    }
+  }
   const toggleGroup = (g: string) =>
     setExpandedGroups(s => { const n = new Set(s); n.has(g) ? n.delete(g) : n.add(g); return n; });
 

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1060,7 +1060,11 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedId = searchParams.get('type') ?? restored.current.id;
   const setSelectedId = (id: string | null) => {
-    restored.current = { kind, id: null };  // дальше выбор ведёт URL, восстановленный id не участвует
+    // Сбрасываем восстановленный id только когда выбор снимается (тип удалён): при обычном выборе
+    // его и так перекроет `?type=`, а обнулить сразу нельзя — URL пишется через startTransition,
+    // и любое срочное обновление в том же такте успело бы отрисовать кадр без выбора (деталь
+    // смонтировалась бы на первом типе списка и тут же перемонтировалась на нужный).
+    if (!id) restored.current = { kind, id: null };
     if (id) localStorage.setItem(lastTypeKey(kind), id);
     else localStorage.removeItem(lastTypeKey(kind));
     setSearchParams(prev => {
@@ -1086,12 +1090,6 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
   const [routeLeave, setRouteLeave] = useState<(() => void) | null>(null);
   useLeaveGuard(anyDirty, (proceed) => setRouteLeave(() => proceed));
 
-  // Заголовок вкладки: выбранный тип замещает раздел.
-  const selectedType = allDocTypes.find(dt => dt.id === selectedId);
-  useDocumentTitle(selectedType
-    ? `${kind === 'Composite' ? 'Составной тип' : 'Тип'} «${selectedType.name}»`
-    : null);
-
   const filtered = allDocTypes
     .filter(dt => dt.kind === kind)
     .sort((a, b) => a.name.localeCompare(b.name, 'ru'));
@@ -1115,6 +1113,12 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
 
   // Выбранный тип: из выбора (если ещё в отфильтрованных) иначе первый.
   const selected = filtered.find(t => t.id === selectedId) ?? filtered[0];
+
+  // Заголовок вкладки: показанный тип замещает раздел. Именно показанный, а не `selectedId`:
+  // тот приходит из URL/памяти и может называть удалённый тип или тип другого kind.
+  useDocumentTitle(selected
+    ? `${kind === 'Composite' ? 'Составной тип' : 'Тип'} «${selected.name}»`
+    : null);
 
   // Дублирование типа со схемой (клиентский клон, issue #210 Этап 2).
   const createDoc = useCreateDocumentType();
@@ -1197,10 +1201,12 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
   // виден только в детали, а рейл стоит свёрнутым и без единой подсветки. Раскрываем один раз
   // на смену выбора — свернув группу руками, пользователь оставляет её свёрнутой.
   const autoExpanded = useRef<string | null>(null);
-  if (selectedId && autoExpanded.current !== selectedId) {
+  if (selectedId) {
     const g = [...byGroup].find(([, items]) => items.some(t => t.id === selectedId))?.[0];
-    if (g !== undefined) {
-      autoExpanded.current = selectedId;
+    // Ключ — тип вместе с группой: сменив группу у открытого типа, пользователь иначе потерял бы
+    // его из рейла (id прежний, новая группа свёрнута).
+    if (g !== undefined && autoExpanded.current !== `${selectedId}:${g}`) {
+      autoExpanded.current = `${selectedId}:${g}`;
       if (!expandedGroups.has(g)) setExpandedGroups(prev => new Set(prev).add(g));
     }
   }

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.124.1</Version>
+    <Version>0.124.2</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #778

## Что сделано

- **Выбор в URL** — `?type=<id>` пишется `replace` (не `push`): F5 и ссылка сохраняют выбор, а стрелки браузера не ходят по каждому клику в списке.
- **Память последнего открытого** — `localStorage`, ключ на страницу: `types-last:Document` / `types-last:Composite`. Обе страницы — один компонент, поэтому память раздельная по `kind`.
- **Порядок разрешения при входе**: `?type=` → localStorage → первый в списке. Восстановленный id, которого больше нет или который не проходит kind-фильтр, молча пропускается — страхует прежний `find ?? filtered[0]`.
- **Конвенция** зафиксирована доккомментом у страницы: «выбор list-detail живёт в URL, последний открытый — в localStorage», кандидат на тиражирование (шаблоны — следующий).

## Сверх плана issue

Рейл по умолчанию **свёрнут по группам**, поэтому восстановленный выбор был бы виден только в детали: список стоял бы свёрнутым, без единой подсветки — то есть «помним, но не показываем». Добавил автораскрытие группы выбранного типа (один раз на смену выбора; свернув группу руками, пользователь оставляет её свёрнутой). Если это лишнее — уберу.

Backend не менялся; версия `0.124.1` → `0.124.2`.

## Проверка

`npx tsc -b` — чисто, `npm test` — 515/515.

Живой прогон на дефолтном dev-стенде (Playwright поверх `e2e/harness.mjs`), 7/7:

- клик пишет `?type=` в URL и открывает тип;
- F5 — выбор на месте;
- уход на «Шаблоны» и возврат без параметра — открыт тот же тип (localStorage);
- ссылка с `?type=` открывает указанный;
- «Типы документов» и «Составные типы» помнят выбор независимо;
- неизвестный `?type=` — открывается первый, страница жива;
- три клика подряд + «назад» — уходит на предыдущую страницу, а не по кликам (replace).

Проверки сверены «от обратного»: с отключённым чтением памяти два пункта краснеют.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKmnY127V4SgRCdei63caL