### PR TITLE
Правки по ревью: проверка блоба у набора, адрес меню по имени, имена пропусков в одном месте (#872)

### DIFF
--- a/src/client/e2e/dialogs-smoke.mjs
+++ b/src/client/e2e/dialogs-smoke.mjs
@@ -65,18 +65,17 @@ const checkedVariant = async () => {
 try {
 
 // ── Разбиение PDF: серверные группы плюс правка поверх ─────────────────────────
-if (!PDF_FILE) {
-  const why = 'нужен набор с распознанными страницами (ИИ-движок), посев его не создаёт';
-  for (const name of ['pdf-grouping-loads-groups', 'pdf-grouping-edit-enables-save', 'pdf-page-viewer-opens'])
-    skip(name, why);
-} else {
-
-await page.goto(`${BASE}/datasets/files/${PDF_FILE}/grouping`);
-await page.waitForSelector('img', { timeout: 30000 });
-await page.waitForTimeout(1500);
+//
+// Проверки объявлены СПИСКОМ, потому что имена нужны дважды: чтобы прогнать и чтобы пропустить.
+// Записанные в двух местах, они разъезжаются молча — переименуй проверку, и прогон продолжил бы
+// печатать «3 пропущено» с именем, которого больше нет, а «79 из 82» перестало бы сходиться.
+// Одно объявление — и такому расхождению взяться неоткуда.
+//
+// `save` — локатор, а не найденный элемент: он ленив, поэтому объявляется до перехода на экран.
 const save = page.getByRole('button', { name: /^Сохранить$/ }).first();
 
-await check('pdf-grouping-loads-groups', async () => {
+const pdfChecks = [
+['pdf-grouping-loads-groups', async () => {
   const t = await page.locator('body').innerText();
   for (const g of ['Обложка', 'Титульный лист', 'Без группы']) {
     if (!t.includes(g)) throw new Error(`группы «${g}» на экране нет`);
@@ -85,9 +84,9 @@ await check('pdf-grouping-loads-groups', async () => {
   // Правки ещё не было — сохранять нечего. Если бы «грязно» и содержимое разошлись, здесь бы и
   // вылезло: кнопка активна на нетронутом экране.
   if (!(await save.isDisabled())) throw new Error('«Сохранить» активна на нетронутом разбиении');
-});
+}],
 
-await check('pdf-grouping-edit-enables-save', async () => {
+['pdf-grouping-edit-enables-save', async () => {
   await page.locator('img').first().click();
   await page.waitForTimeout(600);
   await page.getByRole('button', { name: /Отделить в новый документ/ }).first().click();
@@ -95,9 +94,9 @@ await check('pdf-grouping-edit-enables-save', async () => {
   if (await save.isDisabled()) throw new Error('после правки «Сохранить» так и не стала активной');
   const t = await page.locator('body').innerText();
   if (!/1 документ/.test(t)) throw new Error(`новый документ в сводке не появился: ${t.slice(-300)}`);
-});
+}],
 
-await check('pdf-page-viewer-opens', async () => {
+['pdf-page-viewer-opens', async () => {
   await page.getByRole('button', { name: /Просмотреть лист крупно/ }).first().click();
   await page.waitForTimeout(2500);
   const dlg = page.locator('[role=dialog]').last();
@@ -109,8 +108,17 @@ await check('pdf-page-viewer-opens', async () => {
   if (!ok) throw new Error('изображение листа не разобралось (naturalWidth = 0)');
   await page.keyboard.press('Escape');
   await page.waitForTimeout(600);
-});
+}],
+];
 
+if (!PDF_FILE) {
+  const why = 'нужен набор с распознанными страницами (ИИ-движок), посев его не создаёт';
+  for (const [name] of pdfChecks) skip(name, why);
+} else {
+  await page.goto(`${BASE}/datasets/files/${PDF_FILE}/grouping`);
+  await page.waitForSelector('img', { timeout: 30000 });
+  await page.waitForTimeout(1500);
+  for (const [name, fn] of pdfChecks) await check(name, fn);
 }
 
 // ── Материализация: активный вариант union ────────────────────────────────────
@@ -118,7 +126,17 @@ await page.goto(`${BASE}/datasets`);
 await page.waitForTimeout(2500);
 await page.getByText(DATASET_FILE, { exact: false }).first().click();
 await page.waitForTimeout(2500);
-await page.locator('button[aria-haspopup]').nth(1).click();   // кебаб первого источника
+// Кебаб источника — ПО ИМЕНИ, а не порядковым номером. Раньше стояло `nth(1)` с пояснением
+// «кебаб первого источника», и пояснение было верным лишь по совпадению: `aria-haspopup` на этой
+// странице есть и у КОЛОКОЛЬЧИКА уведомлений в оболочке (`haspopup="dialog"`), он идёт нулевым и
+// сдвигает нумерацию ровно на единицу. Пропади колокольчик — и тот же `nth(1)` молча уехал бы на
+// второй источник (проверено пробой DOM: на экране ровно две такие кнопки — колокольчик и меню
+// источника). Имя ни от оболочки, ни от порядка не зависит.
+const sourceMenu = page.locator('button[aria-label="Действия над источником"]').first();
+if (!(await sourceMenu.count())) {
+  throw new Error(`у набора «${DATASET_FILE}» нет ни одного источника — материализацию открывать не из чего`);
+}
+await sourceMenu.click();
 await page.waitForTimeout(700);
 await page.getByText('Материализация', { exact: false }).first().click();
 await page.waitForTimeout(1800);

--- a/src/client/e2e/seed.mjs
+++ b/src/client/e2e/seed.mjs
@@ -341,21 +341,42 @@ async function ensureCatalogEntries(orgTypeId, personTypeId) {
  * который ищет набор ПО ИМЕНИ, открывал бы первый попавшийся из двух.
  */
 async function ensureDataSetFile(name, bytes, fileName, mimeType) {
+  const send = async (method, path, note) => {
+    const form = new FormData();
+    form.append('file', new Blob([bytes], { type: mimeType }), fileName);
+    form.append('name', name);
+    form.append('scope', 'System');
+    const res = await fetch(`${API}/api${path}`, {
+      method, headers: { Authorization: `Bearer ${token}` }, body: form,
+    });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`${method} ${path} → ${res.status} ${text.slice(0, 300)}`);
+    console.log(`  ${note} набор данных «${name}»`);
+    return JSON.parse(text).id;
+  };
+
   const files = await api('GET', '/datasets/files?scope=System');
   const found = files.find(f => f.name === name);
-  if (found) return found.id;
+  if (!found) return send('POST', '/datasets/files', '+');
 
-  const form = new FormData();
-  form.append('file', new Blob([bytes], { type: mimeType }), fileName);
-  form.append('name', name);
-  form.append('scope', 'System');
-  const res = await fetch(`${API}/api/datasets/files`, {
-    method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: form,
+  // Запись в базе не доказывает, что файл ЛЕЖИТ в хранилище: MinIO живёт в контейнере и
+  // пересоздаётся отдельно от Postgres — та же причина, по которой картинка и вложение выше
+  // проверяются `blobExists`. Здесь спрашиваем скачиванием: у набора нет поля с путём блоба, а
+  // `GET .../download` читает хранилище по-настоящему.
+  //
+  // Молчать об этом нельзя: у CSV-источника нет `CachedData` (кэш пишется только PDF- и
+  // системным), значит КАЖДОЕ чтение — предпросмотр, материализация, экспорт — заново разбирает
+  // блоб. Посев отчитался бы «готов», а прогон упал бы на диалоге, показывая на компонент вместо
+  // пустого хранилища.
+  const dl = await fetch(`${API}/api/datasets/files/${found.id}/download`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
-  const text = await res.text();
-  if (!res.ok) throw new Error(`POST /datasets/files → ${res.status} ${text.slice(0, 300)}`);
-  console.log(`  + набор данных «${name}»`);
-  return JSON.parse(text).id;
+  await dl.arrayBuffer().catch(() => {});   // тело дочитываем, иначе соединение висит
+  if (dl.ok) return found.id;
+
+  // Замена файла, а не пересоздание набора: `PUT` перезаливает блоб и ПЕРЕ-РАЗБИРАЕТ существующие
+  // источники против него — их схема колонок восстанавливается сама, а адрес набора не меняется.
+  return send('PUT', `/datasets/files/${found.id}`, '⟳');
 }
 
 /**
@@ -863,9 +884,10 @@ async function main() {
   const copyTargetSetId = await ensureSet(constructionId, 'СКС-1', 'Демо-комплект СКС');
 
   /**
-   * Набор данных с источниками — предмет четырёх проверок материализации. Источника ДВА: диалог
-   * открывается из кебаба ПЕРВОГО источника, а второй держит форму экрана той же, что на живой
-   * базе, где у счёта разобраны и шапка, и товары.
+   * Набор данных с источниками — предмет четырёх проверок материализации. Диалог открывается из
+   * меню ПЕРВОГО источника; второй держит экран той же формы, что на живой базе, где у счёта
+   * разобраны и шапка, и товары. Проверено удалением: с одним источником прогон остаётся зелёным,
+   * так что второй — про сходство с живым экраном, а не про работоспособность проверок.
    *
    * Файл — CSV, а не PDF: колонки нужны настоящие, а PDF-источник получает их распознаванием,
    * то есть ИИ-движком, которого в CI нет (см. `e2e/README.md`).

--- a/src/server/Directory.Build.props
+++ b/src/server/Directory.Build.props
@@ -3,7 +3,7 @@
        функциональности, PATCH — фиксы; 1.0.0 — первый релиз. К InformationalVersion SDK добавляет
        +<git-sha> (см. target ниже) для трассировки сборок на внутреннем тестировании. -->
   <PropertyGroup>
-    <Version>0.156.0</Version>
+    <Version>0.156.1</Version>
   </PropertyGroup>
 
   <!-- Доменные отказы (BHS.CRG.Domain.Common) доступны без using во всех проектах, кроме


### PR DESCRIPTION
Три находки `/code-review` по #876. Две подтвердились как есть, третья — нет, и вместо неё
исправлено то, что за ней действительно стояло.

## Набор данных не сверялся с хранилищем

Картинка и вложение проходят `blobExists` именно потому, что MinIO живёт в контейнере и
пересоздаётся отдельно от Postgres, — а `ensureDataSetFile` возвращался по одному совпадению
имени. Цена здесь даже выше, чем у остальных фикстур: у CSV-источника нет `CachedData` (кэш
пишется только PDF- и системным), поэтому **каждое** чтение — предпросмотр, материализация,
экспорт — заново разбирает блоб. Посев отчитался бы «готов», а прогон упал бы на диалоге,
показывая на компонент вместо пустого хранилища.

Спрашиваем скачиванием (поля с путём у набора в DTO нет) и чиним `PUT`-ом: он перезаливает файл
и **пере-разбирает существующие источники**, так что схема колонок восстанавливается сама, а
адрес набора не меняется.

**Проверено:** `rm -rf` бакета при живой базе → посев напечатал `⟳ набор данных «Счет на оплату
(посев)»` (и `+` для логотипа с вложением) → все 79 проверок прошли, включая материализацию,
которой нужны колонки.

## Имена пропускаемых проверок стояли в двух местах

Переименуй проверку — и прогон продолжил бы печатать «3 пропущено» с именем, которого больше
нет, а арифметика «79 из 82» в README перестала бы сходиться, причём молча. Проверки разбиения
PDF объявлены одним списком: из него и запускаем, и пропускаем.

## `nth(1)` — не второй источник; ревью тут ошиблось

Посылка находки была, что на экране `aria-haspopup` есть только у меню источников. Проба DOM
показала другое: таких кнопок две — **колокольчик уведомлений** из оболочки (`haspopup="dialog"`)
и меню источника. Колокольчик идёт нулевым, значит `nth(1)` — меню **первого** источника, и
исходный комментарий был верен. Подтверждено и опытом: удалил второй источник — прогон остался
зелёным (то есть второй источник не несущий, он про сходство с живым экраном).

Хрупкость при этом настоящая, только другая: номер держался на присутствии колокольчика — пропади
он, и тот же `nth(1)` молча уехал бы на второй источник. Меню адресуется по
`aria-label="Действия над источником"`: ни от оболочки, ни от порядка это не зависит.

Заодно «нет ни одного источника» теперь называется причиной, а не тридцатисекундным таймаутом
Playwright вне всякой проверки. **Проверка достижима:** удалил оба источника — прогон упал с
`у набора «Счет на оплату (посев)» нет ни одного источника — материализацию открывать не из чего`.

## Проверено целиком

Локально на том же стенде, что и #876: **все 8 прогонов, 79 из 79, 3 пропущено**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013624rSjTBywUbAMUtiHCSJ
