### PR TITLE
Типы: страницы двух kind больше не делят состояние (#782)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -58,8 +58,12 @@ export default function App() {
                 <Route path="reconciliations" element={<ReconciliationsPage />} />
                 <Route path="profile" element={<ProfilePage />} />
                 <Route element={<AdminRoute />}>
-                  <Route path="document-types/*" element={<DocumentTypesPage kind="Document" />} />
-                  <Route path="composite-types/*" element={<DocumentTypesPage kind="Composite" />} />
+                  {/* key — чтобы React перемонтировал страницу между двумя маршрутами: без него это
+                      один экземпляр компонента (тот же тип в той же позиции дерева), и поиск,
+                      раскрытые группы и восстановленный выбор переезжали с одной страницы на
+                      другую (issue #782). */}
+                  <Route path="document-types/*" element={<DocumentTypesPage key="document" kind="Document" />} />
+                  <Route path="composite-types/*" element={<DocumentTypesPage key="composite" kind="Composite" />} />
                   <Route path="templates/*" element={<TemplatesPage />} />
                   <Route path="field-types" element={<PrimitiveTypesPage />} />
                   <Route path="recognition-profiles" element={<RecognitionProfilesPage />} />

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1194,13 +1194,23 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
   // Группы навигации: храним только то, что пользователь переключил руками (true — раскрыл,
   // false — свернул). Нетронутая группа раскрыта, если в ней лежит выбранный тип — иначе
   // восстановленный при входе выбор (#778) виден только в детали, а рейл стоит свёрнутым и без
-  // единой подсветки. Производная открытость сама отрабатывает и смену группы у открытого типа.
-  // При активном поиске все группы раскрыты, чтобы результаты были видны.
+  // единой подсветки. При активном поиске все группы раскрыты, чтобы результаты были видны.
+  //
+  // Сворачивание группы с выбранным типом помним вместе с самим выбором (ключ «тип:группа»):
+  // иначе оно пережило бы и смену группы у открытого типа, и переход выбора в свёрнутую ранее
+  // группу — тип пропал бы из рейла, а подсветки не было бы вовсе.
   const [toggled, setToggled] = useState<Map<string, boolean>>(new Map());
   const searching = query.trim().length > 0;
   const selectedGroup = [...byGroup].find(([, items]) => items.some(t => t.id === selectedId))?.[0];
-  const groupOpen = (g: string) => toggled.get(g) ?? g === selectedGroup;
-  const toggleGroup = (g: string) => setToggled(m => new Map(m).set(g, !groupOpen(g)));
+  const groupKey = (g: string) => g === selectedGroup ? `${selectedId}:${g}` : g;
+  const groupOpen = (g: string) => toggled.get(groupKey(g)) ?? g === selectedGroup;
+  // Считаем от того, что нарисовано (`searching` форсирует раскрытие): клик по шапке во время
+  // поиска иначе записывал бы обратное тому, о чём просил пользователь. Предыдущее значение
+  // читаем из аргумента, а не из замыкания, — два клика в одном такте не схлопываются в один.
+  const toggleGroup = (g: string) => {
+    const key = groupKey(g);
+    setToggled(m => new Map(m).set(key, !(searching || (m.get(key) ?? g === selectedGroup))));
+  };
 
   return (
     <>

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1053,18 +1053,17 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
 
   // Порядок разрешения при входе: `?type=` → localStorage → первый в списке (страхует `?? filtered[0]`
   // ниже, поэтому удалённый или не проходящий kind-фильтр id просто игнорируется).
-  // Память читаем один раз до первого выбора; kind в ключе — на случай, если роутер переиспользует
-  // экземпляр компонента между двумя маршрутами.
-  const restored = useRef<{ kind: DocumentTypeKind; id: string | null } | null>(null);
-  if (restored.current?.kind !== kind) restored.current = { kind, id: localStorage.getItem(lastTypeKey(kind)) };
+  // Память читаем один раз при монтировании: страницы двух kind разведены `key` в App.tsx, так что
+  // прочитанное всегда своё.
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedId = searchParams.get('type') ?? restored.current.id;
+  const [restoredId, setRestoredId] = useState<string | null>(() => localStorage.getItem(lastTypeKey(kind)));
+  const selectedId = searchParams.get('type') ?? restoredId;
   const setSelectedId = (id: string | null) => {
     // Сбрасываем восстановленный id только когда выбор снимается (тип удалён): при обычном выборе
     // его и так перекроет `?type=`, а обнулить сразу нельзя — URL пишется через startTransition,
     // и любое срочное обновление в том же такте успело бы отрисовать кадр без выбора (деталь
     // смонтировалась бы на первом типе списка и тут же перемонтировалась на нужный).
-    if (!id) restored.current = { kind, id: null };
+    if (!id) setRestoredId(null);
     if (id) localStorage.setItem(lastTypeKey(kind), id);
     else localStorage.removeItem(lastTypeKey(kind));
     setSearchParams(prev => {
@@ -1192,26 +1191,16 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
   query: string;
   onQuery: (q: string) => void;
 }) {
-  // Сворачиваемые группы навигации (по умолчанию свёрнуты). При активном поиске все
-  // группы раскрыты, чтобы результаты были видны.
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  // Группы навигации: храним только то, что пользователь переключил руками (true — раскрыл,
+  // false — свернул). Нетронутая группа раскрыта, если в ней лежит выбранный тип — иначе
+  // восстановленный при входе выбор (#778) виден только в детали, а рейл стоит свёрнутым и без
+  // единой подсветки. Производная открытость сама отрабатывает и смену группы у открытого типа.
+  // При активном поиске все группы раскрыты, чтобы результаты были видны.
+  const [toggled, setToggled] = useState<Map<string, boolean>>(new Map());
   const searching = query.trim().length > 0;
-
-  // Группа выбранного типа раскрывается сама: иначе восстановленный при входе выбор (#778)
-  // виден только в детали, а рейл стоит свёрнутым и без единой подсветки. Раскрываем один раз
-  // на смену выбора — свернув группу руками, пользователь оставляет её свёрнутой.
-  const autoExpanded = useRef<string | null>(null);
-  if (selectedId) {
-    const g = [...byGroup].find(([, items]) => items.some(t => t.id === selectedId))?.[0];
-    // Ключ — тип вместе с группой: сменив группу у открытого типа, пользователь иначе потерял бы
-    // его из рейла (id прежний, новая группа свёрнута).
-    if (g !== undefined && autoExpanded.current !== `${selectedId}:${g}`) {
-      autoExpanded.current = `${selectedId}:${g}`;
-      if (!expandedGroups.has(g)) setExpandedGroups(prev => new Set(prev).add(g));
-    }
-  }
-  const toggleGroup = (g: string) =>
-    setExpandedGroups(s => { const n = new Set(s); n.has(g) ? n.delete(g) : n.add(g); return n; });
+  const selectedGroup = [...byGroup].find(([, items]) => items.some(t => t.id === selectedId))?.[0];
+  const groupOpen = (g: string) => toggled.get(g) ?? g === selectedGroup;
+  const toggleGroup = (g: string) => setToggled(m => new Map(m).set(g, !groupOpen(g)));
 
   return (
     <>
@@ -1220,7 +1209,7 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
         {groupOrder.length === 0 && <p className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</p>}
         {groupOrder.map(g => {
           const items = byGroup.get(g)!;
-          const open = searching || expandedGroups.has(g);
+          const open = searching || groupOpen(g);
           return (
             <div key={g || '__ungrouped__'}>
               <button type="button" onClick={() => toggleGroup(g)}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.124.3</Version>
+    <Version>0.124.4</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #782

## Что сделано

**1. `key` на двух маршрутах** (`App.tsx`). `<DocumentTypesPage kind="Document">` и `kind="Composite"` — элементы разных `<Route>`, но для React это один тип компонента в одной позиции дерева: экземпляр не перемонтировался, и состояние переезжало между страницами. Вживую это выглядело так: набрать в поиске `зззз` на «Типах документов», перейти в «Составные типы» — поиск всё ещё `зззз`, список пуст, ничего не выбрано. Баг был до #778; #778 сделал его заметнее, потому что теперь при входе восстанавливается выбор.

**2. Убраны ref-ы из рендера.** #778 оставил в файле шесть ошибок `react-hooks/refs` — чтение и запись `ref.current` в теле рендера. Значение ref не участвует в реконсиляции, так что правило не косметическое:

- восстановленный из памяти id — теперь ленивое состояние; сбрасывает его обработчик (снятие выбора при удалении типа), а не рендер. Guard по `kind` больше не нужен — маршруты разведены `key`;
- автораскрытие группы стало **производным**: храним только то, что пользователь переключил руками, а нетронутая группа открыта, если в ней лежит выбранный тип. Смена группы у открытого типа отрабатывается сама (раньше это чинилось составным ключом `id:группа`), ручное сворачивание по-прежнему уважается.

ESLint по файлу: было 8 ошибок, стало 1 — наследственная (`'_' is assigned a value but never used`), она была и до #778. Второе наследство (`no-unused-expressions` в старом `toggleGroup`) ушло вместе с переписанным переключателем.

Версия `0.124.3` → `0.124.4`. Backend не менялся.

## Проверка

`npx tsc -b` — чисто, `npm test` — 515/515.

Живо, новый прогон (3/3):
- поиск не переезжает между страницами;
- переход по сайдбару открывает последний тип **своей** страницы;
- группа выбранного типа раскрыта при входе, а свёрнутая руками остаётся свёрнутой.

Сверено «от обратного»: убрать `key` — первые две проверки краснеют.

Плюс прежний прогон сценариев #778 (URL, память, раздельность страниц, `replace`, неизвестный `?type=`) — 7/7, не сломались.