### PR TITLE
Редактор типа: индикатор проблем типа в шапке (#794)

### DIFF
--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -46,6 +46,7 @@ import {
   type TypstRender,
 } from '@/shared/api/schema';
 import { danglingKeyRefs, danglingRefPlaces } from './schemaKeyChecks';
+import { typeHealth, healthBadgeLabel } from './typeHealth';
 import { TypstRendersEditor } from './TypstRendersEditor';
 import { useTypstBlocksCheck, TypstBlocksPanel, blocksCheckProblemsByFn } from './TypstBlocksCheck';
 import { schemaToJson, validateFields, TYPE_LABELS, nextAutoKey } from './schemaConstants';
@@ -966,6 +967,24 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
   const children = allDocTypes
     .filter(t => t.parentId === docType.id && t.kind === docType.kind)
     .sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+
+  // Состояние типа (issue #794): красный чип — то, из-за чего схема не сохранится, жёлтый —
+  // «нездоров, но сохраняется». Считаем по сохранённой схеме: правку показывает сама форма, а
+  // сюда тип может приехать не своей правкой, а изменением предка.
+  const schemaDef = docType.schema as unknown as SchemaDefinition;
+  const health = typeHealth(
+    parseSchemaFields(docType.schema),
+    parentType ? resolveEffectiveFields(parentType, allDocTypes).map(f => f.key) : [],
+    parentType ? chainFieldKeys(parentType, allDocTypes) : [],
+    {
+      groups: schemaDef.groups,
+      excludedFields: schemaDef.excludedFields,
+      ungroupedOrder: schemaDef.ungroupedOrder,
+      fieldOverrides: schemaDef.fieldOverrides,
+    },
+    schemaDef.typstRenders ?? [],
+  );
+  const healthLabel = healthBadgeLabel(health);
   return (
     <div className="flex flex-col min-h-0 flex-1">
       {/* Шапка типа — доменные heading/actions поверх общего DetailHeader (issue #210 Этап 1b) */}
@@ -1000,6 +1019,18 @@ function TypeDetail({ docType, allDocTypes, allGroups, onDeleted, dirty, saving,
               {referencedBy.length > 0 && (
                 <span className={`${badge} bg-brand-subtle text-brand`} title={`Используется в: ${referencedBy.map(t => t.name).join(', ')}`}>
                   используется: {referencedBy.length}
+                </span>
+              )}
+              {healthLabel.blocking && (
+                <span className={`${badge} bg-danger-subtle text-danger`}
+                  title={health.blocking.map(b => `• ${b.text}`).join(String.fromCharCode(10))}>
+                  ⚠ {healthLabel.blocking}
+                </span>
+              )}
+              {healthLabel.soft && (
+                <span className={`${badge} bg-warning-subtle text-warning`}
+                  title={health.soft.map(i => `• ${i.text}`).join(String.fromCharCode(10))}>
+                  {healthLabel.soft}
                 </span>
               )}
             </div>

--- a/src/client/src/features/settings/typeHealth.test.ts
+++ b/src/client/src/features/settings/typeHealth.test.ts
@@ -42,8 +42,9 @@ describe('typeHealth — блокирующие проблемы', () => {
 
   it('дублирующееся имя Typst-функции', () => {
     const h = typeHealth([field()], [], [], {}, [
-      { fnName: 'full', body: '' }, { fnName: 'full', body: '' },
-    ] as never);
+      { name: 'Полное', fnName: 'full', block: '[#it]' },
+      { name: 'Ещё одно', fnName: 'full', block: '[#it]' },
+    ]);
     expect(h.blocking.map(b => b.kind)).toEqual(['duplicate-fn']);
   });
 });
@@ -79,5 +80,29 @@ describe('healthBadgeLabel', () => {
       { kind: 'dangling-ref', text: '' }, { kind: 'dangling-ref', text: '' },
     ] });
     expect(two.soft).toBe('2 висячие ссылки');
+  });
+
+  it('склонение верно и за двадцатью — там свой «1/2-4/прочее» врёт', () => {
+    const blocking = (n: number) => healthBadgeLabel({
+      blocking: Array.from({ length: n }, () => ({ kind: 'key-conflict' as const, text: '' })), soft: [],
+    }).blocking;
+    expect(blocking(21)).toBe('не сохранится — 21 ошибка');
+    expect(blocking(22)).toBe('не сохранится — 22 ошибки');
+    expect(blocking(11)).toBe('не сохранится — 11 ошибок');
+    const soft = (n: number) => healthBadgeLabel({
+      blocking: [], soft: Array.from({ length: n }, () => ({ kind: 'dangling-ref' as const, text: '' })),
+    }).soft;
+    expect(soft(21)).toBe('21 висячая ссылка');
+    expect(soft(14)).toBe('14 висячих ссылок');
+  });
+});
+
+describe('typeHealth — ключи сравниваются как сохранены', () => {
+  it('пробел в ключе не делает живую ссылку висячей', () => {
+    // ключ сохраняется как введён; группы и переопределения хранят ровно его
+    const h = typeHealth([{ key: 'Дата ', title: 'Дата', type: 'string' } as SchemaField], [], [], {
+      groups: [{ key: 'g1', title: 'Шапка', fieldKeys: ['Дата '] }],
+    });
+    expect(h.soft).toEqual([]);
   });
 });

--- a/src/client/src/features/settings/typeHealth.test.ts
+++ b/src/client/src/features/settings/typeHealth.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { typeHealth, healthBadgeLabel } from './typeHealth';
+import type { SchemaField } from '@/shared/api/schema';
+
+const field = (over: Partial<SchemaField> = {}): SchemaField => ({
+  key: 'Ключ', title: 'Название', type: 'string', ...over,
+} as SchemaField);
+
+describe('typeHealth — блокирующие проблемы', () => {
+  it('здоровый тип не даёт ни одной', () => {
+    const h = typeHealth([field()], [], [], {});
+    expect(h.blocking).toEqual([]);
+    expect(h.soft).toEqual([]);
+  });
+
+  it('ключ, уже занятый предком, — именно из-за него схема не сохраняется', () => {
+    // живой случай #794: поле «Подписи» есть и у типа, и у предка «Проект»
+    const h = typeHealth([field({ key: 'Подписи', title: 'Подписи' })], ['Подписи', 'Дата'], [], {});
+    expect(h.blocking.map(b => b.kind)).toEqual(['key-conflict']);
+    expect(h.blocking[0].text).toContain('Подписи');
+  });
+
+  it('пустой ключ не тянет за собой остальные жалобы на то же поле', () => {
+    const h = typeHealth([field({ key: '  ', title: '' })], [], [], {});
+    expect(h.blocking.map(b => b.kind)).toEqual(['empty-key']);
+  });
+
+  it('недопустимые символы в ключе и пустое название', () => {
+    const h = typeHealth([field({ key: 'Ключ-с-дефисом', title: ' ' })], [], [], {});
+    expect(h.blocking.map(b => b.kind).sort()).toEqual(['bad-key', 'empty-title']);
+  });
+
+  it('поле составного типа без выбранного типа', () => {
+    const h = typeHealth([field({ type: 'array' })], [], [], {});
+    expect(h.blocking.map(b => b.kind)).toEqual(['missing-type']);
+  });
+
+  it('дубль ключа внутри типа считается один раз, а не по разу на копию', () => {
+    const h = typeHealth([field({ key: 'A' }), field({ key: 'A' }), field({ key: 'A' })], [], [], {});
+    expect(h.blocking.filter(b => b.kind === 'duplicate-key')).toHaveLength(1);
+  });
+
+  it('дублирующееся имя Typst-функции', () => {
+    const h = typeHealth([field()], [], [], {}, [
+      { fnName: 'full', body: '' }, { fnName: 'full', body: '' },
+    ] as never);
+    expect(h.blocking.map(b => b.kind)).toEqual(['duplicate-fn']);
+  });
+});
+
+describe('typeHealth — мягкие проблемы', () => {
+  it('ссылка на удалённое поле в группировке', () => {
+    const h = typeHealth([field({ key: 'A' })], [], [], {
+      groups: [{ key: 'g1', title: 'Шапка', fieldKeys: ['A', 'Пропало'] }],
+    });
+    expect(h.blocking).toEqual([]);
+    expect(h.soft.map(s => s.text)).toEqual(['Ссылка на несуществующее поле «Пропало»']);
+  });
+
+  it('исключение унаследованного поля висячим не считается', () => {
+    // ключ живёт у предка ДО исключений — в этом и смысл исключения
+    const h = typeHealth([field({ key: 'A' })], ['Родительское'], ['Родительское'], {
+      excludedFields: ['Родительское'],
+    });
+    expect(h.soft).toEqual([]);
+  });
+});
+
+describe('healthBadgeLabel', () => {
+  it('склоняет счётчики и молчит, когда проблем нет', () => {
+    expect(healthBadgeLabel({ blocking: [], soft: [] })).toEqual({ blocking: undefined, soft: undefined });
+    const one = healthBadgeLabel({ blocking: [{ kind: 'key-conflict', text: '' }], soft: [] });
+    expect(one.blocking).toBe('не сохранится — 1 ошибка');
+    const five = healthBadgeLabel({
+      blocking: Array.from({ length: 5 }, () => ({ kind: 'key-conflict' as const, text: '' })), soft: [],
+    });
+    expect(five.blocking).toBe('не сохранится — 5 ошибок');
+    const two = healthBadgeLabel({ blocking: [], soft: [
+      { kind: 'dangling-ref', text: '' }, { kind: 'dangling-ref', text: '' },
+    ] });
+    expect(two.soft).toBe('2 висячие ссылки');
+  });
+});

--- a/src/client/src/features/settings/typeHealth.ts
+++ b/src/client/src/features/settings/typeHealth.ts
@@ -1,5 +1,6 @@
 import type { SchemaField, FieldGroup, TypstRender } from '@/shared/api/schema';
 import { danglingKeyRefs } from './schemaKeyChecks';
+import { ruCount } from '@/shared/utils/pluralize';
 
 /**
  * Состояние типа как объекта, а не как формы (issue #794).
@@ -77,6 +78,9 @@ export function typeHealth(
   for (const n of new Set(fns.filter((n, i) => fns.indexOf(n) !== i)))
     blocking.push({ kind: 'duplicate-fn', text: `Имя функции «${n}» задано дважды` });
 
+  // Ключи для сравнения со ссылками берём КАК СОХРАНЕНЫ, без trim: группы, исключения и
+  // переопределения хранят ровно тот же ключ, а редактор сверяет их так же. Обрезав пробелы здесь,
+  // мы объявили бы висячей живую ссылку — и предложили бы её удалить.
   const soft: SoftIssue[] = danglingKeyRefs(
     {
       groups: refs.groups,
@@ -84,18 +88,22 @@ export function typeHealth(
       ungroupedOrder: refs.ungroupedOrder,
       fieldOverrideKeys: Object.keys(refs.fieldOverrides ?? {}),
     },
-    [...chainKeys, ...keys],
+    [...chainKeys, ...own.map(f => f.key)],
   ).map(r => ({ kind: 'dangling-ref' as const, text: `Ссылка на несуществующее поле «${r.key}»` }));
 
   return { blocking, soft };
 }
 
-/** Короткая подпись чипа: счётчик, а не перечисление — детали уходят в подсказку. */
+/**
+ * Короткая подпись чипа: счётчик, а не перечисление — детали уходят в подсказку.
+ * Склонение — общим `ruCount`: свой «1 / 2-4 / остальное» врал бы на 21 («21 ошибок»), а число
+ * ошибок легко переваливает за двадцать — перепривязка типа даёт по конфликту на каждое совпавшее поле.
+ */
 export function healthBadgeLabel(health: TypeHealth): { blocking?: string; soft?: string } {
   const n = health.blocking.length;
   const m = health.soft.length;
   return {
-    blocking: n ? `не сохранится — ${n} ${n === 1 ? 'ошибка' : n < 5 ? 'ошибки' : 'ошибок'}` : undefined,
-    soft: m ? `${m} ${m === 1 ? 'висячая ссылка' : m < 5 ? 'висячие ссылки' : 'висячих ссылок'}` : undefined,
+    blocking: n ? `не сохранится — ${ruCount(n, 'ошибка', 'ошибки', 'ошибок')}` : undefined,
+    soft: m ? ruCount(m, 'висячая ссылка', 'висячие ссылки', 'висячих ссылок') : undefined,
   };
 }

--- a/src/client/src/features/settings/typeHealth.ts
+++ b/src/client/src/features/settings/typeHealth.ts
@@ -1,0 +1,101 @@
+import type { SchemaField, FieldGroup, TypstRender } from '@/shared/api/schema';
+import { danglingKeyRefs } from './schemaKeyChecks';
+
+/**
+ * Состояние типа как объекта, а не как формы (issue #794).
+ *
+ * Тип может доехать до положения, когда схему нельзя сохранить, — и заметить это раньше нажатия
+ * «Сохранить» негде: сообщение живёт под формой, а конфликтный ключ помечен мелкой красной
+ * подписью у поля. Причём привести к такому может правка ПРЕДКА: стоит добавить в родителя поле с
+ * тем же ключом, что уже есть у потомка, и схема потомка перестаёт сохраняться, хотя её никто не
+ * трогал (живой случай — «Подписи» у «Титульный лист исполнительной документации»).
+ *
+ * Поэтому считаем по СОХРАНЁННОЙ схеме: индикатор отвечает на вопрос «в каком состоянии тип»,
+ * а ошибки текущей правки показывает сама форма.
+ *
+ * Проблемы сборки Typst-блоков сюда не входят: их даёт компиляция по запросу, и гонять её при
+ * открытии каждого типа незачем.
+ */
+
+/** Мешает сохранению схемы — ровно те проверки, на которых падает `save()` в редакторе. */
+export interface BlockingIssue {
+  kind: 'key-conflict' | 'empty-key' | 'bad-key' | 'empty-title' | 'missing-type' | 'duplicate-key' | 'duplicate-fn';
+  /** Готовая фраза для перечисления в подсказке. */
+  text: string;
+}
+
+/** Сохранению не мешает, но означает «тип нездоров». */
+export interface SoftIssue {
+  kind: 'dangling-ref';
+  text: string;
+}
+
+export interface TypeHealth {
+  blocking: BlockingIssue[];
+  soft: SoftIssue[];
+}
+
+const KEY_RE = /^[A-Za-zА-Яа-яЁё0-9_]+$/;
+
+/**
+ * @param own собственные поля типа (без унаследованных)
+ * @param inheritedKeys ключи ЭФФЕКТИВНЫХ полей родителя — с ними конфликтует собственное поле
+ * @param chainKeys все ключи цепочки предков ДО исключений: ссылка на исключённое поле законна,
+ *   и по эффективному набору собственное исключение потомка выглядело бы висячим
+ */
+export function typeHealth(
+  own: readonly SchemaField[],
+  inheritedKeys: Iterable<string>,
+  chainKeys: Iterable<string>,
+  refs: {
+    groups?: readonly FieldGroup[];
+    excludedFields?: readonly string[];
+    ungroupedOrder?: readonly string[];
+    fieldOverrides?: Record<string, unknown>;
+  },
+  typstRenders: readonly TypstRender[] = [],
+): TypeHealth {
+  const blocking: BlockingIssue[] = [];
+  const inherited = new Set(inheritedKeys);
+
+  for (const f of own) {
+    const key = f.key.trim();
+    if (!key) { blocking.push({ kind: 'empty-key', text: `Поле «${f.title || 'без названия'}»: пустой ключ` }); continue; }
+    if (!KEY_RE.test(key)) blocking.push({ kind: 'bad-key', text: `Ключ «${key}»: допустимы только буквы, цифры и _` });
+    if (!f.title.trim()) blocking.push({ kind: 'empty-title', text: `Поле «${key}»: пустое название` });
+    if (!f.typeId && ['complex', 'array', 'doc-ref', 'doc-array', 'primitive'].includes(f.type))
+      blocking.push({ kind: 'missing-type', text: `Поле «${key}»: не выбран тип` });
+    if (inherited.has(key))
+      blocking.push({ kind: 'key-conflict', text: `Ключ «${key}» уже есть в родительском типе` });
+  }
+
+  const keys = own.map(f => f.key.trim());
+  for (const k of new Set(keys.filter((k, i) => k && keys.indexOf(k) !== i)))
+    blocking.push({ kind: 'duplicate-key', text: `Ключ «${k}» задан дважды` });
+
+  const fns = typstRenders.map(r => r.fnName.trim()).filter(Boolean);
+  for (const n of new Set(fns.filter((n, i) => fns.indexOf(n) !== i)))
+    blocking.push({ kind: 'duplicate-fn', text: `Имя функции «${n}» задано дважды` });
+
+  const soft: SoftIssue[] = danglingKeyRefs(
+    {
+      groups: refs.groups,
+      excludedFields: refs.excludedFields,
+      ungroupedOrder: refs.ungroupedOrder,
+      fieldOverrideKeys: Object.keys(refs.fieldOverrides ?? {}),
+    },
+    [...chainKeys, ...keys],
+  ).map(r => ({ kind: 'dangling-ref' as const, text: `Ссылка на несуществующее поле «${r.key}»` }));
+
+  return { blocking, soft };
+}
+
+/** Короткая подпись чипа: счётчик, а не перечисление — детали уходят в подсказку. */
+export function healthBadgeLabel(health: TypeHealth): { blocking?: string; soft?: string } {
+  const n = health.blocking.length;
+  const m = health.soft.length;
+  return {
+    blocking: n ? `не сохранится — ${n} ${n === 1 ? 'ошибка' : n < 5 ? 'ошибки' : 'ошибок'}` : undefined,
+    soft: m ? `${m} ${m === 1 ? 'висячая ссылка' : m < 5 ? 'висячие ссылки' : 'висячих ссылок'}` : undefined,
+  };
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.128.1</Version>
+    <Version>0.129.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Closes #794

## Что сделано

В шапке редактора типа, в том же ряду со счётчиками «18 полей · 1 своих / 5 обязательных / 3 составных», появились два чипа состояния:

- **красный** (`bg-danger-subtle` / `text-danger` — MD3 error-container): то, из-за чего схема **не сохранится** — конфликт ключа с предком, пустой или недопустимый ключ, пустое название, поле без выбранного типа, дублирующийся ключ, дублирующееся имя Typst-функции;
- **жёлтый** (`warning-subtle`): висячие ссылки на несуществующие поля в группировке, исключениях и переопределениях — сохранению не мешают, но означают «тип нездоров».

Подпись чипа — счётчик со склонением, перечисление конкретных проблем — в подсказке.

## Решения

- **Считаем по сохранённой схеме.** Индикатор отвечает на вопрос «в каком состоянии тип», а не «что сейчас в форме»: ошибки текущей правки и так показываются под формой. Это важно потому, что тип может стать несохраняемым **без своей правки** — достаточно добавить в предка поле с ключом, который уже есть у потомка.
- **Проблемы сборки Typst-блоков не включены**: их даёт компиляция по запросу (`useTypstBlocksCheck`), гонять её при открытии каждого типа дорого. Если понадобится — отдельным шагом.
- Логика вынесена в `typeHealth.ts` чистой функцией и покрыта тестами (10 новых), а не размазана по компоненту.

Версия `0.128.1` → `0.129.0` (MINOR: функциональность).

## Проверка

`npx tsc -b` — чисто, `npm test` — 533/533, ESLint — 1 наследственная ошибка в `DocumentTypesPage`.

Живой прогон, 3/3. Конфликтный тип **создаётся прогоном и удаляется в конце** — на живых типах проверять нельзя: пока я писал проверку, исходный сломанный тип починили, и она позеленела вхолостую.

```
чипы: ["19 полей · 1 своих","5 обязательных","3 составных",
       "RED ⚠ не сохранится — 1 ошибка","YEL 1 висячая ссылка"]
```

Сверено «от обратного»: если чипы не выводить, краснеют обе проверки на конфликтном типе.

## Побочно: что индикатор нашёл в живой базе

Прогнал те же правила по всем 70 типам:

- **не сохранится — 1 тип**: «Приложение АОСР» (ключ `НомерДокумента` уже есть у предка);
- **висячие ссылки — 9 типов**, включая «Внешний документ» и «Исполнительная схема (форма 3)» (по 6 ссылок в пустоту). Там же видна старая опечатка `ДатаДокумнета` — та самая, ради которой заводилась проверка похожих ключей (#639).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKmnY127V4SgRCdei63caL