### PR TITLE
План по документам: хранение, консолидация и процент готовности (#796, backend)

### DIFF
--- a/src/server/BHS.CRG.Api/Endpoints/Documents/PlanEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/PlanEndpoints.cs
@@ -1,0 +1,46 @@
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Common;
+using MediatR;
+
+namespace BHS.CRG.Api.Endpoints.Documents;
+
+/// <summary>
+/// План по документам (issue #796): строки плана на комплекте и сводка готовности по уровням.
+///
+/// Запись плана доступна роли User, а не только Admin: план — часть работы над комплектом
+/// («сколько актов должно быть в этом разделе»), а не настройка системы.
+/// </summary>
+public static class PlanEndpoints
+{
+    public static void MapPlanEndpoints(this IEndpointRouteBuilder app)
+    {
+        var sets = app.MapGroup("/api/document-sets").RequireAuthorization();
+
+        sets.MapGet("/{id:guid}/plan", async (Guid id, IMediator m, CancellationToken ct)
+            => Results.Ok(await m.Send(new GetDocumentSetPlanQuery(id), ct)));
+
+        // Замена целиком: пришло — то и осталось. Пустой список означает «плана нет» и убирает
+        // проценты с экранов — отдельной команды «удалить план» для этого не нужно.
+        sets.MapPut("/{id:guid}/plan", async (Guid id, PlanRow[] rows, IMediator m, CancellationToken ct) =>
+        {
+            try
+            {
+                await m.Send(new ReplaceDocumentSetPlanCommand(id, rows ?? []), ct);
+                return Results.NoContent();
+            }
+            catch (NotFoundException) { return Results.NotFound(); }
+            catch (InvalidRequestException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        var plans = app.MapGroup("/api/plans").RequireAuthorization();
+
+        plans.MapGet("/summary", async (string? scope, Guid? scopeId, IMediator m, CancellationToken ct) =>
+        {
+            if (!Enum.TryParse<CatalogScope>(scope, ignoreCase: true, out var parsed))
+                return Results.BadRequest(new { error = "Неизвестный уровень: " + scope });
+
+            return Results.Ok(await m.Send(new GetPlanSummaryQuery(parsed, scopeId), ct));
+        });
+    }
+}

--- a/src/server/BHS.CRG.Api/Endpoints/Documents/PlanEndpoints.cs
+++ b/src/server/BHS.CRG.Api/Endpoints/Documents/PlanEndpoints.cs
@@ -17,8 +17,11 @@ public static class PlanEndpoints
     {
         var sets = app.MapGroup("/api/document-sets").RequireAuthorization();
 
-        sets.MapGet("/{id:guid}/plan", async (Guid id, IMediator m, CancellationToken ct)
-            => Results.Ok(await m.Send(new GetDocumentSetPlanQuery(id), ct)));
+        sets.MapGet("/{id:guid}/plan", async (Guid id, IMediator m, CancellationToken ct) =>
+        {
+            try { return Results.Ok(await m.Send(new GetDocumentSetPlanQuery(id), ct)); }
+            catch (NotFoundException) { return Results.NotFound(); }
+        });
 
         // Замена целиком: пришло — то и осталось. Пустой список означает «плана нет» и убирает
         // проценты с экранов — отдельной команды «удалить план» для этого не нужно.
@@ -37,8 +40,17 @@ public static class PlanEndpoints
 
         plans.MapGet("/summary", async (string? scope, Guid? scopeId, IMediator m, CancellationToken ct) =>
         {
-            if (!Enum.TryParse<CatalogScope>(scope, ignoreCase: true, out var parsed))
-                return Results.BadRequest(new { error = "Неизвестный уровень: " + scope });
+            // IsDefined обязателен рядом с TryParse: без него «?scope=99» разбирается успешно и
+            // доезжает до обработчика неопределённым значением перечисления — то есть уровнем,
+            // которого нет, и ответом «плана нет» вместо отказа.
+            if (!Enum.TryParse<CatalogScope>(scope, ignoreCase: true, out var parsed) || !Enum.IsDefined(parsed))
+                return Results.BadRequest(new { error = $"Неизвестная область: «{scope}»." });
+
+            // Уровень без идентификатора (кроме System) — не «пустая стройка», а вопрос ни о чём:
+            // спуск по поддереву вернёт пусто, и ответ «плана нет» неотличим от настоящего уровня
+            // без плана. Сводка проблем отказывает здесь так же.
+            if (parsed != CatalogScope.System && scopeId is null)
+                return Results.BadRequest(new { error = "Для этой области нужен scopeId." });
 
             return Results.Ok(await m.Send(new GetPlanSummaryQuery(parsed, scopeId), ct));
         });

--- a/src/server/BHS.CRG.Api/Program.cs
+++ b/src/server/BHS.CRG.Api/Program.cs
@@ -337,6 +337,8 @@ builder.Services.AddScoped<IRepository<DocumentType>, Repository<DocumentType>>(
 builder.Services.AddScoped<IRepository<Construction>, ConstructionRepository>();
 builder.Services.AddScoped<IRepository<Section>, Repository<Section>>();
 builder.Services.AddScoped<IRepository<DocumentSet>, DocumentSetRepository>();
+// План по документам (issue #796): строки живут на комплекте, уровни выше считаются.
+builder.Services.AddScoped<IRepository<DocumentSetPlanItem>, Repository<DocumentSetPlanItem>>();
 builder.Services.AddScoped<DomainObjectRepository>();
 builder.Services.AddScoped<IRepository<BHS.CRG.Domain.Objects.DomainObject>>(sp => sp.GetRequiredService<DomainObjectRepository>());
 builder.Services.AddScoped<IDomainObjectRepository>(sp => sp.GetRequiredService<DomainObjectRepository>());
@@ -447,6 +449,7 @@ builder.Services.AddScoped<BHS.CRG.Application.Documents.ILevelProfileService, B
 // Спуск «уровень → комплекты поддерева» (issue #625): слою приложения нужен через контракт —
 // AppDbContext ему недоступен, а копия обхода была у него своя.
 builder.Services.AddScoped<BHS.CRG.Application.Common.IScopeSubtree, BHS.CRG.Infrastructure.Common.ScopeSubtreeService>();
+builder.Services.AddScoped<BHS.CRG.Application.Common.IScopeChildren, BHS.CRG.Application.Common.ScopeChildren>();
 builder.Services.AddScoped<BHS.CRG.Application.Objects.IScopeCascade, BHS.CRG.Application.Objects.ScopeCascade>();
 builder.Services.AddScoped<BHS.CRG.Application.Objects.IReferenceIndex,
     BHS.CRG.Infrastructure.Persistence.ReferenceIndex>();
@@ -699,6 +702,7 @@ app.MapTemplateAssetEndpoints();
 app.MapTypstUserLibEndpoints();
 app.MapPrintFormEndpoints();
 app.MapDocumentSetEndpoints();
+app.MapPlanEndpoints();
 app.MapGenerationEndpoints();
 app.MapDataSetEndpoints();
 app.MapDataSetBindingEndpoints();

--- a/src/server/BHS.CRG.Application/Backup/BackupModels.cs
+++ b/src/server/BHS.CRG.Application/Backup/BackupModels.cs
@@ -36,7 +36,8 @@ public record BackupManifest(
     BackupDataSetSource[]? DataSetSources = null,
     BackupDataSetBinding[]? DataSetBindings = null,
     BackupReconciliationDefinition[]? Reconciliations = null,
-    BackupMaterialQualityLink[]? MaterialQualityLinks = null);
+    BackupMaterialQualityLink[]? MaterialQualityLinks = null,
+    BackupDocumentSetPlan[]? DocumentSetPlans = null);
 
 // ── Проектные данные (issue #833) ────────────────────────────────────────────────────────────
 
@@ -61,6 +62,18 @@ public record BackupSection(
 
 public record BackupDocumentSet(
     Guid Id, Guid SectionId, string Name, Guid? ProfileObjectId,
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
+/// <summary>
+/// Строка плана комплекта (issue #796). Секция аддитивная, как и остальные проектные: копия,
+/// снятая новой версией, читается старой — план она просто не увидит.
+///
+/// Планы уровней выше в копию не попадают, потому что их не существует: раздел и стройка
+/// консолидируют комплекты на лету. Восстановился бы такой «план» — и разошёлся бы с суммой
+/// нижележащих при первой же правке.
+/// </summary>
+public record BackupDocumentSetPlan(
+    Guid Id, Guid DocumentSetId, Guid DocumentTypeId, int PlannedCount,
     DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
 
 /// <summary>

--- a/src/server/BHS.CRG.Application/Common/IDomainObjectRepository.cs
+++ b/src/server/BHS.CRG.Application/Common/IDomainObjectRepository.cs
@@ -23,4 +23,15 @@ public interface IDomainObjectRepository : IRepository<DomainObject>
     /// <summary>Число документов по каждому комплекту (лёгкий COUNT, без JSONB) — для счётчиков навигации
     /// и каскадов удаления в дереве стройки. Комплекты без документов в словарь не попадают.</summary>
     Task<IReadOnlyDictionary<Guid, int>> CountDocumentsInSetsAsync(IReadOnlyCollection<Guid> setIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Число ГОТОВЫХ документов по паре (комплект, тип) — для процента готовности по плану (#796).
+    ///
+    /// Готовый — со статусом <c>Generated</c>. Черновик и неудача не готовы: план считает
+    /// выпущенные документы, а не заведённые карточки. Одним группирующим запросом, без JSONB:
+    /// стройка с сотней комплектов иначе означала бы сотню обращений на каждую отрисовку шапки.
+    /// Пары без готовых документов в словарь не попадают.
+    /// </summary>
+    Task<IReadOnlyDictionary<(Guid SetId, Guid TypeId), int>> CountReadyDocumentsByTypeAsync(
+        IReadOnlyCollection<Guid> setIds, CancellationToken ct = default);
 }

--- a/src/server/BHS.CRG.Application/Common/IScopeChildren.cs
+++ b/src/server/BHS.CRG.Application/Common/IScopeChildren.cs
@@ -1,0 +1,44 @@
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
+
+namespace BHS.CRG.Application.Common;
+
+/// <summary>
+/// ПРЯМЫЕ дети уровня — на один шаг вниз, каждый со своим уровнем.
+///
+/// Не путать со спуском <see cref="IScopeSubtree"/> («уровень → ВСЕ комплекты поддерева»): своди их
+/// вместе, и сводка стройки посчитала бы её комплекты дважды — сама и через разделы. Сводкам нужны
+/// именно соседние узлы дерева: они спрашивают у каждого его состояние рекурсивно, и уровень
+/// ребёнка — часть вопроса.
+///
+/// Вынесено из сводки проблем (#454), когда за тем же обходом пришла сводка плана (#796). Второй
+/// копии не заводим осознанно: ровно так же троился спуск, из-за чего и появился IScopeSubtree.
+/// </summary>
+public interface IScopeChildren
+{
+    Task<IReadOnlyList<(CatalogScope Scope, Guid Id)>> ChildrenOfAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct = default);
+}
+
+public class ScopeChildren(
+    IRepository<Construction> constructions,
+    IRepository<Section> sections,
+    IRepository<DocumentSet> sets) : IScopeChildren
+{
+    public async Task<IReadOnlyList<(CatalogScope Scope, Guid Id)>> ChildrenOfAsync(
+        CatalogScope scope, Guid? scopeId, CancellationToken ct = default) => scope switch
+    {
+        CatalogScope.System => [.. (await constructions.GetAllAsync(ct))
+            .Select(c => (CatalogScope.Construction, c.Id))],
+
+        CatalogScope.Construction when scopeId is { } id => [.. (await sections.FindAsync(
+            s => s.ConstructionId == id, ct)).Select(s => (CatalogScope.Section, s.Id))],
+
+        CatalogScope.Section when scopeId is { } id => [.. (await sets.FindAsync(
+            s => s.SectionId == id, ct)).Select(s => (CatalogScope.Set, s.Id))],
+
+        // У комплекта детей в этой оси нет: документы ни проблемами, ни процентом не помечаются —
+        // план живёт на комплекте целиком, а маркер на документе читался бы как «ошибка в нём».
+        _ => [],
+    };
+}

--- a/src/server/BHS.CRG.Application/Documents/Handlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/Handlers.cs
@@ -19,6 +19,7 @@ public class DocumentTypeHandlers(
     IRepository<Template> templateRepo,
     IRepository<QualityDocument> qualityDocRepo,
     IRepository<PrimitiveType> primitiveRepo,
+    IRepository<DocumentSetPlanItem> planRepo,
     IDataSetService dataSetService) :
     IRequestHandler<CreateDocumentTypeCommand, DocumentType>,
     IRequestHandler<UpdateDocumentTypeCommand, DocumentType>,
@@ -388,6 +389,13 @@ public class DocumentTypeHandlers(
         var objects = await objectRepo.FindAsync(o => o.CompositeTypeId == dt.Id, ct);
         if (objects.Count > 0)
             reasons.Add(new("objects", "Созданы объекты (документы или записи общих данных)", objects.Count, []));
+
+        // План по документам ссылается на тип (issue #796). Внешнего ключа там нет намеренно:
+        // каскад унёс бы строки плана вместе с типом, и процент готовности молча поехал бы. Значит
+        // единственная защита — здесь.
+        var planned = await planRepo.FindAsync(p => p.DocumentTypeId == dt.Id, ct);
+        if (planned.Count > 0)
+            reasons.Add(new("plan", "Входит в план комплектов", planned.Count, []));
 
         var templates = await templateRepo.FindAsync(t => t.DocumentTypeId == dt.Id, ct);
         if (templates.Count > 0)

--- a/src/server/BHS.CRG.Application/Documents/PlanCommands.cs
+++ b/src/server/BHS.CRG.Application/Documents/PlanCommands.cs
@@ -1,0 +1,26 @@
+using BHS.CRG.Domain.Catalog;
+using MediatR;
+
+namespace BHS.CRG.Application.Documents;
+
+/// <summary>Строка плана в контракте API: тип и сколько документов этого типа планируется.</summary>
+public record PlanRow(Guid DocumentTypeId, int PlannedCount);
+
+/// <summary>Строка плана с фактом — как её показывает панель плана комплекта.</summary>
+public record PlanRowWithActual(Guid DocumentTypeId, string TypeName, int PlannedCount, int ActualCount);
+
+public record GetDocumentSetPlanQuery(Guid SetId) : IRequest<IReadOnlyList<PlanRowWithActual>>;
+
+/// <summary>
+/// Замена плана ЦЕЛИКОМ, как реквизиты документа: клиент присылает то, что должно остаться.
+/// Точечные добавить/убрать пришлось бы согласовывать с порядком строк на экране — а порядок там
+/// не хранится, он берётся из типов.
+/// </summary>
+public record ReplaceDocumentSetPlanCommand(Guid SetId, IReadOnlyList<PlanRow> Rows) : IRequest;
+
+/// <summary>
+/// Готовность уровня и его непосредственных детей (issue #796). Одним ответом — по той же причине,
+/// что у сводки проблем (#454): проценты нужны на пунктах, ведущих вниз, и запрос-на-ребёнка
+/// превратил бы раздел с десятью комплектами в десять обращений.
+/// </summary>
+public record GetPlanSummaryQuery(CatalogScope Scope, Guid? ScopeId) : IRequest<PlanSummary>;

--- a/src/server/BHS.CRG.Application/Documents/PlanHandlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/PlanHandlers.cs
@@ -24,6 +24,10 @@ public class PlanHandlers(
 {
     public async Task<IReadOnlyList<PlanRowWithActual>> Handle(GetDocumentSetPlanQuery q, CancellationToken ct)
     {
+        // Комплекта нет — это НЕ «комплект без плана». Иначе после устаревшей навигации клиент
+        // получил бы пустую форму плана, заполнил её и упёрся в 404 уже на сохранении.
+        _ = await sets.GetByIdAsync(q.SetId, ct) ?? throw new NotFoundException();
+
         var rows = await plans.FindAsync(p => p.DocumentSetId == q.SetId, ct);
         if (rows.Count == 0) return [];
 
@@ -69,29 +73,45 @@ public class PlanHandlers(
     {
         var children = await scopeChildren.ChildrenOfAsync(q.Scope, q.ScopeId, ct);
 
+        // Неразобранное берём ОДНОЙ сводкой на весь ответ, а не по запросу на уровень. Причин две.
+        //
+        // Цена: подсчёт проблем уровня перебирает определения сверки и замечания всего поддерева —
+        // спрашивать его отдельно у себя и у каждого ребёнка значило бы для стройки с десятью
+        // разделами одиннадцать таких обходов на КАЖДУЮ отрисовку шапки. Ровно от этого уводит
+        // пакетный CountReadyDocumentsByTypeAsync парой строк ниже, и завести здесь то, от чего там
+        // уходили, было бы странно.
+        //
+        // Правда: сводка знает счётчик ребёнка независимо от того, есть ли у ребёнка план. Считай
+        // мы его внутри ProgressAsync, уровень без плана возвращал бы ноль — и System, складывая
+        // детей, показал бы «100 %» рядом с бейджем «7 не разобрано».
+        var problems = await mediator.Send(new GetProblemSummaryQuery(q.Scope, q.ScopeId), ct);
+        var needsByChild = problems.Children.ToDictionary(c => c.ScopeId, c => c.NeedsAttention);
+
         var all = new List<PlanProgressOf>();
         foreach (var (childScope, childId) in children)
-            all.Add(new PlanProgressOf(childId, await ProgressAsync(childScope, childId, ct)));
+            all.Add(new PlanProgressOf(childId,
+                await ProgressAsync(childScope, childId, needsByChild.GetValueOrDefault(childId), ct)));
 
         // Уровни без плана в разбивку не попадают: рисовать там нечего, а «0 %» соврал бы.
         var childProgress = all.Where(c => c.Progress.HasPlan).ToList();
 
         // У System своего уровня нет — он сумма всех строек. Спуск по поддереву для него намеренно
         // пуст («все комплекты базы» — не поддерево), поэтому складываем детей: иначе верхний
-        // уровень всегда показывал бы «плана нет» при полностью расписанных стройках.
+        // уровень всегда показывал бы «плана нет» при полностью расписанных стройках. Счётчик
+        // разбора при этом берём у сводки, а не из слагаемых: у неё он есть и по бесплановым детям.
         if (q.Scope == CatalogScope.System || q.ScopeId is not { } selfId)
-            return new PlanSummary(Sum(all.Select(c => c.Progress)), childProgress);
+            return new PlanSummary(Sum(all.Select(c => c.Progress), problems.NeedsAttention), childProgress);
 
-        return new PlanSummary(await ProgressAsync(q.Scope, selfId, ct), childProgress);
+        return new PlanSummary(await ProgressAsync(q.Scope, selfId, problems.NeedsAttention, ct), childProgress);
     }
 
-    private static PlanProgress Sum(IEnumerable<PlanProgress> parts)
+    private static PlanProgress Sum(IEnumerable<PlanProgress> parts, int needsAttention)
     {
         var list = parts.ToList();
         return new PlanProgress(
             list.Sum(p => p.Planned),
             list.Sum(p => p.Ready),
-            list.Sum(p => p.NeedsAttention),
+            needsAttention,
             list.Sum(p => p.SetsWithoutPlan));
     }
 
@@ -102,10 +122,11 @@ public class PlanHandlers(
     /// устроены счётчики проблем), а сохранённый процент разошёлся бы с фактом при первой же
     /// генерации документа, о которой забыли пересчитать.
     /// </summary>
-    private async Task<PlanProgress> ProgressAsync(CatalogScope scope, Guid scopeId, CancellationToken ct)
+    private async Task<PlanProgress> ProgressAsync(
+        CatalogScope scope, Guid scopeId, int needsAttention, CancellationToken ct)
     {
         var setIds = await subtree.SetIdsUnderAsync(scope, scopeId, ct);
-        if (setIds.Count == 0) return new PlanProgress(0, 0, 0, 0);
+        if (setIds.Count == 0) return new PlanProgress(0, 0, needsAttention, 0);
 
         var rows = await plans.FindAsync(p => setIds.Contains(p.DocumentSetId), ct);
         var setsWithPlan = rows.Select(r => r.DocumentSetId).ToHashSet();
@@ -114,15 +135,13 @@ public class PlanHandlers(
         // иначе «стройка на 100 %» означала бы «единственный комплект с планом закрыт», а про
         // девять остальных экран не сказал бы ничего.
         var withoutPlan = setIds.Count(id => !setsWithPlan.Contains(id));
-        if (rows.Count == 0) return new PlanProgress(0, 0, 0, withoutPlan);
+        if (rows.Count == 0) return new PlanProgress(0, 0, needsAttention, withoutPlan);
 
         var actual = await objects.CountReadyDocumentsByTypeAsync(setsWithPlan, ct);
         var planned = rows.Sum(r => r.PlannedCount);
         var ready = PlanMath.Ready(rows.Select(r =>
             (r.PlannedCount, actual.GetValueOrDefault((r.DocumentSetId, r.DocumentTypeId)))));
 
-        var problems = await mediator.Send(new GetRelatedProblemsQuery(scope, scopeId), ct);
-
-        return new PlanProgress(planned, ready, problems.NeedsAttention, withoutPlan);
+        return new PlanProgress(planned, ready, needsAttention, withoutPlan);
     }
 }

--- a/src/server/BHS.CRG.Application/Documents/PlanHandlers.cs
+++ b/src/server/BHS.CRG.Application/Documents/PlanHandlers.cs
@@ -1,0 +1,128 @@
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Reconciliation;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Common;
+using BHS.CRG.Domain.Documents;
+using MediatR;
+
+namespace BHS.CRG.Application.Documents;
+
+/// <summary>
+/// План по документам: чтение и замена плана комплекта, сводка готовности по уровням (issue #796).
+/// </summary>
+public class PlanHandlers(
+    IRepository<DocumentSetPlanItem> plans,
+    IRepository<DocumentSet> sets,
+    IRepository<DocumentType> types,
+    IDomainObjectRepository objects,
+    IScopeSubtree subtree,
+    IScopeChildren scopeChildren,
+    IMediator mediator) :
+    IRequestHandler<GetDocumentSetPlanQuery, IReadOnlyList<PlanRowWithActual>>,
+    IRequestHandler<ReplaceDocumentSetPlanCommand>,
+    IRequestHandler<GetPlanSummaryQuery, PlanSummary>
+{
+    public async Task<IReadOnlyList<PlanRowWithActual>> Handle(GetDocumentSetPlanQuery q, CancellationToken ct)
+    {
+        var rows = await plans.FindAsync(p => p.DocumentSetId == q.SetId, ct);
+        if (rows.Count == 0) return [];
+
+        var actual = await objects.CountReadyDocumentsByTypeAsync([q.SetId], ct);
+        var byId = (await types.GetAllAsync(ct)).ToDictionary(t => t.Id, t => t.Name);
+
+        return [.. rows
+            .Select(r => new PlanRowWithActual(
+                r.DocumentTypeId,
+                byId.GetValueOrDefault(r.DocumentTypeId, "Тип удалён"),
+                r.PlannedCount,
+                actual.GetValueOrDefault((q.SetId, r.DocumentTypeId))))
+            .OrderBy(r => r.TypeName, StringComparer.CurrentCulture)];
+    }
+
+    public async Task Handle(ReplaceDocumentSetPlanCommand cmd, CancellationToken ct)
+    {
+        _ = await sets.GetByIdAsync(cmd.SetId, ct) ?? throw new NotFoundException();
+
+        // Тип в строке обязан существовать: план ссылается на него, и «план на несуществующий тип»
+        // это тихо неисполнимая позиция, из-за которой процент никогда не дойдёт до ста.
+        var known = (await types.GetAllAsync(ct)).Select(t => t.Id).ToHashSet();
+        foreach (var row in cmd.Rows)
+        {
+            if (!known.Contains(row.DocumentTypeId))
+                throw new InvalidRequestException("В плане указан тип документа, которого нет.");
+            if (row.PlannedCount < 1)
+                throw new InvalidRequestException("Планируемое количество — от 1. Чтобы убрать позицию, удалите строку.");
+        }
+
+        if (cmd.Rows.Select(r => r.DocumentTypeId).Distinct().Count() != cmd.Rows.Count)
+            throw new InvalidRequestException("Тип в плане повторяется — на тип приходится одна строка.");
+
+        foreach (var existing in await plans.FindAsync(p => p.DocumentSetId == cmd.SetId, ct))
+            plans.Remove(existing);
+        foreach (var row in cmd.Rows)
+            await plans.AddAsync(DocumentSetPlanItem.Create(cmd.SetId, row.DocumentTypeId, row.PlannedCount), ct);
+
+        await plans.SaveChangesAsync(ct);
+    }
+
+    public async Task<PlanSummary> Handle(GetPlanSummaryQuery q, CancellationToken ct)
+    {
+        var children = await scopeChildren.ChildrenOfAsync(q.Scope, q.ScopeId, ct);
+
+        var all = new List<PlanProgressOf>();
+        foreach (var (childScope, childId) in children)
+            all.Add(new PlanProgressOf(childId, await ProgressAsync(childScope, childId, ct)));
+
+        // Уровни без плана в разбивку не попадают: рисовать там нечего, а «0 %» соврал бы.
+        var childProgress = all.Where(c => c.Progress.HasPlan).ToList();
+
+        // У System своего уровня нет — он сумма всех строек. Спуск по поддереву для него намеренно
+        // пуст («все комплекты базы» — не поддерево), поэтому складываем детей: иначе верхний
+        // уровень всегда показывал бы «плана нет» при полностью расписанных стройках.
+        if (q.Scope == CatalogScope.System || q.ScopeId is not { } selfId)
+            return new PlanSummary(Sum(all.Select(c => c.Progress)), childProgress);
+
+        return new PlanSummary(await ProgressAsync(q.Scope, selfId, ct), childProgress);
+    }
+
+    private static PlanProgress Sum(IEnumerable<PlanProgress> parts)
+    {
+        var list = parts.ToList();
+        return new PlanProgress(
+            list.Sum(p => p.Planned),
+            list.Sum(p => p.Ready),
+            list.Sum(p => p.NeedsAttention),
+            list.Sum(p => p.SetsWithoutPlan));
+    }
+
+    /// <summary>
+    /// Готовность уровня: план и факт по ВСЕМ комплектам под ним.
+    ///
+    /// Считается на лету, без кэша и предподсчёта: масштаб приложения это позволяет (так же
+    /// устроены счётчики проблем), а сохранённый процент разошёлся бы с фактом при первой же
+    /// генерации документа, о которой забыли пересчитать.
+    /// </summary>
+    private async Task<PlanProgress> ProgressAsync(CatalogScope scope, Guid scopeId, CancellationToken ct)
+    {
+        var setIds = await subtree.SetIdsUnderAsync(scope, scopeId, ct);
+        if (setIds.Count == 0) return new PlanProgress(0, 0, 0, 0);
+
+        var rows = await plans.FindAsync(p => setIds.Contains(p.DocumentSetId), ct);
+        var setsWithPlan = rows.Select(r => r.DocumentSetId).ToHashSet();
+
+        // Комплекты без плана в проценте не участвуют, но и не молчат: их число уходит наверх,
+        // иначе «стройка на 100 %» означала бы «единственный комплект с планом закрыт», а про
+        // девять остальных экран не сказал бы ничего.
+        var withoutPlan = setIds.Count(id => !setsWithPlan.Contains(id));
+        if (rows.Count == 0) return new PlanProgress(0, 0, 0, withoutPlan);
+
+        var actual = await objects.CountReadyDocumentsByTypeAsync(setsWithPlan, ct);
+        var planned = rows.Sum(r => r.PlannedCount);
+        var ready = PlanMath.Ready(rows.Select(r =>
+            (r.PlannedCount, actual.GetValueOrDefault((r.DocumentSetId, r.DocumentTypeId)))));
+
+        var problems = await mediator.Send(new GetRelatedProblemsQuery(scope, scopeId), ct);
+
+        return new PlanProgress(planned, ready, problems.NeedsAttention, withoutPlan);
+    }
+}

--- a/src/server/BHS.CRG.Application/Documents/PlanProgress.cs
+++ b/src/server/BHS.CRG.Application/Documents/PlanProgress.cs
@@ -1,0 +1,61 @@
+namespace BHS.CRG.Application.Documents;
+
+/// <summary>
+/// Готовность по плану на одном уровне (issue #796).
+///
+/// <paramref name="Planned"/> — сумма планируемых количеств; <paramref name="Ready"/> — сколько из
+/// них закрыто (см. <see cref="PlanMath"/>); <paramref name="NeedsAttention"/> — неразобранное
+/// сверкой на этом уровне; <paramref name="SetsWithoutPlan"/> — сколько комплектов под уровнем
+/// плана не имеют и потому в проценте не участвуют.
+/// </summary>
+public record PlanProgress(int Planned, int Ready, int NeedsAttention, int SetsWithoutPlan)
+{
+    /// <summary>План есть? Ноль планируемых — это «плана нет», а не «ничего не готово».</summary>
+    public bool HasPlan => Planned > 0;
+
+    public int? Percent => PlanMath.Percent(Planned, Ready, NeedsAttention);
+}
+
+/// <summary>Готовность ребёнка уровня — для маркеров на пунктах, ведущих вниз.</summary>
+public record PlanProgressOf(Guid Id, PlanProgress Progress);
+
+/// <summary>Свой уровень + разбивка по непосредственным детям, одним ответом (как ProblemSummary, #454).</summary>
+public record PlanSummary(PlanProgress Own, IReadOnlyList<PlanProgressOf> Children);
+
+/// <summary>
+/// Арифметика готовности. Отдельно от запросов — потому что вся спорная часть фичи именно здесь, и
+/// проверяться она должна без базы.
+/// </summary>
+public static class PlanMath
+{
+    /// <summary>
+    /// Закрыто планом: <c>Σ min(готовых типа, план типа)</c>.
+    ///
+    /// <c>min</c> обязателен: пять актов при плане в три — это три закрытые позиции и два документа
+    /// сверх плана, а не 167 % готовности. Типы, которых в плане нет, не участвуют вовсе — иначе
+    /// внеплановая работа надувала бы процент по чужим строкам.
+    /// </summary>
+    public static int Ready(IEnumerable<(int Planned, int Actual)> byType)
+        => byType.Sum(x => Math.Min(x.Actual, x.Planned));
+
+    /// <summary>
+    /// Процент готовности, или null — если плана нет.
+    ///
+    /// Сверка здесь ГЕЙТ, а не множитель: 100 % показывается только когда план закрыт И разбирать
+    /// нечего; иначе процент упирается в 99 %, а неразобранное показывается рядом отдельным
+    /// маркером. Мешать в одной цифре две разные природы — количество документов и качество
+    /// данных — значит получить число, которое ни о чём не говорит.
+    ///
+    /// Округление ВНИЗ по той же причине: 99,6 % это ещё не «сто», и показать «100 %» там, где
+    /// одна позиция не закрыта, — прямая ложь на самом заметном месте экрана.
+    /// </summary>
+    public static int? Percent(int planned, int ready, int needsAttention)
+    {
+        if (planned <= 0) return null;
+
+        var closed = Math.Clamp(ready, 0, planned);
+        if (closed == planned) return needsAttention == 0 ? 100 : 99;
+
+        return Math.Min(99, (int)Math.Floor(closed * 100.0 / planned));
+    }
+}

--- a/src/server/BHS.CRG.Application/Reconciliation/ProblemSummaryHandler.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/ProblemSummaryHandler.cs
@@ -12,16 +12,12 @@ namespace BHS.CRG.Application.Reconciliation;
 /// пунктах, ведущих вниз, и запрос-на-ребёнка превратил бы страницу раздела с десятью комплектами в
 /// десять обращений.
 /// </summary>
-public class ProblemSummaryHandler(
-    IMediator mediator,
-    IRepository<Domain.Documents.Construction> constructions,
-    IRepository<Domain.Documents.Section> sections,
-    IRepository<Domain.Documents.DocumentSet> sets)
+public class ProblemSummaryHandler(IMediator mediator, IScopeChildren scopeChildren)
     : IRequestHandler<GetProblemSummaryQuery, ProblemSummary>
 {
     public async Task<ProblemSummary> Handle(GetProblemSummaryQuery q, CancellationToken ct)
     {
-        var children = await ChildrenOfAsync(q.Scope, q.ScopeId, ct);
+        var children = await scopeChildren.ChildrenOfAsync(q.Scope, q.ScopeId, ct);
 
         var counts = new List<ProblemCount>();
         foreach (var (childScope, childId) in children)
@@ -41,29 +37,4 @@ public class ProblemSummaryHandler(
         var self = await mediator.Send(new GetRelatedProblemsQuery(q.Scope, selfId), ct);
         return new ProblemSummary(self.NeedsAttention, self.HasArithmeticProblems, counts);
     }
-
-    /// <summary>
-    /// ПРЯМЫЕ дети уровня — на один шаг вниз, и это не то же самое, что спуск
-    /// <see cref="Common.IScopeSubtree"/> «уровень → все комплекты поддерева» (issue #625).
-    ///
-    /// Своди их вместе — и сводка стройки посчитала бы её комплекты дважды: сама и через разделы.
-    /// Здесь нужны именно соседние узлы дерева, каждый со своим уровнем: сводка спрашивает у них
-    /// состояние рекурсивно, и уровень ребёнка — часть ответа.
-    /// </summary>
-    private async Task<IReadOnlyList<(CatalogScope Scope, Guid Id)>> ChildrenOfAsync(
-        CatalogScope scope, Guid? scopeId, CancellationToken ct) => scope switch
-    {
-        CatalogScope.System => [.. (await constructions.GetAllAsync(ct))
-            .Select(c => (CatalogScope.Construction, c.Id))],
-
-        CatalogScope.Construction when scopeId is { } id => [.. (await sections.FindAsync(
-            s => s.ConstructionId == id, ct)).Select(s => (CatalogScope.Section, s.Id))],
-
-        CatalogScope.Section when scopeId is { } id => [.. (await sets.FindAsync(
-            s => s.SectionId == id, ct)).Select(s => (CatalogScope.Set, s.Id))],
-
-        // У комплекта детей в этой оси нет: документы проблемами не помечаются — связь находки с
-        // документом слабее, чем выглядит, и маркер на нём читался бы как «ошибка в документе».
-        _ => [],
-    };
 }

--- a/src/server/BHS.CRG.Application/Reconciliation/RelatedProblemsHandler.cs
+++ b/src/server/BHS.CRG.Application/Reconciliation/RelatedProblemsHandler.cs
@@ -15,6 +15,7 @@ namespace BHS.CRG.Application.Reconciliation;
 public class RelatedProblemsHandler(
     IProblemAttribution attribution,
     IScopeSubtree scopeSubtree,
+    IRepository<AgentObservation> observationRepo,
     IMediator mediator) : IRequestHandler<GetRelatedProblemsQuery, RelatedProblems>
 {
     public async Task<RelatedProblems> Handle(GetRelatedProblemsQuery q, CancellationToken ct)
@@ -48,11 +49,13 @@ public class RelatedProblemsHandler(
         //
         // ScopeChain для этого не годится: он отвечает «видно ли отсюда», и System-запись
         // засчиталась бы каждому уровню.
+        // ОДИН запрос на всё поддерево, а не запрос на комплект: у стройки с сотней комплектов
+        // цикл давал сотню обращений на каждую отрисовку бейджа, и с приходом процента готовности
+        // (#796) эта цена стала платиться ещё раз.
         var sets = await scopeSubtree.SetIdsUnderAsync(q.Scope, q.ScopeId, ct);
-        var observations = 0;
-        foreach (var setId in sets)
-            observations += (await mediator.Send(
-                new ListObservationsQuery(CatalogScope.Set, setId, ObservationStatus.New), ct)).Count;
+        var observations = sets.Count == 0 ? 0 : (await observationRepo.FindAsync(
+            o => o.Scope == CatalogScope.Set && o.ScopeId != null
+                 && sets.Contains(o.ScopeId.Value) && o.Status == ObservationStatus.New, ct)).Count;
 
         return new RelatedProblems(
             [.. related.OrderByDescending(r => r.UnresolvedFindings).ThenBy(r => r.Name)],

--- a/src/server/BHS.CRG.Domain/Documents/DocumentSetPlanItem.cs
+++ b/src/server/BHS.CRG.Domain/Documents/DocumentSetPlanItem.cs
@@ -1,0 +1,50 @@
+using BHS.CRG.Domain.Common;
+
+namespace BHS.CRG.Domain.Documents;
+
+/// <summary>
+/// Строка плана комплекта: «документов такого-то типа должно быть столько-то» (issue #796).
+///
+/// План задаётся ТОЛЬКО на комплекте. Планы раздела и стройки не хранятся — они считаются
+/// консолидацией нижележащих: хранить их значило бы завести две записи об одном и том же и ждать,
+/// когда они разойдутся.
+///
+/// Фича строго опциональна: нет строк — нет плана, и процент готовности нигде не показывается.
+/// «Ноль процентов» и «плана нет» — разные вещи, и рисовать второе как первое нельзя.
+/// </summary>
+public class DocumentSetPlanItem : Entity
+{
+    public Guid DocumentSetId { get; private set; }
+    public Guid DocumentTypeId { get; private set; }
+
+    /// <summary>Сколько документов этого типа планируется. Всегда ≥ 1: ноль — это отсутствие строки.</summary>
+    public int PlannedCount { get; private set; }
+
+    private DocumentSetPlanItem() { }
+
+    public static DocumentSetPlanItem Create(Guid documentSetId, Guid documentTypeId, int plannedCount)
+    {
+        // Отказ ПОЛЬЗОВАТЕЛЮ, а не внутренний инвариант: значение приходит из формы плана, и текст
+        // должен доехать до экрана. ArgumentOutOfRangeException превратился бы в «внутреннюю ошибку
+        // сервера» — это ловит DomainExceptionPolicyTests.
+        if (plannedCount < 1)
+            throw new InvalidRequestException(
+                "Планируемое количество — от 1. Ноль означает отсутствие строки плана, а не строку с нулём.");
+
+        return new()
+        {
+            DocumentSetId = documentSetId,
+            DocumentTypeId = documentTypeId,
+            PlannedCount = plannedCount,
+        };
+    }
+
+    /// <summary>Восстановление из резервной копии (issue #833).</summary>
+    public static DocumentSetPlanItem Restore(Guid id, Guid documentSetId, Guid documentTypeId, int plannedCount,
+        DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        => new()
+        {
+            Id = id, DocumentSetId = documentSetId, DocumentTypeId = documentTypeId,
+            PlannedCount = plannedCount, CreatedAt = createdAt, UpdatedAt = updatedAt,
+        };
+}

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -164,6 +164,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             new("Стройки", manifest.Constructions?.Length ?? 0),
             new("Разделы", manifest.Sections?.Length ?? 0),
             new("Комплекты", manifest.DocumentSets?.Length ?? 0),
+            new("Строки плана", manifest.DocumentSetPlans?.Length ?? 0),
             new("Документы комплектов", manifest.Documents?.Length ?? 0),
             new("Выпущенные файлы", manifest.Documents?.Sum(d => d.GeneratedFiles.Length) ?? 0),
             new("Наборы данных", manifest.DataSetFiles?.Length ?? 0),
@@ -320,6 +321,7 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         var constructions = full ? await db.Constructions.AsNoTracking().ToListAsync(ct) : [];
         var sections = full ? await db.Sections.AsNoTracking().ToListAsync(ct) : [];
         var sets = full ? await db.DocumentSets.AsNoTracking().ToListAsync(ct) : [];
+        var setPlans = full ? await db.DocumentSetPlans.AsNoTracking().ToListAsync(ct) : [];
         var documents = full
             ? await db.DomainObjects.AsNoTracking().Include(o => o.Facet)
                 .Where(o => o.Facet != null).ToListAsync(ct)
@@ -413,6 +415,8 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
                 x.Id, x.ConstructionId, x.Name, x.ProfileObjectId, x.CreatedAt, x.UpdatedAt)).ToArray() : null,
             DocumentSets: full ? sets.Select(x => new BackupDocumentSet(
                 x.Id, x.SectionId, x.Name, x.ProfileObjectId, x.CreatedAt, x.UpdatedAt)).ToArray() : null,
+            DocumentSetPlans: full ? setPlans.Select(x => new BackupDocumentSetPlan(
+                x.Id, x.DocumentSetId, x.DocumentTypeId, x.PlannedCount, x.CreatedAt, x.UpdatedAt)).ToArray() : null,
             Documents: full ? documents.Select(o => new BackupDocument(
                 o.Id, o.ScopeId ?? Guid.Empty, o.CompositeTypeId, o.DisplayName, o.Data.RootElement.Clone(),
                 o.Aliases.ToArray(), o.Facet!.Status.ToString(), o.Facet.SortOrder,
@@ -521,6 +525,8 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
             await RestoreConstructionsAsync(manifest.Constructions ?? [], stats, ct);
             await RestoreSectionsAsync(manifest.Sections ?? [], stats, warnings, ct);
             await RestoreDocumentSetsAsync(manifest.DocumentSets ?? [], stats, warnings, ct);
+            // План — после комплектов (носитель) и после типов документов (на них ссылается).
+            await RestoreDocumentSetPlansAsync(manifest.DocumentSetPlans ?? [], stats, warnings, ct);
             await RestoreCommonDataEntriesAsync(manifest.CommonDataEntries, stats, warnings, ct);
             // Документы комплектов — после типов (тип документа) и после комплектов (носитель).
             await RestoreDocumentsAsync(manifest.Documents ?? [], stats, warnings, ct);
@@ -1400,6 +1406,29 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
         var (c, u) = await UpsertAsync(ok.Select(i => (i.Id, DocumentSet.Restore(
             i.Id, i.SectionId, i.Name, i.ProfileObjectId, i.CreatedAt, i.UpdatedAt))), existing, ct);
         stats.Count("Комплекты", c, u);
+    }
+
+    /// <summary>
+    /// Строки плана комплектов (issue #796).
+    ///
+    /// Строка без своего типа документа НЕ восстанавливается: план на несуществующий тип — позиция,
+    /// которую нечем закрыть, и процент готовности навсегда упирался бы в потолок ниже ста без
+    /// видимой причины. Лучше предупредить при восстановлении, чем оставить необъяснимую цифру.
+    /// </summary>
+    private async Task RestoreDocumentSetPlansAsync(
+        BackupDocumentSetPlan[] items, RestoreStats stats, List<string> warnings, CancellationToken ct)
+    {
+        if (items.Length == 0) return;
+        var existing = await db.DocumentSetPlans.Select(x => x.Id).ToHashSetAsync(ct);
+        var sets = await db.DocumentSets.Select(x => x.Id).ToHashSetAsync(ct);
+        var types = await db.DocumentTypes.Select(x => x.Id).ToHashSetAsync(ct);
+
+        var (ok, orphans) = Split(items, i => sets.Contains(i.DocumentSetId) && types.Contains(i.DocumentTypeId));
+        Warn(warnings, orphans.Count, "строк плана", "их комплекта или типа документа нет ни в копии, ни в системе");
+
+        var (c, u) = await UpsertAsync(ok.Select(i => (i.Id, DocumentSetPlanItem.Restore(
+            i.Id, i.DocumentSetId, i.DocumentTypeId, i.PlannedCount, i.CreatedAt, i.UpdatedAt))), existing, ct);
+        stats.Count("Строки плана", c, u);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
+++ b/src/server/BHS.CRG.Infrastructure/Backup/BackupService.cs
@@ -1414,21 +1414,46 @@ public class BackupService(AppDbContext db, IBlobStorage blob, ILogger<BackupSer
     /// Строка без своего типа документа НЕ восстанавливается: план на несуществующий тип — позиция,
     /// которую нечем закрыть, и процент готовности навсегда упирался бы в потолок ниже ста без
     /// видимой причины. Лучше предупредить при восстановлении, чем оставить необъяснимую цифру.
+    ///
+    /// Раскладывается по ПРИРОДНОМУ ключу (комплект, тип), а не по Id — как и связки материалов
+    /// выше, и по той же причине, только острее: правка плана удаляет строки и заводит новые со
+    /// СВЕЖИМИ идентификаторами, значит после любой правки Id в копии заведомо устарел, а пара
+    /// (комплект, тип) осталась прежней. Вставка по Id упёрлась бы в уникальный индекс, а 23505
+    /// здесь означает не «пропустим строку», а откат ВСЕГО восстановления: администратор получил бы
+    /// «Ошибка восстановления БД» и пустую систему из-за одной строки плана.
     /// </summary>
     private async Task RestoreDocumentSetPlansAsync(
         BackupDocumentSetPlan[] items, RestoreStats stats, List<string> warnings, CancellationToken ct)
     {
         if (items.Length == 0) return;
-        var existing = await db.DocumentSetPlans.Select(x => x.Id).ToHashSetAsync(ct);
+        var existing = await db.DocumentSetPlans.AsNoTracking()
+            .Select(x => new { x.Id, x.DocumentSetId, x.DocumentTypeId }).ToListAsync(ct);
+        var byKey = existing.ToDictionary(x => (x.DocumentSetId, x.DocumentTypeId), x => x.Id);
+        var byId = existing.Select(x => x.Id).ToHashSet();
+
         var sets = await db.DocumentSets.Select(x => x.Id).ToHashSetAsync(ct);
         var types = await db.DocumentTypes.Select(x => x.Id).ToHashSetAsync(ct);
 
         var (ok, orphans) = Split(items, i => sets.Contains(i.DocumentSetId) && types.Contains(i.DocumentTypeId));
         Warn(warnings, orphans.Count, "строк плана", "их комплекта или типа документа нет ни в копии, ни в системе");
 
-        var (c, u) = await UpsertAsync(ok.Select(i => (i.Id, DocumentSetPlanItem.Restore(
-            i.Id, i.DocumentSetId, i.DocumentTypeId, i.PlannedCount, i.CreatedAt, i.UpdatedAt))), existing, ct);
-        stats.Count("Строки плана", c, u);
+        int created = 0, updated = 0;
+        foreach (var item in ok)
+        {
+            var targetId = byKey.TryGetValue((item.DocumentSetId, item.DocumentTypeId), out var samePair)
+                ? samePair
+                : item.Id;
+            var exists = targetId != item.Id || byId.Contains(item.Id);
+
+            db.Entry(DocumentSetPlanItem.Restore(
+                targetId, item.DocumentSetId, item.DocumentTypeId, item.PlannedCount,
+                item.CreatedAt, item.UpdatedAt)).State = exists ? EntityState.Modified : EntityState.Added;
+
+            if (exists) updated++; else created++;
+        }
+
+        await db.SaveChangesAsync(ct);
+        stats.Count("Строки плана", created, updated);
     }
 
     /// <summary>

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260825073320_DocumentSetPlans.Designer.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260825073320_DocumentSetPlans.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHS.CRG.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825073320_DocumentSetPlans")]
+    partial class DocumentSetPlans
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/BHS.CRG.Infrastructure/Migrations/20260825073320_DocumentSetPlans.cs
+++ b/src/server/BHS.CRG.Infrastructure/Migrations/20260825073320_DocumentSetPlans.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHS.CRG.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DocumentSetPlans : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "document_set_plans",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DocumentSetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DocumentTypeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlannedCount = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_document_set_plans", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_document_set_plans_document_sets_DocumentSetId",
+                        column: x => x.DocumentSetId,
+                        principalTable: "document_sets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_document_set_plans_DocumentSetId_DocumentTypeId",
+                table: "document_set_plans",
+                columns: new[] { "DocumentSetId", "DocumentTypeId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_document_set_plans_DocumentTypeId",
+                table: "document_set_plans",
+                column: "DocumentTypeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "document_set_plans");
+        }
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/AppDbContext.cs
@@ -28,6 +28,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options)
     public DbSet<Construction> Constructions => Set<Construction>();
     public DbSet<Section> Sections => Set<Section>();
     public DbSet<DocumentSet> DocumentSets => Set<DocumentSet>();
+    public DbSet<DocumentSetPlanItem> DocumentSetPlans => Set<DocumentSetPlanItem>();
     public DbSet<GeneratedFile> GeneratedFiles => Set<GeneratedFile>();
     public DbSet<DocumentSetOutput> DocumentSetOutputs => Set<DocumentSetOutput>();
     public DbSet<Subscription> Subscriptions => Set<Subscription>();

--- a/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DocumentSetPlanConfiguration.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/Configurations/DocumentSetPlanConfiguration.cs
@@ -1,0 +1,30 @@
+using BHS.CRG.Domain.Documents;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BHS.CRG.Infrastructure.Persistence.Configurations;
+
+public class DocumentSetPlanConfiguration : IEntityTypeConfiguration<DocumentSetPlanItem>
+{
+    public void Configure(EntityTypeBuilder<DocumentSetPlanItem> b)
+    {
+        b.ToTable("document_set_plans");
+        b.HasKey(e => e.Id);
+
+        // Строка на тип: замена плана целиком и так не даёт дублей, но опираться на дисциплину
+        // вызывающего в вопросе «сколько документов должно быть» — значит однажды получить план,
+        // где один тип посчитан дважды, и процент, который никто не сойдётся объяснить.
+        b.HasIndex(e => new { e.DocumentSetId, e.DocumentTypeId }).IsUnique();
+
+        b.HasOne<DocumentSet>()
+            .WithMany()
+            .HasForeignKey(e => e.DocumentSetId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // К типу документа внешнего ключа НЕТ, и это осознанно: удаление типа отдельно защищено
+        // проверкой занятости (она теперь видит и планы), а каскад отсюда тихо унёс бы строки
+        // плана вместе с типом — план перестал бы сходиться, и никто бы не понял почему.
+        b.Property(e => e.DocumentTypeId).IsRequired();
+        b.HasIndex(e => e.DocumentTypeId);
+    }
+}

--- a/src/server/BHS.CRG.Infrastructure/Persistence/DomainObjectRepository.cs
+++ b/src/server/BHS.CRG.Infrastructure/Persistence/DomainObjectRepository.cs
@@ -1,5 +1,6 @@
 using BHS.CRG.Application.Common;
 using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Documents;
 using BHS.CRG.Domain.Objects;
 using Microsoft.EntityFrameworkCore;
 
@@ -51,5 +52,21 @@ public class DomainObjectRepository(AppDbContext db) : Repository<DomainObject>(
             .Select(g => new { SetId = g.Key, Count = g.Count() })
             .ToListAsync(ct);
         return rows.ToDictionary(r => r.SetId, r => r.Count);
+    }
+
+    public async Task<IReadOnlyDictionary<(Guid SetId, Guid TypeId), int>> CountReadyDocumentsByTypeAsync(
+        IReadOnlyCollection<Guid> setIds, CancellationToken ct = default)
+    {
+        if (setIds.Count == 0) return new Dictionary<(Guid, Guid), int>();
+
+        var rows = await Db.Set<DomainObject>()
+            .AsNoTracking()
+            .Where(o => o.ScopeLevel == CatalogScope.Set && o.ScopeId != null && setIds.Contains(o.ScopeId.Value)
+                        && o.Facet != null && o.Facet.Status == DocumentStatus.Generated)
+            .GroupBy(o => new { SetId = o.ScopeId!.Value, TypeId = o.CompositeTypeId })
+            .Select(g => new { g.Key.SetId, g.Key.TypeId, Count = g.Count() })
+            .ToListAsync(ct);
+
+        return rows.ToDictionary(r => (r.SetId, r.TypeId), r => r.Count);
     }
 }

--- a/src/server/BHS.CRG.Tests/Documents/PlanMathTests.cs
+++ b/src/server/BHS.CRG.Tests/Documents/PlanMathTests.cs
@@ -1,0 +1,72 @@
+using BHS.CRG.Application.Documents;
+
+namespace BHS.CRG.Tests.Documents;
+
+/// <summary>
+/// Арифметика готовности по плану (issue #796) — вся спорная часть фичи, и проверяется она без базы.
+/// </summary>
+public class PlanMathTests
+{
+    // ── Закрыто планом ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Ready_CountsEachTypeUpToItsPlan()
+        => Assert.Equal(5, PlanMath.Ready([(3, 3), (4, 2)]));
+
+    /// <summary>
+    /// Документы сверх плана процент не надувают. Без <c>min</c> пять актов при плане в три давали
+    /// бы 167 % по одной строке и вытягивали бы весь комплект за незакрытые соседние позиции.
+    /// </summary>
+    [Fact]
+    public void Ready_DoesNotCountDocumentsBeyondThePlan()
+        => Assert.Equal(3, PlanMath.Ready([(3, 5)]));
+
+    [Fact]
+    public void Ready_OfEmptyPlanIsZero()
+        => Assert.Equal(0, PlanMath.Ready([]));
+
+    // ── Процент ───────────────────────────────────────────────────────────────
+
+    /// <summary>Плана нет — процента нет. «0 %» соврал бы: там, где не планировали, ничего и не должно.</summary>
+    [Fact]
+    public void Percent_IsNullWithoutPlan()
+        => Assert.Null(PlanMath.Percent(planned: 0, ready: 0, needsAttention: 0));
+
+    [Fact]
+    public void Percent_IsHundredOnlyWhenPlanClosedAndNothingToReview()
+        => Assert.Equal(100, PlanMath.Percent(planned: 10, ready: 10, needsAttention: 0));
+
+    /// <summary>
+    /// Сверка — гейт финала, а не множитель: план закрыт, но есть неразобранное — 99 %, и рядом
+    /// маркер. Дробить процент долей сверки нельзя: количество документов и качество данных —
+    /// разные природы, и смешанная цифра не значит ничего.
+    /// </summary>
+    [Fact]
+    public void Percent_CapsAt99WhenReviewPending()
+        => Assert.Equal(99, PlanMath.Percent(planned: 10, ready: 10, needsAttention: 1));
+
+    /// <summary>Округление вниз: 99,6 % — это ещё не «сто», и показать сто было бы прямой ложью.</summary>
+    [Fact]
+    public void Percent_RoundsDown()
+        => Assert.Equal(99, PlanMath.Percent(planned: 250, ready: 249, needsAttention: 0));
+
+    [Theory]
+    [InlineData(10, 0, 0)]
+    [InlineData(10, 5, 50)]
+    [InlineData(3, 1, 33)]
+    public void Percent_IsShareOfClosedPositions(int planned, int ready, int expected)
+        => Assert.Equal(expected, PlanMath.Percent(planned, ready, needsAttention: 0));
+
+    /// <summary>
+    /// Готовых больше запланированного процент не ломает. Само по себе такое приходит не из
+    /// <see cref="PlanMath.Ready"/> (там уже <c>min</c>), а из сложения уровней — и «117 %» на
+    /// шапке стройки был бы худшим способом об этом узнать.
+    /// </summary>
+    [Fact]
+    public void Percent_NeverExceedsHundred()
+        => Assert.Equal(100, PlanMath.Percent(planned: 6, ready: 7, needsAttention: 0));
+
+    [Fact]
+    public void Percent_NeverGoesBelowZero()
+        => Assert.Equal(0, PlanMath.Percent(planned: 6, ready: -3, needsAttention: 0));
+}

--- a/src/server/BHS.CRG.Tests/Integration/BackupManifestCoverageTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/BackupManifestCoverageTests.cs
@@ -127,6 +127,7 @@ public class BackupManifestCoverageTests(IntegrationTestFixture fixture)
         ["Construction"] = nameof(BackupManifest.Constructions),
         ["Section"] = nameof(BackupManifest.Sections),
         ["DocumentSet"] = nameof(BackupManifest.DocumentSets),
+        ["DocumentSetPlanItem"] = nameof(BackupManifest.DocumentSetPlans),
         // Документы и их фасета едут одной записью: фасета и есть то, чем документ отличается от
         // записи общих данных, и разъехаться им нельзя.
         ["DocumentFacet"] = nameof(BackupManifest.Documents),
@@ -311,6 +312,8 @@ public class BackupManifestCoverageTests(IntegrationTestFixture fixture)
         db.Constructions.Add(Construction.Restore(constructionId, "Стройка покрытия", Guid.NewGuid(), null, now, now));
         db.Sections.Add(Section.Restore(sectionId, constructionId, "Раздел", null, now, now));
         db.DocumentSets.Add(DocumentSet.Restore(setId, sectionId, "Комплект", null, now, now));
+        db.DocumentSetPlans.Add(DocumentSetPlanItem.Restore(
+            Guid.NewGuid(), setId, docTypeId, 3, now, now));
         db.DomainObjects.Add(DomainObject.RestoreDocument(
             documentId, docTypeId, "Документ покрытия", JsonDocument.Parse("{}"), setId, now, now, null,
             DocumentStatus.Draft, 0, null, null, null, JsonDocument.Parse("{}")));

--- a/src/server/BHS.CRG.Tests/Integration/DocumentPlanTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentPlanTests.cs
@@ -1,12 +1,18 @@
 using System.Text.Json;
+using BHS.CRG.Application.Backup;
 using BHS.CRG.Application.Common;
 using BHS.CRG.Application.Documents;
 using BHS.CRG.Domain.Catalog;
 using BHS.CRG.Domain.Common;
 using BHS.CRG.Domain.Documents;
 using BHS.CRG.Domain.Objects;
+using BHS.CRG.Domain.Reconciliation;
+using BHS.CRG.Application.Reconciliation;
 using MediatR;
+using BHS.CRG.Infrastructure.Backup;
+using BHS.CRG.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BHS.CRG.Tests.Integration;
 
@@ -246,6 +252,91 @@ public class DocumentPlanTests(IntegrationTestFixture fixture) : IAsyncLifetime
 
         await Assert.ThrowsAsync<ConflictException>(() => M(scope).Send(new DeleteDocumentTypeCommand(type)));
     }
+
+    /// <summary>
+    /// Комплекта нет — это НЕ «комплект без плана». Разница видна на устаревшей навигации: клиент
+    /// получил бы пустую форму плана, заполнил и упёрся в 404 уже на сохранении.
+    /// </summary>
+    [Fact]
+    public async Task PlanOfMissingSet_IsNotFound_NotAnEmptyPlan()
+    {
+        using var scope = fixture.Services.CreateScope();
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => M(scope).Send(new GetDocumentSetPlanQuery(Guid.NewGuid())));
+    }
+
+    /// <summary>
+    /// Процент не показывает «сто» при неразобранном НИ НА ОДНОМ уровне — включая верхний, где
+    /// расписанная стройка складывается с бесплановой соседкой. Счётчик разбора берётся у сводки
+    /// проблем, а она знает его и по детям без плана.
+    /// </summary>
+    [Fact]
+    public async Task SystemLevel_DoesNotClaimHundred_WhenAnotherConstructionHasUnreviewedProblems()
+    {
+        var (_, _, planned) = await TreeAsync("Расписанный");
+        var type = await TypeAsync("AOSR");
+        await PlanAsync(planned.Id, (type, 1));
+        await DocumentAsync(planned.Id, type, generated: true);
+
+        // Вторая стройка: плана нет, зато есть неразобранное замечание.
+        var (_, _, other) = await TreeAsync("Без плана");
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new ReportObservationCommand(
+                CatalogScope.Set, other.Id, "key-1", "Замечание", null,
+                ObservationSeverity.Warning, JsonDocument.Parse("{}"), "agent"));
+
+        var atSystem = await SummaryAsync(CatalogScope.System, null);
+        Assert.Equal(1, atSystem.Own.Planned);
+        Assert.Equal(1, atSystem.Own.Ready);
+        Assert.Equal(1, atSystem.Own.NeedsAttention);
+        Assert.Equal(99, atSystem.Own.Percent);
+    }
+
+    /// <summary>
+    /// Восстановление поверх системы, где план УЖЕ правили, не должно ронять весь импорт.
+    ///
+    /// Правка плана удаляет строки и заводит новые со свежими идентификаторами, а пара
+    /// (комплект, тип) остаётся прежней и защищена уникальным индексом. Раскладка по одному лишь
+    /// Id упиралась бы в 23505 — а он здесь означает не «пропустим строку», а откат ВСЕЙ
+    /// транзакции: администратор получил бы «Ошибка восстановления БД» и пустую систему из-за
+    /// одной строки плана. Проверяем именно связку «сняли копию → поправили план → восстановили».
+    /// </summary>
+    [Fact]
+    public async Task Restore_AfterPlanWasEdited_SucceedsAndKeepsOneRowPerType()
+    {
+        var (_, _, set) = await TreeAsync();
+        var type = await TypeAsync("AOSR");
+        await PlanAsync(set.Id, (type, 3));
+
+        byte[] copy;
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var (zip, _) = await BackupOf(scope).ExportAsync(BackupScope.Full);
+            await using var _handle = zip;
+            using var ms = new MemoryStream();
+            await zip.CopyToAsync(ms);
+            copy = ms.ToArray();
+        }
+
+        // Та же позиция плана, другое количество — и, из-за замены целиком, ДРУГОЙ идентификатор.
+        await PlanAsync(set.Id, (type, 4));
+
+        RestoreReport report;
+        using (var scope = fixture.Services.CreateScope())
+            report = await BackupOf(scope).ImportAsync(new MemoryStream(copy));
+
+        Assert.True(report.Success, string.Join("; ", report.Warnings));
+
+        using var check = fixture.Services.CreateScope();
+        var rows = await M(check).Send(new GetDocumentSetPlanQuery(set.Id));
+        var row = Assert.Single(rows);
+        Assert.Equal(3, row.PlannedCount);   // вернулось значение из копии, а не осталось правленое
+    }
+
+    private static BackupService BackupOf(IServiceScope scope) => new(
+        scope.ServiceProvider.GetRequiredService<AppDbContext>(),
+        scope.ServiceProvider.GetRequiredService<IBlobStorage>(),
+        NullLogger<BackupService>.Instance);
 
     /// <summary>Комплект удалён — его план уходит с ним: строки без носителя не оставляем.</summary>
     [Fact]

--- a/src/server/BHS.CRG.Tests/Integration/DocumentPlanTests.cs
+++ b/src/server/BHS.CRG.Tests/Integration/DocumentPlanTests.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+using BHS.CRG.Application.Common;
+using BHS.CRG.Application.Documents;
+using BHS.CRG.Domain.Catalog;
+using BHS.CRG.Domain.Common;
+using BHS.CRG.Domain.Documents;
+using BHS.CRG.Domain.Objects;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BHS.CRG.Tests.Integration;
+
+/// <summary>
+/// План по документам (issue #796): план задаётся на комплекте, уровни выше консолидируются.
+///
+/// Главное, что здесь проверяется, — не «сохранилось ли», а границы честности процента: сверх
+/// плана не считается, комплекты без плана не выдают себя за готовые, «100 %» не показывается при
+/// неразобранной сверке.
+/// </summary>
+[Collection("Integration")]
+public class DocumentPlanTests(IntegrationTestFixture fixture) : IAsyncLifetime
+{
+    public async Task InitializeAsync() => await fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private readonly Guid _userId = Guid.NewGuid();
+
+    private static IMediator M(IServiceScope s) => s.ServiceProvider.GetRequiredService<IMediator>();
+
+    private async Task<(Construction C, Section S, DocumentSet Set)> TreeAsync(string name = "Комплект")
+    {
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+        var c = await m.Send(new CreateConstructionCommand("Объект", _userId));
+        var s = await m.Send(new CreateSectionCommand(c.Id, "ЭОМ"));
+        var set = await m.Send(new CreateDocumentSetCommand(s.Id, name));
+        return (c, s, set);
+    }
+
+    private async Task<Guid> SetInAsync(Guid sectionId, string name)
+    {
+        using var scope = fixture.Services.CreateScope();
+        return (await M(scope).Send(new CreateDocumentSetCommand(sectionId, name))).Id;
+    }
+
+    private async Task<Guid> TypeAsync(string code)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var dt = await M(scope).Send(new CreateDocumentTypeCommand(
+            code, code, DocumentTypeKind.Document, null, JsonDocument.Parse("""{"fields":[]}""")));
+        return dt.Id;
+    }
+
+    /// <summary>Документ в комплекте; <paramref name="generated"/> — «выпущен», а не просто заведён.</summary>
+    private async Task<Guid> DocumentAsync(Guid setId, Guid typeId, bool generated)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var doc = await M(scope).Send(new AddDocumentToSetCommand(setId, typeId));
+        if (!generated) return doc.Id;
+
+        // Через тот же путь, что и настоящая генерация: файл добавляется отдельной записью
+        // (GenerateDocumentHandler делает так же), а объект уже отслеживается — Update() на нём
+        // пометил бы Modified и новорождённый файл, и SaveChanges попытался бы его ОБНОВИТЬ.
+        var repo = scope.ServiceProvider.GetRequiredService<IDomainObjectRepository>();
+        var files = scope.ServiceProvider.GetRequiredService<IRepository<GeneratedFile>>();
+        var tracked = (await repo.GetSetDocumentsAsync(setId, tracked: true)).First(d => d.Id == doc.Id);
+        await files.AddAsync(tracked.AddGeneratedFile(OutputFormat.Pdf, $"blob/{doc.Id}.pdf"));
+        await repo.SaveChangesAsync();
+        return doc.Id;
+    }
+
+    private async Task PlanAsync(Guid setId, params (Guid TypeId, int Count)[] rows)
+    {
+        using var scope = fixture.Services.CreateScope();
+        await M(scope).Send(new ReplaceDocumentSetPlanCommand(setId,
+            [.. rows.Select(r => new PlanRow(r.TypeId, r.Count))]));
+    }
+
+    private async Task<PlanSummary> SummaryAsync(CatalogScope scope_, Guid? id)
+    {
+        using var scope = fixture.Services.CreateScope();
+        return await M(scope).Send(new GetPlanSummaryQuery(scope_, id));
+    }
+
+    // ── План комплекта ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Plan_IsReplacedWholesale_AndShowsActualCounts()
+    {
+        var (_, _, set) = await TreeAsync();
+        var aosr = await TypeAsync("AOSR");
+        var journal = await TypeAsync("JOURNAL");
+
+        await PlanAsync(set.Id, (aosr, 3), (journal, 1));
+        await DocumentAsync(set.Id, aosr, generated: true);
+        await DocumentAsync(set.Id, aosr, generated: false);   // черновик фактом не считается
+
+        using (var scope = fixture.Services.CreateScope())
+        {
+            var rows = await M(scope).Send(new GetDocumentSetPlanQuery(set.Id));
+            Assert.Equal(2, rows.Count);
+            var aosrRow = rows.Single(r => r.DocumentTypeId == aosr);
+            Assert.Equal(3, aosrRow.PlannedCount);
+            Assert.Equal(1, aosrRow.ActualCount);
+        }
+
+        // Замена целиком: прислали одну строку — вторая ушла.
+        await PlanAsync(set.Id, (aosr, 2));
+
+        using var check = fixture.Services.CreateScope();
+        var after = await M(check).Send(new GetDocumentSetPlanQuery(set.Id));
+        Assert.Equal(2, Assert.Single(after).PlannedCount);
+    }
+
+    /// <summary>Пустой список — это «плана нет»: проценты должны исчезнуть с экранов совсем.</summary>
+    [Fact]
+    public async Task EmptyPlan_MeansNoPlan_NotZeroPercent()
+    {
+        var (_, _, set) = await TreeAsync();
+        var type = await TypeAsync("AOSR");
+        await PlanAsync(set.Id, (type, 2));
+        await PlanAsync(set.Id);
+
+        var summary = await SummaryAsync(CatalogScope.Set, set.Id);
+        Assert.False(summary.Own.HasPlan);
+        Assert.Null(summary.Own.Percent);
+    }
+
+    [Fact]
+    public async Task Plan_RejectsUnknownType_ZeroCount_AndDuplicates()
+    {
+        var (_, _, set) = await TreeAsync();
+        var type = await TypeAsync("AOSR");
+        using var scope = fixture.Services.CreateScope();
+        var m = M(scope);
+
+        await Assert.ThrowsAsync<InvalidRequestException>(() => m.Send(
+            new ReplaceDocumentSetPlanCommand(set.Id, [new PlanRow(Guid.NewGuid(), 1)])));
+        await Assert.ThrowsAsync<InvalidRequestException>(() => m.Send(
+            new ReplaceDocumentSetPlanCommand(set.Id, [new PlanRow(type, 0)])));
+        await Assert.ThrowsAsync<InvalidRequestException>(() => m.Send(
+            new ReplaceDocumentSetPlanCommand(set.Id, [new PlanRow(type, 1), new PlanRow(type, 2)])));
+    }
+
+    // ── Процент ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Percent_CountsOnlyGeneratedDocuments_AndNotBeyondThePlan()
+    {
+        var (_, _, set) = await TreeAsync();
+        var aosr = await TypeAsync("AOSR");
+        await PlanAsync(set.Id, (aosr, 2));
+
+        // Три выпущенных при плане в два: закрыто два, а не «150 %».
+        for (var i = 0; i < 3; i++) await DocumentAsync(set.Id, aosr, generated: true);
+        await DocumentAsync(set.Id, aosr, generated: false);
+
+        var summary = await SummaryAsync(CatalogScope.Set, set.Id);
+        Assert.Equal(2, summary.Own.Planned);
+        Assert.Equal(2, summary.Own.Ready);
+        Assert.Equal(100, summary.Own.Percent);
+    }
+
+    /// <summary>Типы вне плана процент не трогают: внеплановая работа — не выполнение плана.</summary>
+    [Fact]
+    public async Task DocumentsOfUnplannedTypes_DoNotAffectPercent()
+    {
+        var (_, _, set) = await TreeAsync();
+        var planned = await TypeAsync("AOSR");
+        var other = await TypeAsync("JOURNAL");
+        await PlanAsync(set.Id, (planned, 2));
+        await DocumentAsync(set.Id, other, generated: true);
+
+        var summary = await SummaryAsync(CatalogScope.Set, set.Id);
+        Assert.Equal(0, summary.Own.Ready);
+        Assert.Equal(0, summary.Own.Percent);
+    }
+
+    // ── Консолидация вверх ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SectionAndConstruction_ConsolidateTheirSets()
+    {
+        var (construction, section, first) = await TreeAsync("Первый");
+        var second = await SetInAsync(section.Id, "Второй");
+        var type = await TypeAsync("AOSR");
+
+        await PlanAsync(first.Id, (type, 2));
+        await PlanAsync(second, (type, 2));
+        await DocumentAsync(first.Id, type, generated: true);
+        await DocumentAsync(second, type, generated: true);
+        await DocumentAsync(second, type, generated: true);
+
+        var atSection = await SummaryAsync(CatalogScope.Section, section.Id);
+        Assert.Equal(4, atSection.Own.Planned);
+        Assert.Equal(3, atSection.Own.Ready);
+        Assert.Equal(75, atSection.Own.Percent);
+        Assert.Equal(2, atSection.Children.Count);
+
+        var atConstruction = await SummaryAsync(CatalogScope.Construction, construction.Id);
+        Assert.Equal(4, atConstruction.Own.Planned);
+        Assert.Equal(3, atConstruction.Own.Ready);
+
+        // Стройка не должна посчитать свои комплекты дважды — сама и через разделы.
+        Assert.Equal(atSection.Own.Planned, atConstruction.Own.Planned);
+    }
+
+    /// <summary>
+    /// Комплект без плана в проценте не участвует, но и не молчит. Иначе «раздел на 100 %» означало
+    /// бы «единственный расписанный комплект закрыт», а про остальные экран не сказал бы ничего.
+    /// </summary>
+    [Fact]
+    public async Task SetsWithoutPlan_AreExcludedFromPercent_ButCounted()
+    {
+        var (_, section, planned) = await TreeAsync("С планом");
+        await SetInAsync(section.Id, "Без плана");
+        var type = await TypeAsync("AOSR");
+
+        await PlanAsync(planned.Id, (type, 1));
+        await DocumentAsync(planned.Id, type, generated: true);
+
+        var summary = await SummaryAsync(CatalogScope.Section, section.Id);
+        Assert.Equal(1, summary.Own.Planned);
+        Assert.Equal(100, summary.Own.Percent);
+        Assert.Equal(1, summary.Own.SetsWithoutPlan);
+        Assert.Single(summary.Children);   // в разбивку попал только расписанный
+    }
+
+    // ── Тип из плана нельзя удалить молча ─────────────────────────────────────
+
+    /// <summary>
+    /// Внешнего ключа от плана к типу нет намеренно (каскад унёс бы строки плана вместе с типом, и
+    /// процент поехал бы молча). Значит проверка занятости — единственная защита, и она обязана
+    /// про план знать.
+    /// </summary>
+    [Fact]
+    public async Task DeletingTypeUsedInPlan_IsRefused()
+    {
+        var (_, _, set) = await TreeAsync();
+        var type = await TypeAsync("AOSR");
+        await PlanAsync(set.Id, (type, 1));
+
+        using var scope = fixture.Services.CreateScope();
+        var usage = await M(scope).Send(new GetDocumentTypeUsageQuery(type));
+        Assert.Contains(usage.Reasons, r => r.Kind == "plan");
+
+        await Assert.ThrowsAsync<ConflictException>(() => M(scope).Send(new DeleteDocumentTypeCommand(type)));
+    }
+
+    /// <summary>Комплект удалён — его план уходит с ним: строки без носителя не оставляем.</summary>
+    [Fact]
+    public async Task DeletingSet_TakesItsPlanWithIt()
+    {
+        var (_, _, set) = await TreeAsync();
+        var type = await TypeAsync("AOSR");
+        await PlanAsync(set.Id, (type, 1));
+
+        using (var scope = fixture.Services.CreateScope())
+            await M(scope).Send(new DeleteDocumentSetCommand(set.Id));
+
+        using var check = fixture.Services.CreateScope();
+        var plans = check.ServiceProvider.GetRequiredService<IRepository<DocumentSetPlanItem>>();
+        Assert.Empty(await plans.FindAsync(p => p.DocumentSetId == set.Id));
+    }
+}

--- a/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
+++ b/src/server/BHS.CRG.Tests/Integration/IntegrationTestFixture.cs
@@ -112,6 +112,7 @@ public class IntegrationTestFixture : WebApplicationFactory<Program>
         "generated_files",
         "document_facets",
         "domain_objects",
+        "document_set_plans",
         "document_sets",
         "sections",
         "constructions",

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.148.1</Version>
+    <Version>0.149.0</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Первая половина #796 — backend. Интерфейс следующим PR.

## Модель

`document_set_plans`: строка на пару (комплект, тип). План задаётся **только на комплекте**; раздел и стройка консолидируются на лету. Хранить их планы значило бы завести вторую запись об одном и том же и ждать, когда она разойдётся с первой.

## Арифметика — вся в `PlanMath`, проверяется без базы

Это единственное место, где фича может соврать, поэтому оно отделено от запросов:

| Правило | Почему так |
|---|---|
| закрыто = `Σ min(готовых, план)` | без `min` пять актов при плане в три дают 167 % по строке и вытягивают комплект за счёт незакрытых соседей |
| готовый = статус `Generated` | план считает выпущенное, а не заведённые карточки |
| типы вне плана не участвуют | внеплановая работа не выполняет план |
| **сверка — гейт, не множитель** | 100 % только когда план закрыт И разбирать нечего; иначе потолок 99 % + маркер. Смешать в одной цифре количество документов и качество данных — получить число ни о чём |
| округление вниз | 99,6 % — ещё не «сто»; «100 %» при незакрытой позиции — ложь на самом заметном месте экрана |
| плана нет → процента нет | «0 %» соврал бы: где не планировали, там ничего и не должно |

Комплекты без плана в проценте не участвуют, **но их число уходит наверх** — иначе «стройка на 100 %» означало бы «единственный расписанный комплект закрыт», а про девять остальных экран не сказал бы ничего.

## API

```
GET  /api/document-sets/{id}/plan     → строки плана с фактом
PUT  /api/document-sets/{id}/plan     ← замена ЦЕЛИКОМ (пустой список = плана нет)
GET  /api/plans/summary?scope=&scopeId=  → { own, children[] }
```

Запись плана доступна роли User: план — часть работы над комплектом, а не настройка системы.

## Что вынесено, а не скопировано

Спуск «прямые дети уровня» жил приватной копией в сводке проблем (#454). За тем же обходом пришла сводка плана — копию вынес в `IScopeChildren` и переиспользовал в обеих. Ровно так же когда-то троился спуск по поддереву, из-за чего появился `IScopeSubtree`.

## Удаление типа

Внешнего ключа от плана к типу **нет намеренно**: каскад унёс бы строки плана вместе с типом, и процент поехал бы молча. Защита — в проверке занятости, куда добавлена причина «Входит в план комплектов» (issue называла это открытым вопросом; механизм `ComputeUsageAsync` уже был готов). К комплекту ключ есть — план без носителя не нужен никому.

## Резервная копия

Секция аддитивная, без bump схемы. Строка без своего типа при восстановлении не воскресает, а даёт предупреждение: план на несуществующий тип — позиция, которую нечем закрыть, то есть потолок ниже ста без видимой причины.

## Два сторожа сработали по дороге, оба по делу

- **политика отказов** потребовала доменное исключение вместо `ArgumentOutOfRangeException`: текст идёт в форму плана, а framework-тип превратился бы в «внутреннюю ошибку сервера»;
- **проверка полноты бэкапа** потребовала реальных данных в новой секции, а не только имени в карте покрытия.

## Проверка

12 тестов на арифметику + 9 интеграционных: замена целиком, факт только по `Generated`, документы сверх плана, чужие типы, консолидация раздела и стройки без двойного счёта, комплекты без плана, отказ удалить тип из плана, каскад от комплекта.

**Весь прогон: 1887 passed, 0 failed.** Версия — 0.149.0.

## Решения по открытым вопросам issue

1. Готовность — по статусу, в аудит схемы не заглядываем (не усложняем).
2. План — **справочный индикатор**, сборку комплекта не запрещает.
3. Клонирование плана из другого комплекта — отложено.
4. Наследование планов по уровням не делаем: план только на комплекте (решение из issue).