### PR TITLE
Долг линта, порция 8: горячая перезагрузка в настройках и шаблонах (#858)

### DIFF
--- a/src/client/e2e/README.md
+++ b/src/client/e2e/README.md
@@ -203,6 +203,38 @@ Playwright берётся из npx-кеша, браузер — из `ms-playwri
 `PLAYWRIGHT_PKG` (путь к `playwright/index.js`) и `CHROMIUM_EXE`
 (путь к `chrome-headless-shell.exe`).
 
+## Smoke редакторов типов и шаблонов (`types-smoke.mjs`, issue #858, порция 8)
+
+Порция вынесла из файлов-компонентов тринадцать функций и хуков (правило
+`react-refresh/only-export-components`). Типы стерегут перенос от опечатки, но не от
+импорта, уведённого к другому символу с подходящей сигнатурой: экран остаётся рабочим и
+показывает не то.
+
+- **field-summary-covers-three-kinds** — свёрнутые карточки полей показывают человеческую
+  сводку типа во всех трёх ветвях `fieldTypeSummary`: составной тип, тип из реестра,
+  базовый скаляр; технических имён (`complex`, `primitive`) наружу не выходит;
+- **field-type-picker-has-all-sections** — пикер типа поля собран `buildFieldTypeOptions`:
+  разделы «Базовые», «Типы полей (реестр)», «Перечисления», «Составные типы»;
+- **field-type-pick-updates-summary** — выбор пишется обратно `decodeFieldType`: сводка
+  поля становится выбранным типом;
+- **dirty-badge-reaches-page-header** — правка формы поднимается реестром редакторов до
+  шапки страницы («есть изменения»);
+- **leave-guard-asks-before-switching-type** — уход с несохранённым спрашивает; это стык
+  реестра и `useDirtyGuard`, которые теперь в разных модулях;
+- **typst-blocks-check-reports-result** — «Проверить блоки» возвращает результат
+  (`useTypstBlocksCheck`);
+- **enum-preview-in-list** — у перечисления длиннее трёх вариантов превью показывает хвост
+  `(+N−3)` — арифметика `humanEnumPreview`;
+- **template-versions-grouped-by-name** — версии сложены под одно имя и отсортированы по
+  убыванию: имя в списке не повторяется, а на строке группы стоит самая свежая версия;
+- **template-params-parsed-from-declaration** — счётчик у «Параметров шаблона» непустой,
+  то есть объявление разобрано (`parseTemplateParams`).
+
+Каждая проверка проверена поломкой того, что стережёт (девять поломок — девять красных
+прогонов). **Не покрыты**: `uniqueCode` (дублирование типа пишет данные — под smoke не
+берём) и `useMaxTemplateVersions` (порог версий виден только на шаблоне, где версий
+больше порога). Их перенос сверен чтением и типами.
+
 ## Запуск
 
 ```bash
@@ -214,6 +246,7 @@ MSYS_NO_PATHCONV=1 npm run test:e2e:dialogs
 MSYS_NO_PATHCONV=1 npm run test:e2e:shared-ui
 MSYS_NO_PATHCONV=1 npm run test:e2e:settings
 MSYS_NO_PATHCONV=1 npm run test:e2e:pages
+MSYS_NO_PATHCONV=1 npm run test:e2e:types
 ```
 
 Учётка по умолчанию — админ `admin@bhs.local` / `Demo12345!` (переопределяется

--- a/src/client/e2e/types-smoke.mjs
+++ b/src/client/e2e/types-smoke.mjs
@@ -1,0 +1,173 @@
+// Smoke по редакторам типов и шаблонам (issue #858, порция 8).
+//
+// Порция вынесла из файлов-компонентов тринадцать функций и хуков: сводку типа поля, сборку
+// списка выбираемых типов и его декодирование, реестр редакторов с диалогом-гардом, проверку
+// Typst-блоков, превью вариантов перечисления, группировку версий шаблона. Перенос механический,
+// и типы его стерегут; НЕ стережёт он одного — что импорт увёл к другому символу с подходящей
+// сигнатурой. Такая ошибка не падает: экран показывает не то, оставаясь работоспособным.
+//
+// Ничего не сохраняет: правки делаются и бросаются вместе с браузером (диалог-гард отвечает
+// «Не сохранять»).
+//
+// Требует поднятых фронта (:5173) и бэка (:5000). Учётка — админская (редакторы типов под
+// AdminRoute).
+//
+// Запуск (Git Bash):  MSYS_NO_PATHCONV=1 node e2e/types-smoke.mjs
+// Код возврата: 0 — все проверки прошли, 1 — есть провал.
+
+import { BASE, launchBrowser, login, createChecks } from './harness.mjs';
+
+const browser = await launchBrowser();
+const page = await browser.newPage({ viewport: { width: 1500, height: 1100 } });
+page.on('pageerror', e => console.log('  ! ошибка страницы:', e.message));
+const { check, summarize } = createChecks();
+
+await login(page);
+
+try {
+
+// ── Типы документов: сводка типа поля на свёрнутых карточках ──────────────────
+await page.goto(`${BASE}/document-types`);
+await page.waitForTimeout(3500);
+
+/**
+ * `fieldTypeSummary` разбирает три случая: составной тип (имя из реестра составных), тип поля или
+ * перечисление (имя из своего реестра) и базовый скаляр (подпись из TYPE_LABELS). Проверяем все три
+ * сразу — увёл бы импорт в другую функцию, пропала бы вся колонка типов или в ней осталась бы
+ * техническая строка вроде «complex».
+ */
+await check('field-summary-covers-three-kinds', async () => {
+  const t = await page.locator('body').innerText();
+  if (!/АОСР/.test(t)) throw new Error('тип АОСР не выбрался сам — проверять нечего');
+  for (const [kind, sample] of [
+    ['составной', 'Организация'],
+    ['из реестра типов полей', 'Цело число'],
+    ['базовый', 'Строка'],
+  ]) {
+    if (!t.includes(sample)) throw new Error(`нет сводки «${sample}» (${kind})`);
+  }
+  // Технические имена наружу не выходят: увидели бы их, если бы сводка перестала резолвить типы.
+  if (/\bcomplex\b|\bprimitive\b/.test(t)) throw new Error('в сводке техническое имя типа вместо человеческого');
+});
+
+// ── Пикер типа поля: список собирает buildFieldTypeOptions ────────────────────
+await check('field-type-picker-has-all-sections', async () => {
+  await page.locator('button').filter({ hasText: 'Дата начала работ' }).first().click();
+  await page.waitForTimeout(1000);
+  await page.locator('button').filter({ hasText: /^Дата$/ }).first().click();
+  await page.waitForTimeout(1500);
+  const t = await page.locator('[role=dialog]').last().innerText();
+  for (const section of ['БАЗОВЫЕ', 'ТИПЫ ПОЛЕЙ (РЕЕСТР)', 'ПЕРЕЧИСЛЕНИЯ', 'СОСТАВНЫЕ ТИПЫ']) {
+    if (!t.includes(section)) throw new Error(`в пикере нет раздела «${section}»`);
+  }
+});
+
+/**
+ * Выбор пишет обратно пару {type, typeId} — это `decodeFieldType`, разбор строки «вид::цель».
+ * Ошибись он видом, поле молча стало бы другим типом, а сводка показала бы что-то третье.
+ */
+await check('field-type-pick-updates-summary', async () => {
+  const picker = page.locator('[role=dialog]').last();
+  await picker.locator('button').filter({ hasText: /^Флаг/ }).first().click();
+  await page.waitForTimeout(1200);
+  const card = page.locator('button').filter({ hasText: 'ДатаНачалаРабот' }).first();
+  const t = await card.innerText();
+  if (!/Флаг/.test(t)) throw new Error(`сводка поля не стала «Флаг»: ${t.replace(/\s+/g, ' ').slice(0, 120)}`);
+});
+
+// ── Реестр редакторов: правка формы поднимается в шапку страницы ──────────────
+await check('dirty-badge-reaches-page-header', async () => {
+  const t = await page.locator('body').innerText();
+  if (!t.includes('есть изменения'))
+    throw new Error('шапка не узнала о правке — реестр редакторов до неё не донёс');
+});
+
+/**
+ * Уход с несохранённым обязан спросить. Это связка реестра (`anyDirty`) и `useDirtyGuard`, которые
+ * теперь живут в разных модулях: не сойдись они, переход прошёл бы молча и правка исчезла бы.
+ */
+await check('leave-guard-asks-before-switching-type', async () => {
+  await page.locator('button').filter({ hasText: /^Приложение АОСР/ }).first().click();
+  await page.waitForTimeout(1200);
+  const t = await page.locator('body').innerText();
+  if (!/Несохранённые изменения/.test(t)) throw new Error('переход прошёл без вопроса о несохранённом');
+  await page.locator('button').filter({ hasText: /^Не сохранять$/ }).first().click();
+  await page.waitForTimeout(2000);
+});
+
+// ── Проверка сборки Typst-блоков ──────────────────────────────────────────────
+await check('typst-blocks-check-reports-result', async () => {
+  await page.locator('button').filter({ hasText: 'Typst-блоки' }).first().click();
+  await page.waitForTimeout(1200);
+  await page.locator('button').filter({ hasText: 'Проверить блоки' }).first().click();
+  await page.waitForTimeout(4000);
+  const t = await page.locator('body').innerText();
+  if (!/Все Typst-блоки собираются|Проблемы сборки блоков/.test(t))
+    throw new Error('проверка блоков не вернула результата');
+});
+
+// ── Типы полей: превью вариантов перечисления в строке списка ─────────────────
+await check('enum-preview-in-list', async () => {
+  await page.goto(`${BASE}/field-types`);
+  await page.waitForTimeout(3000);
+  await page.locator('button').filter({ hasText: /^Перечисления$/ }).first().click();
+  await page.waitForTimeout(1500);
+  // Утверждение считает: у перечисления с N > 3 вариантами превью показывает три подписи и хвост
+  // «(+N−3)». Слабое «где-то на странице есть запятая» тут не годится — оно оставалось бы зелёным
+  // и при пустом превью (проверено: запятых на странице хватает и без него).
+  const rows = (await page.locator('button').allInnerTexts()).map(s => s.replace(/\s+/g, ' ').trim());
+  const long = rows.map(s => [s, /(\d+) вар\./.exec(s)])
+                   .filter(([, m]) => m && Number(m[1]) > 3);
+  if (!long.length) throw new Error('в реестре нет перечисления длиннее трёх вариантов — проверять нечего');
+  for (const [row, m] of long) {
+    const tail = `(+${Number(m[1]) - 3})`;
+    if (!row.includes(tail)) throw new Error(`у строки «${row.slice(0, 60)}» нет хвоста превью ${tail}`);
+  }
+});
+
+// ── Шаблоны: версии собраны в группы по имени ─────────────────────────────────
+await check('template-versions-grouped-by-name', async () => {
+  await page.goto(`${BASE}/templates`);
+  await page.waitForTimeout(3000);
+  await page.locator('button').filter({ hasText: /Тип документа|Выберите тип/ }).first().click();
+  await page.waitForTimeout(1200);
+  const picker = page.locator('[role=dialog]').last();
+  await picker.locator('button').filter({ hasText: /АОСР/ }).first().click();
+  await page.waitForTimeout(3000);
+  if (/Выберите тип документа/.test(await page.locator('body').innerText()))
+    throw new Error('тип не выбрался');
+  // Ищем по кнопкам списка: текст страницы целиком включает и редактор, где «v1» встречается в Typst.
+  const labels = (await page.locator('button').allInnerTexts()).map(s => s.replace(/\s+/g, ' ').trim());
+  const groups = labels.map(s => /^(.+?) v(\d+)$/.exec(s)).filter(Boolean);
+  const versions = labels.map(s => /^v(\d+)\b/.exec(s)).filter(Boolean).map(m => Number(m[1]));
+  if (!groups.length || versions.length < 2)
+    throw new Error(`нет группы с несколькими версиями — проверять нечего: ${labels.slice(-8).join(' | ')}`);
+  // 1. Группировка складывает версии под ОДНО имя: сломайся она — имя стало бы двумя строками.
+  const names = groups.map(m => m[1]);
+  const dup = names.find((n, i) => names.indexOf(n) !== i);
+  if (dup) throw new Error(`имя «${dup}» в списке дважды — версии не сложились в группу`);
+  // 2. Внутри группы версии отсортированы по убыванию, поэтому на строке стоит САМАЯ СВЕЖАЯ.
+  const shown = Number(groups[0][2]);
+  const newest = Math.max(...versions);
+  if (shown !== newest)
+    throw new Error(`на строке группы v${shown}, а самая свежая версия v${newest} — порядок внутри группы потерян`);
+});
+
+/**
+ * Счётчик у «Параметров шаблона» — это длина разобранного JSON-объявления (`parseTemplateParams`).
+ * Разбор защищён try/catch и на любой беде отдаёт пустой список: сломайся он — панель просто
+ * называлась бы «Параметры шаблона» без числа, и объявленные параметры пропали бы молча.
+ */
+await check('template-params-parsed-from-declaration', async () => {
+  const labels = (await page.locator('button').allInnerTexts()).map(s => s.replace(/\s+/g, ' ').trim());
+  const panel = labels.find(s => s.startsWith('Параметры шаблона'));
+  if (!panel) throw new Error('панели параметров шаблона на странице нет');
+  if (!/\(\d+\)$/.test(panel))
+    throw new Error(`у панели нет числа параметров — объявление не разобралось: «${panel}»`);
+});
+
+} finally {
+  await browser.close();
+}
+
+process.exit(summarize('Smoke редакторов типов и шаблонов'));

--- a/src/client/eslint-baseline.json
+++ b/src/client/eslint-baseline.json
@@ -1,3 +1,3 @@
 {
-  "react-refresh/only-export-components": 30
+  "react-refresh/only-export-components": 17
 }

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -18,7 +18,8 @@
     "test:e2e:dialogs": "node e2e/dialogs-smoke.mjs",
     "test:e2e:shared-ui": "node e2e/shared-ui-smoke.mjs",
     "test:e2e:settings": "node e2e/settings-smoke.mjs",
-    "test:e2e:pages": "node e2e/pages-smoke.mjs"
+    "test:e2e:pages": "node e2e/pages-smoke.mjs",
+    "test:e2e:types": "node e2e/types-smoke.mjs"
   },
   "//engines": "Нижнюю границу Node задаёт react-router 8 (>=22.22.0). Соблюдение обеспечивает engine-strict в .npmrc: ниже порога npm ci падает с EBADENGINE. Образ сборки — node:22-alpine, см. deploy/Dockerfile.web.",
   "engines": {

--- a/src/client/src/features/document-sets/editor/DocumentTemplateParams.tsx
+++ b/src/client/src/features/document-sets/editor/DocumentTemplateParams.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { useSetDocumentTemplateParams } from '@/shared/api/documentSets';
-import { parseTemplateParams } from '@/features/templates/TemplateParamsPanel';
+import { parseTemplateParams } from '@/features/templates/templateParams';
 import type { DocumentInstance, Template, TemplateParam } from '@/shared/api/types';
 
 /**

--- a/src/client/src/features/settings/DocumentTypesPage.tsx
+++ b/src/client/src/features/settings/DocumentTypesPage.tsx
@@ -48,21 +48,22 @@ import {
 import { danglingKeyRefs, danglingRefPlaces } from './schemaKeyChecks';
 import { typeHealth, healthBadgeLabel } from './typeHealth';
 import { TypstRendersEditor } from './TypstRendersEditor';
-import { useTypstBlocksCheck, TypstBlocksPanel, blocksCheckProblemsByFn } from './TypstBlocksCheck';
+import { TypstBlocksPanel } from './TypstBlocksCheck';
+import { useTypstBlocksCheck, blocksCheckProblemsByFn } from './useTypstBlocksCheck';
 import { schemaToJson, validateFields, TYPE_LABELS, nextAutoKey } from './schemaConstants';
 import { useTagRegistry, typeTags as typeTagDefs, FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { GroupedFieldsEditor } from './GroupedFieldsEditor';
-import { JsonPreview, FieldBuilder, DefaultValueCell, type FieldRegistries } from './FieldBuilder';
-import {
-  TypeEditorProvider, useRegisterEditor, useTypeEditorRegistry, LeaveGuardDialog, SectionCard,
-} from './typeEditorShell';
+import { JsonPreview, FieldBuilder, DefaultValueCell } from './FieldBuilder';
+import type { FieldRegistries } from './fieldTypeOptions';
+import { LeaveGuardDialog, SectionCard } from './typeEditorShell';
+import { TypeEditorProvider, useRegisterEditor, useTypeEditorRegistry } from './typeEditorRegistry';
 import { ListDetailShell, NavSearchInput, DetailHeader } from '@/shared/ui/ListDetailShell';
 import { useDirtyGuard } from '@/shared/ui/useDirtyGuard';
 import { useLeaveGuard } from '@/shared/ui/NavigationGuard';
 import { RowActionsMenu } from '@/shared/ui/RowActionsMenu';
 import { useRememberedSelection } from '@/shared/hooks/useRememberedSelection';
 import { useToast } from '@/shared/ui/Toast';
-import { uniqueCode } from './PrimitiveTypesPage';
+import { uniqueCode } from './uniqueCode';
 
 /** Единственное членство (issue #197 Фаза C): каждый ключ поля остаётся только в первой группе,
  *  где встречается. Легаси-схемы могли класть поле в несколько групп — нормализуем при загрузке. */

--- a/src/client/src/features/settings/EnumTypesSection.tsx
+++ b/src/client/src/features/settings/EnumTypesSection.tsx
@@ -13,14 +13,6 @@ import { nextAutoKey } from './schemaConstants';
 // PrimitiveTypesPage (EnumTypeDetail). Здесь остаются переиспользуемые куски: редактор вариантов
 // и форма создания (в модалке).
 
-/** Человекочитаемое превью вариантов перечисления для строки списка. */
-export function humanEnumPreview(values: EnumOptionDef[]): string {
-  if (values.length === 0) return 'нет вариантов';
-  const labels = values.map(v => v.label).filter(Boolean);
-  const head = labels.slice(0, 3).join(', ');
-  return labels.length > 3 ? `${head} … (+${labels.length - 3})` : head;
-}
-
 // ─── Values editor (список код|имя) ────────────────────────────────────────────
 
 export function ValuesEditor({ values, onChange }: { values: EnumOptionDef[]; onChange: (v: EnumOptionDef[]) => void }) {

--- a/src/client/src/features/settings/FieldBuilder.tsx
+++ b/src/client/src/features/settings/FieldBuilder.tsx
@@ -4,14 +4,14 @@ import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { DateInput } from '@/shared/ui/DateInput';
 import { Button } from '@/shared/ui/Button';
 import { ConfirmDialog } from '@/shared/ui/ConfirmDialog';
-import { TypePicker, type PickType } from '@/shared/ui/TypePicker';
+import { TypePicker } from '@/shared/ui/TypePicker';
 import type { DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
 import { FIELD_UID, withFieldUid, type SchemaField, type FieldGroup } from '@/shared/api/schema';
-import { TYPE_LABELS, toCamelKey, nextAutoKey, nextSavedKey } from './schemaConstants';
+import { toCamelKey, nextAutoKey, nextSavedKey } from './schemaConstants';
+import { buildFieldTypeOptions, decodeFieldType, fieldTypeSummary, type FieldRegistries } from './fieldTypeOptions';
 import { similarKeyOf } from './schemaKeyChecks';
 import {
   useTagRegistry, fieldTags, findTagEntry, hasTag, tagCode, withTagOrder,
-  type TagDefinition,
 } from '@/shared/api/tags';
 import { FunctionalTagBadge, FunctionalTagChip } from './FunctionalTagChip';
 import { evalComputed, validateComputed, findComputedCycles, referencedKeys } from '@/shared/utils/computedExpression';
@@ -46,64 +46,6 @@ export function JsonPreview({
 }
 
 // ─── Field card (single own field, collapsible) ────────────────────────────────
-
-/** Реестры типов/тэгов, общие для карточки поля — прокидываются и в плоский FieldBuilder,
- *  и в группированный GroupedFieldsEditor (issue #197 Фаза C). */
-export interface FieldRegistries {
-  compositeTypes: DocumentType[];
-  primitiveTypes: PrimitiveTypeDef[];
-  enumTypes: EnumTypeDef[];
-  allDocTypes: DocumentType[];
-  tagRegistry: TagDefinition[] | undefined;
-}
-
-/** Краткая метка типа поля для свёрнутой карточки. */
-export function fieldTypeSummary(f: SchemaField, reg: FieldRegistries): string {
-  if (f.type === 'complex' || f.type === 'array') {
-    const ct = reg.compositeTypes.find(c => c.id === f.typeId);
-    return ct ? ct.name : (f.type === 'array' ? 'Массив' : 'Составной');
-  }
-  if (f.type === 'enum') { const et = reg.enumTypes.find(e => e.id === f.typeId); return et ? et.name : 'Перечисление'; }
-  if (f.type === 'primitive') { const pt = reg.primitiveTypes.find(p => p.id === f.typeId); return pt ? pt.name : 'Тип поля'; }
-  return TYPE_LABELS[f.type] ?? f.type;
-}
-
-// ─── Пикер типа поля (issue #197, переиспользует общий TypePicker) ──────────────
-// Каждый выбираемый тип поля кодируется одним PickType с id вида "kind::targetId":
-// базовые скаляры, реестр типов полей/перечислений, составные (одиночно/список), ссылки на
-// документы (одиночно/список). onSelect декодирует id обратно в пару {type, typeId}.
-const BUILTIN_TYPES: { type: SchemaField['type']; label: string }[] = [
-  { type: 'string', label: 'Строка' },
-  { type: 'text', label: 'Текст' },
-  { type: 'number', label: 'Число' },
-  { type: 'date', label: 'Дата' },
-  { type: 'boolean', label: 'Флаг' },
-  { type: 'image', label: 'Изображение' },
-  { type: 'file', label: 'Файл (вложение)' },
-];
-
-/** Плоский список выбираемых типов поля для TypePicker (сгруппирован по section). */
-export function buildFieldTypeOptions(reg: FieldRegistries): PickType[] {
-  const opts: PickType[] = [];
-  for (const b of BUILTIN_TYPES) opts.push({ id: `builtin::${b.type}`, name: b.label, code: b.type, section: 'Базовые' });
-  for (const pt of reg.primitiveTypes) opts.push({ id: `primitive::${pt.id}`, name: pt.name, code: pt.code, section: 'Типы полей (реестр)' });
-  for (const et of reg.enumTypes) opts.push({ id: `enum::${et.id}`, name: `${et.name} · ${et.values.length}`, code: et.code, section: 'Перечисления' });
-  for (const ct of reg.compositeTypes) opts.push({ id: `complex::${ct.id}`, name: ct.name, code: ct.code, section: 'Составные типы' });
-  for (const ct of reg.compositeTypes) opts.push({ id: `array::${ct.id}`, name: `${ct.name} — список`, code: ct.code, section: 'Списки (массивы)' });
-  const docs = reg.allDocTypes.filter(dt => dt.kind === 'Document');
-  for (const dt of docs) opts.push({ id: `doc-ref::${dt.id}`, name: dt.name, code: dt.code, section: 'Ссылки на документы' });
-  for (const dt of docs) opts.push({ id: `doc-array::${dt.id}`, name: `${dt.name} — список`, code: dt.code, section: 'Списки документов' });
-  return opts;
-}
-
-/** Декодирует id из buildFieldTypeOptions обратно в патч {type, typeId}. */
-export function decodeFieldType(id: string): Pick<SchemaField, 'type' | 'typeId'> {
-  const sep = id.indexOf('::');
-  const kind = id.slice(0, sep);
-  const target = id.slice(sep + 2);
-  if (kind === 'builtin') return { type: target as SchemaField['type'], typeId: undefined };
-  return { type: kind as SchemaField['type'], typeId: target };
-}
 
 interface FieldCardProps {
   field: SchemaField;

--- a/src/client/src/features/settings/GroupedFieldsEditor.tsx
+++ b/src/client/src/features/settings/GroupedFieldsEditor.tsx
@@ -3,7 +3,8 @@ import { GripVertical, Layers, Trash2, Plus, Lock } from 'lucide-react';
 import { MoveButtons } from '@/shared/ui/MoveButtons';
 import { Button } from '@/shared/ui/Button';
 import { FIELD_UID, withFieldUid, type SchemaField, type FieldGroup } from '@/shared/api/schema';
-import { FieldCard, fieldTypeSummary, type FieldRegistries } from './FieldBuilder';
+import { FieldCard } from './FieldBuilder';
+import { fieldTypeSummary, type FieldRegistries } from './fieldTypeOptions';
 
 /**
  * Группированный редактор собственных полей (issue #197 Фаза C): группы = карточки-контейнеры,

--- a/src/client/src/features/settings/PrimitiveTypesPage.tsx
+++ b/src/client/src/features/settings/PrimitiveTypesPage.tsx
@@ -36,11 +36,12 @@ import type { FieldConstraints, PrimitiveTypeDef, EnumTypeDef, EnumOptionDef, Da
 import { formatDateRu } from '@/shared/utils/date';
 import { useTagRegistry, fieldTags } from '@/shared/api/tags';
 import { GroupPicker } from './TypeGroupAccordion';
-import { ValuesEditor, EnumForm, humanEnumPreview } from './EnumTypesSection';
+import { ValuesEditor, EnumForm } from './EnumTypesSection';
+import { humanEnumPreview } from './enumPreview';
+import { uniqueCode } from './uniqueCode';
 import { withRowUids } from '@/shared/utils/rowIdentity';
-import {
-  TypeEditorProvider, useRegisterEditor, useTypeEditorRegistry, LeaveGuardDialog,
-} from './typeEditorShell';
+import { LeaveGuardDialog } from './typeEditorShell';
+import { TypeEditorProvider, useRegisterEditor, useTypeEditorRegistry } from './typeEditorRegistry';
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
 
@@ -83,13 +84,6 @@ function usageBlockedNode(usedByNames: string[]): React.ReactNode | undefined {
       </ul>
     </div>
   );
-}
-
-/** Уникальный код на базе исходного: base2, base3 … (для дублирования типа, issue #210 Этап 2). */
-export function uniqueCode(base: string, existing: Set<string>): string {
-  if (!existing.has(base)) return base;
-  let i = 2; while (existing.has(`${base}${i}`)) i++;
-  return `${base}${i}`;
 }
 
 /** Человекочитаемое превью ограничений для строки списка. Regex не «переводим» (нельзя надёжно) —

--- a/src/client/src/features/settings/SettingsPage.tsx
+++ b/src/client/src/features/settings/SettingsPage.tsx
@@ -14,24 +14,7 @@ import { OrphanBlobsSection } from './OrphanBlobsSection';
 import { MaterialLabelSection } from './MaterialLabelSection';
 import { BackupSection } from './BackupSection';
 import { GithubSettingsSection } from './GithubSettingsSection';
-
-// ─── Settings hook (re-exported for use by other pages) ───────────────────────
-
-export const MAX_VERSIONS_KEY = 'crg.maxTemplateVersions';
-export const DEFAULT_MAX_VERSIONS = 5;
-
-export function useMaxTemplateVersions(): [number, (v: number) => void] {
-  const [value, setValue] = useState(() => {
-    const stored = localStorage.getItem(MAX_VERSIONS_KEY);
-    const parsed = stored ? Number(stored) : NaN;
-    return Number.isFinite(parsed) && parsed >= 2 ? parsed : DEFAULT_MAX_VERSIONS;
-  });
-  function set(v: number) {
-    localStorage.setItem(MAX_VERSIONS_KEY, String(v));
-    setValue(v);
-  }
-  return [value, set];
-}
+import { useMaxTemplateVersions } from './useMaxTemplateVersions';
 
 // ─── Locale settings section ───────────────────────────────────────────────────
 

--- a/src/client/src/features/settings/TypstBlocksCheck.tsx
+++ b/src/client/src/features/settings/TypstBlocksCheck.tsx
@@ -1,13 +1,10 @@
-import { useState } from 'react';
 import { CheckCircle2, AlertCircle, AlertTriangle, ArrowRight } from 'lucide-react';
-import { useToast } from '@/shared/ui/Toast';
-import { useValidateTypstBlocks, type TypstBlockProblem } from '@/shared/api/documentTypes';
-import type { TypstRender } from '@/shared/api/schema';
+import type { TypstBlockProblem } from '@/shared/api/documentTypes';
 
 /**
- * Проверка сборки Typst-блоков (issue #309, фаза 2). Глобальна и межтипова: результат живёт в двух
- * зонах — блоки ТЕКУЩЕГО типа показываем инлайн-панелью здесь, а проблему в ДРУГОМ типе (цикл/чужая
- * ссылка) — тостом-указателем «Перейти» (инвариант тостов: тост для off-screen результата).
+ * Инлайн-панель проблем сборки Typst-блоков ТЕКУЩЕГО типа (issue #309, фаза 2). Проверку запускает
+ * `useTypstBlocksCheck` — он же показывает тост-указатель на проблему в ДРУГОМ типе; здесь только
+ * отображение.
  */
 const CODE_LABEL: Record<string, string> = {
   cycle: 'взаимные ссылки',
@@ -18,40 +15,6 @@ const CODE_LABEL: Record<string, string> = {
   syntax: 'синтаксис',
   'checker-unavailable': 'проверка недоступна',
 };
-
-export function useTypstBlocksCheck(typeId: string, onSelectType: (id: string) => void) {
-  const validate = useValidateTypstBlocks();
-  const toast = useToast();
-  const [problems, setProblems] = useState<TypstBlockProblem[] | null>(null);
-
-  async function run(renders: TypstRender[]) {
-    try {
-      const res = await validate.mutateAsync({ typeId, renders });
-      setProblems(res);
-      // Off-screen проблема (в другом типе) → тост-указатель с навигацией.
-      const other = res.find(p => p.severity === 'error' && p.typeId && p.typeId !== typeId);
-      if (other?.typeId) {
-        toast.error(`Блок «${other.fnName ?? '—'}» в типе «${other.typeName ?? '—'}» больше не собирается`, {
-          action: { label: 'Перейти', onClick: () => onSelectType(other.typeId!) },
-        });
-      }
-    } catch (e) {
-      toast.apiError(e, 'Не удалось проверить блоки');
-    }
-  }
-
-  return { problems, checking: validate.isPending, run, reset: () => setProblems(null) };
-}
-
-/** Карта fnName → худшая severity для блоков ТЕКУЩЕГО типа — для бейджей на карточках. */
-export function blocksCheckProblemsByFn(problems: TypstBlockProblem[] | null, typeId: string): Record<string, 'error' | 'warning'> {
-  const m: Record<string, 'error' | 'warning'> = {};
-  for (const p of problems ?? []) {
-    if (!p.fnName || (p.typeId && p.typeId !== typeId)) continue;
-    if (p.severity === 'error' || m[p.fnName] !== 'error') m[p.fnName] = p.severity;
-  }
-  return m;
-}
 
 export function TypstBlocksPanel({ problems, currentTypeId, onSelectType }: {
   problems: TypstBlockProblem[];

--- a/src/client/src/features/settings/enumPreview.ts
+++ b/src/client/src/features/settings/enumPreview.ts
@@ -1,0 +1,12 @@
+import type { EnumOptionDef } from '@/shared/api/types';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+/** Человекочитаемое превью вариантов перечисления для строки списка. */
+export function humanEnumPreview(values: EnumOptionDef[]): string {
+  if (values.length === 0) return 'нет вариантов';
+  const labels = values.map(v => v.label).filter(Boolean);
+  const head = labels.slice(0, 3).join(', ');
+  return labels.length > 3 ? `${head} … (+${labels.length - 3})` : head;
+}

--- a/src/client/src/features/settings/fieldTypeOptions.ts
+++ b/src/client/src/features/settings/fieldTypeOptions.ts
@@ -1,0 +1,66 @@
+import type { DocumentType, PrimitiveTypeDef, EnumTypeDef } from '@/shared/api/types';
+import type { SchemaField } from '@/shared/api/schema';
+import type { PickType } from '@/shared/ui/TypePicker';
+import type { TagDefinition } from '@/shared/api/tags';
+import { TYPE_LABELS } from './schemaConstants';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+/** Реестры типов/тэгов, общие для карточки поля — прокидываются и в плоский FieldBuilder,
+ *  и в группированный GroupedFieldsEditor (issue #197 Фаза C). */
+export interface FieldRegistries {
+  compositeTypes: DocumentType[];
+  primitiveTypes: PrimitiveTypeDef[];
+  enumTypes: EnumTypeDef[];
+  allDocTypes: DocumentType[];
+  tagRegistry: TagDefinition[] | undefined;
+}
+
+/** Краткая метка типа поля для свёрнутой карточки. */
+export function fieldTypeSummary(f: SchemaField, reg: FieldRegistries): string {
+  if (f.type === 'complex' || f.type === 'array') {
+    const ct = reg.compositeTypes.find(c => c.id === f.typeId);
+    return ct ? ct.name : (f.type === 'array' ? 'Массив' : 'Составной');
+  }
+  if (f.type === 'enum') { const et = reg.enumTypes.find(e => e.id === f.typeId); return et ? et.name : 'Перечисление'; }
+  if (f.type === 'primitive') { const pt = reg.primitiveTypes.find(p => p.id === f.typeId); return pt ? pt.name : 'Тип поля'; }
+  return TYPE_LABELS[f.type] ?? f.type;
+}
+
+// ─── Пикер типа поля (issue #197, переиспользует общий TypePicker) ──────────────
+// Каждый выбираемый тип поля кодируется одним PickType с id вида "kind::targetId":
+// базовые скаляры, реестр типов полей/перечислений, составные (одиночно/список), ссылки на
+// документы (одиночно/список). onSelect декодирует id обратно в пару {type, typeId}.
+const BUILTIN_TYPES: { type: SchemaField['type']; label: string }[] = [
+  { type: 'string', label: 'Строка' },
+  { type: 'text', label: 'Текст' },
+  { type: 'number', label: 'Число' },
+  { type: 'date', label: 'Дата' },
+  { type: 'boolean', label: 'Флаг' },
+  { type: 'image', label: 'Изображение' },
+  { type: 'file', label: 'Файл (вложение)' },
+];
+
+/** Плоский список выбираемых типов поля для TypePicker (сгруппирован по section). */
+export function buildFieldTypeOptions(reg: FieldRegistries): PickType[] {
+  const opts: PickType[] = [];
+  for (const b of BUILTIN_TYPES) opts.push({ id: `builtin::${b.type}`, name: b.label, code: b.type, section: 'Базовые' });
+  for (const pt of reg.primitiveTypes) opts.push({ id: `primitive::${pt.id}`, name: pt.name, code: pt.code, section: 'Типы полей (реестр)' });
+  for (const et of reg.enumTypes) opts.push({ id: `enum::${et.id}`, name: `${et.name} · ${et.values.length}`, code: et.code, section: 'Перечисления' });
+  for (const ct of reg.compositeTypes) opts.push({ id: `complex::${ct.id}`, name: ct.name, code: ct.code, section: 'Составные типы' });
+  for (const ct of reg.compositeTypes) opts.push({ id: `array::${ct.id}`, name: `${ct.name} — список`, code: ct.code, section: 'Списки (массивы)' });
+  const docs = reg.allDocTypes.filter(dt => dt.kind === 'Document');
+  for (const dt of docs) opts.push({ id: `doc-ref::${dt.id}`, name: dt.name, code: dt.code, section: 'Ссылки на документы' });
+  for (const dt of docs) opts.push({ id: `doc-array::${dt.id}`, name: `${dt.name} — список`, code: dt.code, section: 'Списки документов' });
+  return opts;
+}
+
+/** Декодирует id из buildFieldTypeOptions обратно в патч {type, typeId}. */
+export function decodeFieldType(id: string): Pick<SchemaField, 'type' | 'typeId'> {
+  const sep = id.indexOf('::');
+  const kind = id.slice(0, sep);
+  const target = id.slice(sep + 2);
+  if (kind === 'builtin') return { type: target as SchemaField['type'], typeId: undefined };
+  return { type: kind as SchemaField['type'], typeId: target };
+}

--- a/src/client/src/features/settings/typeEditorRegistry.ts
+++ b/src/client/src/features/settings/typeEditorRegistry.ts
@@ -1,0 +1,70 @@
+import { createContext, useContext, useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+// ─── Реестр редакторов (явное сохранение, issue #197 / #210) ─────────────────────
+// Общий для страниц-редакторов типа list-detail (Типы документов, Типы полей). Дочерние формы
+// публикуют своё состояние dirty и функцию сохранения; страница агрегирует их в одну кнопку
+// «Сохранить» в шапке, бейдж «есть изменения» и диалог-гард при уходе. Сохранение может бросить —
+// тогда переход не выполняется. Полноценный ListDetailShell извлечём позже (после 3-й страницы).
+export interface TypeEditorRegistry {
+  publish: (key: string, dirty: boolean, save: () => Promise<void>, reset?: () => void) => void;
+  unpublish: (key: string) => void;
+}
+const TypeEditorContext = createContext<TypeEditorRegistry | null>(null);
+export const TypeEditorProvider = TypeEditorContext.Provider;
+
+/** Публикует dirty/save/reset текущей формы в реестр страницы (save/reset всегда берутся свежими через
+ *  ref). `reset` откатывает локальное состояние формы к сохранённому — для кнопки «Отмена» (issue #210). */
+export function useRegisterEditor(key: string, dirty: boolean, save: () => Promise<void>, reset?: () => void) {
+  const ctx = useContext(TypeEditorContext);
+  const saveRef = useRef(save);
+  const resetRef = useRef(reset);
+  /**
+   * Свежий колбэк для отложенного вызова. Обновляется ЭФФЕКТОМ, а не присваиванием в рендере
+   * (issue #858): рендер обязан быть чистым, а запись в ref — побочное действие, которое к тому же
+   * случалось бы и на брошенном рендере (StrictMode, прерванный конкурентный проход).
+   *
+   * Эффект именно СЛОЙНЫЙ (useLayoutEffect). Обычный отложен до после отрисовки, и между коммитом и
+   * его срабатыванием ref держит ПРЕДЫДУЩИЙ колбэк — с прежним состоянием формы. Нажатие
+   * «Сохранить» в шапке, попавшее в эту щель, отправило бы прежние значения. Слойный эффект
+   * выполняется в том же задании, что и коммит: события в промежуток не попадают, щели нет.
+   */
+  useLayoutEffect(() => {
+    saveRef.current = save;
+    resetRef.current = reset;
+  });
+  useEffect(() => {
+    ctx?.publish(key, dirty, () => saveRef.current(), () => resetRef.current?.());
+  }, [ctx, key, dirty]);
+  useEffect(() => () => ctx?.unpublish(key), [ctx, key]);
+}
+
+/** Агрегатор реестра для корня list-detail страницы: dirty-состояние + saveAll + resetAll + provider value. */
+export function useTypeEditorRegistry() {
+  const [dirtyMap, setDirtyMap] = useState<Record<string, boolean>>({});
+  const saversRef = useRef<Record<string, () => Promise<void>>>({});
+  const resettersRef = useRef<Record<string, () => void>>({});
+  const registry = useMemo<TypeEditorRegistry>(() => ({
+    publish: (key, dirty, save, reset) => {
+      saversRef.current[key] = save;
+      if (reset) resettersRef.current[key] = reset;
+      setDirtyMap(m => m[key] === dirty ? m : { ...m, [key]: dirty });
+    },
+    unpublish: (key) => {
+      delete saversRef.current[key];
+      delete resettersRef.current[key];
+      setDirtyMap(m => (key in m ? (() => { const n = { ...m }; delete n[key]; return n; })() : m));
+    },
+  }), []);
+  const anyDirty = Object.values(dirtyMap).some(Boolean);
+  const [saving, setSaving] = useState(false);
+  const saveAll = async () => {
+    setSaving(true);
+    try { for (const s of Object.values(saversRef.current)) await s(); }
+    finally { setSaving(false); }
+  };
+  const resetAll = () => { for (const r of Object.values(resettersRef.current)) r(); };
+  return { registry, anyDirty, saving, saveAll, resetAll };
+}

--- a/src/client/src/features/settings/typeEditorShell.tsx
+++ b/src/client/src/features/settings/typeEditorShell.tsx
@@ -1,73 +1,11 @@
-import { createContext, useContext, useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal } from '@/shared/ui/Modal';
 import { Button } from '@/shared/ui/Button';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
-// ─── Реестр редакторов (явное сохранение, issue #197 / #210) ─────────────────────
-// Общий для страниц-редакторов типа list-detail (Типы документов, Типы полей). Дочерние формы
-// публикуют своё состояние dirty и функцию сохранения; страница агрегирует их в одну кнопку
-// «Сохранить» в шапке, бейдж «есть изменения» и диалог-гард при уходе. Сохранение может бросить —
-// тогда переход не выполняется. Полноценный ListDetailShell извлечём позже (после 3-й страницы).
-export interface TypeEditorRegistry {
-  publish: (key: string, dirty: boolean, save: () => Promise<void>, reset?: () => void) => void;
-  unpublish: (key: string) => void;
-}
-const TypeEditorContext = createContext<TypeEditorRegistry | null>(null);
-export const TypeEditorProvider = TypeEditorContext.Provider;
-
-/** Публикует dirty/save/reset текущей формы в реестр страницы (save/reset всегда берутся свежими через
- *  ref). `reset` откатывает локальное состояние формы к сохранённому — для кнопки «Отмена» (issue #210). */
-export function useRegisterEditor(key: string, dirty: boolean, save: () => Promise<void>, reset?: () => void) {
-  const ctx = useContext(TypeEditorContext);
-  const saveRef = useRef(save);
-  const resetRef = useRef(reset);
-  /**
-   * Свежий колбэк для отложенного вызова. Обновляется ЭФФЕКТОМ, а не присваиванием в рендере
-   * (issue #858): рендер обязан быть чистым, а запись в ref — побочное действие, которое к тому же
-   * случалось бы и на брошенном рендере (StrictMode, прерванный конкурентный проход).
-   *
-   * Эффект именно СЛОЙНЫЙ (useLayoutEffect). Обычный отложен до после отрисовки, и между коммитом и
-   * его срабатыванием ref держит ПРЕДЫДУЩИЙ колбэк — с прежним состоянием формы. Нажатие
-   * «Сохранить» в шапке, попавшее в эту щель, отправило бы прежние значения. Слойный эффект
-   * выполняется в том же задании, что и коммит: события в промежуток не попадают, щели нет.
-   */
-  useLayoutEffect(() => {
-    saveRef.current = save;
-    resetRef.current = reset;
-  });
-  useEffect(() => {
-    ctx?.publish(key, dirty, () => saveRef.current(), () => resetRef.current?.());
-  }, [ctx, key, dirty]);
-  useEffect(() => () => ctx?.unpublish(key), [ctx, key]);
-}
-
-/** Агрегатор реестра для корня list-detail страницы: dirty-состояние + saveAll + resetAll + provider value. */
-export function useTypeEditorRegistry() {
-  const [dirtyMap, setDirtyMap] = useState<Record<string, boolean>>({});
-  const saversRef = useRef<Record<string, () => Promise<void>>>({});
-  const resettersRef = useRef<Record<string, () => void>>({});
-  const registry = useMemo<TypeEditorRegistry>(() => ({
-    publish: (key, dirty, save, reset) => {
-      saversRef.current[key] = save;
-      if (reset) resettersRef.current[key] = reset;
-      setDirtyMap(m => m[key] === dirty ? m : { ...m, [key]: dirty });
-    },
-    unpublish: (key) => {
-      delete saversRef.current[key];
-      delete resettersRef.current[key];
-      setDirtyMap(m => (key in m ? (() => { const n = { ...m }; delete n[key]; return n; })() : m));
-    },
-  }), []);
-  const anyDirty = Object.values(dirtyMap).some(Boolean);
-  const [saving, setSaving] = useState(false);
-  const saveAll = async () => {
-    setSaving(true);
-    try { for (const s of Object.values(saversRef.current)) await s(); }
-    finally { setSaving(false); }
-  };
-  const resetAll = () => { for (const r of Object.values(resettersRef.current)) r(); };
-  return { registry, anyDirty, saving, saveAll, resetAll };
-}
+// Оформительские куски страниц-редакторов типа list-detail (issue #197 / #210): диалог-гард
+// при уходе с несохранёнными правками и свёрнутая карточка-секция. Сам реестр редакторов —
+// в `typeEditorRegistry.ts` (issue #858: компонент и хуки в одном модуле лишают файл горячей
+// подмены).
 
 /** MD3-диалог-гард при уходе с выбранного элемента с несохранёнными правками. */
 export function LeaveGuardDialog({ open, saving, onSave, onDiscard, onCancel }: {

--- a/src/client/src/features/settings/uniqueCode.ts
+++ b/src/client/src/features/settings/uniqueCode.ts
@@ -1,0 +1,9 @@
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+/** Уникальный код на базе исходного: base2, base3 … (для дублирования типа, issue #210 Этап 2). */
+export function uniqueCode(base: string, existing: Set<string>): string {
+  if (!existing.has(base)) return base;
+  let i = 2; while (existing.has(`${base}${i}`)) i++;
+  return `${base}${i}`;
+}

--- a/src/client/src/features/settings/useMaxTemplateVersions.ts
+++ b/src/client/src/features/settings/useMaxTemplateVersions.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+export const MAX_VERSIONS_KEY = 'crg.maxTemplateVersions';
+export const DEFAULT_MAX_VERSIONS = 5;
+
+export function useMaxTemplateVersions(): [number, (v: number) => void] {
+  const [value, setValue] = useState(() => {
+    const stored = localStorage.getItem(MAX_VERSIONS_KEY);
+    const parsed = stored ? Number(stored) : NaN;
+    return Number.isFinite(parsed) && parsed >= 2 ? parsed : DEFAULT_MAX_VERSIONS;
+  });
+  function set(v: number) {
+    localStorage.setItem(MAX_VERSIONS_KEY, String(v));
+    setValue(v);
+  }
+  return [value, set];
+}

--- a/src/client/src/features/settings/useTypstBlocksCheck.ts
+++ b/src/client/src/features/settings/useTypstBlocksCheck.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useToast } from '@/shared/ui/Toast';
+import { useValidateTypstBlocks, type TypstBlockProblem } from '@/shared/api/documentTypes';
+import type { TypstRender } from '@/shared/api/schema';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+/**
+ * Проверка сборки Typst-блоков (issue #309, фаза 2). Глобальна и межтипова: результат живёт в двух
+ * зонах — блоки ТЕКУЩЕГО типа показываем инлайн-панелью здесь, а проблему в ДРУГОМ типе (цикл/чужая
+ * ссылка) — тостом-указателем «Перейти» (инвариант тостов: тост для off-screen результата).
+ */
+export function useTypstBlocksCheck(typeId: string, onSelectType: (id: string) => void) {
+  const validate = useValidateTypstBlocks();
+  const toast = useToast();
+  const [problems, setProblems] = useState<TypstBlockProblem[] | null>(null);
+
+  async function run(renders: TypstRender[]) {
+    try {
+      const res = await validate.mutateAsync({ typeId, renders });
+      setProblems(res);
+      // Off-screen проблема (в другом типе) → тост-указатель с навигацией.
+      const other = res.find(p => p.severity === 'error' && p.typeId && p.typeId !== typeId);
+      if (other?.typeId) {
+        toast.error(`Блок «${other.fnName ?? '—'}» в типе «${other.typeName ?? '—'}» больше не собирается`, {
+          action: { label: 'Перейти', onClick: () => onSelectType(other.typeId!) },
+        });
+      }
+    } catch (e) {
+      toast.apiError(e, 'Не удалось проверить блоки');
+    }
+  }
+
+  return { problems, checking: validate.isPending, run, reset: () => setProblems(null) };
+}
+
+/** Карта fnName → худшая severity для блоков ТЕКУЩЕГО типа — для бейджей на карточках. */
+export function blocksCheckProblemsByFn(problems: TypstBlockProblem[] | null, typeId: string): Record<string, 'error' | 'warning'> {
+  const m: Record<string, 'error' | 'warning'> = {};
+  for (const p of problems ?? []) {
+    if (!p.fnName || (p.typeId && p.typeId !== typeId)) continue;
+    if (p.severity === 'error' || m[p.fnName] !== 'error') m[p.fnName] = p.severity;
+  }
+  return m;
+}

--- a/src/client/src/features/templates/TemplateParamsPanel.tsx
+++ b/src/client/src/features/templates/TemplateParamsPanel.tsx
@@ -5,17 +5,13 @@ import { useUpdateTemplateParameters } from '@/shared/api/templates';
 import { moveItem } from '@/shared/utils/moveItem';
 import type { Template, TemplateParam } from '@/shared/api/types';
 import { newLocalId } from '@/shared/utils/localId';
+import { parseTemplateParams } from './templateParams';
 
 /** Строка редактора: параметр плюс устойчивый идентификатор — он нужен ключом списка при перестановке. */
 type Row = { id: string; p: TemplateParam };
 
 /** Свой тип перетаскиваемых данных: текстовый сделал бы ручку источником текста для всей страницы. */
 const DRAG_MIME = 'application/x-crg-template-param';
-
-export function parseTemplateParams(json: string | null): TemplateParam[] {
-  if (!json) return [];
-  try { const a = JSON.parse(json); return Array.isArray(a) ? (a as TemplateParam[]) : []; } catch { return []; }
-}
 
 /**
  * Объявление параметров шаблона (имя/подпись/тип/значение по умолчанию) — чтобы одним шаблоном

--- a/src/client/src/features/templates/TemplateSidebar.tsx
+++ b/src/client/src/features/templates/TemplateSidebar.tsx
@@ -9,28 +9,10 @@ import type { Template, DocumentType } from '@/shared/api/types';
 import { useDeleteTemplate, type TemplateUsage } from '@/shared/api/templates';
 import { ruCount } from '@/shared/utils/pluralize';
 import { TemplateAssetsPanel } from './TemplateAssetsPanel';
+import type { TemplateGroup } from './groupTemplates';
 
 /** Карта использования версий (templateId → usage); пустой объект, пока не загружено. */
 export type TemplateUsageMap = Record<string, TemplateUsage>;
-// ─── Template grouping ────────────────────────────────────────────────────────
-
-export interface TemplateGroup {
-  name: string;
-  versions: Template[];
-}
-
-export function groupTemplates(templates: Template[]): TemplateGroup[] {
-  const map = new Map<string, Template[]>();
-  for (const t of templates) {
-    const arr = map.get(t.name) ?? [];
-    arr.push(t);
-    map.set(t.name, arr);
-  }
-  return [...map.entries()].map(([name, versions]) => ({
-    name,
-    versions: [...versions].sort((a, b) => b.version - a.version),
-  }));
-}
 
 // ─── Version cleanup modal ────────────────────────────────────────────────────
 

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -11,13 +11,14 @@ import { ruCount } from '@/shared/utils/pluralize';
 import { useListDocumentTypes } from '@/shared/api/documentTypes';
 import { useListTemplates, useCreateTemplate, useDeleteTemplate, useDuplicateTemplate, useTemplatesUsage } from '@/shared/api/templates';
 import type { Template, DocumentType } from '@/shared/api/types';
-import { useMaxTemplateVersions } from '@/features/settings/SettingsPage';
+import { useMaxTemplateVersions } from '@/features/settings/useMaxTemplateVersions';
 import { buildBlankTypst } from './templateBlank';
 import { EditorPanel } from './EditorPanel';
 import { UserLibPanel } from './UserLibPanel';
 import { SystemLibPanel } from './SystemLibPanel';
 import { TypeBlocksPanel } from './TypeBlocksPanel';
-import { TemplateSidebar, DocTypeSelector, VersionCleanupModal, groupTemplates, type TemplateGroup } from './TemplateSidebar';
+import { TemplateSidebar, DocTypeSelector, VersionCleanupModal } from './TemplateSidebar';
+import { groupTemplates, type TemplateGroup } from './groupTemplates';
 // ─── New template form ────────────────────────────────────────────────────────
 
 interface NewTemplateFormProps {

--- a/src/client/src/features/templates/groupTemplates.ts
+++ b/src/client/src/features/templates/groupTemplates.ts
@@ -1,0 +1,22 @@
+import type { Template } from '@/shared/api/types';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+export interface TemplateGroup {
+  name: string;
+  versions: Template[];
+}
+
+export function groupTemplates(templates: Template[]): TemplateGroup[] {
+  const map = new Map<string, Template[]>();
+  for (const t of templates) {
+    const arr = map.get(t.name) ?? [];
+    arr.push(t);
+    map.set(t.name, arr);
+  }
+  return [...map.entries()].map(([name, versions]) => ({
+    name,
+    versions: [...versions].sort((a, b) => b.version - a.version),
+  }));
+}

--- a/src/client/src/features/templates/templateParams.ts
+++ b/src/client/src/features/templates/templateParams.ts
@@ -1,0 +1,9 @@
+import type { TemplateParam } from '@/shared/api/types';
+
+// Отдельным файлом от компонента (issue #858): модуль, экспортирующий и компонент, и
+// функцию, не может быть границей горячей подмены — правка поднимается вверх по импортам.
+
+export function parseTemplateParams(json: string | null): TemplateParam[] {
+  if (!json) return [];
+  try { const a = JSON.parse(json); return Array.isArray(a) ? (a as TemplateParam[]) : []; } catch { return []; }
+}

--- a/src/client/src/shared/ui/ListDetailShell.tsx
+++ b/src/client/src/shared/ui/ListDetailShell.tsx
@@ -7,7 +7,7 @@ import { SearchInput } from './SearchInput';
  * Тонкий layout-примитив «list-detail со вторичной навигацией» (issue #210, разбор с Архитектором+
  * Дизайнером). Владеет ТОЛЬКО рамками (шапка страницы, колонка навигации фикс. ширины 320px, область
  * detail) и Save-кластером в шапке detail. Модель навигации (табы/группы/список) и содержимое detail —
- * per-page слоты; реестр агрегации dirty — отдельный модуль (features/settings/typeEditorShell).
+ * per-page слоты; реестр агрегации dirty — отдельный модуль (features/settings/typeEditorRegistry).
  * НЕ клиент этого shell: редактор документа (#192) — там навигация ВНУТРИ сущности + preview-панель.
  */
 export function ListDetailShell({ title, subtitle, titleIcon, titleBadge, breadcrumb, headerAction, overlay, nav, navWidth = 'w-80', detail }: {

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.152.6</Version>
+    <Version>0.152.7</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Тринадцать вхождений `react-refresh/only-export-components` — восемь файлов редакторов типов и шаблонов. Храповик **30 → 17**.

## Что уехало

| Файл | Уехало | Осталось |
|---|---|---|
| `FieldBuilder` | реестры + `fieldTypeSummary`/`buildFieldTypeOptions`/`decodeFieldType` → `fieldTypeOptions.ts` | компоненты |
| `typeEditorShell` | реестр редакторов → `typeEditorRegistry.ts` | диалог-гард, карточка-секция |
| `TypstBlocksCheck` | `useTypstBlocksCheck` + карта проблем → свой файл | панель |
| `EnumTypesSection` | `humanEnumPreview` → `enumPreview.ts` | редактор вариантов |
| `PrimitiveTypesPage` | `uniqueCode` → свой файл | страница |
| `SettingsPage` | `useMaxTemplateVersions` → свой файл | страница |
| `TemplateParamsPanel` | `parseTemplateParams` → `templateParams.ts` | панель |
| `TemplateSidebar` | `groupTemplates` + тип группы → свой файл | сайдбар |

Комментарий про тост-указатель уехал вместе с хуком, который его показывает: в файле панели он описывал бы чужой код.

## Живой прогон `types-smoke.mjs` (9 проверок)

Он нужен именно здесь. Типы стерегут перенос от опечатки, но **не** от импорта, уведённого к другому символу с подходящей сигнатурой: экран остаётся рабочим и показывает не то.

Проверки: сводка типа поля во всех трёх ветвях, разделы пикера типа, запись выбора обратно, подъём «есть изменения» в шапку, вопрос при уходе с несохранённым, результат проверки Typst-блоков, хвост `(+N−3)` в превью перечисления, группировка версий (имя не повторяется + на строке самая свежая), счётчик разобранных параметров шаблона.

**Каждая проверена поломкой того, что стережёт** — девять поломок, девять красных прогонов, каждый раз краснела нужная:

```
--- декодер типа поля путает вид
   ✗ field-type-pick-updates-summary — сводка поля не стала «Флаг»: … Строка
--- превью перечисления без хвоста
   ✗ enum-preview-in-list — у строки «Стадия проекта … 4 вар.» нет хвоста превью (+1)
--- версии внутри группы не отсортированы
   ✗ template-versions-grouped-by-name — на строке группы v40, а самая свежая v41
```

**Не покрыты двое** (сказано и в `e2e/README.md`): `uniqueCode` — дублирование типа пишет данные, под smoke не берём; `useMaxTemplateVersions` — порог виден только там, где версий больше порога. Их перенос сверен чтением и типами.

## Проверено

`tsc -b`, сборка, 583 юнит-теста, храповик 30 → 17 и все восемь живых прогонов: types 9, fields 15, dialogs 13, settings 8, pages 8, shared-ui 6, keyboard 11, routing 11.

Версия **0.152.7** (PATCH). Осталось: 17 вхождений в наборах данных, комплектах и документах качества — последняя порция.