### PR TITLE
Открытый объект вне поиска — отдельной строкой в рейле (#792)

### DIFF
--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -193,13 +193,16 @@ export function QualityDocsPage() {
             {docRow(outsideList)}
           </>
         )}
-        <NavSection label={stateFilter ? STATE_META[stateFilter].label : 'Документы'} />
+        {(visibleDocs.length > 0 || !outsideList) &&
+          <NavSection label={stateFilter ? STATE_META[stateFilter].label : 'Документы'} />}
         {/* Одноимённым документам дописываем номер (issue #588): в библиотеке два сертификата
             назывались одинаково, а внутри — разные номера, органы и области продукции. Приписывать
             номер ВСЕМ незачем: тогда он примелькается и перестанет читаться там, где нужен. */}
         {visibleDocs.map(docRow)}
         {visibleDocs.length === 0 && (
-          <p className="text-xs text-fg4 px-3 py-4 text-center">Ничего не найдено.</p>
+          <p className="text-xs text-fg4 px-3 py-4 text-center">
+            {outsideList ? 'Больше ничего не найдено.' : 'Ничего не найдено.'}
+          </p>
         )}
       </div>
     </>

--- a/src/client/src/features/quality-docs/QualityDocsPage.tsx
+++ b/src/client/src/features/quality-docs/QualityDocsPage.tsx
@@ -134,6 +134,16 @@ export function QualityDocsPage() {
 
 
   const current = selected ? docs.find(d => d.id === selected) ?? null : null;
+  const outsideList = current && !visibleDocs.some(d => d.id === current.id) ? current : null;
+
+  const docRow = (d: QualityDocument) => (
+    <NavItem key={d.id} icon={<ShieldCheck size={15} />}
+      label={isAmbiguous(d, ambiguousNames)
+        ? `${d.displayName} · ${docNumberOf(d, docTypes) || 'без номера'}`
+        : d.displayName}
+      count={linksByDoc.get(d.id)?.length ?? 0}
+      active={selected === d.id} onClick={() => setSelected(d.id)} />
+  );
 
   // Если ни у одного документа срок не резолвится тэгом, состояния по сроку посчитать нельзя —
   // и об этом надо сказать, а не показывать пустоту (в живой базе ровно так: реквизит
@@ -174,18 +184,20 @@ export function QualityDocsPage() {
             причине просроченные документы не прячутся из подсказок.
           </p>
         )}
+        {/* Открытый документ, не прошедший поиск, показываем отдельной строкой (issue #792): иначе
+            он остаётся в детали, но пропадает из рейла — ни строки, ни подсветки, и снять выбор
+            неоткуда. */}
+        {outsideList && (
+          <>
+            <NavSection label="Открыт, вне поиска" />
+            {docRow(outsideList)}
+          </>
+        )}
         <NavSection label={stateFilter ? STATE_META[stateFilter].label : 'Документы'} />
         {/* Одноимённым документам дописываем номер (issue #588): в библиотеке два сертификата
             назывались одинаково, а внутри — разные номера, органы и области продукции. Приписывать
             номер ВСЕМ незачем: тогда он примелькается и перестанет читаться там, где нужен. */}
-        {visibleDocs.map(d => (
-          <NavItem key={d.id} icon={<ShieldCheck size={15} />}
-            label={isAmbiguous(d, ambiguousNames)
-              ? `${d.displayName} · ${docNumberOf(d, docTypes) || 'без номера'}`
-              : d.displayName}
-            count={linksByDoc.get(d.id)?.length ?? 0}
-            active={selected === d.id} onClick={() => setSelected(d.id)} />
-        ))}
+        {visibleDocs.map(docRow)}
         {visibleDocs.length === 0 && (
           <p className="text-xs text-fg4 px-3 py-4 text-center">Ничего не найдено.</p>
         )}

--- a/src/client/src/features/reconciliations/ReconciliationsPage.tsx
+++ b/src/client/src/features/reconciliations/ReconciliationsPage.tsx
@@ -191,6 +191,10 @@ export function ReconciliationsPage() {
     return q ? items.filter(i => i.name.toLowerCase().includes(q)) : items;
   }, [items, search]);
 
+  // Открытая сверка, не прошедшая поиск, остаётся в рейле отдельной строкой (issue #792): иначе
+  // деталь показывает её, а в списке ни строки, ни подсветки.
+  const outsideSearch = selected && !filtered.some(i => i.id === selected.id) ? selected : null;
+
   const attentionCount = findings.filter(needsAttention).length;
   const shown = onlyAttention ? findings.filter(needsAttention) : findings;
 
@@ -202,18 +206,28 @@ export function ReconciliationsPage() {
     else toast.success(runSummary(result));
   }
 
+  const reconciliationRow = (i: typeof items[number]) => (
+    <NavItem key={i.id} icon={<Scale size={16} />} label={i.name}
+      active={view === 'reconciliation' && i.id === selectedId}
+      onClick={() => { setView('reconciliation'); setSelectedId(i.id); setRunId(null); }} />
+  );
+
   const nav = (
     <>
       <NavSearchInput value={search} onChange={setSearch} placeholder="Поиск сверки…" />
       <div className="flex-1 overflow-y-auto px-2 pb-2">
-        <NavSection label="Сверки" />
-        {filtered.map(i => (
-          <NavItem key={i.id} icon={<Scale size={16} />} label={i.name}
-            active={view === 'reconciliation' && i.id === selectedId}
-            onClick={() => { setView('reconciliation'); setSelectedId(i.id); setRunId(null); }} />
-        ))}
+        {outsideSearch && (
+          <>
+            <NavSection label="Открыта, вне поиска" />
+            {reconciliationRow(outsideSearch)}
+          </>
+        )}
+        {filtered.length > 0 && <NavSection label="Сверки" />}
+        {filtered.map(reconciliationRow)}
         {filtered.length === 0 && !isLoading && (
-          <p className="px-3 py-2 text-sm text-fg4">Сверок нет</p>
+          <p className="px-3 py-2 text-sm text-fg4">
+            {outsideSearch ? 'Больше ничего не найдено' : 'Сверок нет'}
+          </p>
         )}
 
         {/* Отдельной секцией, а не в общем списке: находка сверки — результат арифметики,

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -1243,11 +1243,44 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
     setToggled(m => new Map(m).set(key, !(searching || (m.get(key) ?? g === selectedGroup))));
   };
 
+  const typeRow = (t: DocumentType) => {
+    const active = t.id === selectedId;
+    const Icon = t.kind === 'Composite' ? Boxes : FileText;
+    return (
+      <button key={t.id} type="button" onClick={() => onSelect(t.id)}
+        ref={active ? activeRow : undefined}
+        aria-current={active ? 'true' : undefined}
+        className={`w-full flex items-center gap-2.5 px-3 h-11 rounded-full text-left transition-colors ${
+          active ? 'bg-brand-subtle text-brand-hover font-medium' : 'text-fg2 hover:bg-muted'}`}>
+        <Icon size={17} className="shrink-0" />
+        <span className="flex-1 truncate text-sm">{t.name}</span>
+        <span className="text-xs text-fg4 shrink-0">{fieldCount(t, allDocTypes)}</span>
+      </button>
+    );
+  };
+
+  // Открытый тип, не прошедший поиск, остаётся в рейле отдельной строкой (issue #792). Программный
+  // переход (#784) снимает поиск сам, а вот набранный руками запрос иначе прятал бы открытый тип:
+  // деталь показывает его, а в списке ни строки, ни подсветки.
+  const listedIds = new Set([...byGroup.values()].flat().map(t => t.id));
+  const outside = selectedId && !listedIds.has(selectedId)
+    ? allDocTypes.find(t => t.id === selectedId) ?? null : null;
+
   return (
     <>
       <NavSearchInput value={query} onChange={onQuery} placeholder="Поиск типа…" />
       <div className="flex-1 overflow-y-auto px-2 pb-3">
-        {groupOrder.length === 0 && <p className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</p>}
+        {outside && (
+          <>
+            <div className="px-3 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wide text-fg4">Открыт, вне поиска</div>
+            {typeRow(outside)}
+          </>
+        )}
+        {groupOrder.length === 0 && (
+          <p className="px-3 py-6 text-center text-sm text-fg4">
+            {outside ? 'Больше ничего не найдено' : 'Ничего не найдено'}
+          </p>
+        )}
         {groupOrder.map(g => {
           const items = byGroup.get(g)!;
           const open = searching || groupOpen(g);
@@ -1261,21 +1294,7 @@ function TypeListPanel({ groupOrder, byGroup, allDocTypes, selectedId, onSelect,
                 <span className="truncate flex-1 text-left">{g || 'Без группы'}</span>
                 <span className="opacity-70">{items.length}</span>
               </button>
-              {open && items.map(t => {
-                const active = t.id === selectedId;
-                const Icon = t.kind === 'Composite' ? Boxes : FileText;
-                return (
-                  <button key={t.id} type="button" onClick={() => onSelect(t.id)}
-                    ref={active ? activeRow : undefined}
-                    aria-current={active ? 'true' : undefined}
-                    className={`w-full flex items-center gap-2.5 px-3 h-11 rounded-full text-left transition-colors ${
-                      active ? 'bg-brand-subtle text-brand-hover font-medium' : 'text-fg2 hover:bg-muted'}`}>
-                    <Icon size={17} className="shrink-0" />
-                    <span className="flex-1 truncate text-sm">{t.name}</span>
-                    <span className="text-xs text-fg4 shrink-0">{fieldCount(t, allDocTypes)}</span>
-                  </button>
-                );
-              })}
+              {open && items.map(typeRow)}
             </div>
           );
         })}

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -6,7 +6,7 @@ import {
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
-import { ListDetailShell, NavSearchInput, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
+import { ListDetailShell, NavSearchInput, NavSection, DetailHeader, useDirtyGuard } from '@/shared/ui/ListDetailShell';
 import { useLeaveGuard } from '@/shared/ui/NavigationGuard';
 import { useRememberedSelection } from '@/shared/hooks/useRememberedSelection';
 import { TextField } from '@/shared/ui/TextField';
@@ -544,14 +544,39 @@ function FieldTypeListPanel({ mode, onMode, primitives, enums, selectedId, onSel
   query: string; onQuery: (q: string) => void;
 }) {
   const q = query.trim().toLowerCase();
-  const items: { id: string; name: string; code: string; chip: string; preview: string; icon: React.ComponentType<{ size?: number; className?: string }> }[] =
-    mode === 'primitive'
-      ? primitives.filter(t => !q || `${t.name} ${t.code}`.toLowerCase().includes(q))
-          .map(t => ({ id: t.id, name: t.name, code: t.code, chip: BASE_TYPE_LABEL[t.baseType] ?? t.baseType, preview: humanConstraintPreview(t.baseType, t.constraints), icon: baseTypeIcon(t.baseType) }))
-      : enums.filter(t => !q || `${t.name} ${t.code}`.toLowerCase().includes(q))
-          // Чип во вкладке «Перечисления» = счётчик вариантов (безликое «Перечисление» = шум);
-          // в primitive-режиме чип — базовый тип. Единый смысл: одна вторичная метка, различающая строки.
-          .map(t => ({ id: t.id, name: t.name, code: t.code, chip: `${t.values.length} вар.`, preview: humanEnumPreview(t.values), icon: ListIcon }));
+  // Чип во вкладке «Перечисления» = счётчик вариантов (безликое «Перечисление» = шум);
+  // в primitive-режиме чип — базовый тип. Единый смысл: одна вторичная метка, различающая строки.
+  type Row = { id: string; name: string; code: string; chip: string; preview: string; icon: React.ComponentType<{ size?: number; className?: string }> };
+  const allRows: Row[] = mode === 'primitive'
+    ? primitives.map(t => ({ id: t.id, name: t.name, code: t.code, chip: BASE_TYPE_LABEL[t.baseType] ?? t.baseType, preview: humanConstraintPreview(t.baseType, t.constraints), icon: baseTypeIcon(t.baseType) }))
+    : enums.map(t => ({ id: t.id, name: t.name, code: t.code, chip: `${t.values.length} вар.`, preview: humanEnumPreview(t.values), icon: ListIcon }));
+  const items = q ? allRows.filter(t => `${t.name} ${t.code}`.toLowerCase().includes(q)) : allRows;
+  // Открытый тип, не прошедший поиск, остаётся в рейле отдельной строкой (issue #792): иначе он
+  // виден только в детали, а в списке ни строки, ни подсветки.
+  const outside = selectedId && !items.some(t => t.id === selectedId)
+    ? allRows.find(t => t.id === selectedId) ?? null : null;
+
+  const typeRow = (t: Row) => {
+    const active = t.id === selectedId;
+    const Icon = t.icon;
+    return (
+      <button key={t.id} type="button" onClick={() => onSelect(t.id)} aria-current={active ? 'true' : undefined}
+        className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-left transition-colors ${
+          active ? 'bg-brand-subtle text-brand-hover' : 'hover:bg-muted'}`}>
+        <Icon size={17} className={`shrink-0 ${active ? 'text-brand-hover' : 'text-fg4'}`} />
+        <span className="min-w-0 flex-1">
+          {/* Строка 1 — только имя, полный приоритет ширины. */}
+          <span className={`block text-sm font-medium truncate ${active ? 'text-brand-hover' : 'text-fg1'}`}>{t.name}</span>
+          {/* Строка 2 — код (mono, capped) · превью; оба truncate, длинный код не ломает строку 1. */}
+          <span className="flex items-baseline gap-1 min-w-0 text-fg4">
+            <span className="font-mono text-[11px] truncate max-w-[45%] shrink-0" title={t.code}>{t.code}</span>
+            {t.preview && <span className="text-xs truncate min-w-0">{`· ${t.preview}`}</span>}
+          </span>
+        </span>
+        <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-muted text-fg3 shrink-0">{t.chip}</span>
+      </button>
+    );
+  };
 
   const tab = (m: Mode, label: string) => (
     <button type="button" onClick={() => onMode(m)}
@@ -569,28 +594,18 @@ function FieldTypeListPanel({ mode, onMode, primitives, enums, selectedId, onSel
       </div>
       <NavSearchInput value={query} onChange={onQuery} placeholder="Поиск типа…" />
       <div className="flex-1 overflow-y-auto px-2 pb-3 space-y-0.5">
-        {items.length === 0 && <p className="px-3 py-6 text-center text-sm text-fg4">Ничего не найдено</p>}
-        {items.map(t => {
-          const active = t.id === selectedId;
-          const Icon = t.icon;
-          return (
-            <button key={t.id} type="button" onClick={() => onSelect(t.id)} aria-current={active ? 'true' : undefined}
-              className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-left transition-colors ${
-                active ? 'bg-brand-subtle text-brand-hover' : 'hover:bg-muted'}`}>
-              <Icon size={17} className={`shrink-0 ${active ? 'text-brand-hover' : 'text-fg4'}`} />
-              <span className="min-w-0 flex-1">
-                {/* Строка 1 — только имя, полный приоритет ширины. */}
-                <span className={`block text-sm font-medium truncate ${active ? 'text-brand-hover' : 'text-fg1'}`}>{t.name}</span>
-                {/* Строка 2 — код (mono, capped) · превью; оба truncate, длинный код не ломает строку 1. */}
-                <span className="flex items-baseline gap-1 min-w-0 text-fg4">
-                  <span className="font-mono text-[11px] truncate max-w-[45%] shrink-0" title={t.code}>{t.code}</span>
-                  {t.preview && <span className="text-xs truncate min-w-0">{`· ${t.preview}`}</span>}
-                </span>
-              </span>
-              <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-muted text-fg3 shrink-0">{t.chip}</span>
-            </button>
-          );
-        })}
+        {outside && (
+          <>
+            <NavSection label="Открыт, вне поиска" />
+            {typeRow(outside)}
+          </>
+        )}
+        {items.length === 0 && (
+          <p className="px-3 py-6 text-center text-sm text-fg4">
+            {outside ? 'Больше ничего не найдено' : 'Ничего не найдено'}
+          </p>
+        )}
+        {items.map(typeRow)}
       </div>
     </>
   );

--- a/src/client/src/features/settings/RecognitionProfilesPage.tsx
+++ b/src/client/src/features/settings/RecognitionProfilesPage.tsx
@@ -343,9 +343,8 @@ export function RecognitionProfilesPage() {
   const { data: profiles = [], isLoading } = useListRecognitionProfiles();
   const { data: kinds = [] } = useRecognitionKinds();
   // Удалённый id страхует `?? filtered[0]` ниже — восстановление молча уходит на первый профиль.
-  // Отфильтрованный поиском НЕ страхует: `selected` ищет по всем профилям, поэтому выбранный
-  // остаётся открытым в детали, даже когда его строки в списке нет. Поведение прежнее (поиск при
-  // входе пуст, так что восстановления это не касается), меняем его не здесь.
+  // Выбранный ищется по всем профилям, а не по отфильтрованным: не прошедший поиск профиль
+  // остаётся открытым и показывается в рейле отдельной строкой (issue #792, см. `outsideFilter`).
   const { values, remember } = useRememberedSelection(PROFILES_LAST_KEY, SELECTION_KEYS);
   const selectedId = values.profile || null;
   const setSelectedId = (id: string | null) => remember({ profile: id ?? '' });
@@ -405,7 +404,11 @@ export function RecognitionProfilesPage() {
               {builtIn.map(row)}
               {custom.length > 0 && <NavSection label="Свои" />}
               {custom.map(row)}
-              {filtered.length === 0 && <p className="text-sm text-fg4 px-3 py-2">Ничего не найдено</p>}
+              {filtered.length === 0 && (
+                <p className="text-sm text-fg4 px-3 py-2">
+                  {outsideFilter ? 'Больше ничего не найдено' : 'Ничего не найдено'}
+                </p>
+              )}
             </div>
           </div>
         }

--- a/src/client/src/features/settings/RecognitionProfilesPage.tsx
+++ b/src/client/src/features/settings/RecognitionProfilesPage.tsx
@@ -362,6 +362,9 @@ export function RecognitionProfilesPage() {
   const builtIn = filtered.filter(p => p.isBuiltIn);
   const custom = filtered.filter(p => !p.isBuiltIn);
   const selected = profiles.find(p => p.id === selectedId) ?? filtered[0];
+  // Открытый профиль, не прошедший поиск, показываем отдельной строкой (issue #792): иначе он
+  // остаётся в детали, но пропадает из рейла — ни строки, ни подсветки, и снять выбор неоткуда.
+  const outsideFilter = selected && !filtered.some(p => p.id === selected.id) ? selected : null;
 
   const row = (p: RecognitionProfile) => (
     <button key={p.id} type="button" onClick={() => setSelectedId(p.id)}
@@ -392,6 +395,12 @@ export function RecognitionProfilesPage() {
           <div className="flex flex-col min-h-0">
             <div className="p-2"><NavSearchInput value={query} onChange={setQuery} placeholder="Поиск профиля…" /></div>
             <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-0.5">
+              {outsideFilter && (
+                <>
+                  <NavSection label="Открыт, вне поиска" />
+                  {row(outsideFilter)}
+                </>
+              )}
               {builtIn.length > 0 && <NavSection label="Встроенные" />}
               {builtIn.map(row)}
               {custom.length > 0 && <NavSection label="Свои" />}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.128.0</Version>
+    <Version>0.128.1</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #792 — выбран вариант 2 («показывать выбранного вне фильтра»).

## Что сделано

Выбранный объект резолвился по полному списку, а рейл строился из отфильтрованного: стоило набрать запрос, не пропускающий открытое, — деталь продолжала его показывать, а в списке не оставалось ни строки, ни подсветки, и снять выбор было неоткуда.

Теперь такой объект выводится отдельной секцией **«Открыт, вне поиска»** над списком. Поиск при этом остаётся поиском — можно посмотреть соседей, не теряя открытого, — а рейл и деталь снова говорят одно и то же.

Сделано на обеих страницах, где списки расходились:
- `RecognitionProfilesPage` — выбор искался в `profiles`, рейл строился из `filtered`;
- `QualityDocsPage` — выбор искался в `docs`, рейл строился из `visibleDocs` (там же вынесен `docRow`, чтобы строка рисовалась одинаково в обеих секциях).

Версия `0.128.0` → `0.128.1` (PATCH: исправление поведения, новой функциональности нет).

## Проверка

`npx tsc -b` — чисто, `npm test` — 523/523, ESLint — 1 наследственная ошибка в `RecognitionProfilesPage` (была до правки).

Живой прогон, 4/4 — на обеих страницах:
- открытый объект, не прошедший поиск, остаётся в рейле в секции «Открыт, вне поиска» и подсвечен;
- при пустом поиске лишней секции нет, подсветка на месте.

Сверено «от обратного»: если убрать вычисление «вне фильтра», краснеют обе проверки про поиск (в документах видно, что остаются только секции «Требует внимания» и «Документы»).

Прежние прогоны целы: документы качества 8/8, профили и наборы 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKmnY127V4SgRCdei63caL