### PR TITLE
Линт начисто: мемо, которое не мемоизировало, и названные причины (#870)

### DIFF
--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -12,7 +12,7 @@ import { VariantPicker } from '@/features/document-sets/fields/ComplexFields';
 import { UnionDiscriminatorEditor } from './UnionDiscriminatorEditor';
 import { discriminatorProblem } from './unionDiscriminator';
 import { buildPreviewModel, getPath, type LeafCol } from './materializePreviewModel';
-import { resolveEffectiveFields } from '@/shared/api/schema';
+import { resolveEffectiveFields, type SchemaField } from '@/shared/api/schema';
 import { parseSourceColumnNames } from '@/shared/api/datasetHelpers';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
@@ -23,6 +23,8 @@ import type { DataSetSource, MaterializeDiscriminator } from '@/shared/api/types
  * маппинг колонок → поля типа ОДИН РАЗ на источнике. Дальше поля документов, чьи тип совместим,
  * ссылаются на этот источник без маппинга (тип↔тип). Материализация — после всех обработок.
  */
+const NO_FIELDS: SchemaField[] = [];
+
 export function MaterializationDialog({ source, onClose }: { source: DataSetSource; onClose: () => void }) {
   const { data: allDocTypes = [] } = useListDocumentTypes();
   const [typeId, setTypeId] = useState(source.materializeTypeId ?? '');
@@ -53,7 +55,21 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
     const computed = (source.computedColumns ?? []).map(c => c.alias).filter(Boolean);
     return [...new Set([...parseSourceColumnNames(source.cachedSchema), ...computed])];
   }, [source.cachedSchema, source.computedColumns]);
-  const effectiveFields = selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : [];
+  /**
+   * Поля выбранного типа — МЕМОИЗИРОВАННЫЕ. Считались инлайном, то есть давали НОВЫЙ массив на
+   * каждый рендер; стоя в зависимостях модели предпросмотра, они лишали её мемоизацию смысла —
+   * сравнение по ссылке не совпадало никогда (issue #870).
+   *
+   * Честно про цену: сколько это стоило, НЕ измерено. Проба показала, что при вводе в диалог
+   * модель не пересобиралась вовсе, то есть видимой платы на этом экране может и не быть. Правка
+   * не про скорость, а про то, чтобы мемо либо работало, либо его не стояло.
+   *
+   * Пустой список — модульной константой: инлайновый `[]` — новая ссылка каждый раз, ровно та
+   * нестабильная пустышка, что уже давала в проекте цикл memo → effect (issue #305).
+   */
+  const effectiveFields = useMemo(
+    () => (selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : NO_FIELDS),
+    [selectedType, allDocTypes]);
   // Union-тип (issue #320/#391): «заполняется ровно один вариант» — маппим один активный вариант,
   // а не все поля union разом. Материализатор кладёт один ключ на строку → корректный union-экземпляр.
   const isUnion = !!selectedType

--- a/src/client/src/features/datasets/MaterializationDialog.tsx
+++ b/src/client/src/features/datasets/MaterializationDialog.tsx
@@ -16,17 +16,20 @@ import { resolveEffectiveFields, type SchemaField } from '@/shared/api/schema';
 import { parseSourceColumnNames } from '@/shared/api/datasetHelpers';
 import { FUNCTIONAL_TAG } from '@/shared/api/tags';
 import { isFileAttachment, formatBytes } from '@/shared/api/attachments';
-import type { DataSetSource, MaterializeDiscriminator } from '@/shared/api/types';
+import type { DataSetSource, DocumentType, MaterializeDiscriminator } from '@/shared/api/types';
+
+// Пустые значения — модульными константами, а не инлайновыми `[]`: инлайновый литерал даёт новую
+// ссылку каждый рендер и ломает мемоизацию ниже по течению (issue #305, #870).
+const NO_FIELDS: SchemaField[] = [];
+const NO_TYPES: DocumentType[] = [];
 
 /**
  * Материализация источника в тип (issue #19): пользователь выбирает тип (составной/документ) и
  * маппинг колонок → поля типа ОДИН РАЗ на источнике. Дальше поля документов, чьи тип совместим,
  * ссылаются на этот источник без маппинга (тип↔тип). Материализация — после всех обработок.
  */
-const NO_FIELDS: SchemaField[] = [];
-
 export function MaterializationDialog({ source, onClose }: { source: DataSetSource; onClose: () => void }) {
-  const { data: allDocTypes = [] } = useListDocumentTypes();
+  const { data: allDocTypes = NO_TYPES } = useListDocumentTypes();
   const [typeId, setTypeId] = useState(source.materializeTypeId ?? '');
   const [rawMapping, setMapping] = useState<Record<string, string>>(source.materializeMapping ?? {});
   const [showPreview, setShowPreview] = useState(false);
@@ -64,8 +67,7 @@ export function MaterializationDialog({ source, onClose }: { source: DataSetSour
    * модель не пересобиралась вовсе, то есть видимой платы на этом экране может и не быть. Правка
    * не про скорость, а про то, чтобы мемо либо работало, либо его не стояло.
    *
-   * Пустой список — модульной константой: инлайновый `[]` — новая ссылка каждый раз, ровно та
-   * нестабильная пустышка, что уже давала в проекте цикл memo → effect (issue #305).
+   * Пустой список — модульная константа `NO_FIELDS`, причина — в комментарии у её объявления.
    */
   const effectiveFields = useMemo(
     () => (selectedType ? resolveEffectiveFields(selectedType, allDocTypes) : NO_FIELDS),

--- a/src/client/src/features/templates/TemplatesPage.tsx
+++ b/src/client/src/features/templates/TemplatesPage.tsx
@@ -186,6 +186,13 @@ export function TemplatesPage() {
         persist(selectedTypeId, active.id);
       }
     }
+    // Зависимость ровно от `templates` — это и есть условие «приехал список, выбери в нём»
+    // (issue #870). Линт просит добавить `selectedTypeId`, `persist`, `selectedTemplate` и
+    // `setSelectedTemplate` — добавлять их НЕЛЬЗЯ: с `selectedTypeId` эффект побежит на смене типа
+    // ДО того, как приедут шаблоны нового, и авто-выбор возьмёт шаблон чужого типа из ещё не
+    // обновившегося списка; `persist` пересоздаётся каждый рендер, то есть эффект бежал бы на
+    // каждый. Смена типа и так меняет `templates` — у запроса свой ключ на тип.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [templates]);
 
   function handleTypeChange(id: string) {

--- a/src/client/src/shared/utils/computedExpression.ts
+++ b/src/client/src/shared/utils/computedExpression.ts
@@ -23,7 +23,10 @@ export function evalComputed(expression: string, values: Record<string, unknown>
   if (!expression.trim()) return { value: undefined };
   try {
     const get = (key: string) => values[key];
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    // `new Function` здесь НАМЕРЕННО: вычисляемая колонка — это выражение, которое пишет админ,
+    // и другого способа его посчитать в браузере нет. Строка не приходит извне: источник — поле
+    // настройки, доступное только роли Admin. Директивы eslint тут не было бы толку — правила
+    // `no-implied-eval`/`no-new-func` в конфиге проекта не включены, и подавлять нечего.
     const fn = new Function('get', `"use strict"; return (${expression});`);
     const value = fn(get);
     return { value };
@@ -41,7 +44,8 @@ export function validateComputed(
   let syntaxError: string | undefined;
   if (expression.trim()) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+      // `new Function` намеренно — см. пояснение в evalComputed выше; здесь выражение только
+      // компилируется, без запуска.
       new Function('get', `"use strict"; return (${expression});`);
     } catch (e) {
       syntaxError = e instanceof Error ? e.message : String(e);

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.152.9</Version>
+    <Version>0.152.10</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Закрывает #870. После этого в линте **ноль ошибок и ноль предупреждений**.

## `MaterializationDialog` — мемо, которое не мемоизировало

`effectiveFields` считались инлайном: новый массив на каждый рендер. Стоя в зависимостях модели предпросмотра, они лишали её мемоизацию смысла — сравнение по ссылке не совпадало никогда. Теперь `useMemo`, пустой список — модульной константой (инлайновый `[]` — та самая нестабильная пустышка, что уже давала в проекте цикл memo → effect, #305).

**Честно про цену: не измерено.** Разовая проба (метка в `buildPreviewModel`, ввод шести символов в диалоге) насчитала **ноль** пересборок — и до правки, и после. При вводе диалог модель не пересобирает вовсе, то есть видимой платы на этом экране может не быть. Правка не про скорость, а про то, чтобы мемо либо работало, либо его не стояло. Исходное утверждение в issue я поправил отдельным комментарием там же.

## `TemplatesPage` — зависимости узкие намеренно

Линт просит добавить `selectedTypeId`, `persist`, `selectedTemplate`, `setSelectedTemplate`. **Добавлять нельзя:**

- с `selectedTypeId` эффект побежит на смене типа **до** того, как приедут шаблоны нового типа, и авто-выбор возьмёт шаблон чужого типа из ещё не обновившегося списка;
- `persist` пересоздаётся каждый рендер — эффект бежал бы на каждый.

Зависимость ровно от `templates` и есть условие «приехал список — выбери в нём»; смена типа меняет список сама (у запроса свой ключ на тип). Поставлен явный `eslint-disable-next-line` с причиной: предупреждение без объяснения хуже подавленного с объяснением — первое каждый следующий читатель разбирает заново.

## Попутно

Два мёртвых `eslint-disable` у `new Function`: правила, которые они подавляли (`no-implied-eval`, `no-new-func`), в конфиге проекта не включены — подавлять нечего. Заменены обычным комментарием: намерение осталось (выражение пишет админ, другого способа посчитать его в браузере нет), линт замолчал.

## Проверено

`tsc -b`, сборка, 607 юнит-тестов, линт **0 ошибок / 0 предупреждений** и живые прогоны: dialogs 13, pages 8, fields 16, types 9.

**Оговорка:** один прогон `types` из четырёх дал 8/9, какая именно проверка упала — не поймал; три последующих зелёные. Похоже на неустойчивость прогона, а не на правку (она этих экранов не касается) — но говорю, раз видел.

Версия **0.152.10** (PATCH).