### PR TITLE
Устаревшие данные видны там, где их читают (#815, часть 2: интерфейс)

### DIFF
--- a/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
+++ b/src/client/src/features/document-sets/catalog/EntryDataSetBindings.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
 import { Database, Pencil, Trash2, Plus } from 'lucide-react';
 import { IconButton } from '@/shared/ui/Button';
+import { StaleSourceAction } from '@/shared/ui/StaleSourceAction';
+import { ruCount } from '@/shared/utils/pluralize';
 import {
   useListDataSetFiles, useAvailableDataSetFiles,
   useCreateDataSetBinding, useUpdateDataSetBinding, useDeleteDataSetBinding, useAutoMapDataSetSource,
@@ -158,10 +160,13 @@ function EntryBindingRow({
           <div className="text-xs text-fg4 mt-0.5">
             {file?.name} · {source?.materializeTypeId
               ? `материализация → ${allDocTypes.find(t => t.id === source.materializeTypeId)?.name ?? 'тип'}`
-              : `${mappedCount} пол${mappedCount === 1 ? 'е' : 'я'} привязано`}
+              : `${ruCount(mappedCount, 'поле привязано', 'поля привязано', 'полей привязано')}`}
             {targetFieldKey && ` · таблица: ${targetFieldKey}`}
           </div>
         </div>
+        {/* Тот же признак и то же действие, что в форме документа (issue #815): строки привязок у
+            каталога и документа свои, но расходиться им в этом нельзя. */}
+        <StaleSourceAction source={source} />
         <IconButton label="Редактировать маппинг" size="sm" onClick={() => setEditing(e => !e)}>
           <Pencil size={13} />
         </IconButton>

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -26,7 +26,7 @@ import { buildRecognitionFields, codesFromLabels } from '@/features/quality-docs
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
 import { SourceOriginIcon } from '@/shared/ui/SourceOriginIcon';
-import { computeBoundFieldKeys, mergeBindingPreviewsIntoValues, computeRecognizedFieldKeys
+import { computeBoundFieldKeys, mergeBindingPreviewsIntoValues, computeRecognizedFieldKeys, computeStaleFieldKeys, staleReasonText
 } from '@/shared/api/datasetHelpers';
 import { EntryDataSetBindings } from './EntryDataSetBindings';
 import {
@@ -264,6 +264,18 @@ export function CatalogEntryForm({
   // Какие из связанных полей приходят из распознанного источника: человек видит значок «из
   // источника» и не знает, что значение прочитала модель со скана (см. SourceOriginIcon).
   const recognizedBoundKeys = computeRecognizedFieldKeys(bindings);
+  // Устаревшие источники записи: та же оговорка, что в форме документа, но здесь у неё есть ещё
+  // один адресат — кнопка «Обновить из источника» (issue #815).
+  const staleBoundKeys = computeStaleFieldKeys(bindings);
+  const staleReasonOfKey = (key: string) =>
+    bindings.find(b => b.source?.recognitionStale
+      && (b.targetFieldKey === key
+        || Object.keys(Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {})).includes(key)))
+      ?.source?.staleReason ?? null;
+  const staleBindings = bindings.filter(b => b.source?.recognitionStale);
+  const staleBindingHint = staleBindings.length === 0
+    ? undefined
+    : `${staleReasonText(staleBindings[0].source?.staleReason)} — подтянутся значения от прежнего файла.`;
   const { refetch: refetchBindingPreview, isFetching: refreshingFromSource } =
     usePreviewDataSetBindings({ ownerId: entry?.id });
   // Проверка связок (issue #99) — по требованию.
@@ -391,7 +403,8 @@ export function CatalogEntryForm({
               <div key={field.key}>
                 <label className="flex items-center gap-1.5 text-sm font-medium text-fg2 mb-1">
                   {field.title}
-                  <SourceOriginIcon origin={recognizedBoundKeys.has(field.key) ? 'Recognized' : undefined} plural />
+                  <SourceOriginIcon origin={recognizedBoundKeys.has(field.key) ? 'Recognized' : undefined} plural
+                    stale={staleBoundKeys.has(field.key)} staleReason={staleReasonOfKey(field.key)} />
                 </label>
                 <div className="rounded-md border border-stroke overflow-x-auto bg-muted">
                   {rows.length === 0 ? (
@@ -434,7 +447,8 @@ export function CatalogEntryForm({
               <div key={field.key}>
                 <label className="flex items-center gap-1.5 text-sm font-medium text-fg2 mb-1">
                   {field.title}
-                  <SourceOriginIcon origin={recognizedBoundKeys.has(field.key) ? 'Recognized' : undefined} />
+                  <SourceOriginIcon origin={recognizedBoundKeys.has(field.key) ? 'Recognized' : undefined}
+                    stale={staleBoundKeys.has(field.key)} staleReason={staleReasonOfKey(field.key)} />
                 </label>
                 <div className="w-full border border-stroke rounded-md px-3 py-2 text-sm bg-muted text-fg2">
                   {refId ? <BoundRefValue entryId={refId} /> : (display ?? <em className="text-fg4">нет данных</em>)}
@@ -551,7 +565,9 @@ export function CatalogEntryForm({
         <div className="space-y-4">
           {normal.length > 0 && fieldStack(normal)}
           <AutoFieldsSection count={auto.length}
-            recognizedCount={auto.filter(f => recognizedBoundKeys.has(f.key)).length}>
+            recognizedCount={auto.filter(f => recognizedBoundKeys.has(f.key)).length}
+            staleCount={auto.filter(f => staleBoundKeys.has(f.key)).length}
+            staleHint={staleBindingHint}>
             {fieldStack(auto)}
           </AutoFieldsSection>
         </div>
@@ -683,8 +699,12 @@ export function CatalogEntryForm({
           />
           {bindings.length > 0 && (
             <div className="flex items-center gap-2">
+              {/* Оговорка при устаревшем источнике (issue #815): кнопка подтянет ИМЕННО СТАРЫЕ
+                  значения, а человек будет уверен, что обновился до актуальных. Молчать здесь —
+                  худший вариант из трёх: обновление выглядит удавшимся. */}
               <Button type="button" variant="outlined" size="sm" onClick={handleRefreshFromSource}
-                loading={refreshingFromSource} icon={<RefreshCw size={14} />}>
+                loading={refreshingFromSource} icon={<RefreshCw size={14} />}
+                title={staleBindingHint}>
                 Обновить из источника
               </Button>
               <Button type="button" variant="outlined" size="sm" onClick={() => runBindingCheck()}

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -26,7 +26,7 @@ import { buildRecognitionFields, codesFromLabels } from '@/features/quality-docs
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
 import { SourceOriginIcon } from '@/shared/ui/SourceOriginIcon';
-import { computeBoundFieldKeys, mergeBindingPreviewsIntoValues, computeRecognizedFieldKeys, computeStaleFieldKeys, staleReasonText
+import { computeBoundFieldKeys, mergeBindingPreviewsIntoValues, computeRecognizedFieldKeys, computeStaleFieldKeys, computeStaleReasonByField, staleReasonText
 } from '@/shared/api/datasetHelpers';
 import { EntryDataSetBindings } from './EntryDataSetBindings';
 import {
@@ -267,11 +267,8 @@ export function CatalogEntryForm({
   // Устаревшие источники записи: та же оговорка, что в форме документа, но здесь у неё есть ещё
   // один адресат — кнопка «Обновить из источника» (issue #815).
   const staleBoundKeys = computeStaleFieldKeys(bindings);
-  const staleReasonOfKey = (key: string) =>
-    bindings.find(b => b.source?.recognitionStale
-      && (b.targetFieldKey === key
-        || Object.keys(Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {})).includes(key)))
-      ?.source?.staleReason ?? null;
+  const staleReasons = computeStaleReasonByField(bindings);
+  const staleReasonOfKey = (key: string) => staleReasons.get(key) ?? null;
   const staleBindings = bindings.filter(b => b.source?.recognitionStale);
   // Причину называем только когда она у всех устаревших источников ОДНА: смешав четыре под одной
   // формулировкой, подсказка соврала бы про три из них.

--- a/src/client/src/features/document-sets/catalog/index.tsx
+++ b/src/client/src/features/document-sets/catalog/index.tsx
@@ -273,9 +273,19 @@ export function CatalogEntryForm({
         || Object.keys(Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {})).includes(key)))
       ?.source?.staleReason ?? null;
   const staleBindings = bindings.filter(b => b.source?.recognitionStale);
-  const staleBindingHint = staleBindings.length === 0
+  // Причину называем только когда она у всех устаревших источников ОДНА: смешав четыре под одной
+  // формулировкой, подсказка соврала бы про три из них.
+  const staleReasonCommon = new Set(staleBindings.map(b => b.source?.staleReason ?? null)).size === 1
+    ? staleReasonText(staleBindings[0]?.source?.staleReason)
+    : 'Источники этих полей изменились после распознавания';
+  // Два адресата — две подсказки: у кнопки речь о том, ЧТО она сейчас подтянет, у секции полей —
+  // о том, откуда взялись показанные значения. Один текст на обоих был бы неточен на каждом.
+  const staleRefreshHint = staleBindings.length === 0
     ? undefined
-    : `${staleReasonText(staleBindings[0].source?.staleReason)} — подтянутся значения от прежнего файла.`;
+    : `${staleReasonCommon} — подтянутся значения от прежнего файла.`;
+  const staleFieldsHint = staleBindings.length === 0
+    ? undefined
+    : `${staleReasonCommon}. Перераспознать можно в списке наборов данных ниже.`;
   const { refetch: refetchBindingPreview, isFetching: refreshingFromSource } =
     usePreviewDataSetBindings({ ownerId: entry?.id });
   // Проверка связок (issue #99) — по требованию.
@@ -567,7 +577,7 @@ export function CatalogEntryForm({
           <AutoFieldsSection count={auto.length}
             recognizedCount={auto.filter(f => recognizedBoundKeys.has(f.key)).length}
             staleCount={auto.filter(f => staleBoundKeys.has(f.key)).length}
-            staleHint={staleBindingHint}>
+            staleHint={staleFieldsHint}>
             {fieldStack(auto)}
           </AutoFieldsSection>
         </div>
@@ -704,7 +714,7 @@ export function CatalogEntryForm({
                   худший вариант из трёх: обновление выглядит удавшимся. */}
               <Button type="button" variant="outlined" size="sm" onClick={handleRefreshFromSource}
                 loading={refreshingFromSource} icon={<RefreshCw size={14} />}
-                title={staleBindingHint}>
+                title={staleRefreshHint}>
                 Обновить из источника
               </Button>
               <Button type="button" variant="outlined" size="sm" onClick={() => runBindingCheck()}

--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -11,6 +11,8 @@ import type { DocumentInstance, DocumentType, DataSetSource, DataSetBinding, Dat
 import { DATA_SET_FORMAT_LABELS, SCOPE_LABELS } from '@/shared/api/types';
 import { resolveEffectiveFields, isScalarField, type SchemaField } from '@/shared/api/schema';
 import { parseSourceColumnNames, parseRefMapping, buildRefMappingByName, buildRefMappingByIdentity, parseFileMapping, buildFileMapping, parseInlineMapping, buildInlineMapping } from '@/shared/api/datasetHelpers';
+import { StaleSourceAction } from '@/shared/ui/StaleSourceAction';
+import { ruCount } from '@/shared/utils/pluralize';
 import { FUNCTIONAL_TAG, hasTag } from '@/shared/api/tags';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
 /** Совместимость по наследованию: childId == ancestorId либо childId — потомок ancestorId по parentId. */
@@ -615,11 +617,12 @@ function BindingRow({
             <span className="text-xs text-fg4">
               {file?.name} · {source?.materializeTypeId
                 ? `материализация → ${allDocTypes.find(t => t.id === source.materializeTypeId)?.name ?? 'тип'}`
-                : `${mappedCount} пол${mappedCount === 1 ? 'е' : 'я'} привязано`}
+                : `${ruCount(mappedCount, 'поле привязано', 'поля привязано', 'полей привязано')}`}
               {targetFieldKey && ` · таблица: ${targetFieldKey}`}
             </span>
           </div>
         </div>
+        <StaleSourceAction source={source} />
         <button
           onClick={() => setEditing(e => !e)}
           className="p-1.5 rounded text-xs text-fg3"

--- a/src/client/src/features/document-sets/editor/DataSetsTab.tsx
+++ b/src/client/src/features/document-sets/editor/DataSetsTab.tsx
@@ -7,7 +7,7 @@ import {
   useCreateDataSetBinding, useUpdateDataSetBinding, useDeleteDataSetBinding,
   useAutoMapDataSetSource, usePreviewDataSetBindings,
 } from '@/shared/api/datasets';
-import type { DocumentInstance, DocumentType, DataSetSource, DataSetBinding, DataSetBindingPreviewResult } from '@/shared/api/types';
+import type { DocumentInstance, DocumentType, DataSetBinding, DataSetBindingPreviewResult, ComputedColumn } from '@/shared/api/types';
 import { DATA_SET_FORMAT_LABELS, SCOPE_LABELS } from '@/shared/api/types';
 import { resolveEffectiveFields, isScalarField, type SchemaField } from '@/shared/api/schema';
 import { parseSourceColumnNames, parseRefMapping, buildRefMappingByName, buildRefMappingByIdentity, parseFileMapping, buildFileMapping, parseInlineMapping, buildInlineMapping } from '@/shared/api/datasetHelpers';
@@ -214,7 +214,9 @@ export function MappingEditor({
   hideModeSelector = false,
   allowDocRef = false,
 }: {
-  source: DataSetSource;
+  // Узкий контракт вместо полного источника: редактору нужны ровно две вещи, а привязка приносит
+  // урезанный DTO — требуя здесь DataSetSource, тип обещал бы поля, которых в ответе нет (issue #815).
+  source: { cachedSchema: string; computedColumns?: ComputedColumn[] | null };
   schemaFields: SchemaField[];
   tabularFields: SchemaField[];
   allDocTypes: DocumentType[];

--- a/src/client/src/features/document-sets/editor/RequisitesTab.tsx
+++ b/src/client/src/features/document-sets/editor/RequisitesTab.tsx
@@ -7,7 +7,7 @@ import { useUpdateRequisites, useResolutionDiagnostics, brokenRefPaths, useAudit
 import { valueIssuesByPath, deepIssueCount, issueCountInFields } from '@/shared/api/valueIssues';
 import { ValueIssueHint, ValueIssueBadge } from '@/shared/ui/ValueIssue';
 import { FUNCTIONAL_TAG, hasTag } from '@/shared/api/tags';
-import type { DocumentInstance, DocumentType, PrimitiveTypeDef, EnumTypeDef, CommonDataEntry } from '@/shared/api/types';
+import type { DocumentInstance, DocumentType, PrimitiveTypeDef, EnumTypeDef, CommonDataEntry, DataSetStaleReason } from '@/shared/api/types';
 import { SCOPE_LABELS, isFieldRef } from '@/shared/api/types';
 import { useCommonDataForSet } from '@/shared/api/commonData';
 import { groupEffectiveFields, parseSchemaFields, getDefaultValues, isScalarField, type SchemaField } from '@/shared/api/schema';
@@ -17,7 +17,7 @@ import { validateConstraint, isMissing, PrimitiveInput, FileField, ImageField, c
 import { evalComputed, referencedKeys } from '@/shared/utils/computedExpression';
 import { DocumentPreviewPanel } from './DocumentPreviewPanel';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
-import { computeRecognizedFieldKeys } from '@/shared/api/datasetHelpers';
+import { computeRecognizedFieldKeys, computeStaleFieldKeys, staleReasonText } from '@/shared/api/datasetHelpers';
 import { SourceOriginIcon } from '@/shared/ui/SourceOriginIcon';
 import { mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
 import { Button } from '@/shared/ui/Button';
@@ -36,18 +36,25 @@ export type SaveRef = { current: (() => Promise<boolean>) | null };
 /// Плашка для doc-ref/doc-array поля, которое заполняется привязанным источником данных:
 /// ручные ссылки скрываем, т.к. при генерации источник перезаписывает поле целиком
 /// (см. issue #17 — «источник ИЛИ ссылки», взаимоисключающе).
-function SourceBoundDocField({ recognized }: { recognized?: boolean }) {
+function SourceBoundDocField(
+  { recognized, stale, staleReason }:
+  { recognized?: boolean; stale?: boolean; staleReason?: DataSetStaleReason | null },
+) {
+  const tone = stale ? 'text-warning' : 'text-brand';
   return (
     <div className="flex items-center gap-2 border border-brand/40 rounded-lg px-3 py-2 bg-brand/5">
       {recognized
-        ? <ScanText size={14} className="text-brand shrink-0" />
-        : <Database size={14} className="text-brand shrink-0" />}
+        ? <ScanText size={14} className={`${tone} shrink-0`} />
+        : <Database size={14} className={`${tone} shrink-0`} />}
       <span className="text-xs text-fg3">
         {recognized
           // Плашка вместо самих ссылок — единственное, что человек тут видит; промолчав о
           // происхождении здесь, мы оставили бы doc-ref немым, закрыв дверь у соседних полей.
           ? 'Заполняется из привязанного источника — значения распознаны со скана, возможны ошибки чтения.'
           : 'Заполняется из привязанного источника данных — правьте связку по иконке источника у поля.'}
+        {/* Устаревание дописывается второй фразой, а не заменяет первую: происхождение и годность —
+            разные вопросы, и ответ на один не отменяет другого (issue #815). */}
+        {stale && <span className="text-warning"> {staleReasonText(staleReason)}.</span>}
       </span>
     </div>
   );
@@ -120,6 +127,27 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
   // происхождения считает сервер). Человеку у read-only поля иначе неоткуда узнать, что значение
   // прочитала модель, — а к прочитанному моделью и доверие другое.
   const recognizedBoundFields = useMemo(() => computeRecognizedFieldKeys(dsBindings), [dsBindings]);
+  // Поля, чей источник УСТАРЕЛ (issue #815): данные разошлись с файлом, из которого их читали. Это
+  // не подмножество распознанных — устареть может и парсерный источник, не разобравшийся против
+  // нового файла, поэтому счёт и подпись отдельные.
+  const staleBoundFields = useMemo(() => computeStaleFieldKeys(dsBindings), [dsBindings]);
+  // Причина в подсказке — только когда она у всех устаревших источников ОДНА. Смешав четыре
+  // причины под одной формулировкой, подсказка соврала бы про три из них.
+  const staleHint = useMemo(() => {
+    const reasons = new Set(dsBindings.filter(b => b.source?.recognitionStale).map(b => b.source?.staleReason ?? null));
+    const common = reasons.size === 1 ? [...reasons][0] : undefined;
+    const what = common !== undefined
+      ? staleReasonText(common)
+      : 'Источники этих полей изменились после распознавания';
+    // Глагол здесь законен: обзор источников документа открывается кнопкой в шапке, уходить из
+    // формы (и терять несохранённое) не нужно.
+    return `${what}. Перераспознать можно в «Источниках».`;
+  }, [dsBindings]);
+  const staleReasonOf = (key: string) =>
+    dsBindings.find(b => b.source?.recognitionStale
+      && (b.targetFieldKey === key
+        || Object.keys(Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {})).includes(key)))
+      ?.source?.staleReason ?? null;
   // Скалярные поля — для per-field привязки «линза» (issue #296, фаза 1): выбор источника на поле +
   // авто-предложение покрыть остальные скалярные поля этого источника.
   const scalarSchemaFields = useMemo(() => schemaFields.filter(f => isScalarField(f) && f.type !== 'file'), [schemaFields]);
@@ -436,15 +464,19 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
                     {/* Широкие поля (многострочный текст, картинка, файл) подписываются здесь, и
                         признак происхождения им нужен ровно так же: связанное текстовое поле
                         read-only, и узнать, что значение прочитано со скана, иначе неоткуда. */}
-                    {recognizedBoundFields.has(field.key) && (
+                    {(recognizedBoundFields.has(field.key) || staleBoundFields.has(field.key)) && (
                       <span className="ml-1 inline-block align-text-bottom">
-                        <SourceOriginIcon origin="Recognized" />
+                        <SourceOriginIcon
+                          origin={recognizedBoundFields.has(field.key) ? 'Recognized' : undefined}
+                          stale={staleBoundFields.has(field.key)}
+                          staleReason={staleReasonOf(field.key)} />
                       </span>
                     )}
                   </label>
                 )}
                 {field.type === 'complex' ? (
-                  bound ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)} /> : (
+                  bound ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)}
+                    stale={staleBoundFields.has(field.key)} staleReason={staleReasonOf(field.key)} /> : (
                   <div>
                     <div className="flex items-center justify-between mb-1">
                       <label className="block text-xs font-medium text-fg2 pr-5">
@@ -461,20 +493,23 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
                   </div>
                   )
                 ) : field.type === 'array' ? (
-                  bound ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)} /> : (
+                  bound ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)}
+                    stale={staleBoundFields.has(field.key)} staleReason={staleReasonOf(field.key)} /> : (
                   <ArrayFieldEditor field={field} allDocTypes={allDocTypes} value={raw}
                     onChange={v => setValue(field.key, v)} showValidation={showValidation}
                     setId={setId} otherInstances={otherInstances} docRefMode="instance"
                     brokenPaths={brokenPaths} basePath={field.key} savedAt={instance.updatedAt} />
                   )
                 ) : field.type === 'doc-ref' ? (
-                  sourceBoundFields.has(field.key) ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)} /> : (
+                  sourceBoundFields.has(field.key) ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)}
+                    stale={staleBoundFields.has(field.key)} staleReason={staleReasonOf(field.key)} /> : (
                     <DocRefField field={field} allDocTypes={allDocTypes} value={raw}
                       onChange={v => setValue(field.key, v)} otherInstances={otherInstances} setId={setId}
                       broken={brokenPaths.has(field.key)} />
                   )
                 ) : field.type === 'doc-array' ? (
-                  sourceBoundFields.has(field.key) ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)} /> : (
+                  sourceBoundFields.has(field.key) ? <SourceBoundDocField recognized={recognizedBoundFields.has(field.key)}
+                    stale={staleBoundFields.has(field.key)} staleReason={staleReasonOf(field.key)} /> : (
                     <DocArrayField field={field} allDocTypes={allDocTypes} value={raw}
                       onChange={v => setValue(field.key, v)} otherInstances={otherInstances} setId={setId}
                       brokenPaths={brokenPaths} basePath={field.key} savedAt={instance.updatedAt} />
@@ -520,9 +555,12 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
                     {field.title}
                     {field.required && <span className="ml-0.5 text-danger">*</span>}
                     {primitiveDef && <span className="ml-1 text-[10px] text-fg4 font-normal">· {primitiveDef.name}</span>}
-                    {recognizedBoundFields.has(field.key) && (
+                    {(recognizedBoundFields.has(field.key) || staleBoundFields.has(field.key)) && (
                       <span className="ml-1 inline-block align-text-bottom">
-                        <SourceOriginIcon origin="Recognized" />
+                        <SourceOriginIcon
+                          origin={recognizedBoundFields.has(field.key) ? 'Recognized' : undefined}
+                          stale={staleBoundFields.has(field.key)}
+                          staleReason={staleReasonOf(field.key)} />
                       </span>
                     )}
                   </label>
@@ -558,7 +596,9 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
         <div className="space-y-4">
           {normal.length > 0 && fieldGrid(normal)}
           <AutoFieldsSection count={auto.length}
-            recognizedCount={auto.filter(f => recognizedBoundFields.has(f.key)).length}>
+            recognizedCount={auto.filter(f => recognizedBoundFields.has(f.key)).length}
+            staleCount={auto.filter(f => staleBoundFields.has(f.key)).length}
+            staleHint={staleHint}>
             {fieldGrid(auto)}
           </AutoFieldsSection>
         </div>

--- a/src/client/src/features/document-sets/editor/RequisitesTab.tsx
+++ b/src/client/src/features/document-sets/editor/RequisitesTab.tsx
@@ -17,7 +17,7 @@ import { validateConstraint, isMissing, PrimitiveInput, FileField, ImageField, c
 import { evalComputed, referencedKeys } from '@/shared/utils/computedExpression';
 import { DocumentPreviewPanel } from './DocumentPreviewPanel';
 import { useListDataSetBindings, usePreviewDataSetBindings } from '@/shared/api/datasets';
-import { computeRecognizedFieldKeys, computeStaleFieldKeys, staleReasonText } from '@/shared/api/datasetHelpers';
+import { computeRecognizedFieldKeys, computeStaleFieldKeys, computeStaleReasonByField, staleReasonText } from '@/shared/api/datasetHelpers';
 import { SourceOriginIcon } from '@/shared/ui/SourceOriginIcon';
 import { mergeBindingPreviewsIntoValues } from '@/shared/api/datasetHelpers';
 import { Button } from '@/shared/ui/Button';
@@ -143,11 +143,10 @@ export function RequisitesTab({ instance, setId, schemaFields, allDocTypes, docT
     // формы (и терять несохранённое) не нужно.
     return `${what}. Перераспознать можно в «Источниках».`;
   }, [dsBindings]);
-  const staleReasonOf = (key: string) =>
-    dsBindings.find(b => b.source?.recognitionStale
-      && (b.targetFieldKey === key
-        || Object.keys(Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {})).includes(key)))
-      ?.source?.staleReason ?? null;
+  // Причина берётся ТЕМ ЖЕ разбором привязки, что и множества выше (issue #815): свой поиск здесь
+  // расходился с ним на табличных привязках и мог показать полю причину чужого источника.
+  const staleReasons = useMemo(() => computeStaleReasonByField(dsBindings), [dsBindings]);
+  const staleReasonOf = (key: string) => staleReasons.get(key) ?? null;
   // Скалярные поля — для per-field привязки «линза» (issue #296, фаза 1): выбор источника на поле +
   // авто-предложение покрыть остальные скалярные поля этого источника.
   const scalarSchemaFields = useMemo(() => schemaFields.filter(f => isScalarField(f) && f.type !== 'file'), [schemaFields]);

--- a/src/client/src/features/document-sets/editor/index.tsx
+++ b/src/client/src/features/document-sets/editor/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { Pencil, Database, X } from 'lucide-react';
 import { DocumentObservationsChip } from './DocumentObservations';
 import { useRenameDocumentInstance, useResolutionDiagnostics, brokenRefPaths } from '@/shared/api/documentSets';
+import { useListDataSetBindings } from '@/shared/api/datasets';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import type { DocumentInstance, DocumentType } from '@/shared/api/types';
 import { resolveEffectiveFields, compositeFieldHasTag } from '@/shared/api/schema';
@@ -77,6 +78,14 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
   // (тот же queryKey) — без второго запроса; гейт по наличию ссылок в сохранённых реквизитах.
   const { data: editorDiagnostics } = useResolutionDiagnostics(instance.id, containsRef(instance.requisites));
   const brokenTabCount = useMemo(() => brokenRefPaths(editorDiagnostics).size, [editorDiagnostics]);
+  // Устаревшие источники документа (issue #815) — счёт по ИСТОЧНИКАМ, а не по полям: действие
+  // («Перераспознать») применяется к источнику, и «устарели источники: 2» отвечает на вопрос
+  // «сколько раз мне это делать». Признак висит здесь потому, что шапка видна всегда: секция
+  // связанных полей свёрнута по умолчанию, а из разделов формы виден только открытый.
+  const { data: docBindings = [] } = useListDataSetBindings({ ownerId: instance.id });
+  const staleSourceCount = useMemo(
+    () => new Set(docBindings.filter(b => b.source?.recognitionStale).map(b => b.sourceId)).size,
+    [docBindings]);
   const [dataSourcesOpen, setDataSourcesOpen] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [pendingTab, setPendingTab] = useState<InstanceTab | null>(null);
@@ -202,8 +211,21 @@ export function InstanceEditor({ instance, setId, docType, allDocTypes, otherIns
           {/* Источники данных (issue #296, фаза 3): пакетные операции уровня документа — обзор
               привязок, «Проверить данные», «Из шаблона». Точечная привязка — на самих полях. */}
           <Button variant="text" size="sm" icon={<Database size={15} />} onClick={() => setDataSourcesOpen(true)}
-            className="shrink-0" title="Обзор привязок, проверка данных, шаблоны">
+            className="shrink-0"
+            title={staleSourceCount > 0
+              ? `${ruCount(staleSourceCount, 'источник устарел', 'источника устарели', 'источников устарели')}: данные от прежнего файла. Откройте, чтобы перераспознать.`
+              : 'Обзор привязок, проверка данных, шаблоны'}
+            // На узком окне подпись скрыта и кнопка становится icon-only, а title доступен только
+            // мышью — счётчик обязан попасть в доступное имя, иначе для клавиатуры и скринридера
+            // сигнала нет вовсе ровно там, где он единственный.
+            aria-label={staleSourceCount > 0 ? `Источники: устарели ${staleSourceCount}` : 'Источники'}>
             <span className="hidden sm:inline">Источники</span>
+            {staleSourceCount > 0 && (
+              <span className="ml-1 inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full
+                bg-warning-subtle text-warning text-[10px] font-medium tabular-nums align-middle">
+                {staleSourceCount}
+              </span>
+            )}
           </Button>
           {editable && (
             <div className="flex items-center gap-2 shrink-0">

--- a/src/client/src/features/document-sets/fields/ComplexFields.tsx
+++ b/src/client/src/features/document-sets/fields/ComplexFields.tsx
@@ -1049,7 +1049,8 @@ function isRowEmpty(row: Record<string, unknown> | undefined, subFields: SchemaF
 /** Сворачиваемая секция «Заполняются автоматически» (issue #102, P2): read-only поля из источника
  *  прячем по умолчанию, чтобы длинная форма не выглядела «портянкой» одинаковых боксов. */
 export function AutoFieldsSection(
-  { count, recognizedCount = 0, children }: { count: number; recognizedCount?: number; children: ReactNode },
+  { count, recognizedCount = 0, staleCount = 0, staleHint, children }:
+  { count: number; recognizedCount?: number; staleCount?: number; staleHint?: string; children: ReactNode },
 ) {
   const [open, setOpen] = useState(false);
   return (
@@ -1076,6 +1077,14 @@ export function AutoFieldsSection(
               {/* Совпали — говорим словом: сравнивать два числа на глаз читателю не должно
                   приходиться (в прошлый раз этот дефект пришлось записать в «не чиним»). */}
               {recognizedCount === count ? 'все со сканов' : `со сканов: ${recognizedCount}`}
+            </span>
+          )}
+          {/* Устаревание — ОТДЕЛЬНОЕ слагаемое, а не оттенок предыдущего (issue #815): устареть
+              может и обычный источник, не разобравшийся против нового файла, так что «со сканов: 0 ·
+              устарело: 2» — законная строка. Цвет warning: это оговорка к данным, а не поломка. */}
+          {staleCount > 0 && (
+            <span className="text-warning" title={staleHint}>
+              {' · '}устарело: {staleCount}
             </span>
           )}
         </span>

--- a/src/client/src/shared/api/datasetHelpers.test.ts
+++ b/src/client/src/shared/api/datasetHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseSourceColumns, parseSourceColumnNames, countFilterConditions, cleanFilterNode,
   mergeBindingPreviewsIntoValues, computeBoundFieldKeys, computeRecognizedFieldKeys,
+  computeStaleFieldKeys, staleReasonText,
   isFileMappingValue, parseFileMapping, buildFileMapping, nextSourceName,
 } from './datasetHelpers';
 import type { FilterGroup, DataSetBindingPreviewResult } from './types';
@@ -256,5 +257,61 @@ describe('computeRecognizedFieldKeys', () => {
       { targetFieldKey: 'Схемы', mapping: {}, source: recognized },
     ]);
     expect(keys).toEqual(new Set(['Схемы']));
+  });
+});
+
+describe('computeStaleFieldKeys', () => {
+  const stale = { origin: 'Recognized' as const, recognitionStale: true };
+  const fresh = { origin: 'Recognized' as const, recognitionStale: false };
+
+  it('устаревание считается по ВСЕМ источникам, а не только распознанным', () => {
+    // Парсерный источник, не разобравшийся против нового файла, тоже устарел — и человеку у поля
+    // это так же важно. Свяжи признак с распознаванием, и такое поле промолчало бы.
+    const keys = computeStaleFieldKeys([
+      { targetFieldKey: 'Материалы', mapping: {}, source: { origin: 'Parsed', recognitionStale: true } },
+      { targetFieldKey: 'Схемы', mapping: {}, source: fresh },
+    ]);
+    expect(keys).toEqual(new Set(['Материалы']));
+  });
+
+  it('разбирает привязку теми же правилами, что и происхождение', () => {
+    const bindings: Parameters<typeof computeStaleFieldKeys>[0] = [
+      { targetFieldKey: null, mapping: { Шифр: 'A' }, source: stale },
+      { targetFieldKey: null, mapping: {}, source: { ...stale, materializeMapping: { Титул: 'B' } } },
+      { targetFieldKey: 'Схемы', mapping: {}, source: stale },
+    ];
+    expect(computeStaleFieldKeys(bindings)).toEqual(new Set(['Шифр', 'Титул', 'Схемы']));
+    // Ровно те же ключи считает признак происхождения — множества разные только по условию.
+    expect(computeRecognizedFieldKeys(bindings)).toEqual(new Set(['Шифр', 'Титул', 'Схемы']));
+  });
+
+  it('свежие источники не помечаются', () => {
+    expect(computeStaleFieldKeys([
+      { targetFieldKey: 'Схемы', mapping: {}, source: fresh },
+      { targetFieldKey: 'Прочее', mapping: {}, source: undefined },
+    ]).size).toBe(0);
+  });
+});
+
+describe('staleReasonText', () => {
+  it('каждая причина называется своим словом', () => {
+    const texts = (['FileReplaced', 'NotParsedAgainstNewFile', 'TableBoundariesChanged', 'ProfileChanged'] as const)
+      .map(r => staleReasonText(r));
+    expect(new Set(texts).size).toBe(4);
+    expect(texts.every(t => t.length > 0)).toBe(true);
+  });
+
+  it('незнакомая причина не оставляет читателя без ответа', () => {
+    // Признак пришёл с сервера, значит что-то случилось; промолчать хуже, чем сказать общее.
+    expect(staleReasonText(null)).toBe('Данные источника устарели');
+    expect(staleReasonText(undefined)).toBe('Данные источника устарели');
+  });
+
+  it('текст — констатация, без глагола', () => {
+    // Действие дописывает место показа: путь к «Перераспознать» есть не отовсюду, а подсказка,
+    // требующая невыполнимого, обесценивается так же, как та, что горит всегда.
+    for (const r of ['FileReplaced', 'NotParsedAgainstNewFile', 'TableBoundariesChanged', 'ProfileChanged'] as const) {
+      expect(staleReasonText(r)).not.toMatch(/[Пп]ерераспозна|[Пп]роверьте|[Оо]ткройте/);
+    }
   });
 });

--- a/src/client/src/shared/api/datasetHelpers.test.ts
+++ b/src/client/src/shared/api/datasetHelpers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseSourceColumns, parseSourceColumnNames, countFilterConditions, cleanFilterNode,
   mergeBindingPreviewsIntoValues, computeBoundFieldKeys, computeRecognizedFieldKeys,
-  computeStaleFieldKeys, staleReasonText,
+  computeStaleFieldKeys, computeStaleReasonByField, staleReasonText,
   isFileMappingValue, parseFileMapping, buildFileMapping, nextSourceName,
 } from './datasetHelpers';
 import type { FilterGroup, DataSetBindingPreviewResult } from './types';
@@ -313,5 +313,32 @@ describe('staleReasonText', () => {
     for (const r of ['FileReplaced', 'NotParsedAgainstNewFile', 'TableBoundariesChanged', 'ProfileChanged'] as const) {
       expect(staleReasonText(r)).not.toMatch(/[Пп]ерераспозна|[Пп]роверьте|[Оо]ткройте/);
     }
+  });
+});
+
+describe('computeStaleReasonByField', () => {
+  it('поле получает причину СВОЕГО источника, а не совпавшего по ключу', () => {
+    // Табличная привязка названа целевым полем, и её маппинг описывает колонки строк, а не
+    // реквизиты. Отдельный поиск причины совпадал и по тому, и по другому — и поле «Шифр»
+    // получало причину от таблицы, которая его не заполняет.
+    const reasons = computeStaleReasonByField([
+      {
+        targetFieldKey: 'Схемы', mapping: { Шифр: 'A' },
+        source: { recognitionStale: true, staleReason: 'TableBoundariesChanged' },
+      },
+      {
+        targetFieldKey: null, mapping: { Шифр: 'B' },
+        source: { recognitionStale: true, staleReason: 'FileReplaced' },
+      },
+    ]);
+    expect(reasons.get('Схемы')).toBe('TableBoundariesChanged');
+    expect(reasons.get('Шифр')).toBe('FileReplaced');
+  });
+
+  it('свежие источники в карту не попадают', () => {
+    const reasons = computeStaleReasonByField([
+      { targetFieldKey: 'Схемы', mapping: {}, source: { recognitionStale: false, staleReason: 'FileReplaced' } },
+    ]);
+    expect(reasons.size).toBe(0);
   });
 });

--- a/src/client/src/shared/api/datasetHelpers.ts
+++ b/src/client/src/shared/api/datasetHelpers.ts
@@ -181,14 +181,6 @@ export function computeBoundFieldKeys(
 }
 
 /**
- * Происхождение значений по ключу поля: к какому источнику поле привязано, оттуда и признак
- * (issue про точку потребления). Рядом с `computeBoundFieldKeys` и по тем же правилам разбора
- * привязки — скалярные ключи лежат в маппинге, табличное поле названо в `targetFieldKey`.
- *
- * Возвращаются ТОЛЬКО распознанные: `Parsed` и `System` в интерфейсе ничего не меняют — у них нет
- * действия для читателя, а метка без действия становится фоном, который перестают замечать.
- */
-/**
  * Почему данные источника устарели — ОДНОЙ фразой-констатацией, без глагола (issue #815).
  *
  * Действие дописывает место показа, а не эта функция: путь к «Перераспознать» есть не отовсюду, и
@@ -218,6 +210,7 @@ interface FieldKeyBinding {
   source?: {
     origin?: DataOrigin;
     recognitionStale?: boolean;
+    staleReason?: DataSetStaleReason | null;
     materializeMapping?: Record<string, string> | null;
   };
 }
@@ -229,6 +222,21 @@ interface FieldKeyBinding {
  * спрашивают о разном, но отвечают об одних и тех же полях. Своя копия у каждого признака уже
  * однажды разъехалась по правилу fallback'а — и часть полей осталась read-only без объяснения.
  */
+/**
+ * Ключи полей ОДНОЙ привязки — единственное место, где привязка разбирается на поля.
+ *
+ * Табличная привязка названа целевым полем и маппингом поля НЕ покрывает: у неё маппинг описывает
+ * колонки строк, а не реквизиты документа. Смешай эти два случая — и поле получило бы признак от
+ * источника, который его не заполняет.
+ */
+function bindingFieldKeys(b: FieldKeyBinding): string[] {
+  if (b.targetFieldKey) return [b.targetFieldKey];
+  // Эффективный маппинг — собственный, а при пустом берётся с материализации источника: ровно так
+  // же считаются поля, которые форма делает read-only. Разойдись эти два правила — часть полей
+  // стала бы нередактируемой без объяснения, откуда взялось значение.
+  return Object.keys(Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {}));
+}
+
 function computeFieldKeysWhere(
   bindings: FieldKeyBinding[],
   matches: (b: FieldKeyBinding) => boolean,
@@ -236,16 +244,19 @@ function computeFieldKeysWhere(
   const keys = new Set<string>();
   for (const b of bindings) {
     if (!matches(b)) continue;
-    if (b.targetFieldKey) { keys.add(b.targetFieldKey); continue; }
-    // Эффективный маппинг — собственный, а при пустом берётся с материализации источника: ровно так
-    // же считаются поля, которые форма делает read-only. Разойдись эти два правила — часть полей
-    // стала бы нередактируемой без объяснения, откуда взялось значение.
-    const effective = Object.keys(b.mapping).length > 0 ? b.mapping : (b.source?.materializeMapping ?? {});
-    for (const key of Object.keys(effective)) keys.add(key);
+    for (const key of bindingFieldKeys(b)) keys.add(key);
   }
   return keys;
 }
 
+/**
+ * Происхождение значений по ключу поля: к какому источнику поле привязано, оттуда и признак
+ * (issue про точку потребления). Рядом с `computeBoundFieldKeys` и по тем же правилам разбора
+ * привязки — скалярные ключи лежат в маппинге, табличное поле названо в `targetFieldKey`.
+ *
+ * Возвращаются ТОЛЬКО распознанные: `Parsed` и `System` в интерфейсе ничего не меняют — у них нет
+ * действия для читателя, а метка без действия становится фоном, который перестают замечать.
+ */
 export function computeRecognizedFieldKeys(bindings: FieldKeyBinding[]): Set<string> {
   return computeFieldKeysWhere(bindings, b => b.source?.origin === 'Recognized');
 }
@@ -258,6 +269,27 @@ export function computeRecognizedFieldKeys(bindings: FieldKeyBinding[]): Set<str
  */
 export function computeStaleFieldKeys(bindings: FieldKeyBinding[]): Set<string> {
   return computeFieldKeysWhere(bindings, b => b.source?.recognitionStale === true);
+}
+
+/**
+ * Поле → причина, по которой его источник устарел. Тем же разбором привязки, что и множества выше:
+ * искать причину отдельным условием уже приводило к тому, что полю показывали причину чужого
+ * источника — табличная привязка совпадала и по целевому полю, и по ключам своего маппинга.
+ *
+ * Поле заполняет одна привязка; если их всё же две, берётся первая — спорить о причине бессмысленно,
+ * когда сама настройка противоречива.
+ */
+export function computeStaleReasonByField(
+  bindings: FieldKeyBinding[],
+): Map<string, DataSetStaleReason | null | undefined> {
+  const byField = new Map<string, DataSetStaleReason | null | undefined>();
+  for (const b of bindings) {
+    if (b.source?.recognitionStale !== true) continue;
+    for (const key of bindingFieldKeys(b)) {
+      if (!byField.has(key)) byField.set(key, b.source?.staleReason);
+    }
+  }
+  return byField;
 }
 
 /** Recursively counts non-empty conditions in a filter tree. */

--- a/src/client/src/shared/api/datasetHelpers.ts
+++ b/src/client/src/shared/api/datasetHelpers.ts
@@ -212,16 +212,30 @@ export function staleReasonText(reason: DataSetStaleReason | null | undefined): 
   }
 }
 
-export function computeRecognizedFieldKeys(
-  bindings: {
-    targetFieldKey: string | null;
-    mapping: Record<string, string>;
-    source?: { origin?: DataOrigin; materializeMapping?: Record<string, string> | null };
-  }[],
+interface FieldKeyBinding {
+  targetFieldKey: string | null;
+  mapping: Record<string, string>;
+  source?: {
+    origin?: DataOrigin;
+    recognitionStale?: boolean;
+    materializeMapping?: Record<string, string> | null;
+  };
+}
+
+/**
+ * Ключи полей, которые заполняет привязка, удовлетворяющая условию.
+ *
+ * Разбор привязки на ключи полей — ОДИН на все признаки (issue #815): происхождение и устаревание
+ * спрашивают о разном, но отвечают об одних и тех же полях. Своя копия у каждого признака уже
+ * однажды разъехалась по правилу fallback'а — и часть полей осталась read-only без объяснения.
+ */
+function computeFieldKeysWhere(
+  bindings: FieldKeyBinding[],
+  matches: (b: FieldKeyBinding) => boolean,
 ): Set<string> {
   const keys = new Set<string>();
   for (const b of bindings) {
-    if (b.source?.origin !== 'Recognized') continue;
+    if (!matches(b)) continue;
     if (b.targetFieldKey) { keys.add(b.targetFieldKey); continue; }
     // Эффективный маппинг — собственный, а при пустом берётся с материализации источника: ровно так
     // же считаются поля, которые форма делает read-only. Разойдись эти два правила — часть полей
@@ -230,6 +244,20 @@ export function computeRecognizedFieldKeys(
     for (const key of Object.keys(effective)) keys.add(key);
   }
   return keys;
+}
+
+export function computeRecognizedFieldKeys(bindings: FieldKeyBinding[]): Set<string> {
+  return computeFieldKeysWhere(bindings, b => b.source?.origin === 'Recognized');
+}
+
+/**
+ * Поля, чей источник УСТАРЕЛ: данные разошлись с файлом, из которого их читали (issue #815).
+ *
+ * Считается по всем источникам, а не только распознанным: устареть может и парсерный источник,
+ * не разобравшийся против нового файла, — и человеку у поля это так же важно, как распознавание.
+ */
+export function computeStaleFieldKeys(bindings: FieldKeyBinding[]): Set<string> {
+  return computeFieldKeysWhere(bindings, b => b.source?.recognitionStale === true);
 }
 
 /** Recursively counts non-empty conditions in a filter tree. */

--- a/src/client/src/shared/api/datasets.ts
+++ b/src/client/src/shared/api/datasets.ts
@@ -333,6 +333,31 @@ export function useRecognizeFile() {
   });
 }
 
+/**
+ * Перераспознать ОДИН источник (issue #815) — то же действие, что «Распознать» в наборах, но адресно.
+ *
+ * Нужно там, где на устаревшие данные смотрят: в форме документа их видно, а файлового «Распознать
+ * заново» оттуда предлагать нельзя — оно перезаписывает ручную корректировку разбиения всего набора.
+ * ГОСТ-набор уходит в фоновую задачу (202 + jobId), счёт распознаётся синхронно; 409 — тот же
+ * конфликт ручной правки, что и у файлового вызова.
+ */
+export function useRecognizeSource() {
+  const qc = useQueryClient();
+  return useMutation<{ jobId?: string }, Error, { sourceId: string; confirm?: boolean }>({
+    mutationFn: ({ sourceId, confirm }) =>
+      apiClient.post(`/datasets/sources/${sourceId}/recognize`, undefined,
+        { params: confirm ? { confirm: true } : undefined }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['jobs', 'active'] });
+      invalidateSources(qc);
+      // Привязки везут копию источника (в т.ч. признак устаревания) — без этого чип «устарело»
+      // остался бы висеть в форме документа до её перезакрытия. Синхронный путь (счёт) обновится
+      // здесь, фоновый — по завершении задачи (useActiveJobs).
+      qc.invalidateQueries({ queryKey: ['datasets', 'bindings'] });
+    },
+  });
+}
+
 /** 409 от /recognize — набор уже правился вручную, нужно явное подтверждение перезаписи. */
 export function isManualGroupingConflict(err: unknown): boolean {
   return (err as { response?: { status?: number } })?.response?.status === 409;

--- a/src/client/src/shared/api/jobs.ts
+++ b/src/client/src/shared/api/jobs.ts
@@ -45,6 +45,12 @@ export function useActiveJobs(): ActiveJob[] {
       qc.invalidateQueries({ queryKey: ['datasets', 'files'] });
       // Кандидаты источника меняются после распознавания таблицы (issue #385) — обновляем их тоже.
       qc.invalidateQueries({ queryKey: ['datasets', 'source-candidates'] });
+      // Привязки везут копию источника — в том числе признак устаревания и число строк (issue #815).
+      // Без них человек, дождавшийся конца перераспознавания, видел бы в форме документа прежний чип
+      // «устарело» и прежние значения: расхождение картинки с фактом читается не как задержка, а как
+      // «не сработало», и следующим движением жмут кнопку ещё раз.
+      qc.invalidateQueries({ queryKey: ['datasets', 'bindings'] });
+      qc.invalidateQueries({ queryKey: ['datasets', 'bindings-preview'] });
       qc.invalidateQueries({ queryKey: ['notifications'] });
     }
     prevIds.current = current;

--- a/src/client/src/shared/api/types.ts
+++ b/src/client/src/shared/api/types.ts
@@ -430,13 +430,50 @@ export type DataOrigin = 'Parsed' | 'Recognized' | 'System';
 
 /** Привязка набора данных к объекту — только Mapping. Filter/Transformation/Sort — на DataSetSource.
  * Владелец — единый ownerId (DomainObject: документ или запись общих данных). */
+/**
+ * Что перезапустит «Перераспознать» у источника — считает СЕРВЕР (issue #815).
+ *
+ * `None` — действия нет вовсе (источник не из PDF): предлагать его значит вести в тупик, эндпоинт
+ * отобьёт вызов на входе. `Source` — перезапустится только этот источник. `File` — распознавание
+ * ВСЕГО набора: минуты работы модели и перезапись всех его проекций, о чём человек должен узнать
+ * до нажатия, а не после.
+ */
+export type RecognizeScope = 'None' | 'Source' | 'File';
+
+/**
+ * Источник в составе привязки — УЗКИЙ DTO (`BindingSourceDto` на сервере), а не полный
+ * `DataSetSource`.
+ *
+ * Перечислен полями, а не выведен из `DataSetSource`, потому что однажды именно это и подвело:
+ * тип обещал полный источник, точка потребления читала `recognitionStale`, сервер его не слал —
+ * и весь показ устаревания молча ничего не рисовал, а TypeScript был доволен. Добавляя сюда поле,
+ * добавьте его и в `BindingSourceDto`, иначе оно будет вечно `undefined`.
+ */
+export interface DataSetBindingSource {
+  id: string;
+  name: string;
+  sheetOrPath: string;
+  cachedSchema: string;
+  cachedRowCount: number;
+  file?: Pick<DataSetFile, 'id' | 'name' | 'format' | 'scope' | 'scopeId'>;
+  materializeTypeId: string | null;
+  materializeMapping: Record<string, string> | null;
+  origin?: DataOrigin;
+  recognitionStale?: boolean;
+  staleReason?: DataSetStaleReason | null;
+  bindingCount?: number | null;
+  recognizeScope?: RecognizeScope;
+  /** Вычисляемые колонки: в `cachedSchema` их нет, а маппить по ним можно (issue #49). */
+  computedColumns?: ComputedColumn[] | null;
+}
+
 export interface DataSetBinding {
   id: string;
   ownerId: string;
   sourceId: string;
   targetFieldKey: string | null;
   mapping: Record<string, string>;
-  source?: DataSetSource & { file?: Pick<DataSetFile, 'id' | 'name' | 'format' | 'scope' | 'scopeId'> };
+  source?: DataSetBindingSource;
 }
 
 /** Владелец привязки к набору данных — единый объект (документ или запись общих данных). */

--- a/src/client/src/shared/ui/SourceOriginIcon.tsx
+++ b/src/client/src/shared/ui/SourceOriginIcon.tsx
@@ -1,25 +1,33 @@
 import { DatabaseZap, ScanText } from 'lucide-react';
-import type { DataOrigin } from '@/shared/api/types';
+import type { DataOrigin, DataSetStaleReason } from '@/shared/api/types';
+import { staleReasonText } from '@/shared/api/datasetHelpers';
 
 /**
  * Значок «откуда это значение» у поля, заполняемого источником данных.
  *
  * Значок ОДИН и меняет форму, а не добавляется рядом: у поля и так конкурируют метки о поломках
  * (нерешённые ссылки, нарушенные ограничения, обязательность), и шестая отняла бы у них внимание.
- * Цветом различие тоже не передаётся — warning и danger в проекте означают «есть оговорка» и
- * «данные испорчены», а происхождение не про поломку: здесь ничего не сломано.
  *
- * Показывается только распознанное. `Parsed` и `System` оставляют прежний вид: у них нет действия
- * для читателя, а метка без действия превращается в фон.
+ * У него две НЕЗАВИСИМЫЕ оси (issue #815):
+ *   форма — происхождение (распознано со скана / подставляется из источника),
+ *   цвет  — состояние (норма / данные разошлись с файлом).
+ * Независимость здесь не украшение: устареть может и парсерный источник, у которого происхождение
+ * обычное, — свяжи цвет с формой, и такое поле промолчало бы.
+ *
+ * Происхождение показывается только распознанное: у `Parsed` и `System` нет действия для читателя,
+ * а метка без действия превращается в фон. Устаревание показывается у любого.
  */
-export function SourceOriginIcon({ origin, plural }: { origin?: DataOrigin; plural?: boolean }) {
+export function SourceOriginIcon(
+  { origin, plural, stale, staleReason }:
+  { origin?: DataOrigin; plural?: boolean; stale?: boolean; staleReason?: DataSetStaleReason | null },
+) {
   const recognized = origin === 'Recognized';
   // «Возможны ошибки чтения», а НЕ «сверьте с оригиналом»: сверять неоткуда — пути к самому скану
   // из формы нет (ссылка у поля ведёт на запись каталога, пикер источника — только на выбор
   // источника). Подсказка, требующая невыполнимого, обесценивается ровно так же, как та, что висит
   // всегда. Поэтому здесь констатация свойства и его следствия, без глагола: что делать дальше,
   // человек решит сам, а появится путь к листу — вернём и действие.
-  const title = recognized
+  const originText = recognized
     ? plural
       ? 'Строки распознаны со скана — возможны ошибки чтения'
       : 'Значение распознано со скана — возможны ошибки чтения'
@@ -27,11 +35,17 @@ export function SourceOriginIcon({ origin, plural }: { origin?: DataOrigin; plur
       ? 'Значения подставляются из источника данных'
       : 'Значение подставляется из источника данных';
 
+  // Причина устаревания — без глагола по той же причине: «Перераспознать» живёт в наборах данных,
+  // а уход туда из формы документа потерял бы несохранённые реквизиты. Действие человек найдёт там,
+  // где путь к нему есть, — в обзоре источников документа (кнопка «Источники» в шапке).
+  const title = stale ? `${originText}. ${staleReasonText(staleReason)}` : originText;
+  const cls = stale ? 'text-warning' : 'text-brand';
+
   return (
     <span title={title}>
       {recognized
-        ? <ScanText size={12} className="text-brand" aria-hidden />
-        : <DatabaseZap size={12} className="text-brand" aria-hidden />}
+        ? <ScanText size={12} className={cls} aria-hidden />
+        : <DatabaseZap size={12} className={cls} aria-hidden />}
       {/* Подсказка на span доступна только мышью — тем, кто ведёт форму с клавиатуры, признак
           обязан достаться текстом (проект keyboard-first, issue #107). */}
       <span className="sr-only">{title}</span>

--- a/src/client/src/shared/ui/StaleSourceAction.tsx
+++ b/src/client/src/shared/ui/StaleSourceAction.tsx
@@ -5,7 +5,7 @@ import { staleReasonText } from '@/shared/api/datasetHelpers';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { RecognitionBlockedDialog } from '@/features/datasets/RecognitionBlockedDialog';
 import { ruCount } from '@/shared/utils/pluralize';
-import type { DataSetSource } from '@/shared/api/types';
+import type { DataSetBindingSource } from '@/shared/api/types';
 
 /**
  * Чип «устарело» и действие «Перераспознать» у привязки к устаревшему источнику (issue #815).
@@ -19,13 +19,17 @@ import type { DataSetSource } from '@/shared/api/types';
  * наборы данных потерял бы несохранённые правки формы (и адреса у источника уровня комплекта там
  * попросту нет).
  */
-export function StaleSourceAction({ source }: { source: Pick<DataSetSource, 'id' | 'recognitionStale' | 'staleReason' | 'bindingCount'> | undefined }) {
+export function StaleSourceAction({ source }: { source: DataSetBindingSource | undefined }) {
   const recognize = useRecognizeSource();
   const [confirm, setConfirm] = useState(false);
   const [refusal, setRefusal] = useState<RecognitionRefusal | null>(null);
   const [groupingConflict, setGroupingConflict] = useState(false);
 
+  // Действие предлагаем ТОЛЬКО там, где оно существует: у источника не из PDF эндпоинт отбивает
+  // вызов на входе, и кнопка вела бы в диалог отказа. Кто это решает — сервер: правило и есть
+  // поведение перераспознавания (issue #815).
   if (!source?.recognitionStale) return null;
+  const scope = source.recognizeScope ?? 'None';
 
   function run(confirmOverwrite?: boolean) {
     recognize.mutate({ sourceId: source!.id, confirm: confirmOverwrite }, {
@@ -43,18 +47,25 @@ export function StaleSourceAction({ source }: { source: Pick<DataSetSource, 'id'
         className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-warning-subtle text-warning shrink-0">
         <AlertTriangle size={10} /> устарело
       </span>
+      {scope !== 'None' && (
       <button type="button" onClick={() => setConfirm(true)} disabled={recognize.isPending}
         className="p-1.5 rounded text-warning disabled:opacity-50 shrink-0"
         title="Перераспознать источник" aria-label="Перераспознать источник">
         {recognize.isPending ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
       </button>
+      )}
 
       <ConfirmDialog open={confirm} onOpenChange={o => { if (!o) setConfirm(false); }}
         title="Перераспознать источник?"
         description={
           <div className="space-y-2">
             <p>{staleReasonText(source.staleReason)}.</p>
-            <p>Займёт несколько минут.</p>
+            {/* Масштаб называем прямо: у проекций ГОСТ-альбома перезапускается распознавание ВСЕГО
+                набора — все его листы и все проекции разом. Умолчать значило бы обещать точечное
+                действие там, где оно тратит минуты работы модели и переписывает соседние источники. */}
+            <p>{scope === 'File'
+              ? 'Распознавание запустится для всего набора — обновятся все его источники. Займёт несколько минут.'
+              : 'Займёт несколько минут.'}</p>
             {/* Число привязок — честность, а не украшение: человек жмёт кнопку в СВОЁМ документе и
                 не ждёт, что тронет данные в чужих. Счёт приходит с источником (issue #417). */}
             {(source.bindingCount ?? 0) > 1 && (

--- a/src/client/src/shared/ui/StaleSourceAction.tsx
+++ b/src/client/src/shared/ui/StaleSourceAction.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { AlertTriangle, RefreshCw, Loader2 } from 'lucide-react';
+import { useRecognizeSource, isManualGroupingConflict, recognitionRefusal, type RecognitionRefusal } from '@/shared/api/datasets';
+import { staleReasonText } from '@/shared/api/datasetHelpers';
+import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
+import { RecognitionBlockedDialog } from '@/features/datasets/RecognitionBlockedDialog';
+import { ruCount } from '@/shared/utils/pluralize';
+import type { DataSetSource } from '@/shared/api/types';
+
+/**
+ * Чип «устарело» и действие «Перераспознать» у привязки к устаревшему источнику (issue #815).
+ *
+ * Один компонент на обе точки потребления — форму документа и форму записи каталога: строки
+ * привязок там свои, но признак и действие обязаны выглядеть и вести себя одинаково. Чип взят
+ * дословно из списка источников в наборах данных, где живёт та же метка.
+ *
+ * Действие адресное — перераспознаётся ИМЕННО этот источник. Файловое «Распознать заново» из формы
+ * предлагать нельзя: оно способно стереть ручную корректировку разбиения всего набора, а уход в
+ * наборы данных потерял бы несохранённые правки формы (и адреса у источника уровня комплекта там
+ * попросту нет).
+ */
+export function StaleSourceAction({ source }: { source: Pick<DataSetSource, 'id' | 'recognitionStale' | 'staleReason' | 'bindingCount'> | undefined }) {
+  const recognize = useRecognizeSource();
+  const [confirm, setConfirm] = useState(false);
+  const [refusal, setRefusal] = useState<RecognitionRefusal | null>(null);
+  const [groupingConflict, setGroupingConflict] = useState(false);
+
+  if (!source?.recognitionStale) return null;
+
+  function run(confirmOverwrite?: boolean) {
+    recognize.mutate({ sourceId: source!.id, confirm: confirmOverwrite }, {
+      onError: err => {
+        // Ручная правка разбиения дороже автораспознавания — 409 спрашивает, а не глотается.
+        if (isManualGroupingConflict(err)) { setGroupingConflict(true); return; }
+        setRefusal(recognitionRefusal(err));
+      },
+    });
+  }
+
+  return (
+    <>
+      <span title={staleReasonText(source.staleReason)}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-warning-subtle text-warning shrink-0">
+        <AlertTriangle size={10} /> устарело
+      </span>
+      <button type="button" onClick={() => setConfirm(true)} disabled={recognize.isPending}
+        className="p-1.5 rounded text-warning disabled:opacity-50 shrink-0"
+        title="Перераспознать источник" aria-label="Перераспознать источник">
+        {recognize.isPending ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
+      </button>
+
+      <ConfirmDialog open={confirm} onOpenChange={o => { if (!o) setConfirm(false); }}
+        title="Перераспознать источник?"
+        description={
+          <div className="space-y-2">
+            <p>{staleReasonText(source.staleReason)}.</p>
+            <p>Займёт несколько минут.</p>
+            {/* Число привязок — честность, а не украшение: человек жмёт кнопку в СВОЁМ документе и
+                не ждёт, что тронет данные в чужих. Счёт приходит с источником (issue #417). */}
+            {(source.bindingCount ?? 0) > 1 && (
+              <p>Источник используется не только здесь — на него ссылаются{' '}
+                <b>{ruCount(source.bindingCount!, 'привязка', 'привязки', 'привязок')}</b>, данные обновятся везде.</p>
+            )}
+          </div>
+        }
+        confirmLabel="Перераспознать"
+        onConfirm={() => run()} />
+
+      <ConfirmDialog open={groupingConflict} onOpenChange={o => { if (!o) setGroupingConflict(false); }}
+        title="Разбиение было скорректировано вручную"
+        description={<p>Повторное распознавание сотрёт ручные правки разбиения на документы. Продолжить?</p>}
+        confirmLabel="Перераспознать"
+        onConfirm={() => run(true)} />
+
+      {refusal && (
+        <RecognitionBlockedDialog message={refusal.message} configurable={refusal.configurable}
+          onClose={() => setRefusal(null)} />
+      )}
+    </>
+  );
+}

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.135.0</Version>
+    <Version>0.136.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Вторая половина #815, поверх #817 (тот же стек — мержить после него).

## Что видел человек до

Поле заполнено, значок из #810 говорит «распознано со скана». Что значение прочитано из файла, который с тех пор заменили, не сообщал никто: признак жил только в наборах данных.

## Три яруса

Проверка «виден ли элемент по умолчанию» убила два очевидных носителя подряд:

- **значок у поля** — секция «Заполняются автоматически» свёрнута всегда;
- **факт в заголовке секции** (носитель из #810) — вкладка реквизитов list-detail, и в drawer-режиме рендерится тело ТОЛЬКО активного раздела. Устаревшие поля в третьем разделе не увидит тот, кто стоит в первом. Для происхождения это было терпимо, для годности — нет.

Поэтому главный носитель — **бейдж на кнопке «Источники»** в шапке: видна всегда, независимо от раздела, ширины окна и свёрнутости секции, и ведёт к тому самому обзору, где действие живёт. Считает источники, а не поля — «сколько раз мне это делать». Счётчик продублирован в `aria-label`: на узком окне подпись кнопки скрыта, и `title` остался бы доступен только мышью.

Ниже — факт в заголовке секции («устарело: 4», warning) и значок у поля.

## Значок: вторая ось

Форма несёт происхождение (`ScanText` / `DatabaseZap`), цвет — состояние (brand / warning). Оси независимы, и это проверяется первым же случаем: устареть может парсерный источник, у которого происхождение обычное. Свяжи цвет с формой — такое поле промолчало бы.

Причина устаревания едет текстом: четыре состояния цветом не передать, а разведя одно из них в danger, интерфейс сказал бы «данные испорчены» там, где они целы, просто старые.

## Действие

Строка привязки — общий компонент для обзора источников документа и списка привязок записи каталога: чип «устарело» (дословно тот же, что в наборах) плюс адресное «Перераспознать». Подтверждение называет причину и, если источник используется не только здесь, число привязок — человек жмёт кнопку в своём документе и не ждёт, что тронет чужие данные.

Из формы не уводим никуда: уход потерял бы несохранённые правки, у источника уровня комплекта нет адреса на странице наборов, а тамошнее «Распознать заново» файловое и способно стереть ручную корректировку разбиения.

## Дефект, без которого фича читалась бы как сломанная

Инвалидация по завершении фоновой задачи знала три ключа, привязок и их превью среди них не было. Человек, дождавшийся конца перераспознавания, видел бы прежний чип и прежние значения — а расхождение картинки с фактом читается не как задержка, а как «не сработало».

## Попутно

- оговорка у «Обновить из источника» в каталоге: при устаревшем источнике кнопка подтянет старые значения, выглядя при этом успешной;
- разбор привязки на ключи полей сведён к одному хелперу на оба признака — своя копия у каждого уже однажды разъехалась по правилу fallback'а;
- «5 поля привязано» → `ruCount`.

## Проверки

`npx tsc -b`, `npm test` — 548 зелёных (было 542).

Живьём не смотрел: устаревших источников в базе нет ни одного, так что показывать сейчас нечего — экраны проверю на данных, когда они появятся.

Разбор согласован с Дизайнером; его проверка «лечит ли действие каждую причину» вскрыла баг с табличным источником, закрытый в #817.