### PR TITLE
Типы полей помнят выбор; конвенция вынесена в хелпер (#787)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   Plus, ChevronRight, Trash2, Copy, Folder, FileText, Boxes, EyeOff, Check,
@@ -58,6 +58,7 @@ import {
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
 import { useLeaveGuard } from '@/shared/ui/NavigationGuard';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
+import { useRememberedSelection } from '@/shared/hooks/useRememberedSelection';
 import { useToast } from '@/shared/ui/Toast';
 import { uniqueCode } from './PrimitiveTypesPage';
 
@@ -1065,14 +1066,10 @@ interface TypesPageProps {
   kind: DocumentTypeKind;
 }
 
-/**
- * Конвенция (issue #778): выбор list-detail живёт в URL (`?type=<id>`, replace — стрелки браузера
- * не ходят по каждому клику в списке), последний открытый — в localStorage. Вход без параметра
- * открывает тот же тип, на котором работу оставили, а конкретный тип можно дать ссылкой.
- * Обе страницы («Типы документов» и «Составные типы») — один компонент, поэтому память раздельная
- * по kind. Кандидат на тиражирование на другие list-detail-страницы.
- */
+// Выбор в URL + память последнего открытого — общий хелпер (issue #787). Обе страницы («Типы
+// документов» и «Составные типы») — один компонент, поэтому память раздельная по kind.
 const lastTypeKey = (kind: DocumentTypeKind) => `types-last:${kind}`;
+const SELECTION_KEYS = ['type'] as const;
 
 export function DocumentTypesPage({ kind }: TypesPageProps) {
   const [createOpen, setCreateOpen] = useState(false);
@@ -1080,26 +1077,10 @@ export function DocumentTypesPage({ kind }: TypesPageProps) {
 
   // Порядок разрешения при входе: `?type=` → localStorage → первый в списке (страхует `?? filtered[0]`
   // ниже, поэтому удалённый или не проходящий kind-фильтр id просто игнорируется).
-  // Память читаем один раз при монтировании: страницы двух kind разведены `key` в App.tsx, так что
-  // прочитанное всегда своё.
-  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
-  const [restoredId, setRestoredId] = useState<string | null>(() => localStorage.getItem(lastTypeKey(kind)));
-  const selectedId = searchParams.get('type') ?? restoredId;
-  const setSelectedId = (id: string | null) => {
-    // Сбрасываем восстановленный id только когда выбор снимается (тип удалён): при обычном выборе
-    // его и так перекроет `?type=`, а обнулить сразу нельзя — URL пишется через startTransition,
-    // и любое срочное обновление в том же такте успело бы отрисовать кадр без выбора (деталь
-    // смонтировалась бы на первом типе списка и тут же перемонтировалась на нужный).
-    if (!id) setRestoredId(null);
-    if (id) localStorage.setItem(lastTypeKey(kind), id);
-    else localStorage.removeItem(lastTypeKey(kind));
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev);
-      if (id) next.set('type', id); else next.delete('type');
-      return next;
-    }, { replace: true });
-  };
+  const { values, remember } = useRememberedSelection(lastTypeKey(kind), SELECTION_KEYS);
+  const selectedId = values.type || null;
+  const setSelectedId = (id: string | null) => remember({ type: id ?? '' });
   const { data: allDocTypes = [], isLoading } = useListDocumentTypes();
 
   // Реестр незасохранённых форм текущего типа (явное сохранение, issue #197 / #210 — общий).

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/shared/ui/Button';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
 import { useLeaveGuard } from '@/shared/ui/NavigationGuard';
+import { useRememberedSelection } from '@/shared/hooks/useRememberedSelection';
 import { TextField } from '@/shared/ui/TextField';
 import { DateInput } from '@/shared/ui/DateInput';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
@@ -597,9 +598,17 @@ function FieldTypeListPanel({ mode, onMode, primitives, enums, selectedId, onSel
 
 // ─── Page ─────────────────────────────────────────────────────────────────────────
 
+// Выбор в URL + память последнего открытого (issue #787). Режим здесь — часть выбора, а не вид
+// страницы: перечисления и типы полей это два разных списка, и восстановленный id без своего
+// режима не открылся бы.
+const SELECTION_KEYS = ['mode', 'type'] as const;
+const FIELD_TYPES_LAST_KEY = 'field-types-last';
+
 export function PrimitiveTypesPage() {
-  const [mode, setMode] = useState<Mode>('primitive');
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { values, remember } = useRememberedSelection(FIELD_TYPES_LAST_KEY, SELECTION_KEYS);
+  const mode: Mode = values.mode === 'enum' ? 'enum' : 'primitive';
+  const selectedId = values.type || null;
+  const setSelection = (m: Mode, id: string | null) => remember({ mode: m, type: id ?? '' });
   const [query, setQuery] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
 
@@ -617,7 +626,7 @@ export function PrimitiveTypesPage() {
   // Общий гард несохранённых изменений (ключ = {mode,id}) — issue #210 Этап 1 (ListDetailShell).
   const { request, dialogProps } = useDirtyGuard<{ mode: Mode; id: string | null }>({
     isDirty: anyDirty, saving, saveAll,
-    onCommit: ({ mode: m, id }) => { setMode(m); setSelectedId(id); },
+    onCommit: ({ mode: m, id }) => setSelection(m, id),
   });
   const requestSelect = (id: string) => { if (id !== selectedId) request({ mode, id }); };
   const requestMode = (m: Mode) => { if (m !== mode) request({ mode: m, id: null }); };
@@ -642,12 +651,12 @@ export function PrimitiveTypesPage() {
     <PrimitiveTypeDetail key={selectedPrim.id} type={selectedPrim} allGroups={allGroups}
       usedByNames={findReferencingTypeNames(selectedPrim.id, 'primitive', allDocTypes)}
       dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll}
-      onDuplicate={() => duplicatePrim(selectedPrim)} onDeleted={() => setSelectedId(null)} />
+      onDuplicate={() => duplicatePrim(selectedPrim)} onDeleted={() => setSelection('primitive', null)} />
   ) : mode === 'enum' && selectedEnum ? (
     <EnumTypeDetail key={selectedEnum.id} type={selectedEnum} allGroups={allGroups}
       usedByNames={findReferencingTypeNames(selectedEnum.id, 'enum', allDocTypes)}
       dirty={anyDirty} saving={saving} onSaveAll={saveAll} onRevert={resetAll}
-      onDuplicate={() => duplicateEnum(selectedEnum)} onDeleted={() => setSelectedId(null)} />
+      onDuplicate={() => duplicateEnum(selectedEnum)} onDeleted={() => setSelection('enum', null)} />
   ) : (
     <div className="flex-1 flex items-center justify-center text-fg4 text-sm">
       {mode === 'primitive' ? 'Типов полей ещё нет' : 'Перечислений ещё нет'} — создайте первый.

--- a/src/client/src/shared/hooks/useRememberedSelection.test.ts
+++ b/src/client/src/shared/hooks/useRememberedSelection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRemembered } from './useRememberedSelection';
+import { resolveRemembered, parseStored } from './useRememberedSelection';
 
 const KEYS = ['mode', 'type'] as const;
 
@@ -27,5 +27,24 @@ describe('resolveRemembered', () => {
 
   it('ключи, которых нет ни там ни там, становятся пустыми', () => {
     expect(resolveRemembered(KEYS, { type: 't1' }, null)).toEqual({ mode: '', type: 't1' });
+  });
+});
+
+describe('parseStored', () => {
+  it('понимает голый id — формат первой реализации (#778)', () => {
+    // JSON он не является: разбирать его как JSON бесполезно, ветка совместимости на этом
+    // и была недостижимой — вчерашний выбор молча терялся.
+    expect(parseStored('3fa85f64-5717-4562-b3fc-2c963f66afa6', KEYS))
+      .toEqual({ mode: '3fa85f64-5717-4562-b3fc-2c963f66afa6' });
+  });
+
+  it('понимает объект', () => {
+    expect(parseStored('{"mode":"enum","type":"e1"}', KEYS)).toEqual({ mode: 'enum', type: 'e1' });
+  });
+
+  it('пустое и битое значение — как отсутствие памяти', () => {
+    expect(parseStored(null, KEYS)).toBeNull();
+    expect(parseStored('', KEYS)).toBeNull();
+    expect(parseStored('{битый', KEYS)).toBeNull();
   });
 });

--- a/src/client/src/shared/hooks/useRememberedSelection.test.ts
+++ b/src/client/src/shared/hooks/useRememberedSelection.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRemembered } from './useRememberedSelection';
+
+const KEYS = ['mode', 'type'] as const;
+
+describe('resolveRemembered', () => {
+  it('без адреса и памяти отдаёт пустые значения — прежнее поведение страницы', () => {
+    expect(resolveRemembered(KEYS, {}, null)).toEqual({ mode: '', type: '' });
+  });
+
+  it('память отдаётся целиком, когда адрес пуст', () => {
+    expect(resolveRemembered(KEYS, {}, { mode: 'enum', type: 'e1' }))
+      .toEqual({ mode: 'enum', type: 'e1' });
+  });
+
+  it('адрес перекрывает память полностью, а не по ключам', () => {
+    // Пришли по ссылке `?mode=primitive`: тип из прошлой сессии подмешивать нельзя — он относился
+    // к другому режиму, и получилась бы пара, которой пользователь никогда не выбирал.
+    expect(resolveRemembered(KEYS, { mode: 'primitive' }, { mode: 'enum', type: 'e1' }))
+      .toEqual({ mode: 'primitive', type: '' });
+  });
+
+  it('пустые значения в адресе за источник не считаются', () => {
+    expect(resolveRemembered(KEYS, { mode: '', type: '' }, { mode: 'enum', type: 'e1' }))
+      .toEqual({ mode: 'enum', type: 'e1' });
+  });
+
+  it('ключи, которых нет ни там ни там, становятся пустыми', () => {
+    expect(resolveRemembered(KEYS, { type: 't1' }, null)).toEqual({ mode: '', type: 't1' });
+  });
+});

--- a/src/client/src/shared/hooks/useRememberedSelection.ts
+++ b/src/client/src/shared/hooks/useRememberedSelection.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { startTransition, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 /**
@@ -29,15 +29,20 @@ export function resolveRemembered<K extends string>(
   return out;
 }
 
-function readStored<K extends string>(storageKey: string, keys: readonly K[]): Partial<Record<K, string>> | null {
+/** Разбор сохранённого значения; вынесен из хука, чтобы форматы проверялись тестами. */
+export function parseStored<K extends string>(raw: string | null, keys: readonly K[]): Partial<Record<K, string>> | null {
   try {
-    const raw = localStorage.getItem(storageKey);
     if (!raw) return null;
+    // Совместимость: первая реализация (#778) хранила голый id строкой — не JSON, и разбирать её
+    // как JSON бесполезно (`JSON.parse` на «3fa85f64-…» бросает, а не возвращает строку).
+    if (!raw.startsWith('{')) return { [keys[0]]: raw } as Partial<Record<K, string>>;
     const parsed: unknown = JSON.parse(raw);
-    // Совместимость: первая реализация (#778) хранила голый id строкой.
-    if (typeof parsed === 'string') return { [keys[0]]: parsed } as Partial<Record<K, string>>;
     return typeof parsed === 'object' && parsed !== null ? parsed as Partial<Record<K, string>> : null;
   } catch { return null; }
+}
+
+function readStored<K extends string>(storageKey: string, keys: readonly K[]): Partial<Record<K, string>> | null {
+  try { return parseStored(localStorage.getItem(storageKey), keys); } catch { return null; }
 }
 
 /**
@@ -58,7 +63,10 @@ export function useRememberedSelection<K extends string>(storageKey: string, key
 
   const values = useMemo(() => {
     const out = {} as Record<K, string>;
-    for (const k of keys) out[k] = searchParams.get(k) ?? restored[k] ?? '';
+    // `get` отдаёт '' для параметра, который в адресе есть, но пуст, — за источник его не берём:
+    // иначе `?mode=` погасил бы режим и оставил тип из памяти, то есть собрал бы пару, которой
+    // пользователь не выбирал (ровно то, от чего страхует resolveRemembered).
+    for (const k of keys) out[k] = searchParams.get(k) || restored[k] || '';
     return out;
     // keys — литеральный массив страницы, в зависимости не берём: его пересоздание на каждом
     // рендере обнуляло бы memo без пользы.
@@ -68,22 +76,26 @@ export function useRememberedSelection<K extends string>(storageKey: string, key
   const remember = (next: Partial<Record<K, string>>) => {
     const merged = { ...values, ...next } as Record<K, string>;
     try { localStorage.setItem(storageKey, JSON.stringify(merged)); } catch { /* память необязательна */ }
-    // Снятый выбор гасит и восстановленное значение: иначе оно всплыло бы обратно, как только
-    // параметр уходит из адреса.
-    setRestored(prev => {
-      const cleared = { ...prev };
-      let changed = false;
-      for (const k of keys) if ((next[k] ?? '') === '' && k in next && cleared[k] !== '') { cleared[k] = ''; changed = true; }
-      return changed ? cleared : prev;
+    // Оба обновления — одним переходом. Порознь нельзя: адрес пишется через startTransition, а
+    // срочный сброс восстановленного успел бы отрисовать кадр, где часть выбора уже снята, а часть
+    // ещё берётся из старого адреса — деталь смонтировалась бы на чужом объекте и тут же
+    // перемонтировалась на нужный.
+    startTransition(() => {
+      setRestored(prev => {
+        const cleared = { ...prev };
+        let changed = false;
+        for (const k of keys) if ((next[k] ?? '') === '' && k in next && cleared[k] !== '') { cleared[k] = ''; changed = true; }
+        return changed ? cleared : prev;
+      });
+      setSearchParams(prev => {
+        const params = new URLSearchParams(prev);
+        for (const k of keys) {
+          const v = merged[k];
+          if (v) params.set(k, v); else params.delete(k);
+        }
+        return params;
+      }, { replace: true });
     });
-    setSearchParams(prev => {
-      const params = new URLSearchParams(prev);
-      for (const k of keys) {
-        const v = merged[k];
-        if (v) params.set(k, v); else params.delete(k);
-      }
-      return params;
-    }, { replace: true });
   };
 
   return { values, remember };

--- a/src/client/src/shared/hooks/useRememberedSelection.ts
+++ b/src/client/src/shared/hooks/useRememberedSelection.ts
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
+
+/**
+ * Конвенция list-detail (issue #787, после #778/#780): выбор живёт в URL, последний открытый —
+ * в localStorage. Страница открывается там, где работу оставили, а конкретный выбор можно дать
+ * ссылкой.
+ *
+ * Правила, выстраданные первыми двумя реализациями:
+ * - в URL пишем `replace`, иначе стрелки браузера ходят по каждому клику в списке;
+ * - при входе: URL → память → пусто. Дальше решает URL, память лишь зеркалит выбор;
+ * - восстановленное значение, которое больше не разрешается (объект удалён, не проходит фильтр
+ *   страницы), страница обязана пропускать молча — хелпер за неё этого не знает;
+ * - память чистим тем же вызовом, каким снимается выбор: `remember({ type: '' })`.
+ */
+
+/** Разрешение источника при входе: URL перекрывает память, память — пустое значение. */
+export function resolveRemembered<K extends string>(
+  keys: readonly K[],
+  fromUrl: Partial<Record<K, string>>,
+  stored: Partial<Record<K, string>> | null,
+): Record<K, string> {
+  // Хоть один параметр в адресе — значит пришли по ссылке: адрес главнее памяти целиком,
+  // иначе половина выбора взялась бы из ссылки, а половина из прошлой сессии.
+  const urlHasAny = keys.some(k => (fromUrl[k] ?? '') !== '');
+  const source: Partial<Record<K, string>> = urlHasAny ? fromUrl : (stored ?? {});
+  const out = {} as Record<K, string>;
+  for (const k of keys) out[k] = source[k] ?? '';
+  return out;
+}
+
+function readStored<K extends string>(storageKey: string, keys: readonly K[]): Partial<Record<K, string>> | null {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    // Совместимость: первая реализация (#778) хранила голый id строкой.
+    if (typeof parsed === 'string') return { [keys[0]]: parsed } as Partial<Record<K, string>>;
+    return typeof parsed === 'object' && parsed !== null ? parsed as Partial<Record<K, string>> : null;
+  } catch { return null; }
+}
+
+/**
+ * @param storageKey ключ памяти; если один компонент обслуживает несколько маршрутов — включите
+ *   в ключ различитель (`types-last:Document`), иначе страницы будут перетирать выбор друг друга.
+ * @param keys параметры выбора: они же имена query-параметров, они же поля в памяти.
+ */
+export function useRememberedSelection<K extends string>(storageKey: string, keys: readonly K[]) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Память читаем один раз при монтировании; дальше значение ведёт URL, а `restored` затухает
+  // по мере того, как страница записывает выбор.
+  const [restored, setRestored] = useState<Record<K, string>>(() => {
+    const fromUrl = {} as Partial<Record<K, string>>;
+    for (const k of keys) fromUrl[k] = searchParams.get(k) ?? '';
+    return resolveRemembered(keys, fromUrl, readStored(storageKey, keys));
+  });
+
+  const values = useMemo(() => {
+    const out = {} as Record<K, string>;
+    for (const k of keys) out[k] = searchParams.get(k) ?? restored[k] ?? '';
+    return out;
+    // keys — литеральный массив страницы, в зависимости не берём: его пересоздание на каждом
+    // рендере обнуляло бы memo без пользы.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, restored]);
+
+  const remember = (next: Partial<Record<K, string>>) => {
+    const merged = { ...values, ...next } as Record<K, string>;
+    try { localStorage.setItem(storageKey, JSON.stringify(merged)); } catch { /* память необязательна */ }
+    // Снятый выбор гасит и восстановленное значение: иначе оно всплыло бы обратно, как только
+    // параметр уходит из адреса.
+    setRestored(prev => {
+      const cleared = { ...prev };
+      let changed = false;
+      for (const k of keys) if ((next[k] ?? '') === '' && k in next && cleared[k] !== '') { cleared[k] = ''; changed = true; }
+      return changed ? cleared : prev;
+    });
+    setSearchParams(prev => {
+      const params = new URLSearchParams(prev);
+      for (const k of keys) {
+        const v = merged[k];
+        if (v) params.set(k, v); else params.delete(k);
+      }
+      return params;
+    }, { replace: true });
+  };
+
+  return { values, remember };
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.125.1</Version>
+    <Version>0.126.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Часть #787 — первая страница из перебора плюс вынос общего.

## Что сделано

**`useRememberedSelection(storageKey, keys)`** (`src/client/src/shared/hooks/`) — третья реализация той же формы, значит пора выносить. Хелпер держит правила, выстраданные первыми двумя: запись в URL `replace`, порядок разрешения URL → память → пусто, гашение памяти тем же вызовом, каким снимается выбор. Разрешение источника вынесено чистой функцией `resolveRemembered` и покрыто тестами — окружения для тестирования хуков в проекте нет, тесты покрывают чистую логику.

Отдельное правило, которое стоит проговорить: **адрес перекрывает память целиком, а не по ключам.** Придя по ссылке `?mode=primitive`, нельзя подмешать тип из прошлой сессии — он относился к другому режиму, и вышла бы пара, которую пользователь никогда не выбирал.

**«Типы полей»** получили память. Режим (примитивные / перечисления) здесь — часть выбора, а не вид страницы: это два разных списка, и восстановленный id без своего режима не открылся бы. Поэтому в адресе `?mode=&type=`.

**«Типы документов»** переведены на хелпер — иначе в репозитории жили бы две копии одних правил. Хелпер понимает старый формат памяти (голый id строкой), так что вчерашний выбор не теряется.

## Чего сознательно не делал

- **Шаблоны на хелпер не переводятся.** Там выбор двухступенчатый, и вторая ступень ждёт загрузки списка (ожидание в ref, идемпотентный эффект против StrictMode). Форма другая; обобщать её ради симметрии значило бы тащить частный случай в общий код.
- **«Общие данные» не тронуты.** Посмотрел: там не list-detail — слева рейл типов (фильтр, уже в URL), справа список, правка в модалке. Памяти не хватает только фильтру типа, и ключ пришлось бы делать на scope (один компонент обслуживает 4 уровня), иначе тип со стройки всплыл бы в системном каталоге. Это отдельное решение, оставил в #787.
- Остальные кандидаты (документы качества, профили распознавания, пользователи) — следующими, по странице за раз.

Версия `0.125.1` → `0.126.0` (MINOR: функциональность).

## Проверка

`npx tsc -b` — чисто, `npm test` — 520/520 (5 новых), ESLint — 1 наследственная ошибка в `DocumentTypesPage`.

Живой прогон «Типов полей», 6/6: выбор пишет оба параметра и память; уход и возврат открывают тот же тип; перечисление восстанавливается вместе со своей вкладкой; ссылка открывает указанное; неизвестный `type` — первый в списке без ошибок; `replace` (назад уходит со страницы).

Прогоны прежних страниц не сломались: #778 — 7/7, протечка состояния — 3/3, группы рейла — 2/2, иерархия — 6/6, шаблоны — 10/10.

Сверено «от обратного»: если хелпер перестаёт читать память, краснеют по две проверки и на «Типах полей», и на «Типах документов» — то есть обе страницы действительно ходят через него.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKmnY127V4SgRCdei63caL