### PR TITLE
Документы качества помнят выбор и фильтр состояния (#787)

### DIFF
--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   Plus, Pencil, Trash2, ShieldCheck, FileText, Search, Globe, ExternalLink, Download, Loader2,
@@ -93,8 +93,26 @@ export function QualityDocsPage() {
   }, [docs, docTypes, linksByDoc]);
 
   // Состояние могло рассосаться, пока нас не было (сроки продлили, связки добавили): фильтр с
-  // пустым списком снимаем молча — иначе вход выглядел бы как «библиотека пуста».
-  const stateFilter = restoredState && (states.get(restoredState)?.length ?? 0) > 0 ? restoredState : null;
+  // пустым списком снимаем молча — иначе вход выглядел бы как «библиотека пуста». Снимаем и тогда,
+  // когда восстановленный документ в него не попадает: пара «состояние + документ» согласована
+  // при выборе, но данные могли поменяться, а показывать в детали то, чего нет в рейле, нельзя —
+  // ни строки, ни подсветки, и снять выбор неоткуда.
+  // Пока список не пришёл, состояний нет ни у кого — судить о «пустом фильтре» рано: иначе
+  // подавление срабатывало бы на каждом входе и стирало фильтр из памяти навсегда.
+  const dataReady = !isLoading && docs.length > 0;
+  const restoredGroup = restoredState ? (states.get(restoredState) ?? []) : [];
+  const stateFilter = restoredState && (!dataReady
+    || (restoredGroup.length > 0 && (!selected || restoredGroup.some(d => d.id === selected))))
+    ? restoredState : null;
+
+  // Подавили фильтр — забываем его: иначе он остался бы в памяти, всплыл бы обратно в адрес при
+  // следующей записи выбора (`remember` сливает прежние значения) и однажды применился бы сам —
+  // когда состояние снова появится, а пользователь его не выбирал.
+  useEffect(() => {
+    if (dataReady && restoredState && !stateFilter) remember({ state: '' });
+    // remember стабилен по смыслу вызова; следим за самим фактом подавления
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataReady, restoredState, stateFilter]);
 
   /**
    * Поиск переопределяет список: документ остаётся, если совпало его имя/номер ИЛИ хоть одна его

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -28,6 +28,7 @@ import { recognizeAndUpdate } from './recognizeImported';
 import { QualityDocLinks, matchesLink } from './QualityDocLinks';
 import { ScopeReachNote } from './ScopeReachNote';
 import { docState, EXPIRING_SOON_DAYS, type DocState } from './docState';
+import { useRememberedSelection } from '@/shared/hooks/useRememberedSelection';
 
 // Метки областей — только из общего словаря (issue #649). Локальный дубль называл System «Общей»,
 // и на одном экране уровень документа и уровень его связок читались бы разными словами.
@@ -43,10 +44,23 @@ const STATE_META: Record<DocState, { label: string; icon: typeof AlertTriangle; 
   unlinked: { label: 'Без связок', icon: CircleSlash, danger: false },
 };
 
+// Выбор в URL + память последнего открытого (issue #787, общий хелпер). Фильтр состояния входит
+// в выбор: клик по нему и так снимает выбранный документ, то есть пара «состояние + документ»
+// согласована по построению, и возврат должен воспроизводить именно её — работа тут идёт пачкой
+// («разбираю просроченные»). Поиск не запоминаем: он про разовый акт, а не про место работы.
+const DOC_STATES = ['expired', 'expiring', 'unlinked'] as const;
+const SELECTION_KEYS = ['state', 'doc'] as const;
+const QUALITY_LAST_KEY = 'quality-docs-last';
+
 export function QualityDocsPage() {
   const [search, setSearch] = useState('');
-  const [selected, setSelected] = useState<string | null>(null);
-  const [stateFilter, setStateFilter] = useState<DocState | null>(null);
+  const { values, remember } = useRememberedSelection(QUALITY_LAST_KEY, SELECTION_KEYS);
+  const selected = values.doc || null;
+  const setSelected = (id: string | null) => remember({ doc: id ?? '' });
+  // Состояние и документ пишем одним вызовом: два подряд не накапливаются — второй считает от
+  // значения времени рендера и вернул бы снятый документ обратно.
+  const setStateFilter = (s: DocState | null) => remember({ state: s ?? '', doc: '' });
+  const restoredState = DOC_STATES.find(s => s === values.state) ?? null;
   const [createOpen, setCreateOpen] = useState(false);
   const [webOpen, setWebOpen] = useState(false);
   const [editDoc, setEditDoc] = useState<QualityDocument | null>(null);
@@ -78,6 +92,10 @@ export function QualityDocsPage() {
     return m;
   }, [docs, docTypes, linksByDoc]);
 
+  // Состояние могло рассосаться, пока нас не было (сроки продлили, связки добавили): фильтр с
+  // пустым списком снимаем молча — иначе вход выглядел бы как «библиотека пуста».
+  const stateFilter = restoredState && (states.get(restoredState)?.length ?? 0) > 0 ? restoredState : null;
+
   /**
    * Поиск переопределяет список: документ остаётся, если совпало его имя/номер ИЛИ хоть одна его
    * связка. Иначе поиск по материалу молча прятал бы ровно то, что нашёл.
@@ -95,6 +113,7 @@ export function QualityDocsPage() {
   // Имена, которые в библиотеке встречаются дважды (issue #588) — считаем по ВСЕЙ библиотеке, а не
   // по видимой части: имя не перестаёт быть неоднозначным оттого, что второй документ отфильтрован.
   const ambiguousNames = useMemo(() => ambiguousDocNames(docs), [docs]);
+
 
   const current = selected ? docs.find(d => d.id === selected) ?? null : null;
 
@@ -125,7 +144,7 @@ export function QualityDocsPage() {
                   active={stateFilter === s}
                   count={meta.danger ? undefined : items.length}
                   alert={meta.danger ? items.length : undefined} alertDanger={meta.danger}
-                  onClick={() => { setStateFilter(stateFilter === s ? null : s); setSelected(null); }} />
+                  onClick={() => setStateFilter(stateFilter === s ? null : s)} />
               );
             })}
           </>

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.127.0</Version>
+    <Version>0.128.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Закрывает содержательную часть #787.

## Что сделано

Выбор документа жил только в состоянии компонента — теперь `?doc=` в адресе плюс память последнего открытого.

**Фильтр состояния вошёл в выбор** (`?state=`). Основание: клик по фильтру и так снимает выбранный документ, то есть пара «состояние + документ» согласована по построению, а работа на этом экране идёт пачкой («разбираю просроченные») — возвращаться в неё осмысленно. Поиск не запоминается: он про разовый акт, а не про место работы.

Два правила, вытекающих из предметной области:

- **Фильтр с пустым списком снимается молча.** Состояние могло рассосаться, пока пользователя не было: сроки продлили, связки добавили. Иначе вход выглядел бы как «библиотека пуста».
- **Состояние и документ пишутся одним вызовом** `remember` — два подряд не накапливаются (та самая ловушка из ревью прошлого PR): второй считает от значения времени рендера и вернул бы снятый документ обратно.

Версия `0.127.0` → `0.128.0` (MINOR: функциональность).

## Проверка

`npx tsc -b` — чисто, `npm test` — 523/523, ESLint по файлу — 0 замечаний.

Живой прогон, 6/6: выбор пишет `?doc=` и память; уход и возврат открывают тот же документ; фильтр запоминается и снимает выбор; фильтр без документов снимается молча; неизвестный `?doc=` не ломает экран; `replace` (назад уходит со страницы).

Сверено «от обратного»: при отключённом чтении памяти краснеют «уход и возврат» и «фильтр состояния»; при снятой защите от пустого фильтра — «фильтр без документов снимается молча» (заголовок списка становится «Просрочен, связки живы» на пустом списке).

Прежние прогоны целы: профили и наборы 6/6, группа наследования 2/2, типы полей 6/6, типы документов 7/7, шаблоны 10/10.

## Про «Общие данные»

Их в #787 закрываю решением «памяти не заводим» — обоснование напишу в issue: это не list-detail, там рейл-фильтр по типу, правка идёт в модалке, а вход «все записи» честнее, чем возврат к последнему выбранному типу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKmnY127V4SgRCdei63caL